### PR TITLE
Harden security, frontend stability, and ops

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 
 # ─── Required ────────────────────────────────────────────────────────────────
 
+# Environment: "development" or "production".
+# In production the app REFUSES to start with default/change-me secrets.
+ENVIRONMENT=development
+
 # App secrets — MUST change before production (use: python -c "import secrets; print(secrets.token_hex(32))")
 SECRET_KEY=change-me-to-random-64-char-string
 JWT_SECRET=change-me-to-random-64-char-string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt -r requirements-dev.txt
+          pip install ruff
+
+      - name: Lint (ruff)
+        run: ruff check backend/
+
+      - name: Tests (pytest)
+        run: python -m pytest backend/tests/ -q
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Frontend has pre-existing eslint debt (~29 issues: unused vars,
+      # set-state-in-effect, react-compiler hints). Surfaced here but not
+      # yet blocking — remove continue-on-error once the debt is burned down.
+      - name: Lint (eslint)
+        run: npm run lint
+        continue-on-error: true
+
+      - name: Build (vite)
+        run: npm run build

--- a/backend/auth/dependencies.py
+++ b/backend/auth/dependencies.py
@@ -42,13 +42,14 @@ def require_auth(request: Request, obsyd_token: str | None = Cookie(None)) -> di
 
 
 def require_pro(request: Request, obsyd_token: str | None = Cookie(None)) -> dict:
-    """Require Pro subscription (paid or in-trial). Raises 401/403 otherwise."""
-    user = require_auth(request, obsyd_token)
+    """Require Pro subscription (paid or in-trial). Raises 401/403 otherwise.
 
-    # JWT sub_status is a fast-path. It can become stale (subscription changes
-    # between token-issue and now), so a "free" claim still triggers a DB read.
-    if user.get("sub_status") == "pro":
-        return user
+    The JWT's sub_status claim is deliberately NOT trusted: a token lives up to
+    jwt_expiry_days, so a refunded/downgraded user would otherwise keep Pro
+    access until expiry. Every Pro request verifies against the DB (cheap on
+    SQLite, single indexed lookup).
+    """
+    user = require_auth(request, obsyd_token)
 
     db = SessionLocal()
     try:

--- a/backend/auth/subscription_check.py
+++ b/backend/auth/subscription_check.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 from backend.models.subscription import Subscription
 
-
 # Status values that grant Pro access immediately (no expiry check needed).
 PRO_STATUSES_UNCONDITIONAL: frozenset[str] = frozenset(
     {

--- a/backend/collectors/portwatch.py
+++ b/backend/collectors/portwatch.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 import httpx
 
 from backend.database import SessionLocal
-from backend.models.ports import PortActivity, Disruption
+from backend.models.ports import Disruption, PortActivity
 
 logger = logging.getLogger(__name__)
 

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -42,6 +42,7 @@ from backend.collectors.retention import run_retention
 from backend.collectors.sts_collector import collect_sts_events
 from backend.database import SessionLocal
 from backend.notifications.alert_runner import process_alert_rules
+from backend.notifications.collector_watchdog import check_collectors
 from backend.notifications.daily_email import send_daily_email
 from backend.notifications.trial_drip import process_trial_drip
 from backend.providers.price_provider import get_live_prices as refresh_live_prices
@@ -367,6 +368,15 @@ def start_scheduler():
         run_retention,
         CronTrigger(hour=4, minute=0),
         id="retention_daily",
+        **JOB_DEFAULTS,
+    )
+
+    # Collector watchdog: daily 09:00 UTC — emails ops if a collector
+    # stopped writing within its freshness window (see routes/health.py).
+    scheduler.add_job(
+        check_collectors,
+        CronTrigger(hour=9, minute=0),
+        id="collector_watchdog_daily",
         **JOB_DEFAULTS,
     )
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -5,6 +5,10 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    # Deployment environment: "development" or "production".
+    # In production, default secrets cause a hard startup failure.
+    environment: str = "development"
+
     # Database
     database_url: str = "sqlite:///./obsyd.db"
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ from backend.collectors.scheduler import start_scheduler, stop_scheduler
 from backend.database import init_db
 from backend.migrations import run_migrations
 from backend.observability import TraceIDMiddleware, setup_logging
+from backend.routes import alert_rules as alert_rules_routes
 from backend.routes import alerts, health, ports, prices, sentiment, vessels, voyages, weather
 from backend.routes import analytics as analytics_routes
 from backend.routes import auth as auth_routes
@@ -32,12 +33,31 @@ from backend.routes import settings as settings_routes
 from backend.routes import signals as signals_routes
 from backend.routes import thermal as thermal_routes
 from backend.routes import waitlist as waitlist_routes
-from backend.routes import alert_rules as alert_rules_routes
 from backend.routes import webhooks as webhooks_routes
 from backend.signals.sentiment_scorer import compute_sentiment_score
 
 setup_logging()
 logger = logging.getLogger(__name__)
+
+# Strong references to fire-and-forget tasks (asyncio only keeps weak ones).
+_background_tasks: set = set()
+
+
+def _create_task_logged(coro, name: str) -> asyncio.Task:
+    """Spawn a background task whose crash is logged instead of silently dropped."""
+    task = asyncio.create_task(coro, name=name)
+    _background_tasks.add(task)
+
+    def _on_done(t: asyncio.Task) -> None:
+        _background_tasks.discard(t)
+        if t.cancelled():
+            return
+        exc = t.exception()
+        if exc:
+            logger.error("Background task %r failed: %s", name, exc, exc_info=exc)
+
+    task.add_done_callback(_on_done)
+    return task
 
 
 @asynccontextmanager
@@ -53,6 +73,11 @@ async def lifespan(app: FastAPI):
         val = getattr(settings, name)
         raw = val.get_secret_value() if hasattr(val, "get_secret_value") else val
         if "change-me" in raw:
+            if settings.environment == "production":
+                raise RuntimeError(
+                    f"SECURITY: {name} uses the default value — refusing to start. "
+                    "Set it in .env (e.g. `openssl rand -hex 32`)."
+                )
             logger.warning("SECURITY: %s uses default value — set it in .env before production!", name)
 
     start_scheduler()
@@ -66,19 +91,19 @@ async def lifespan(app: FastAPI):
 
     # Phase 3: Background data collection (staggered, non-blocking)
     await asyncio.sleep(3)
-    asyncio.create_task(collect_portwatch())
-    asyncio.create_task(collect_jodi())
+    _create_task_logged(collect_portwatch(), "portwatch")
+    _create_task_logged(collect_jodi(), "jodi")
     logger.info("Startup: PortWatch + JODI collection started (background)")
 
     await asyncio.sleep(3)
-    asyncio.create_task(collect_gdelt_volume())
-    asyncio.create_task(collect_gdelt_sentiment())
-    asyncio.create_task(compute_sentiment_score())
-    asyncio.create_task(collect_finnhub_news())
+    _create_task_logged(collect_gdelt_volume(), "gdelt_volume")
+    _create_task_logged(collect_gdelt_sentiment(), "gdelt_sentiment")
+    _create_task_logged(compute_sentiment_score(), "sentiment_score")
+    _create_task_logged(collect_finnhub_news(), "finnhub_news")
     logger.info("Startup: GDELT + Finnhub + Sentiment started (background)")
 
     await asyncio.sleep(3)
-    asyncio.create_task(backfill_geofence_events())
+    _create_task_logged(backfill_geofence_events(), "geofence_backfill")
     logger.info("Startup: Geofence backfill started (background)")
 
     # FRED backfill (one-time: extends WTI/Brent back to 2019)
@@ -96,29 +121,29 @@ async def lifespan(app: FastAPI):
         db_session.close()
 
     # Initial fleet summary for today
-    asyncio.create_task(create_daily_fleet_summary())
+    _create_task_logged(create_daily_fleet_summary(), "fleet_summary")
     logger.info("Startup: Fleet summary scheduled")
 
     # Pro features: backfill crack spreads + equities if empty
     from backend.collectors.crack_spreads import collect_crack_spreads
     from backend.collectors.equities import collect_equities
 
-    asyncio.create_task(collect_crack_spreads())
-    asyncio.create_task(collect_equities())
+    _create_task_logged(collect_crack_spreads(), "crack_spreads")
+    _create_task_logged(collect_equities(), "equities")
     logger.info("Startup: Crack spreads + equities collection started (background)")
 
     # STS detection initial run
     from backend.collectors.sts_collector import collect_sts_events
 
-    asyncio.create_task(collect_sts_events())
+    _create_task_logged(collect_sts_events(), "sts_events")
     logger.info("Startup: STS detection started (background)")
 
     # Analytics: initial computation
     from backend.analytics.disruption_score import compute_disruption_score
     from backend.analytics.tonne_miles import compute_tonne_miles
 
-    asyncio.create_task(compute_tonne_miles())
-    asyncio.create_task(compute_disruption_score())
+    _create_task_logged(compute_tonne_miles(), "tonne_miles")
+    _create_task_logged(compute_disruption_score(), "disruption_score")
     logger.info("Startup: Analytics (tonne-miles, disruption score) started (background)")
 
     # Daily Briefing Email status

--- a/backend/models/fleet.py
+++ b/backend/models/fleet.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, Float, Integer
+from sqlalchemy import Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base

--- a/backend/models/jodi.py
+++ b/backend/models/jodi.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import String, Float, DateTime, Integer
+from sqlalchemy import DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base

--- a/backend/models/ports.py
+++ b/backend/models/ports.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import String, Float, Integer, DateTime
+from sqlalchemy import DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base

--- a/backend/models/prices.py
+++ b/backend/models/prices.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import String, Float, DateTime, Integer
+from sqlalchemy import DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base

--- a/backend/models/sentiment.py
+++ b/backend/models/sentiment.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import String, Float, DateTime, Integer, Text
+from sqlalchemy import DateTime, Float, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base

--- a/backend/models/thermal.py
+++ b/backend/models/thermal.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import String, Float, DateTime, Integer
+from sqlalchemy import DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base

--- a/backend/models/weather.py
+++ b/backend/models/weather.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import String, Float, DateTime, Integer, Text
+from sqlalchemy import DateTime, Float, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base

--- a/backend/notifications/collector_watchdog.py
+++ b/backend/notifications/collector_watchdog.py
@@ -1,0 +1,98 @@
+"""
+Collector watchdog — daily ops alert when a data collector goes stale.
+
+Runs via APScheduler (daily 09:00 UTC). Reuses the staleness thresholds
+from the health route, so /api/health/collectors and this alert always
+agree. Emails OPS_EMAIL via Resend; logs (and skips) when no key is set.
+"""
+
+import logging
+from datetime import datetime
+
+import httpx
+from sqlalchemy import func
+
+from backend.config import settings
+from backend.database import SessionLocal
+from backend.models.prices import EIAPrice, FREDSeries
+from backend.models.sentiment import GDELTVolume
+from backend.models.vessels import VesselPosition
+from backend.notifications.daily_email import OPS_EMAIL
+from backend.routes.health import STALENESS
+
+logger = logging.getLogger(__name__)
+
+
+def _collect_staleness(db) -> dict:
+    """Return {collector: {'fresh': bool, 'last_seen': datetime|None}}."""
+    now = datetime.utcnow()
+    last = {
+        "eia": db.query(func.max(EIAPrice.fetched_at)).scalar(),
+        "fred": db.query(func.max(FREDSeries.fetched_at)).scalar(),
+        "ais": db.query(func.max(VesselPosition.timestamp)).scalar(),
+        "gdelt": db.query(func.max(GDELTVolume.created_at)).scalar(),
+    }
+    return {
+        key: {
+            "fresh": ts is not None and (now - ts) <= STALENESS[key],
+            "last_seen": ts,
+        }
+        for key, ts in last.items()
+    }
+
+
+async def check_collectors():
+    """Daily watchdog: email ops when one or more collectors are stale."""
+    db = SessionLocal()
+    try:
+        status = _collect_staleness(db)
+    except Exception as e:
+        logger.error("Collector watchdog: staleness check failed: %s", e)
+        return
+    finally:
+        db.close()
+
+    stale = {k: v for k, v in status.items() if not v["fresh"]}
+    if not stale:
+        logger.info("Collector watchdog: all collectors fresh")
+        return
+
+    names = ", ".join(stale)
+    logger.warning("Collector watchdog: STALE collectors: %s", names)
+
+    api_key = settings.resend_api_key
+    if not api_key:
+        logger.warning("Collector watchdog: RESEND_API_KEY not set, alert logged only")
+        return
+    if hasattr(api_key, "get_secret_value"):
+        api_key = api_key.get_secret_value()
+
+    rows = "".join(
+        f"<tr><td><strong>{k}</strong></td>"
+        f"<td>{v['last_seen'].isoformat() if v['last_seen'] else 'never'}</td>"
+        f"<td>{STALENESS[k]}</td></tr>"
+        for k, v in stale.items()
+    )
+    html = (
+        f"<p>The following OBSYD collectors have not written data within their freshness window:</p>"
+        f"<table border='1' cellpadding='6' cellspacing='0'>"
+        f"<tr><th>Collector</th><th>Last seen (UTC)</th><th>Threshold</th></tr>{rows}</table>"
+        f"<p>Check: <code>journalctl -u obsyd --since '-24h' | grep -i error</code></p>"
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(
+                "https://api.resend.com/emails",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={
+                    "from": "OBSYD <briefing@obsyd.dev>",
+                    "to": [OPS_EMAIL],
+                    "subject": f"OBSYD ALERT: stale collectors — {names}",
+                    "html": html,
+                },
+            )
+            resp.raise_for_status()
+        logger.info("Collector watchdog: alert email sent (%s)", names)
+    except Exception as e:
+        logger.error("Collector watchdog: alert email failed: %s", e)

--- a/backend/notifications/trial_drip.py
+++ b/backend/notifications/trial_drip.py
@@ -24,7 +24,7 @@ so drip-stage advancement is bounded per run (DRIP_SEND_BUDGET).
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Optional
 
 import httpx

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -1,31 +1,60 @@
-from fastapi import APIRouter, Depends
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, text
 from sqlalchemy.orm import Session
-from sqlalchemy import func
 
 from backend.database import get_db
 from backend.models.prices import EIAPrice, FREDSeries
-from backend.models.vessels import VesselPosition
 from backend.models.sentiment import GDELTVolume
+from backend.models.vessels import VesselPosition
 
 router = APIRouter()
 
+# Staleness thresholds per collector — matched to each source's cadence.
+# A collector is "up" only if it has written within its window, so a
+# silently-crashed collector flips to false instead of staying green forever.
+STALENESS = {
+    "eia": timedelta(days=14),  # weekly releases
+    "fred": timedelta(days=7),  # daily series
+    "ais": timedelta(hours=2),  # continuous stream
+    "gdelt": timedelta(hours=24),  # 15-min cadence, generous window
+}
+
 
 @router.get("/health")
-async def health_check():
+async def health_check(db: Session = Depends(get_db)):
+    """Liveness + DB readiness. Returns 503 if the DB is unreachable,
+    so the health-check cron restarts the service."""
+    try:
+        db.execute(text("SELECT 1"))
+    except Exception:
+        raise HTTPException(status_code=503, detail="database unreachable")
     return {"status": "ok", "service": "obsyd"}
 
 
 @router.get("/api/health/collectors")
 async def collector_status(db: Session = Depends(get_db)):
-    """Check which data collectors have recent data."""
-    eia_count = db.query(func.count(EIAPrice.id)).scalar()
-    fred_count = db.query(func.count(FREDSeries.id)).scalar()
-    ais_count = db.query(func.count(VesselPosition.id)).scalar()
-    gdelt_count = db.query(func.count(GDELTVolume.id)).scalar()
+    """Check which data collectors have written recently (not just ever)."""
+    now = datetime.utcnow()
+
+    last_eia = db.query(func.max(EIAPrice.fetched_at)).scalar()
+    last_fred = db.query(func.max(FREDSeries.fetched_at)).scalar()
+    last_ais = db.query(func.max(VesselPosition.timestamp)).scalar()
+    last_gdelt = db.query(func.max(GDELTVolume.created_at)).scalar()
+
+    def fresh(last, key):
+        return last is not None and (now - last) <= STALENESS[key]
 
     return {
-        "eia": eia_count > 0,
-        "fred": fred_count > 0,
-        "ais": ais_count > 0,
-        "gdelt": gdelt_count > 0,
+        "eia": fresh(last_eia, "eia"),
+        "fred": fresh(last_fred, "fred"),
+        "ais": fresh(last_ais, "ais"),
+        "gdelt": fresh(last_gdelt, "gdelt"),
+        "last_seen": {
+            "eia": last_eia.isoformat() if last_eia else None,
+            "fred": last_fred.isoformat() if last_fred else None,
+            "ais": last_ais.isoformat() if last_ais else None,
+            "gdelt": last_gdelt.isoformat() if last_gdelt else None,
+        },
     }

--- a/backend/routes/thermal.py
+++ b/backend/routes/thermal.py
@@ -18,7 +18,7 @@ async def get_hotspots(
     query = db.query(ThermalHotspot)
     if area:
         query = query.filter(ThermalHotspot.area_name == area)
-    rows = query.all()
+    rows = query.limit(2000).all()
     return [
         {
             "lat": r.latitude,
@@ -37,7 +37,7 @@ async def get_hotspots(
 @router.get("/refineries")
 async def get_refinery_status(db: Session = Depends(get_db)):
     """Get refinery thermal status: active/inactive based on nearby hotspots."""
-    hotspots = db.query(ThermalHotspot).all()
+    hotspots = db.query(ThermalHotspot).limit(5000).all()
 
     result = []
     for ref in REFINERIES:

--- a/backend/routes/voyages.py
+++ b/backend/routes/voyages.py
@@ -26,10 +26,16 @@ async def get_recent_voyages(
         .all()
     )
 
+    # Batch-fetch registry data for all MMSIs (avoids one query per voyage)
+    mmsi_list = list({r.mmsi for r in rows})
+    registry_map = {}
+    if mmsi_list:
+        regs = db.query(VesselRegistry).filter(VesselRegistry.mmsi.in_(mmsi_list)).all()
+        registry_map = {reg.mmsi: reg for reg in regs}
+
     result = []
     for r in rows:
-        # Try to get ship_class from registry
-        reg = db.query(VesselRegistry).filter(VesselRegistry.mmsi == r.mmsi).first()
+        reg = registry_map.get(r.mmsi)
         result.append(
             {
                 "mmsi": r.mmsi,

--- a/backend/routes/weather.py
+++ b/backend/routes/weather.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from backend.collectors.noaa import fetch_marine_conditions
 from backend.database import get_db
 from backend.models.weather import WeatherAlert
-from backend.collectors.noaa import fetch_marine_conditions
 
 router = APIRouter(prefix="/api/weather", tags=["weather"])
 

--- a/backend/signals/user_alert_rules.py
+++ b/backend/signals/user_alert_rules.py
@@ -62,7 +62,6 @@ def evaluate_chokepoint_anomaly(
     if direction not in ("above", "below", "either"):
         return None
 
-    today_str = now.strftime("%Y-%m-%d")
     latest = (
         db.query(GeofenceEvent)
         .filter(GeofenceEvent.zone == zone)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,7 +35,6 @@ from sqlalchemy.pool import StaticPool
 import backend.database as _db_module
 from backend.database import Base
 
-
 # Modules that did `from backend.database import SessionLocal` at import time
 # and therefore hold their own binding. Every test that hits the DB must
 # rebind `SessionLocal` in each of these namespaces too.

--- a/backend/tests/test_alert_rules.py
+++ b/backend/tests/test_alert_rules.py
@@ -23,7 +23,6 @@ from backend.models.vessels import FloatingStorageEvent, GeofenceEvent
 from backend.notifications import alert_runner
 from backend.signals import user_alert_rules
 
-
 NOW = datetime(2026, 5, 20, 12, 0, 0)
 
 
@@ -52,7 +51,9 @@ def _make_pro(db_session, email: str, *, trial: bool = False):
                 email=email,
                 status="trialing",
                 plan="pro",
-                trial_ends_at=NOW + timedelta(days=10),
+                # Relative to real now: require_pro re-checks the DB against
+                # wall-clock utcnow, so a fixed past NOW would read as expired.
+                trial_ends_at=datetime.utcnow() + timedelta(days=10),
             )
         )
     else:

--- a/backend/tests/test_correlation.py
+++ b/backend/tests/test_correlation.py
@@ -21,7 +21,6 @@ from backend.signals.correlation import (
     _pearson,
 )
 
-
 # ----------------------------- _pearson -----------------------------
 
 

--- a/backend/tests/test_health_and_pro_gate.py
+++ b/backend/tests/test_health_and_pro_gate.py
@@ -1,0 +1,120 @@
+"""
+Tests for the hardened /health endpoints and the require_pro DB-recheck.
+
+Covers:
+  - /health returns 200 with a reachable DB
+  - /api/health/collectors reports stale collectors as down (not just "ever wrote")
+  - require_pro no longer trusts a stale "pro" JWT claim (refund/downgrade case)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from backend.auth.dependencies import require_pro
+from backend.auth.jwt import create_token
+from backend.main import app
+from backend.models.subscription import Subscription
+from backend.models.vessels import VesselPosition
+
+
+@pytest.fixture
+def client(db_session):
+    return TestClient(app)
+
+
+def _position(mmsi: str, ts: datetime) -> VesselPosition:
+    return VesselPosition(
+        mmsi=mmsi,
+        ship_type=80,
+        latitude=26.5,
+        longitude=56.5,
+        sog=12.0,
+        cog=90.0,
+        zone="hormuz",
+        timestamp=ts,
+    )
+
+
+# ─── /health ─────────────────────────────────────────────────────────────────
+
+
+def test_health_ok_with_db(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+# ─── /api/health/collectors staleness ───────────────────────────────────────
+
+
+def test_collectors_empty_db_reports_all_down(client):
+    body = client.get("/api/health/collectors").json()
+    assert body["eia"] is False
+    assert body["fred"] is False
+    assert body["ais"] is False
+    assert body["gdelt"] is False
+    assert body["last_seen"]["ais"] is None
+
+
+def test_collectors_stale_ais_reports_down(client, db_session):
+    # Data exists, but older than the 2h AIS freshness window
+    db_session.add(_position("111111111", datetime.utcnow() - timedelta(days=2)))
+    db_session.commit()
+    body = client.get("/api/health/collectors").json()
+    assert body["ais"] is False
+    assert body["last_seen"]["ais"] is not None
+
+
+def test_collectors_fresh_ais_reports_up(client, db_session):
+    db_session.add(_position("222222222", datetime.utcnow()))
+    db_session.commit()
+    body = client.get("/api/health/collectors").json()
+    assert body["ais"] is True
+
+
+# ─── require_pro DB-recheck (refund/downgrade case) ─────────────────────────
+
+
+def test_pro_jwt_claim_without_subscription_is_rejected(db_session):
+    """A token minted with sub_status=pro must NOT grant access once the
+    subscription is gone from the DB (refund before token expiry)."""
+    token = create_token("refunded@example.com", subscription_status="pro")
+    with pytest.raises(HTTPException) as exc:
+        require_pro(None, token)
+    assert exc.value.status_code == 403
+
+
+def test_pro_jwt_claim_with_expired_subscription_is_rejected(db_session):
+    db_session.add(
+        Subscription(
+            email="expired@example.com",
+            status="expired",
+            plan="pro",
+            lemon_squeezy_id="ls-expired",
+        )
+    )
+    db_session.commit()
+    token = create_token("expired@example.com", subscription_status="pro")
+    with pytest.raises(HTTPException) as exc:
+        require_pro(None, token)
+    assert exc.value.status_code == 403
+
+
+def test_pro_jwt_claim_with_active_subscription_is_allowed(db_session):
+    db_session.add(
+        Subscription(
+            email="active@example.com",
+            status="active",
+            plan="pro",
+            lemon_squeezy_id="ls-active",
+        )
+    )
+    db_session.commit()
+    token = create_token("active@example.com", subscription_status="pro")
+    user = require_pro(None, token)
+    assert user["email"] == "active@example.com"

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -8,8 +8,6 @@ exposes X-Trace-Id.
 
 from __future__ import annotations
 
-import os
-
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient

--- a/backend/tests/test_subscription_check.py
+++ b/backend/tests/test_subscription_check.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from backend.auth.subscription_check import is_pro
 from backend.models.subscription import Subscription
 
-
 NOW = datetime(2026, 5, 20, 12, 0, 0)
 
 

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -25,7 +25,6 @@ from backend.config import settings
 from backend.main import app
 from backend.models.subscription import Subscription
 
-
 WEBHOOK_SECRET = "test-lemonsqueezy-webhook-secret"
 WEBHOOK_PATH = "/api/webhooks/lemonsqueezy"
 

--- a/deploy/backup-db.sh
+++ b/deploy/backup-db.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# OBSYD SQLite backup script
+#
+# Uses `sqlite3 .backup` (safe with WAL mode / running app, unlike plain cp).
+# Keeps RETENTION_DAYS daily snapshots locally; optionally syncs offsite.
+#
+# Install (as obsyd user):
+#   crontab -e
+#   30 3 * * * /home/obsyd/obsyd/deploy/backup-db.sh >> /home/obsyd/backups/backup.log 2>&1
+#
+# Offsite sync (recommended — a VPS disk is a single point of failure):
+#   export OBSYD_BACKUP_REMOTE="user@host:/path/to/backups/"  (in crontab line or ~/.profile)
+
+set -euo pipefail
+
+APP_DIR="${OBSYD_APP_DIR:-/home/obsyd/obsyd}"
+BACKUP_DIR="${OBSYD_BACKUP_DIR:-/home/obsyd/backups}"
+RETENTION_DAYS="${OBSYD_BACKUP_RETENTION_DAYS:-14}"
+REMOTE="${OBSYD_BACKUP_REMOTE:-}"
+
+STAMP=$(date +%Y%m%d-%H%M%S)
+mkdir -p "$BACKUP_DIR"
+
+backup_one() {
+    local db_path="$1"
+    local name
+    name=$(basename "$db_path" .db)
+    if [ ! -f "$db_path" ]; then
+        echo "[$STAMP] skip: $db_path not found"
+        return 0
+    fi
+    local out="$BACKUP_DIR/${name}-${STAMP}.db"
+    sqlite3 "$db_path" ".backup '$out'"
+    gzip "$out"
+    echo "[$STAMP] backed up $db_path -> ${out}.gz ($(du -h "${out}.gz" | cut -f1))"
+}
+
+backup_one "$APP_DIR/obsyd.db"
+backup_one "$APP_DIR/data/portwatch.db"
+
+# Rotate: delete local snapshots older than RETENTION_DAYS
+find "$BACKUP_DIR" -name '*.db.gz' -mtime +"$RETENTION_DAYS" -delete
+
+# Optional offsite sync
+if [ -n "$REMOTE" ]; then
+    rsync -az --delete-after "$BACKUP_DIR/" "$REMOTE"
+    echo "[$STAMP] synced to $REMOTE"
+fi
+
+echo "[$STAMP] backup complete ($(find "$BACKUP_DIR" -name '*.db.gz' | wc -l | tr -d ' ') snapshots retained)"

--- a/deploy/obsyd.service
+++ b/deploy/obsyd.service
@@ -1,6 +1,10 @@
 [Unit]
 Description=OBSYD Backend (uvicorn)
 After=network.target
+# Stop restart-looping after 5 failed starts within 5 minutes
+# (e.g. broken .env) instead of hammering every few seconds.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -10,8 +14,27 @@ WorkingDirectory=/home/obsyd/obsyd
 EnvironmentFile=/home/obsyd/obsyd/.env
 Environment="PATH=/home/obsyd/obsyd/.venv/bin"
 ExecStart=/home/obsyd/obsyd/.venv/bin/uvicorn backend.main:app --host 127.0.0.1 --port 8000 --workers 1
-Restart=always
-RestartSec=5
+Restart=on-failure
+RestartSec=10
+
+# --- Hardening ---
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectSystem=strict
+ProtectHome=read-only
+# App dir needs write access (SQLite DBs: obsyd.db, data/portwatch.db)
+ReadWritePaths=/home/obsyd/obsyd
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+RestrictRealtime=yes
+
+# --- Resource limits (caps runaway memory, generous for normal operation) ---
+MemoryHigh=1536M
+MemoryMax=2G
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/setup-vps.sh
+++ b/deploy/setup-vps.sh
@@ -50,9 +50,15 @@ systemctl reload nginx
 echo "nginx configured and reloaded"
 
 # 6. Health-check cron
-echo "[6/6] Installing health-check cron..."
+echo "[6/7] Installing health-check cron..."
 (crontab -l 2>/dev/null | grep -v obsyd; echo "*/5 * * * * curl -sf http://127.0.0.1:8000/health > /dev/null || systemctl restart obsyd") | crontab -
 echo "Cron health-check installed"
+
+# 7. Daily DB backup cron (as obsyd user; offsite target via OBSYD_BACKUP_REMOTE)
+echo "[7/7] Installing daily backup cron..."
+chmod +x /home/obsyd/obsyd/deploy/backup-db.sh
+sudo -u obsyd bash -c '(crontab -l 2>/dev/null | grep -v backup-db.sh; echo "30 3 * * * /home/obsyd/obsyd/deploy/backup-db.sh >> /home/obsyd/backups/backup.log 2>&1") | crontab -'
+echo "Daily backup cron installed (03:30, retention 14 days)"
 
 echo ""
 echo "=== VPS base setup complete ==="

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -173,14 +173,16 @@ function Dashboard() {
   }, [])
 
   useEffect(() => {
+    const controller = new AbortController()
+    const { signal } = controller
     async function fetchData() {
       try {
         const [eiaRes, zonesRes, liveRes, aisRes, gdeltRes] = await Promise.all([
-          fetch(`${API}/prices/eia?limit=500`),
-          fetch(`${API}/vessels/zones`),
-          fetch(`${API}/prices/live`),
-          fetch(`${API}/vessels/positions?limit=1`),
-          fetch(`${API}/sentiment/status`),
+          fetch(`${API}/prices/eia?limit=500`, { signal }),
+          fetch(`${API}/vessels/zones`, { signal }),
+          fetch(`${API}/prices/live`, { signal }),
+          fetch(`${API}/vessels/positions?limit=1`, { signal }),
+          fetch(`${API}/sentiment/status`, { signal }),
         ])
         if (!eiaRes.ok) throw new Error(`EIA API: ${eiaRes.status}`)
         if (!zonesRes.ok) throw new Error(`Zones API: ${zonesRes.status}`)
@@ -207,25 +209,30 @@ function Dashboard() {
           setGdeltActive(gdelt.active)
         }
 
-        fetch(`${API}/weather/alerts`)
+        fetch(`${API}/weather/alerts`, { signal })
           .then((r) => (r.ok ? r.json() : []))
           .then(setWeatherAlerts)
-          .catch((e) => console.error('Weather alerts fetch:', e))
+          .catch((e) => {
+            if (e.name !== 'AbortError') console.error('Weather alerts fetch:', e)
+          })
 
-        fetch(`${API}/portwatch/summary`)
+        fetch(`${API}/portwatch/summary`, { signal })
           .then((r) => (r.ok ? r.json() : null))
           .then((d) => { if (d?.disruptions) setDisruptions(d.disruptions) })
-          .catch(() => {})
+          .catch((e) => {
+            if (e.name !== 'AbortError') console.error('PortWatch summary fetch:', e)
+          })
       } catch (e) {
+        if (e.name === 'AbortError') return
         setError(e.message)
       } finally {
-        setLoading(false)
+        if (!signal.aborted) setLoading(false)
       }
     }
     fetchData()
 
     const interval = setInterval(() => {
-      fetch(`${API}/prices/live`)
+      fetch(`${API}/prices/live`, { signal })
         .then((r) => (r.ok ? r.json() : null))
         .then((live) => {
           if (live?.available) {
@@ -233,9 +240,14 @@ function Dashboard() {
             setLiveSource(live.source || null)
           }
         })
-        .catch(() => {})
+        .catch((e) => {
+          if (e.name !== 'AbortError') console.error('Live prices poll:', e)
+        })
     }, 15 * 60 * 1000)
-    return () => clearInterval(interval)
+    return () => {
+      clearInterval(interval)
+      controller.abort()
+    }
   }, [])
 
   if (loading) {

--- a/frontend/src/components/DisruptionScorePanel.jsx
+++ b/frontend/src/components/DisruptionScorePanel.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
 import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
 import {
   ResponsiveContainer,
   AreaChart,
@@ -55,19 +55,14 @@ function CustomTooltip({ active, payload, label }) {
 }
 
 export default function DisruptionScorePanel() {
-  const [data, setData] = useState(null)
-  const [loading, setLoading] = useState(true)
+  const { data, loading, error } = useFetchWithError(`${API}/analytics/disruption-score?days=90`)
 
-  useEffect(() => {
-    fetch(`${API}/analytics/disruption-score?days=90`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => {
-        setData(d)
-        setLoading(false)
-      })
-      .catch(() => setLoading(false))
-  }, [])
-
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">DISRUPTION INDEX // FETCH ERROR</div>
+      </div>
+    )
   if (!data?.available && !loading) return null
 
   const score = data?.current?.score ?? 0

--- a/frontend/src/components/EIAPredictionPanel.jsx
+++ b/frontend/src/components/EIAPredictionPanel.jsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react'
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 
@@ -43,19 +42,14 @@ export function EIAPredictionMini() {
 }
 
 export default function EIAPredictionPanel() {
-  const [data, setData] = useState(null)
-  const [loading, setLoading] = useState(true)
+  const { data, loading, error } = useFetchWithError(`${API}/analytics/eia-prediction`)
 
-  useEffect(() => {
-    fetch(`${API}/analytics/eia-prediction`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => {
-        setData(d)
-        setLoading(false)
-      })
-      .catch(() => setLoading(false))
-  }, [])
-
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">HOUSTON TANKERS // FETCH ERROR</div>
+      </div>
+    )
   if (!data?.available && !loading) return null
 
   const pred = data?.current

--- a/frontend/src/components/FreightProxyPanel.jsx
+++ b/frontend/src/components/FreightProxyPanel.jsx
@@ -12,16 +12,23 @@ export default function FreightProxyPanel() {
   const containerRef = useRef(null)
 
   useEffect(() => {
+    const controller = new AbortController()
+    const { signal } = controller
     Promise.all([
-      fetch(`${API}/analytics/freight-proxy?days=90`).then((r) => (r.ok ? r.json() : null)),
-      fetch(`${API}/analytics/tonne-miles?days=90`).then((r) => (r.ok ? r.json() : null)),
+      fetch(`${API}/analytics/freight-proxy?days=90`, { signal }).then((r) => (r.ok ? r.json() : null)),
+      fetch(`${API}/analytics/tonne-miles?days=90`, { signal }).then((r) => (r.ok ? r.json() : null)),
     ])
       .then(([fp, tm]) => {
         setData(fp)
         setTmData(tm)
         setLoading(false)
       })
-      .catch(() => setLoading(false))
+      .catch((e) => {
+        if (e.name === 'AbortError') return
+        console.error('FreightProxyPanel fetch:', e)
+        setLoading(false)
+      })
+    return () => controller.abort()
   }, [])
 
   // Chart

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -16,15 +16,21 @@ export default function Header({ aisActive, gdeltActive, compactMode, onToggleCo
   const [menuOpen, setMenuOpen] = useState(false)
 
   useEffect(() => {
+    const controller = new AbortController()
     function poll() {
-      fetch('/api/health/collectors')
+      fetch('/api/health/collectors', { signal: controller.signal })
         .then((r) => (r.ok ? r.json() : null))
         .then(setHealth)
-        .catch((e) => console.error('Health poll:', e))
+        .catch((e) => {
+          if (e.name !== 'AbortError') console.error('Health poll:', e)
+        })
     }
     poll()
     const id = setInterval(poll, 60_000)
-    return () => clearInterval(id)
+    return () => {
+      clearInterval(id)
+      controller.abort()
+    }
   }, [])
 
   const eiaOk = health?.eia ?? false

--- a/frontend/src/components/JODIPanel.jsx
+++ b/frontend/src/components/JODIPanel.jsx
@@ -15,7 +15,9 @@ export default function JODIPanel() {
   const [error, setError] = useState(null)
 
   useEffect(() => {
-    fetch(`${API}/jodi/summary`)
+    const controller = new AbortController()
+    const { signal } = controller
+    fetch(`${API}/jodi/summary`, { signal })
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         setSummary(d)
@@ -23,21 +25,27 @@ export default function JODIPanel() {
         if (d) {
           Promise.all(
             TOP5.map((c) =>
-              fetch(`${API}/jodi/production?country=${c}&limit=3`)
+              fetch(`${API}/jodi/production?country=${c}&limit=3`, { signal })
                 .then((r) => (r.ok ? r.json() : []))
                 .then((rows) => [c, rows])
             )
-          ).then((results) => {
-            const h = {}
-            for (const [c, rows] of results) h[c] = rows
-            setHistory(h)
-          })
+          )
+            .then((results) => {
+              const h = {}
+              for (const [c, rows] of results) h[c] = rows
+              setHistory(h)
+            })
+            .catch((e) => {
+              if (e.name !== 'AbortError') console.error('JODIPanel history fetch:', e)
+            })
         }
       })
       .catch((e) => {
+        if (e.name === 'AbortError') return
         console.error('JODIPanel fetch:', e)
         setError(e.message)
       })
+    return () => controller.abort()
   }, [])
 
   const changes = useMemo(() => {

--- a/frontend/src/components/ReroutingIndex.jsx
+++ b/frontend/src/components/ReroutingIndex.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
 import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
 import {
   ResponsiveContainer,
   AreaChart,
@@ -40,15 +40,14 @@ function CustomTooltip({ active, payload, label }) {
 }
 
 export default function ReroutingIndex() {
-  const [data, setData] = useState(null)
+  const { data, error } = useFetchWithError(`${API}/signals/rerouting-index?days=365`)
 
-  useEffect(() => {
-    fetch(`${API}/signals/rerouting-index?days=365`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then(setData)
-      .catch((e) => console.error('ReroutingIndex fetch:', e))
-  }, [])
-
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">REROUTING INDEX // FETCH ERROR</div>
+      </div>
+    )
   if (!data?.available) return null
 
   const { current, history, events } = data

--- a/frontend/src/components/StatCards.jsx
+++ b/frontend/src/components/StatCards.jsx
@@ -121,9 +121,10 @@ export default function StatCards({ data, live: liveProp, liveSource: liveSource
 
   // StatCards fetches its own live prices — independent of App.jsx
   useEffect(() => {
+    const controller = new AbortController()
     let retryTimeout
     function fetchLive() {
-      fetch('/api/prices/live')
+      fetch('/api/prices/live', { signal: controller.signal })
         .then((r) => (r.ok ? r.json() : null))
         .then((d) => {
           if (d?.available && d.prices && Object.keys(d.prices).length >= 3) {
@@ -134,13 +135,18 @@ export default function StatCards({ data, live: liveProp, liveSource: liveSource
             retryTimeout = setTimeout(fetchLive, 10_000)
           }
         })
-        .catch(() => {
+        .catch((e) => {
+          if (e.name === 'AbortError') return
           retryTimeout = setTimeout(fetchLive, 10_000)
         })
     }
     fetchLive()
     const interval = setInterval(fetchLive, 2 * 60 * 1000) // repoll every 2min
-    return () => { clearInterval(interval); clearTimeout(retryTimeout) }
+    return () => {
+      clearInterval(interval)
+      clearTimeout(retryTimeout)
+      controller.abort()
+    }
   }, [])
 
   // Use own fetched data, fall back to parent prop
@@ -148,10 +154,14 @@ export default function StatCards({ data, live: liveProp, liveSource: liveSource
   const liveSource = ownSource || liveSourceProp
 
   useEffect(() => {
-    fetch('/api/prices/commodities')
+    const controller = new AbortController()
+    fetch('/api/prices/commodities', { signal: controller.signal })
       .then((r) => (r.ok ? r.json() : null))
       .then(setCommodities)
-      .catch((e) => console.error('Commodities fetch:', e))
+      .catch((e) => {
+        if (e.name !== 'AbortError') console.error('Commodities fetch:', e)
+      })
+    return () => controller.abort()
   }, [])
 
   const metals = commodities?.metals || {}

--- a/frontend/src/components/TonneMilesPanel.jsx
+++ b/frontend/src/components/TonneMilesPanel.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
 import {
   ResponsiveContainer,
   AreaChart,
@@ -33,21 +34,15 @@ function CustomTooltip({ active, payload, label }) {
 }
 
 export default function TonneMilesPanel() {
-  const [data, setData] = useState(null)
-  const [loading, setLoading] = useState(true)
   const [days, setDays] = useState(90)
+  const { data, loading, error } = useFetchWithError(`${API}/analytics/tonne-miles?days=${days}`)
 
-  useEffect(() => {
-    setLoading(true)
-    fetch(`${API}/analytics/tonne-miles?days=${days}`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => {
-        setData(d)
-        setLoading(false)
-      })
-      .catch(() => setLoading(false))
-  }, [days])
-
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">TONNE-MILES // FETCH ERROR</div>
+      </div>
+    )
   if (!data?.available && !loading) return null
 
   const current = data?.current

--- a/frontend/src/components/VesselMap.jsx
+++ b/frontend/src/components/VesselMap.jsx
@@ -157,34 +157,41 @@ export default function VesselMap({ zones = [], weatherAlerts = [] }) {
     [weatherAlerts],
   )
 
-  const fetchVessels = useCallback(async () => {
+  const fetchVessels = useCallback(async (signal) => {
     try {
-      const fetches = [fetch(`${API}/vessels/positions?limit=2000`)]
-      if (mode === 'global') fetches.push(fetch(`${API}/vessels/global?limit=5000`))
+      const fetches = [fetch(`${API}/vessels/positions?limit=2000`, { signal })]
+      if (mode === 'global') fetches.push(fetch(`${API}/vessels/global?limit=5000`, { signal }))
       const results = await Promise.all(fetches)
       const posData = results[0].ok ? await results[0].json() : null
       const globalData = results.length > 1 && results[1]?.ok ? await results[1].json() : null
       if (Array.isArray(posData)) setVessels(posData)
       if (Array.isArray(globalData)) setGlobalVessels(globalData)
-    } catch {
-      // silent fail, will retry
+    } catch (e) {
+      if (e.name !== 'AbortError') console.error('VesselMap vessels poll:', e)
+      // will retry on next interval
     }
   }, [mode])
 
   useEffect(() => {
     // VesselMap stays renderable even with partial-overlay failures; we log
     // each fetch failure so it's debuggable from the browser console.
-    fetch(`${API}/ports/summary`)
+    const controller = new AbortController()
+    const { signal } = controller
+    const logError = (label) => (e) => {
+      if (e.name !== 'AbortError') console.error(label, e)
+    }
+
+    fetch(`${API}/ports/summary`, { signal })
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => { if (d) setPortwatch(d) })
-      .catch((e) => console.error('VesselMap ports/summary:', e))
+      .catch(logError('VesselMap ports/summary:'))
 
-    fetch(`${API}/weather/marine`)
+    fetch(`${API}/weather/marine`, { signal })
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => { if (d?.zones) setMarine(d.zones) })
-      .catch((e) => console.error('VesselMap weather/marine:', e))
+      .catch(logError('VesselMap weather/marine:'))
 
-    fetch(`${API}/thermal/hotspots`)
+    fetch(`${API}/thermal/hotspots`, { signal })
       .then((r) => (r.ok ? r.json() : []))
       .then((data) => {
         if (Array.isArray(data)) {
@@ -192,18 +199,24 @@ export default function VesselMap({ zones = [], weatherAlerts = [] }) {
           if (data.length > 0) setThermalAvailable(true)
         }
       })
-      .catch((e) => console.error('VesselMap thermal/hotspots:', e))
+      .catch(logError('VesselMap thermal/hotspots:'))
 
-    fetch(`${API}/vessels/floating-storage`)
+    fetch(`${API}/vessels/floating-storage`, { signal })
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => { if (d?.events) setFloatingStorage(d.events.filter((e) => e.status === 'active')) })
-      .catch((e) => console.error('VesselMap vessels/floating-storage:', e))
+      .catch(logError('VesselMap vessels/floating-storage:'))
+
+    return () => controller.abort()
   }, [])
 
   useEffect(() => {
-    fetchVessels()
-    const id = setInterval(fetchVessels, POLL_INTERVAL)
-    return () => clearInterval(id)
+    const controller = new AbortController()
+    fetchVessels(controller.signal)
+    const id = setInterval(() => fetchVessels(controller.signal), POLL_INTERVAL)
+    return () => {
+      clearInterval(id)
+      controller.abort()
+    }
   }, [fetchVessels])
 
   const isGlobal = mode === 'global'

--- a/frontend/src/hooks/useFetchWithError.js
+++ b/frontend/src/hooks/useFetchWithError.js
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+// Module-level stale-while-revalidate cache: panels that unmount on a tab
+// switch re-render instantly from the last payload while revalidating in
+// the background — instead of flashing a skeleton and re-fetching cold.
+const swrCache = new Map() // url -> last successful (transformed) payload
+
 /**
  * Tiny replacement for the `.catch(() => {})` pattern that hides
  * errors in many panels. Always returns the same shape and never
@@ -7,7 +12,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
  *
  *   const { data, loading, error, refetch } = useFetchWithError(url, opts)
  *
- * Aborts on unmount + on re-fetch.
+ * Aborts on unmount + on re-fetch. Serves cached data instantly on
+ * remount (stale-while-revalidate).
  *
  * `opts.transform(json)` lets the panel adapt the payload shape in
  * one place (e.g. unwrap `{ data: ... }`).
@@ -17,15 +23,22 @@ import { useCallback, useEffect, useRef, useState } from 'react'
  */
 export default function useFetchWithError(url, opts = {}) {
   const { transform, deps = [], headers, signalRef } = opts
-  const [data, setData] = useState(null)
+  const [data, setData] = useState(() => (swrCache.has(url) ? swrCache.get(url) : null))
   const [error, setError] = useState(null)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(() => !swrCache.has(url))
   const reqRef = useRef(0)
 
   const run = useCallback(
     async (controller) => {
       const myReq = ++reqRef.current
-      setLoading(true)
+      // Serve stale data immediately while revalidating; only show the
+      // loading state when we have nothing cached for this URL yet.
+      if (swrCache.has(url)) {
+        setData(swrCache.get(url))
+        setLoading(false)
+      } else {
+        setLoading(true)
+      }
       setError(null)
       try {
         const res = await fetch(url, {
@@ -38,7 +51,9 @@ export default function useFetchWithError(url, opts = {}) {
         }
         const json = await res.json()
         if (myReq !== reqRef.current) return // a newer call superseded us
-        setData(transform ? transform(json) : json)
+        const payload = transform ? transform(json) : json
+        swrCache.set(url, payload)
+        setData(payload)
       } catch (e) {
         if (e.name === 'AbortError') return
         if (myReq !== reqRef.current) return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,8 @@ line-length = 120
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+# conftest deliberately sets os.environ before importing backend modules
+# so pydantic_settings picks up test values — imports cannot move to the top.
+"backend/tests/conftest.py" = ["E402"]


### PR DESCRIPTION
Implements the prioritized improvements from a full project analysis (backend / frontend / infra), across three areas.

## Verification
- Backend `ruff check backend/` — **clean** (also burned down pre-existing import/lint debt)
- Backend `pytest` — **74 passed** (incl. 7 new tests)
- App import — **87 routes OK**
- Frontend `vite build` — **OK**
- Frontend `eslint` — **30 → 29** problems (no new errors introduced; remaining are pre-existing debt)

## Security & data-loss (Phase 1)
- **Default secrets:** production now refuses to start with `change-me` secrets (`RuntimeError` instead of a warning); new `ENVIRONMENT` flag
- **Pro gating:** `require_pro` always re-checks the DB instead of trusting the JWT `sub_status` claim — refund/downgrade applies immediately rather than after token expiry (up to 30 days)
- **Backups:** `deploy/backup-db.sh` (safe `sqlite3 .backup` + gzip, 14-day rotation, optional offsite rsync), wired into `setup-vps.sh` cron
- **N+1:** `routes/voyages` batch-fetches the registry via `IN()`
- **Startup tasks:** background tasks log crashes via `add_done_callback` instead of failing silently

## Frontend stability (Phase 2)
- **Memory leaks:** `AbortController` in all pollers (Header, StatCards, VesselMap, App) — no more set-state-after-unmount
- **Silent failures:** migrate TonneMiles / DisruptionScore / Rerouting / EIAPrediction panels to `useFetchWithError` with visible error UI; replace `.catch(() => {})`
- **Tab switching:** module-level stale-while-revalidate cache in `useFetchWithError` — instant render instead of cold refetch

## Ops (Phase 3)
- **CI:** `.github/workflows/ci.yml` — ruff + pytest + vite build gates (frontend eslint non-blocking until pre-existing debt is cleared)
- **systemd hardening:** `NoNewPrivileges`, `ProtectSystem=strict`, `ReadWritePaths`, `StartLimitBurst`, `MemoryMax`
- **Health checks:** `/health` does a DB ping (503 → cron restart); `/api/health/collectors` reports **staleness** instead of ever-wrote
- **Alerting:** `collector_watchdog` emails ops daily when a collector goes stale (reuses Resend + shared staleness thresholds)

## Out of scope (follow-ups)
Upsert utility dedup, `Depends(get_db)` standardization, VesselMap split, frontend eslint debt burn-down, Postgres migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)