### PR TITLE
Fix backwardation component reading wrong dict shape (always 0.0)

### DIFF
--- a/backend/analytics/disruption_score.py
+++ b/backend/analytics/disruption_score.py
@@ -178,11 +178,15 @@ def _backwardation_component() -> float:
     try:
         from backend.signals.market_structure import _fetch_structure
 
-        data = _fetch_structure()
-        if not data or "BRENT" not in data.get("curves", {}):
+        # _fetch_structure() returns the curve dict directly: {"WTI": {...},
+        # "BRENT": {...}}. The "curves" wrapper is added only by
+        # get_market_structure(); reading data["curves"] here always missed and
+        # silently returned 0.0, suppressing a live backwardation signal.
+        curves = _fetch_structure()
+        if not curves or "BRENT" not in curves:
             return 0.0
 
-        brent = data["curves"]["BRENT"]
+        brent = curves["BRENT"]
         spread_pct = brent.get("spread_pct", 0)
 
         if spread_pct >= 0:

--- a/backend/analytics/market_report.py
+++ b/backend/analytics/market_report.py
@@ -980,9 +980,13 @@ class MarketReportGenerator:
         try:
             from backend.signals.market_structure import _fetch_structure
 
+            # _fetch_structure() returns the curve dict directly (no "curves"
+            # wrapper — that's get_market_structure's shape). Reading
+            # structure["curves"] always missed and dropped market structure
+            # from the report.
             structure = _fetch_structure()
-            if structure and "BRENT" in structure.get("curves", {}):
-                brent_curve = structure["curves"]["BRENT"]
+            if structure and "BRENT" in structure:
+                brent_curve = structure["BRENT"]
                 data["market_structure"] = {
                     "spread_pct": brent_curve.get("spread_pct", 0),
                     "structure": brent_curve.get("structure", "flat"),

--- a/backend/tests/test_disruption_components.py
+++ b/backend/tests/test_disruption_components.py
@@ -1,0 +1,54 @@
+"""Tests for disruption-score components.
+
+Focus: the backwardation component, which silently returned 0.0 for its entire
+history because it read _fetch_structure() through get_market_structure()'s
+"curves" wrapper. The validation backtest flagged it as a flat (zero-variance)
+signal; these tests pin the corrected shape so it can't regress.
+"""
+
+from __future__ import annotations
+
+from backend.analytics import disruption_score
+
+
+def _patch_structure(monkeypatch, payload):
+    # _backwardation_component imports _fetch_structure inside the function,
+    # so patching the source-module attribute is what takes effect.
+    monkeypatch.setattr(
+        "backend.signals.market_structure._fetch_structure",
+        lambda: payload,
+    )
+
+
+def test_backwardation_nonzero_for_unwrapped_curve_shape(monkeypatch):
+    # Regression: _fetch_structure returns the curve dict DIRECTLY. The old
+    # code read data["curves"]["BRENT"] and always got 0.0 — this would fail it.
+    _patch_structure(monkeypatch, {"WTI": {"spread_pct": -1.88}, "BRENT": {"spread_pct": -1.69}})
+    assert disruption_score._backwardation_component() > 0
+
+
+def test_backwardation_value_for_known_spread(monkeypatch):
+    # spread_pct -1.5 -> abs 1.5 in (1, 2] -> 20 + (1.5 - 1) * 40 = 40.0
+    _patch_structure(monkeypatch, {"BRENT": {"spread_pct": -1.5}})
+    assert abs(disruption_score._backwardation_component() - 40.0) < 1e-6
+
+
+def test_backwardation_contango_is_zero(monkeypatch):
+    # Positive spread = contango = no disruption signal.
+    _patch_structure(monkeypatch, {"BRENT": {"spread_pct": 1.2}})
+    assert disruption_score._backwardation_component() == 0.0
+
+
+def test_backwardation_deep_caps_at_100(monkeypatch):
+    _patch_structure(monkeypatch, {"BRENT": {"spread_pct": -9.0}})
+    assert disruption_score._backwardation_component() == 100.0
+
+
+def test_backwardation_missing_brent_is_zero(monkeypatch):
+    _patch_structure(monkeypatch, {"WTI": {"spread_pct": -1.0}})
+    assert disruption_score._backwardation_component() == 0.0
+
+
+def test_backwardation_empty_is_zero(monkeypatch):
+    _patch_structure(monkeypatch, {})
+    assert disruption_score._backwardation_component() == 0.0


### PR DESCRIPTION
Found by the signal validation framework (#2) on its first real run against production data: the disruption score's backwardation component was flagged as flat (zero variance, nan IC) across its entire 93-day history.

## Root cause
`_fetch_structure()` returns the curve dict **directly** (`{"WTI": {...}, "BRENT": {...}}`); the `"curves"` wrapper is added only by `get_market_structure()`. Two call sites read the raw output through that wrapper:

```python
data = _fetch_structure()
if "BRENT" not in data.get("curves", {}):   # .get("curves") -> {} -> always True
    return 0.0                               # -> constant 0.0
```

So the component returned 0.0 on every run, silently suppressing a live backwardation signal during a genuine supply-stress period.

## Affected
- `disruption_score.py` — backwardation component dead (the nan-IC the backtest caught)
- `market_report.py` — market structure silently dropped from the report

Not affected: `evaluator.py` and `daily_email.py` correctly use the wrapped `get_market_structure()`.

## Impact
Live, the component now returns **48.4** instead of 0.0 → **+7.3 composite points** (weight 0.15). The previous backtest therefore ran with one of six components dead; historical `disruption_score_history` values are systematically ~7 points low.

## Fix & verification
- Read the unwrapped curve dict directly in both call sites
- 6 regression tests for the backwardation component (the first fails on the old code)
- Verified live end-to-end: 0.0 -> 48.4
- Full suite **92 -> 98**, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)