### PR TITLE
Signal validation framework (P1: metrics + disruption weight backtest)

### DIFF
--- a/backend/analytics/validation/__init__.py
+++ b/backend/analytics/validation/__init__.py
@@ -1,0 +1,13 @@
+"""Signal validation framework.
+
+Measures whether Obsyd's signals carry a verifiable forward-return
+relationship, and prunes signal components that add nothing — the same
+rigor applied to the disabled ValueKick lineup layer.
+
+See docs/signal-validation.md for the full design.
+
+Layering:
+  metrics.py  — pure, numpy-only statistics (no DB, no network). Unit-tested.
+  prices.py   — FRED price access + forward-return alignment.
+  weights.py  — disruption-score weight backtest (pure core + thin DB adapter).
+"""

--- a/backend/analytics/validation/metrics.py
+++ b/backend/analytics/validation/metrics.py
@@ -1,0 +1,155 @@
+"""Pure statistical metrics for signal validation.
+
+numpy-only, no DB and no network — every function takes arrays in and
+returns scalars/dicts out, so they are trivially unit-testable against
+synthetic series with a known answer.
+
+Two evaluation modes (see docs/signal-validation.md):
+  - continuous signals -> rank IC + HAC-robust t-stat
+  - event / threshold signals -> event study (lift vs baseline + hit rate)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "rankdata",
+    "pearson",
+    "spearman_ic",
+    "newey_west_tstat",
+    "event_study",
+]
+
+
+def rankdata(a: np.ndarray) -> np.ndarray:
+    """Average-tie ranks (1-based), matching scipy.stats.rankdata('average').
+
+    Implemented in numpy so the project keeps a single math dependency.
+    """
+    a = np.asarray(a, dtype=float)
+    sorter = np.argsort(a, kind="mergesort")
+    inv = np.empty(len(a), dtype=np.intp)
+    inv[sorter] = np.arange(len(a), dtype=np.intp)
+    a_sorted = a[sorter]
+    obs = np.r_[True, a_sorted[1:] != a_sorted[:-1]]
+    dense = obs.cumsum()[inv]
+    # `count[i]` = number of values strictly less than the i-th dense group.
+    count = np.r_[np.nonzero(obs)[0], len(a)]
+    # Mid-rank for ties: average of the first and last position in the group.
+    return 0.5 * (count[dense] + count[dense - 1] + 1)
+
+
+def pearson(x: np.ndarray, y: np.ndarray) -> float:
+    """Pearson correlation. Returns nan on degenerate input."""
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    xc = x - x.mean()
+    yc = y - y.mean()
+    dx = np.sqrt((xc * xc).sum())
+    dy = np.sqrt((yc * yc).sum())
+    if dx == 0 or dy == 0:
+        return float("nan")
+    return float((xc * yc).sum() / (dx * dy))
+
+
+def _finite_pair(x: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    mask = np.isfinite(x) & np.isfinite(y)
+    return x[mask], y[mask]
+
+
+def spearman_ic(signal: np.ndarray, forward_return: np.ndarray) -> float:
+    """Rank information coefficient: Spearman correlation between the signal
+    level and the forward return. nan if fewer than 3 aligned observations."""
+    x, y = _finite_pair(signal, forward_return)
+    if len(x) < 3:
+        return float("nan")
+    return pearson(rankdata(x), rankdata(y))
+
+
+def newey_west_tstat(x: np.ndarray, y: np.ndarray, lag: int) -> float:
+    """HAC (Newey-West) t-stat that corr(x, y) != 0.
+
+    With overlapping forward-return windows (e.g. 7d returns sampled daily),
+    observations are autocorrelated and the naive t-stat overstates
+    significance. We form the standardized cross-product g_t = z(x)_t * z(y)_t
+    (whose mean is the Pearson r) and estimate the variance of its mean with a
+    Bartlett-kernel HAC estimator using `lag` lags. Set lag = horizon_days - 1.
+
+    Returns nan when there are too few points to estimate `lag` covariances.
+    """
+    x, y = _finite_pair(x, y)
+    n = len(x)
+    lag = max(0, int(lag))
+    if n < max(3, lag + 2):
+        return float("nan")
+    sx = x.std(ddof=0)
+    sy = y.std(ddof=0)
+    if sx == 0 or sy == 0:
+        return float("nan")
+    zx = (x - x.mean()) / sx
+    zy = (y - y.mean()) / sy
+    g = zx * zy
+    gbar = g.mean()  # == Pearson r
+    gc = g - gbar
+    var = float((gc @ gc) / n)  # gamma_0
+    for lcov in range(1, lag + 1):
+        weight = 1.0 - lcov / (lag + 1)
+        gamma = float((gc[lcov:] @ gc[:-lcov]) / n)
+        var += 2.0 * weight * gamma
+    if var <= 0:
+        return float("nan")
+    se = np.sqrt(var / n)
+    if se == 0:
+        return float("nan")
+    return float(gbar / se)
+
+
+def event_study(
+    signal: np.ndarray,
+    forward_return: np.ndarray,
+    threshold: float,
+    *,
+    direction: str = "above",
+) -> dict:
+    """Compare forward returns on days the signal crosses a threshold vs the
+    unconditional baseline.
+
+    direction="above": event = signal >= threshold, "hit" = forward return > 0.
+    direction="below": event = signal <= threshold, "hit" = forward return < 0.
+
+    Returns counts, mean event vs baseline return, lift (event - baseline) and
+    directional hit rate. All-nan-safe; returns n_event=0 when nothing fires.
+    """
+    if direction not in ("above", "below"):
+        raise ValueError("direction must be 'above' or 'below'")
+    sig, ret = _finite_pair(signal, forward_return)
+    n = len(ret)
+    base = {
+        "n_total": int(n),
+        "n_event": 0,
+        "mean_event": float("nan"),
+        "mean_base": float(ret.mean()) if n else float("nan"),
+        "lift": float("nan"),
+        "hit_rate": float("nan"),
+    }
+    if n == 0:
+        return base
+    event = sig >= threshold if direction == "above" else sig <= threshold
+    n_event = int(event.sum())
+    if n_event == 0:
+        return base
+    ev_ret = ret[event]
+    mean_event = float(ev_ret.mean())
+    mean_base = float(ret.mean())
+    hits = ev_ret > 0 if direction == "above" else ev_ret < 0
+    return {
+        "n_total": int(n),
+        "n_event": n_event,
+        "mean_event": mean_event,
+        "mean_base": mean_base,
+        "lift": mean_event - mean_base,
+        "hit_rate": float(hits.mean()),
+    }

--- a/backend/analytics/validation/prices.py
+++ b/backend/analytics/validation/prices.py
@@ -1,0 +1,65 @@
+"""Forward-return series from FRED daily oil prices.
+
+Ground truth for signal validation. Mirrors the look-up discipline already
+used in signals/alert_outcomes.py: prices are taken "on or before" a target
+date (FRED skips weekends/holidays), and a horizon return is only emitted
+once the price series has actually caught up to the target date — never
+peeking at data that didn't exist yet.
+"""
+
+from __future__ import annotations
+
+import bisect
+from datetime import datetime, timedelta
+
+import numpy as np
+
+from backend.models.prices import FREDSeries
+
+BRENT_SERIES = "DCOILBRENTEU"
+WTI_SERIES = "DCOILWTICO"
+
+
+def load_price_map(db, series_id: str = BRENT_SERIES) -> dict[str, float]:
+    """date(YYYY-MM-DD) -> price for a FRED series, ascending."""
+    rows = (
+        db.query(FREDSeries.date, FREDSeries.value)
+        .filter(FREDSeries.series_id == series_id)
+        .order_by(FREDSeries.date.asc())
+        .all()
+    )
+    return {r.date: float(r.value) for r in rows if r.value is not None}
+
+
+def _on_or_before(sorted_dates: list[str], price_map: dict[str, float], target: str) -> float | None:
+    idx = bisect.bisect_right(sorted_dates, target) - 1
+    if idx < 0:
+        return None
+    return price_map[sorted_dates[idx]]
+
+
+def forward_log_returns(
+    price_map: dict[str, float],
+    signal_dates: list[str],
+    horizon_days: int,
+) -> np.ndarray:
+    """Forward log return over `horizon_days` calendar days for each signal date.
+
+    return[i] = ln( P(date_i + h) / P(date_i) ), using on-or-before lookup at
+    both ends. Emits nan when the price series hasn't reached date_i + h yet
+    (so it is never computed with look-ahead) or when a price is missing/zero.
+    """
+    if not price_map:
+        return np.full(len(signal_dates), np.nan)
+    sorted_dates = sorted(price_map)
+    last_known = sorted_dates[-1]
+    out = np.full(len(signal_dates), np.nan)
+    for i, d in enumerate(signal_dates):
+        target = (datetime.strptime(d, "%Y-%m-%d") + timedelta(days=horizon_days)).strftime("%Y-%m-%d")
+        if target > last_known:
+            continue  # data hasn't caught up — leave nan, fill on a later run
+        p0 = _on_or_before(sorted_dates, price_map, d)
+        ph = _on_or_before(sorted_dates, price_map, target)
+        if p0 and ph and p0 > 0 and ph > 0:
+            out[i] = float(np.log(ph / p0))
+    return out

--- a/backend/analytics/validation/weights.py
+++ b/backend/analytics/validation/weights.py
@@ -1,0 +1,239 @@
+"""Disruption-score weight backtest.
+
+The flagship validation: the disruption score combines 6 components with
+fixed weights (disruption_score.WEIGHTS). This module measures whether those
+weights — and each component — actually relate to forward Brent returns, the
+same "does this layer improve the score?" test applied to ValueKick.
+
+Design: a pure, DB-free core (testable with planted data) plus a thin adapter
+that loads DisruptionScoreHistory + FRED. Methodology guardrails:
+  - one observation per day (last row; dedupes the 2-hourly cadence)
+  - forward returns never use look-ahead (see prices.forward_log_returns)
+  - weights are evaluated OUT-OF-SAMPLE: IC-proportional weights are fit on a
+    training prefix and scored on a held-out suffix; in-sample fit is never
+    reported
+  - HAC t-stats (overlap = horizon-1) so overlapping windows don't inflate
+    significance
+  - n < MIN_CONFIDENT_N is never called "confident"
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from backend.analytics.validation import metrics
+
+# Component order is fixed and shared with the DB adapter below.
+COMPONENT_NAMES = ("hormuz", "cape", "storage", "crack", "backwardation", "sentiment")
+
+# Below this sample size we refuse to make any predictive claim.
+MIN_CONFIDENT_N = 30
+
+# An ablation must improve OOS IC by at least this much to flag a "drop".
+DROP_IMPROVEMENT_EPS = 0.02
+
+
+def _normalize(weights: np.ndarray) -> np.ndarray:
+    total = float(np.abs(weights).sum())
+    if total == 0:
+        return weights
+    return weights / total
+
+
+def composite_ic(components: np.ndarray, weights: np.ndarray, forward_return: np.ndarray) -> float:
+    """Rank IC of the weighted composite vs forward return."""
+    composite = components @ weights
+    return metrics.spearman_ic(composite, forward_return)
+
+
+def component_ics(components: np.ndarray, forward_return: np.ndarray) -> list[float]:
+    """Marginal rank IC of each component column vs forward return."""
+    return [metrics.spearman_ic(components[:, j], forward_return) for j in range(components.shape[1])]
+
+
+def ic_proportional_weights(components: np.ndarray, forward_return: np.ndarray) -> np.ndarray:
+    """Weights proportional to each component's IC (clipped at 0 so a component
+    that points the wrong way gets no weight rather than negative weight)."""
+    ics = np.array(component_ics(components, forward_return), dtype=float)
+    ics = np.nan_to_num(ics, nan=0.0)
+    ics = np.clip(ics, 0.0, None)
+    if ics.sum() == 0:
+        return np.full(components.shape[1], 1.0 / components.shape[1])
+    return _normalize(ics)
+
+
+def run_backtest(
+    components: np.ndarray,
+    forward_return: np.ndarray,
+    *,
+    base_weights: np.ndarray,
+    component_names: tuple[str, ...] = COMPONENT_NAMES,
+    horizon_days: int = 7,
+    train_frac: float = 0.6,
+) -> dict:
+    """Evaluate weighting schemes out-of-sample and produce keep/drop verdicts.
+
+    `components`: (n, k) matrix of component scores, chronologically ordered.
+    `forward_return`: (n,) forward returns aligned to the same rows (may contain
+        nan for rows whose horizon hasn't matured — those rows are dropped).
+    """
+    components = np.asarray(components, dtype=float)
+    forward_return = np.asarray(forward_return, dtype=float)
+    k = components.shape[1]
+
+    # Drop rows without a matured forward return.
+    row_mask = np.isfinite(forward_return) & np.all(np.isfinite(components), axis=1)
+    comp = components[row_mask]
+    ret = forward_return[row_mask]
+    n = len(ret)
+
+    base_weights = _normalize(np.asarray(base_weights, dtype=float))
+    equal_weights = np.full(k, 1.0 / k)
+
+    result: dict = {
+        "horizon_days": horizon_days,
+        "n": int(n),
+        "confident": bool(n >= MIN_CONFIDENT_N),
+        "component_names": list(component_names),
+    }
+
+    if n < 3:
+        result["note"] = "insufficient data — need aligned signal/return rows"
+        return result
+
+    # Full-sample marginal ICs + HAC t-stats (descriptive, in-sample).
+    full_ics = component_ics(comp, ret)
+    hac_lag = max(0, horizon_days - 1)
+    full_t = [
+        metrics.newey_west_tstat(comp[:, j], ret, hac_lag) for j in range(k)
+    ]
+
+    # Out-of-sample split: fit IC-proportional weights on the training prefix,
+    # score every scheme on the held-out suffix.
+    split = max(2, int(n * train_frac))
+    if split >= n - 1:
+        # Too little data for a clean split — report descriptive only.
+        result["note"] = "too few rows for an out-of-sample split; ICs are in-sample only"
+        result["components"] = [
+            {
+                "name": component_names[j],
+                "ic_in_sample": _round(full_ics[j]),
+                "hac_t": _round(full_t[j]),
+                "weight_current": _round(float(base_weights[j])),
+            }
+            for j in range(k)
+        ]
+        return result
+
+    train_c, train_r = comp[:split], ret[:split]
+    test_c, test_r = comp[split:], ret[split:]
+    fitted = ic_proportional_weights(train_c, train_r)
+
+    oos = {
+        "current": composite_ic(test_c, base_weights, test_r),
+        "equal": composite_ic(test_c, equal_weights, test_r),
+        "ic_proportional_oos": composite_ic(test_c, fitted, test_r),
+    }
+    result["oos_ic"] = {key: _round(val) for key, val in oos.items()}
+    result["oos_n"] = int(len(test_r))
+
+    # Drop-one-out ablation on the held-out suffix, relative to current weights.
+    full_oos_ic = oos["current"]
+    comp_rows = []
+    for j in range(k):
+        w_drop = base_weights.copy()
+        w_drop[j] = 0.0
+        w_drop = _normalize(w_drop)
+        ic_without = composite_ic(test_c, w_drop, test_r)
+        improvement = _safe_sub(ic_without, full_oos_ic)
+        verdict = "drop?" if (improvement is not None and improvement >= DROP_IMPROVEMENT_EPS) else "keep"
+        comp_rows.append(
+            {
+                "name": component_names[j],
+                "ic_in_sample": _round(full_ics[j]),
+                "hac_t": _round(full_t[j]),
+                "weight_current": _round(float(base_weights[j])),
+                "weight_ic_fit": _round(float(fitted[j])),
+                "oos_ic_without": _round(ic_without),
+                "oos_ic_delta_if_dropped": _round(improvement),
+                "verdict": verdict,
+            }
+        )
+    result["components"] = comp_rows
+    return result
+
+
+def _round(x, nd: int = 4):
+    if x is None:
+        return None
+    try:
+        if np.isnan(x):
+            return None
+    except TypeError:
+        return None
+    return round(float(x), nd)
+
+
+def _safe_sub(a: float, b: float):
+    if a is None or b is None or np.isnan(a) or np.isnan(b):
+        return None
+    return a - b
+
+
+# ─── DB adapter ──────────────────────────────────────────────────────────────
+
+
+def load_disruption_components(db) -> tuple[list[str], np.ndarray]:
+    """One observation per day from DisruptionScoreHistory (last row of each
+    day), as (dates, (n, 6) matrix) in component order COMPONENT_NAMES."""
+    from backend.models.analytics import DisruptionScoreHistory
+
+    rows = (
+        db.query(DisruptionScoreHistory)
+        .order_by(
+            DisruptionScoreHistory.date.asc(),
+            DisruptionScoreHistory.created_at.asc(),
+        )
+        .all()
+    )
+    by_day: dict[str, DisruptionScoreHistory] = {}
+    for r in rows:
+        by_day[r.date] = r  # later row of the same day overwrites — keeps last
+    dates = sorted(by_day)
+    matrix = np.array(
+        [
+            [
+                by_day[d].hormuz_component,
+                by_day[d].cape_component,
+                by_day[d].storage_component,
+                by_day[d].crack_component,
+                by_day[d].backwardation_component,
+                by_day[d].sentiment_component,
+            ]
+            for d in dates
+        ],
+        dtype=float,
+    )
+    return dates, matrix
+
+
+def backtest_disruption(db, horizon_days: int = 7) -> dict:
+    """Load real data and run the backtest. Returns the run_backtest dict,
+    or a {'n': 0, ...} stub when there isn't any history yet."""
+    from backend.analytics.disruption_score import WEIGHTS
+    from backend.analytics.validation.prices import BRENT_SERIES, forward_log_returns, load_price_map
+
+    dates, components = load_disruption_components(db)
+    if len(dates) == 0:
+        return {"horizon_days": horizon_days, "n": 0, "confident": False, "note": "no disruption_score_history rows"}
+
+    price_map = load_price_map(db, BRENT_SERIES)
+    forward = forward_log_returns(price_map, dates, horizon_days)
+    base_weights = np.array([WEIGHTS[name] for name in COMPONENT_NAMES], dtype=float)
+    return run_backtest(
+        components,
+        forward,
+        base_weights=base_weights,
+        component_names=COMPONENT_NAMES,
+        horizon_days=horizon_days,
+    )

--- a/backend/scripts/backtest_disruption_weights.py
+++ b/backend/scripts/backtest_disruption_weights.py
@@ -1,0 +1,84 @@
+"""Print the disruption-score weight backtest as a keep/drop table.
+
+Run from the repo root (locally with a copy of obsyd.db, or on the VPS)::
+
+    python -m backend.scripts.backtest_disruption_weights            # 7d horizon
+    python -m backend.scripts.backtest_disruption_weights 1 7 30     # several horizons
+
+For each component it shows the in-sample rank IC vs forward Brent returns,
+the HAC (Newey-West) t-stat, the current vs IC-fitted weight, and an
+out-of-sample drop-one-out verdict. With little history the honest output is
+"insufficient data" — that is the point, not a bug.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from backend.analytics.validation.weights import MIN_CONFIDENT_N, backtest_disruption
+from backend.database import SessionLocal
+
+
+def _fmt(x, width=9, nd=3):
+    if x is None:
+        return "—".rjust(width)
+    return f"{x:.{nd}f}".rjust(width)
+
+
+def _print_report(res: dict) -> None:
+    h = res["horizon_days"]
+    n = res.get("n", 0)
+    print(f"\n=== Disruption-score weight backtest — {h}d forward Brent ===")
+    print(f"observations (one per day): {n}", end="")
+    if not res.get("confident"):
+        print(f"   [PRELIMINARY — need n>={MIN_CONFIDENT_N} before any public claim]")
+    else:
+        print("   [confident sample]")
+
+    if "note" in res:
+        print(f"note: {res['note']}")
+
+    oos = res.get("oos_ic")
+    if oos:
+        print(f"out-of-sample composite IC (test n={res.get('oos_n')}):")
+        print(f"    current weights     : {_fmt(oos.get('current'))}")
+        print(f"    equal weights       : {_fmt(oos.get('equal'))}")
+        print(f"    IC-fitted (OOS)     : {_fmt(oos.get('ic_proportional_oos'))}")
+
+    comps = res.get("components")
+    if not comps:
+        return
+    print()
+    header = f"{'component':<14}{'IC':>9}{'HAC t':>9}{'w_cur':>9}{'w_fit':>9}{'oos_drop':>10}{'verdict':>9}"
+    print(header)
+    print("-" * len(header))
+    for c in comps:
+        print(
+            f"{c['name']:<14}"
+            f"{_fmt(c.get('ic_in_sample'))}"
+            f"{_fmt(c.get('hac_t'))}"
+            f"{_fmt(c.get('weight_current'))}"
+            f"{_fmt(c.get('weight_ic_fit'))}"
+            f"{_fmt(c.get('oos_ic_delta_if_dropped'), width=10)}"
+            f"{c.get('verdict', '—'):>9}"
+        )
+    print(
+        "\nverdict 'drop?' = removing the component improved out-of-sample IC "
+        "(candidate for pruning); 'keep' = it helps or is neutral."
+    )
+
+
+def main(argv: list[str]) -> int:
+    horizons = [int(a) for a in argv[1:]] or [7]
+    db = SessionLocal()
+    try:
+        for h in horizons:
+            res = backtest_disruption(db, horizon_days=h)
+            _print_report(res)
+    finally:
+        db.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/tests/test_validation_metrics.py
+++ b/backend/tests/test_validation_metrics.py
@@ -1,0 +1,106 @@
+"""Unit tests for the pure validation metrics.
+
+Synthetic series with a known answer — no DB, no network. These gate the
+math, so a refactor that breaks the statistics fails loudly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from backend.analytics.validation import metrics
+
+
+def test_rankdata_matches_average_ties():
+    # values: 10, 10, 20, 30 -> ranks 1.5, 1.5, 3, 4
+    r = metrics.rankdata(np.array([10.0, 10.0, 20.0, 30.0]))
+    assert list(r) == [1.5, 1.5, 3.0, 4.0]
+
+
+def test_spearman_perfect_monotonic_is_one():
+    x = np.arange(50.0)
+    y = x ** 2  # strictly increasing but nonlinear -> Spearman == 1
+    assert metrics.spearman_ic(x, y) == 1.0
+
+
+def test_spearman_perfect_inverse_is_minus_one():
+    x = np.arange(50.0)
+    y = -x
+    assert metrics.spearman_ic(x, y) == -1.0
+
+
+def test_spearman_pure_noise_is_near_zero():
+    rng = np.random.default_rng(42)
+    x = rng.normal(size=2000)
+    y = rng.normal(size=2000)
+    assert abs(metrics.spearman_ic(x, y)) < 0.1
+
+
+def test_spearman_too_few_points_is_nan():
+    assert np.isnan(metrics.spearman_ic([1.0], [2.0]))
+
+
+def test_newey_west_large_t_for_strong_relationship():
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=500)
+    y = x + rng.normal(scale=0.1, size=500)  # near-perfect
+    t = metrics.newey_west_tstat(x, y, lag=0)
+    assert t > 10
+
+
+def test_newey_west_small_t_for_noise():
+    rng = np.random.default_rng(1)
+    x = rng.normal(size=500)
+    y = rng.normal(size=500)
+    t = metrics.newey_west_tstat(x, y, lag=6)
+    assert abs(t) < 2.5  # no real relationship -> not significant
+
+
+def test_newey_west_overlap_shrinks_t_vs_naive():
+    # Overlapping-window case: a slow signal and overlapping forward returns
+    # both inherit persistence from a common AR(1) factor, so the cross-product
+    # g_t = z(x)*z(y) is autocorrelated. The HAC t-stat (lag>0) must then be
+    # smaller in magnitude than the naive lag-0 one, which ignores the overlap.
+    rng = np.random.default_rng(7)
+    n = 800
+    factor = np.zeros(n)
+    for i in range(1, n):
+        factor[i] = 0.9 * factor[i - 1] + rng.normal()
+    x = factor + rng.normal(scale=0.3, size=n)
+    y = factor + rng.normal(scale=0.3, size=n)
+    t_naive = abs(metrics.newey_west_tstat(x, y, lag=0))
+    t_hac = abs(metrics.newey_west_tstat(x, y, lag=20))
+    assert t_hac < t_naive
+
+
+def test_event_study_planted_lift_and_hit_rate():
+    # When signal is high, forward return is positive; otherwise random small.
+    rng = np.random.default_rng(3)
+    n = 400
+    signal = rng.uniform(0, 100, size=n)
+    forward = rng.normal(scale=0.01, size=n)
+    high = signal >= 80
+    forward[high] += 0.05  # planted positive drift after high signal
+    res = metrics.event_study(signal, forward, threshold=80, direction="above")
+    assert res["n_event"] == int(high.sum())
+    assert res["lift"] > 0.02
+    assert res["hit_rate"] > 0.8
+    assert res["n_total"] == n
+
+
+def test_event_study_no_events_is_safe():
+    res = metrics.event_study(
+        np.array([1.0, 2.0, 3.0]), np.array([0.1, -0.1, 0.0]), threshold=100, direction="above"
+    )
+    assert res["n_event"] == 0
+    assert np.isnan(res["mean_event"])
+    assert not np.isnan(res["mean_base"])
+
+
+def test_event_study_below_direction_counts_negative_hits():
+    signal = np.array([10.0, 5.0, 1.0, 2.0])
+    forward = np.array([0.0, -0.02, -0.03, 0.01])
+    res = metrics.event_study(signal, forward, threshold=5, direction="below")
+    # events: signal <= 5 -> indices 1,2,3; hits = forward < 0 -> indices 1,2
+    assert res["n_event"] == 3
+    assert abs(res["hit_rate"] - 2 / 3) < 1e-9

--- a/backend/tests/test_validation_weights.py
+++ b/backend/tests/test_validation_weights.py
@@ -1,0 +1,82 @@
+"""Unit tests for the disruption-score weight backtest core.
+
+Planted data: one predictive component + five noise components. The backtest
+must rank the predictive one highest and flag noise components as drop
+candidates — the ValueKick "does this layer help?" test.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from backend.analytics.validation import weights
+from backend.analytics.validation.prices import forward_log_returns
+
+
+def _planted(n=400, seed=11):
+    """Component 0 is predictive of the forward return; 1..5 are noise."""
+    rng = np.random.default_rng(seed)
+    k = 6
+    comps = rng.uniform(0, 100, size=(n, k))
+    forward = 0.001 * (comps[:, 0] - 50) + rng.normal(scale=0.005, size=n)
+    base_weights = np.array([0.25, 0.20, 0.10, 0.15, 0.15, 0.15])
+    return comps, forward, base_weights
+
+
+def test_predictive_component_has_highest_ic():
+    comps, forward, _ = _planted()
+    ics = weights.component_ics(comps, forward)
+    assert np.argmax(ics) == 0
+    assert ics[0] > 0.5
+    for j in range(1, 6):
+        assert abs(ics[j]) < 0.2
+
+
+def test_ic_proportional_weights_concentrate_on_signal():
+    comps, forward, _ = _planted()
+    w = weights.ic_proportional_weights(comps, forward)
+    assert abs(w.sum() - 1.0) < 1e-9
+    assert w[0] > 0.5  # most weight on the predictive component
+
+
+def test_ic_fitted_beats_equal_weights_out_of_sample():
+    comps, forward, base = _planted()
+    res = weights.run_backtest(comps, forward, base_weights=base, horizon_days=7)
+    oos = res["oos_ic"]
+    assert oos["ic_proportional_oos"] >= oos["equal"]
+
+
+def test_ablation_flags_a_noise_component_and_keeps_signal():
+    comps, forward, base = _planted()
+    res = weights.run_backtest(comps, forward, base_weights=base, horizon_days=7)
+    rows = {c["name"]: c for c in res["components"]}
+    names = res["component_names"]
+    signal_name = names[0]
+    # The predictive component must never be a drop candidate.
+    assert rows[signal_name]["verdict"] == "keep"
+    # At least one of the five noise components should be flagged for pruning.
+    noise_verdicts = [rows[names[j]]["verdict"] for j in range(1, 6)]
+    assert "drop?" in noise_verdicts
+
+
+def test_small_sample_is_not_confident():
+    comps, forward, base = _planted(n=20)
+    res = weights.run_backtest(comps, forward, base_weights=base, horizon_days=7)
+    assert res["confident"] is False
+
+
+def test_nan_returns_rows_are_dropped():
+    comps, forward, base = _planted(n=100)
+    forward[:10] = np.nan  # immature horizon rows
+    res = weights.run_backtest(comps, forward, base_weights=base, horizon_days=7)
+    assert res["n"] == 90
+
+
+def test_forward_log_returns_no_lookahead():
+    # Price series only reaches 2026-01-10; a 7d return from 2026-01-08 would
+    # need 2026-01-15, which doesn't exist yet -> must be nan, not fabricated.
+    price_map = {f"2026-01-{d:02d}": 80.0 + d for d in range(1, 11)}
+    dates = ["2026-01-02", "2026-01-08"]
+    out = forward_log_returns(price_map, dates, horizon_days=7)
+    assert np.isfinite(out[0])  # 01-02 + 7d = 01-09, available
+    assert np.isnan(out[1])     # 01-08 + 7d = 01-15, not available

--- a/docs/signal-validation.md
+++ b/docs/signal-validation.md
@@ -1,0 +1,177 @@
+# Signal Validation Framework — Design
+
+> **Status:** P1 shipped — `backend/analytics/validation/` (metrics, prices,
+> disruption weight backtest) + `backend/scripts/backtest_disruption_weights.py`,
+> 18 unit tests. P2–P4 (scorecard table, API, event-study generalization,
+> frontend badges) still open.
+
+## Context & goal
+
+Obsyd has ~20 signals (disruption score, tonne-miles, rerouting index, crack
+spread, floating storage, EIA prediction, …). They look plausible but none
+carries a **verifiable claim** that it predicts anything. That's the actual
+moat at the €15 price point: not data completeness (Kpler/Vortexa win that),
+but *validated, transparent, backtested* indicators with a published track
+record.
+
+Goal: turn each signal from "plausible dashboard" into "indicator with a
+measured forward-return relationship, an honest sample size, and a track
+record" — and use the same evidence to **prune** signals/components that add
+nothing (the discipline already applied to the disabled ValueKick lineup
+layer).
+
+This is deliberately the same rigor as ValueKick: measure against ground
+truth, compare side-by-side with a naive baseline, drop layers that don't
+improve.
+
+## What already exists (leverage, don't rebuild)
+
+| Asset | Use |
+|---|---|
+| `signals/alert_outcomes.py` | FRED price lookup (`_price_on_or_before`), T+0/1/7/30 snapshot pattern. Reuse the price-access helpers. |
+| `DisruptionScoreHistory` (every 2h, 6 components + composite per date) | Ready-made panel dataset for the **weight backtest** — no new collection needed. |
+| `EIAPredictionHistory` (`prediction`/`actual_eia_change`/`correct`, `pearson_r`, `optimal_lag_days`) | The template for a per-signal scorecard row. |
+| `FreightProxyHistory` (`brent_corr_30d`, `rerouting_corr_30d`) | Precedent for storing rolling correlations alongside a signal. |
+| FRED `DCOILBRENTEU`, `DCOILWTICO` (daily) | Price ground truth for forward returns. |
+
+## Two evaluation modes
+
+Signals come in two shapes; each needs a different metric.
+
+**A. Continuous signals** (disruption score, tonne-miles, rerouting index,
+freight proxy) — a level/index per day.
+- Metric: **rank information coefficient (IC)** = Spearman correlation between
+  the signal level at day *D* and the forward Brent return over horizon *h*.
+- Plus directional **hit rate**: of the days the signal was in its top tercile,
+  how often was the forward return positive (or whatever the signal claims)?
+
+**B. Event / threshold signals** (alerts, "rerouting index > 110", anomaly
+fires) — discrete events.
+- Metric: **event study**. Mean (and distribution of) forward return in the
+  *h* days after the event vs an unconditional baseline; hit rate; lead time.
+- This is exactly what `alert_outcomes` already collects per alert — generalize
+  it from `alerts` to any threshold crossing on a `*_history` series.
+
+## Architecture
+
+```
+backend/analytics/validation/
+  __init__.py
+  prices.py        # forward-return series from FRED (reuse alert_outcomes helpers)
+  metrics.py       # rank IC, hit rate, event-study, Newey-West t-stat — pure functions, unit-tested
+  scorecards.py    # per-signal evaluation -> SignalScorecard rows
+  weights.py       # disruption-score weight backtest (walk-forward)
+models/validation.py  # SignalScorecard table
+routes/validation.py  # GET /api/validation/scorecards, /api/validation/disruption-weights
+```
+
+### New table: `SignalScorecard`
+
+One row per (signal, horizon, as_of) — rolling, recomputed weekly.
+
+```python
+class SignalScorecard(Base):
+    __tablename__ = "signal_scorecards"
+    id: int (pk)
+    signal: str            # "disruption_score", "rerouting_index", ...
+    horizon_days: int       # 1 / 7 / 30
+    as_of: str              # YYYY-MM-DD of computation
+    n: int                  # sample size (observations / events)
+    mode: str               # "continuous" | "event"
+    ic: float | None        # Spearman rank IC (continuous)
+    hit_rate: float | None  # directional hit rate
+    mean_fwd_high: float | None  # mean fwd return, signal high tercile / post-event
+    mean_fwd_base: float | None  # unconditional baseline
+    t_stat: float | None    # Newey-West adjusted (overlapping windows)
+    p_value: float | None
+    confident: int          # 1 iff n >= MIN_N and gates pass
+    created_at: datetime
+```
+
+### Schedule + API
+
+- Weekly scheduler job `recompute_scorecards()` (cheap; reads `*_history` + FRED).
+- `GET /api/validation/scorecards` → all signals' latest scorecards (public).
+- `GET /api/validation/disruption-weights` → the weight-backtest table (Pro).
+
+### Frontend
+
+- A small **Track Record badge** on each panel header: `IC 0.31 · 7d · n=84`
+  or, until the gate passes, `Track record: building (n=12/30)`.
+- A `/validation` methodology page: how each metric is computed, the
+  walk-forward setup, and the caveats below. Open-sourcing the methodology is
+  itself a credibility feature.
+
+## Flagship: disruption-score weight backtest
+
+The highest-value first deliverable because the data already exists in
+`DisruptionScoreHistory`. Mirrors the ValueKick "does this layer improve the
+score?" test.
+
+Steps (`weights.py`):
+1. Collapse `DisruptionScoreHistory` to **one observation per day** (last row
+   of each day — dedupes the 2-hourly cadence).
+2. Align each day to **forward Brent return** at h ∈ {1,7,30}d from FRED.
+3. Per component, compute marginal rank IC vs forward return.
+4. **Walk-forward** weight evaluation (no in-sample fitting):
+   - Split history into expanding windows; on each, derive weights from the
+     *past* only, apply to the *next* block, record out-of-sample composite IC.
+   - Compare four weightings out-of-sample: (a) current fixed weights,
+     (b) equal weights, (c) IC-proportional weights, (d) drop-one-out ablations.
+5. Output a recommendation table: each component's marginal contribution and a
+   verdict — **"keep" / "drop (no OOS contribution)"**, exactly like the
+   shelved lineup layer. A component whose ablation *improves* OOS IC is a
+   removal candidate.
+
+Honest expected outcome on day one: **n is small** (weeks–months, one Hormuz
+regime). The first result may well be "insufficient data to claim predictive
+power" — and saying that plainly *is* the product.
+
+## Methodology guardrails (the part that makes it credible)
+
+These are non-negotiable; without them the numbers are worse than useless.
+
+1. **No look-ahead.** A signal value dated *D* must use only data known at *D*.
+   The disruption components already use lagged PortWatch data, so they're
+   conservative — but verify `date` reflects knowledge time, not compute time,
+   and never fit on data after the return window.
+2. **Overlapping windows.** Daily obs with 7/30d forward returns overlap →
+   autocorrelation inflates t-stats. Use **Newey-West** standard errors (or
+   non-overlapping sampling). `metrics.py` does this; unit-test it against a
+   known case.
+3. **Multiple testing.** ~20 signals × 3 horizons = 60 tests; some look great
+   by chance. Report a **Benjamini-Hochberg FDR** flag and surface it on the
+   methodology page. Don't cherry-pick the best signal and headline it.
+4. **Walk-forward, not in-sample.** Any weight optimization is evaluated only
+   out-of-sample. In-sample "optimized" performance is never shown.
+5. **Regime honesty.** State the sample window and that it's dominated by one
+   regime. n<30 → never `confident=1`, never a public claim.
+
+## What we will NOT claim
+
+- No "this signal predicts oil prices" until `confident=1` *and* FDR-survived.
+- No precision we don't have: report ranges/sample sizes, not point forecasts.
+- The EIA panel's existing hedge ("informational, not a prediction") stays
+  until its scorecard earns the upgrade.
+
+## Phased rollout
+
+- **P1 — metrics core + disruption weight backtest (shippable alone).**
+  `prices.py`, `metrics.py` (unit-tested), `weights.py`, a CLI/script that
+  prints the weight-recommendation table. No schema/UI yet. Proves value and
+  tells us which components to keep.
+- **P2 — scorecards persistence + API.** `SignalScorecard` table + migration,
+  `scorecards.py` over the continuous signals, weekly job, `/api/validation/*`.
+- **P3 — generalize event-study** from `alert_outcomes` to threshold crossings
+  on any `*_history` series; fold alert track record into scorecards.
+- **P4 — frontend.** Track-record badges + `/validation` methodology page.
+
+## Verification
+
+- `metrics.py`: unit tests with synthetic series of known IC / known
+  event-study effect / known Newey-West t-stat (deterministic, no network).
+- `weights.py`: test that a planted predictive component ranks above pure-noise
+  components, and that ablation flags the noise component for removal.
+- Backtest on real history is run via script; results reviewed manually before
+  any number is surfaced (no auto-publishing of unvetted claims).
+- Existing suite stays green; new tests gate the math, not the data volume.


### PR DESCRIPTION
First slice of the signal validation plan (`docs/signal-validation.md`) — turn signals from plausible dashboards into measured, backtested indicators, and prune components that don't contribute. Same discipline as ValueKick: measure against ground truth, compare to a naive baseline, drop layers that don't help.

## What's here
`backend/analytics/validation/` — pure core + thin DB adapter:
- **`metrics.py`** — numpy-only: average-tie rank IC (Spearman), Newey-West HAC t-stat (overlap = horizon−1, so overlapping forward-return windows don't inflate significance), event study (lift vs baseline + hit rate)
- **`prices.py`** — forward log returns from FRED Brent/WTI with strict **no-look-ahead** (a return is emitted only once the price series reaches date+horizon)
- **`weights.py`** — disruption-score weight backtest: per-component IC, IC-fitted weights evaluated **out-of-sample** vs current/equal, drop-one-out ablation → keep/drop verdicts. `n<30` is never "confident".
- **`backend/scripts/backtest_disruption_weights.py`** — prints the keep/drop table.

## Methodology guardrails
No look-ahead · HAC t-stats for overlapping windows · out-of-sample weight evaluation (never in-sample fit) · honest sample-size gate.

## Verification
- 18 unit tests: known-IC synthetic series, planted event-study effect, HAC shrinkage under overlap, predictive-vs-noise ablation, no-look-ahead on forward returns
- Full suite **74 → 92 passed**, **ruff clean**
- End-to-end on planted data: the predictive component gets the highest IC + HAC t-stat + IC-fit weight (keep), a noise component is flagged drop?, and IC-fitted weights beat current/equal out-of-sample

## Note
This validates the **math**. The real verdict on Obsyd's 6 components comes from running the script against the production `obsyd.db`; with little history the honest output is "PRELIMINARY — need n>=30".

## Follow-ups (out of scope)
P2 scorecard table + `/api/validation` + weekly job · P3 generalize event-study from `alert_outcomes` to any threshold series · P4 frontend track-record badges + `/validation` methodology page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)