### PR TITLE
Signal validation P2: scorecard persistence + API + weekly job

### DIFF
--- a/backend/analytics/validation/scorecards.py
+++ b/backend/analytics/validation/scorecards.py
@@ -1,0 +1,171 @@
+"""Compute and persist per-signal scorecards.
+
+For each continuous signal (a `*_history` table with a scalar level) and each
+horizon, measure the forward-Brent-return relationship: rank IC, HAC t-stat,
+and a top-tercile event study (mean forward return when the signal is high vs
+the unconditional baseline). Results are upserted into `signal_scorecards`,
+one row per (signal, horizon, as_of).
+
+Honest by construction: n < MIN_CONFIDENT_N is never flagged confident; the
+p-value is HAC-robust so overlapping windows don't masquerade as significance.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import numpy as np
+
+from backend.analytics.validation import metrics
+from backend.analytics.validation.prices import BRENT_SERIES, forward_log_returns, load_price_map
+from backend.analytics.validation.weights import MIN_CONFIDENT_N
+
+logger = logging.getLogger(__name__)
+
+HORIZONS = (1, 7, 30)
+TOP_TERCILE_Q = 2 / 3  # "signal high" = top third of its own distribution
+
+# Continuous signals: a history table + the scalar column to evaluate.
+# Imported lazily inside the loader to avoid import cycles at module load.
+SIGNAL_SPECS = (
+    ("disruption_score", "DisruptionScoreHistory", "composite_score"),
+    ("tonne_miles", "TonneMilesHistory", "tonne_miles_index"),
+    ("freight_proxy", "FreightProxyHistory", "proxy_index"),
+)
+
+
+def _two_sided_p(t_stat: float) -> float | None:
+    """Normal-approx two-sided p-value for a t/z statistic (large-sample)."""
+    if t_stat is None or (isinstance(t_stat, float) and math.isnan(t_stat)):
+        return None
+    # P(|Z| > |t|) = 2 * (1 - Phi(|t|)); Phi via erf, stdlib only.
+    return float(2.0 * (1.0 - 0.5 * (1.0 + math.erf(abs(t_stat) / math.sqrt(2.0)))))
+
+
+def load_signal_series(db, table_name: str, value_col: str) -> tuple[list[str], np.ndarray]:
+    """Return (dates, values) for a signal, one observation per day (last row
+    of each day — dedupes sub-daily cadences like the 2-hourly disruption score)."""
+    from backend.models import analytics as analytics_models
+
+    model = getattr(analytics_models, table_name)
+    rows = (
+        db.query(model.date, getattr(model, value_col), model.created_at)
+        .order_by(model.date.asc(), model.created_at.asc())
+        .all()
+    )
+    by_day: dict[str, float] = {}
+    for date_str, value, _created in rows:
+        if value is not None:
+            by_day[date_str] = float(value)  # last write per day wins
+    dates = sorted(by_day)
+    return dates, np.array([by_day[d] for d in dates], dtype=float)
+
+
+def score_signal(name: str, dates: list[str], values: np.ndarray, price_map: dict, horizon: int) -> dict:
+    """Compute one scorecard dict for a signal at a horizon (no DB writes)."""
+    fwd = forward_log_returns(price_map, dates, horizon)
+    mask = np.isfinite(values) & np.isfinite(fwd)
+    n = int(mask.sum())
+    sig, ret = values[mask], fwd[mask]
+
+    card = {
+        "signal": name,
+        "horizon_days": horizon,
+        "n": n,
+        "mode": "continuous",
+        "ic": None,
+        "hit_rate": None,
+        "mean_fwd_high": None,
+        "mean_fwd_base": None,
+        "t_stat": None,
+        "p_value": None,
+        "confident": 1 if n >= MIN_CONFIDENT_N else 0,
+    }
+    if n < 3:
+        return card
+
+    ic = metrics.spearman_ic(sig, ret)
+    t = metrics.newey_west_tstat(sig, ret, lag=horizon - 1)
+    threshold = float(np.quantile(sig, TOP_TERCILE_Q))
+    es = metrics.event_study(sig, ret, threshold, direction="above")
+
+    card.update(
+        ic=_clean(ic),
+        t_stat=_clean(t),
+        p_value=_two_sided_p(t),
+        hit_rate=_clean(es["hit_rate"]),
+        mean_fwd_high=_clean(es["mean_event"]),
+        mean_fwd_base=_clean(es["mean_base"]),
+    )
+    return card
+
+
+def _clean(x):
+    if x is None:
+        return None
+    try:
+        if np.isnan(x):
+            return None
+    except TypeError:
+        return None
+    return float(x)
+
+
+def recompute_scorecards(db, as_of: str) -> list[dict]:
+    """Compute every signal × horizon and upsert into signal_scorecards for
+    `as_of` (YYYY-MM-DD). Returns the computed cards."""
+    from backend.models.validation import SignalScorecard
+
+    price_map = load_price_map(db, BRENT_SERIES)
+    cards: list[dict] = []
+
+    for name, table_name, value_col in SIGNAL_SPECS:
+        try:
+            dates, values = load_signal_series(db, table_name, value_col)
+        except Exception as e:
+            logger.warning("scorecards: load failed for %s: %s", name, e)
+            continue
+        if len(dates) == 0:
+            continue
+        for horizon in HORIZONS:
+            card = score_signal(name, dates, values, price_map, horizon)
+            cards.append(card)
+            _upsert(db, SignalScorecard, card, as_of)
+
+    db.commit()
+    logger.info("scorecards: recomputed %d cards as_of %s", len(cards), as_of)
+    return cards
+
+
+def _upsert(db, model, card: dict, as_of: str) -> None:
+    existing = (
+        db.query(model)
+        .filter(model.signal == card["signal"], model.horizon_days == card["horizon_days"], model.as_of == as_of)
+        .first()
+    )
+    fields = dict(card, as_of=as_of)
+    if existing:
+        for key, val in fields.items():
+            setattr(existing, key, val)
+    else:
+        db.add(model(**fields))
+
+
+async def recompute_scorecards_job() -> dict:
+    """Scheduler entry point. Never raises."""
+    from datetime import datetime, timezone
+
+    from backend.database import SessionLocal
+
+    as_of = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    db = SessionLocal()
+    try:
+        cards = recompute_scorecards(db, as_of)
+        return {"as_of": as_of, "count": len(cards)}
+    except Exception as e:
+        logger.error("scorecards job failed: %s", e)
+        db.rollback()
+        return {"as_of": as_of, "count": 0, "error": str(e)}
+    finally:
+        db.close()

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -25,6 +25,7 @@ from backend.analytics.eia_prediction import compute_eia_prediction
 from backend.analytics.freight_proxy import compute_freight_proxy
 from backend.analytics.supply_demand import compute_supply_demand
 from backend.analytics.tonne_miles import compute_tonne_miles
+from backend.analytics.validation.scorecards import recompute_scorecards_job
 from backend.collectors.crack_spreads import collect_crack_spreads
 from backend.collectors.eia import collect_eia
 from backend.collectors.equities import collect_equities
@@ -377,6 +378,15 @@ def start_scheduler():
         check_collectors,
         CronTrigger(hour=9, minute=0),
         id="collector_watchdog_daily",
+        **JOB_DEFAULTS,
+    )
+
+    # Signal scorecards: weekly Monday 05:00 UTC — recompute each signal's
+    # forward-return track record (rank IC, HAC t, hit rate) vs Brent.
+    scheduler.add_job(
+        recompute_scorecards_job,
+        CronTrigger(day_of_week="mon", hour=5, minute=0),
+        id="signal_scorecards_weekly",
         **JOB_DEFAULTS,
     )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,7 @@ from backend.routes import portwatch as portwatch_routes
 from backend.routes import settings as settings_routes
 from backend.routes import signals as signals_routes
 from backend.routes import thermal as thermal_routes
+from backend.routes import validation as validation_routes
 from backend.routes import waitlist as waitlist_routes
 from backend.routes import webhooks as webhooks_routes
 from backend.signals.sentiment_scorer import compute_sentiment_score
@@ -207,3 +208,4 @@ app.include_router(alert_rules_routes.router)
 app.include_router(email_routes.router)
 app.include_router(voyages.router)
 app.include_router(analytics_routes.router)
+app.include_router(validation_routes.router)

--- a/backend/models/validation.py
+++ b/backend/models/validation.py
@@ -1,0 +1,33 @@
+"""Persisted signal scorecards — the rolling track record per signal.
+
+One row per (signal, horizon_days, as_of). Recomputed weekly from each
+signal's *_history table vs forward Brent returns. See
+docs/signal-validation.md and backend/analytics/validation/.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class SignalScorecard(Base):
+    __tablename__ = "signal_scorecards"
+    __table_args__ = (UniqueConstraint("signal", "horizon_days", "as_of", name="uq_scorecard_signal_horizon_asof"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    signal: Mapped[str] = mapped_column(String, index=True)       # "disruption_score", ...
+    horizon_days: Mapped[int] = mapped_column(Integer)            # 1 / 7 / 30
+    as_of: Mapped[str] = mapped_column(String, index=True)        # YYYY-MM-DD of computation
+    n: Mapped[int] = mapped_column(Integer, default=0)            # aligned observations
+    mode: Mapped[str] = mapped_column(String, default="continuous")  # continuous | event
+    ic: Mapped[float | None] = mapped_column(Float, nullable=True)         # Spearman rank IC
+    hit_rate: Mapped[float | None] = mapped_column(Float, nullable=True)   # directional, top tercile
+    mean_fwd_high: Mapped[float | None] = mapped_column(Float, nullable=True)  # fwd ret, signal-high
+    mean_fwd_base: Mapped[float | None] = mapped_column(Float, nullable=True)  # unconditional baseline
+    t_stat: Mapped[float | None] = mapped_column(Float, nullable=True)     # Newey-West HAC
+    p_value: Mapped[float | None] = mapped_column(Float, nullable=True)
+    confident: Mapped[int] = mapped_column(Integer, default=0)    # 1 iff n >= MIN_CONFIDENT_N
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/routes/validation.py
+++ b/backend/routes/validation.py
@@ -1,0 +1,72 @@
+"""Signal validation endpoints — track records + the disruption weight backtest.
+
+GET /api/validation/scorecards         (public) — latest per-signal track record
+GET /api/validation/disruption-weights (Pro)    — live weight backtest table
+"""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from backend.analytics.validation.weights import MIN_CONFIDENT_N, backtest_disruption
+from backend.auth.dependencies import require_pro
+from backend.database import get_db
+from backend.models.validation import SignalScorecard
+
+router = APIRouter(prefix="/api/validation", tags=["validation"])
+
+
+@router.get("/scorecards")
+async def get_scorecards(db: Session = Depends(get_db)):
+    """Latest per-signal track record (one set per signal × horizon).
+
+    Public, but deliberately honest: each card carries `n` and `confident`
+    (n >= MIN_CONFIDENT_N). The frontend should show "building (n/30)" until a
+    card is confident, and never present an unconfident card as a claim.
+    """
+    latest_as_of = db.query(func.max(SignalScorecard.as_of)).scalar()
+    if not latest_as_of:
+        return {"available": False, "min_confident_n": MIN_CONFIDENT_N, "signals": {}}
+
+    rows = (
+        db.query(SignalScorecard)
+        .filter(SignalScorecard.as_of == latest_as_of)
+        .order_by(SignalScorecard.signal.asc(), SignalScorecard.horizon_days.asc())
+        .all()
+    )
+    signals: dict[str, list] = {}
+    for r in rows:
+        signals.setdefault(r.signal, []).append(
+            {
+                "horizon_days": r.horizon_days,
+                "n": r.n,
+                "ic": r.ic,
+                "t_stat": r.t_stat,
+                "p_value": r.p_value,
+                "hit_rate": r.hit_rate,
+                "mean_fwd_high": r.mean_fwd_high,
+                "mean_fwd_base": r.mean_fwd_base,
+                "confident": bool(r.confident),
+            }
+        )
+    return {
+        "available": True,
+        "as_of": latest_as_of,
+        "min_confident_n": MIN_CONFIDENT_N,
+        "signals": signals,
+    }
+
+
+@router.get("/disruption-weights")
+async def get_disruption_weights(
+    horizon: int = Query(7, ge=1, le=60),
+    _user=Depends(require_pro),
+    db: Session = Depends(get_db),
+):
+    """Live disruption-score weight backtest at the requested horizon (Pro).
+
+    Per-component IC + HAC t-stat, out-of-sample composite IC (current vs equal
+    vs IC-fitted), and drop-one-out keep/drop verdicts. `confident` is False
+    until there is enough matured history.
+    """
+    return backtest_disruption(db, horizon_days=horizon)

--- a/backend/tests/test_validation_scorecards.py
+++ b/backend/tests/test_validation_scorecards.py
@@ -1,0 +1,117 @@
+"""Tests for scorecard computation, persistence, and the validation API."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.analytics.validation import scorecards
+from backend.main import app
+from backend.models.analytics import DisruptionScoreHistory
+from backend.models.prices import FREDSeries
+from backend.models.validation import SignalScorecard
+
+
+@pytest.fixture
+def client(db_session):
+    return TestClient(app)
+
+
+def _seed(db, n_days=80, seed=4):
+    """Plant disruption history where the composite predicts the 7d-forward
+    Brent move, plus a matching FRED Brent series."""
+    rng = np.random.default_rng(seed)
+    start = date(2026, 1, 1)
+    composite = rng.uniform(0, 100, size=n_days)
+    price = [80.0]
+    for i in range(1, n_days + 12):
+        drift = 0.02 * (composite[i - 7] - 50) if 0 <= i - 7 < n_days else 0.0
+        price.append(price[-1] + drift + rng.normal(scale=0.3))
+    for i in range(n_days):
+        d = (start + timedelta(days=i)).strftime("%Y-%m-%d")
+        # two rows per day to exercise the one-obs-per-day dedup
+        for _ in range(2):
+            db.add(
+                DisruptionScoreHistory(
+                    date=d,
+                    composite_score=float(composite[i]),
+                    hormuz_component=0,
+                    cape_component=0,
+                    storage_component=0,
+                    crack_component=0,
+                    backwardation_component=0,
+                    sentiment_component=0,
+                )
+            )
+    for i in range(n_days + 12):
+        d = (start + timedelta(days=i)).strftime("%Y-%m-%d")
+        db.add(FREDSeries(series_id="DCOILBRENTEU", date=d, value=float(price[i])))
+    db.commit()
+
+
+def test_load_signal_series_dedupes_to_one_per_day(db_session):
+    _seed(db_session, n_days=30)
+    dates, values = scorecards.load_signal_series(db_session, "DisruptionScoreHistory", "composite_score")
+    assert len(dates) == 30  # 60 rows -> 30 distinct days
+    assert len(values) == 30
+
+
+def test_recompute_writes_cards_for_every_signal_and_horizon(db_session):
+    _seed(db_session)
+    cards = scorecards.recompute_scorecards(db_session, as_of="2026-06-11")
+    # disruption_score has data; the other two signals have no history -> skipped
+    ds_cards = [c for c in cards if c["signal"] == "disruption_score"]
+    assert {c["horizon_days"] for c in ds_cards} == set(scorecards.HORIZONS)
+    rows = db_session.query(SignalScorecard).filter(SignalScorecard.signal == "disruption_score").all()
+    assert len(rows) == len(scorecards.HORIZONS)
+
+
+def test_recompute_is_idempotent_per_as_of(db_session):
+    _seed(db_session)
+    scorecards.recompute_scorecards(db_session, as_of="2026-06-11")
+    scorecards.recompute_scorecards(db_session, as_of="2026-06-11")  # upsert, not duplicate
+    rows = db_session.query(SignalScorecard).filter(SignalScorecard.as_of == "2026-06-11").all()
+    assert len(rows) == len(scorecards.HORIZONS)  # only disruption_score had data
+
+
+def test_predictive_signal_shows_positive_ic(db_session):
+    _seed(db_session)
+    cards = scorecards.recompute_scorecards(db_session, as_of="2026-06-11")
+    card_7d = next(c for c in cards if c["signal"] == "disruption_score" and c["horizon_days"] == 7)
+    # Planted predictive signal: positive IC, HAC-significant, high hit rate.
+    assert card_7d["ic"] is not None and card_7d["ic"] > 0.15
+    assert card_7d["t_stat"] > 2.0
+    assert card_7d["hit_rate"] > 0.7
+    assert card_7d["confident"] == 1  # n >= 30
+
+
+def test_two_sided_p_matches_known_values():
+    # |z|=1.96 -> p ~ 0.05; z=0 -> p=1
+    assert abs(scorecards._two_sided_p(1.959964) - 0.05) < 1e-3
+    assert abs(scorecards._two_sided_p(0.0) - 1.0) < 1e-9
+
+
+def test_scorecards_api_returns_latest(client, db_session):
+    _seed(db_session)
+    scorecards.recompute_scorecards(db_session, as_of="2026-06-11")
+    resp = client.get("/api/validation/scorecards")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert body["as_of"] == "2026-06-11"
+    assert "disruption_score" in body["signals"]
+    assert len(body["signals"]["disruption_score"]) == len(scorecards.HORIZONS)
+
+
+def test_scorecards_api_empty_is_graceful(client, db_session):
+    resp = client.get("/api/validation/scorecards")
+    assert resp.status_code == 200
+    assert resp.json()["available"] is False
+
+
+def test_disruption_weights_api_requires_pro(client, db_session):
+    resp = client.get("/api/validation/disruption-weights")
+    assert resp.status_code == 401


### PR DESCRIPTION
Builds on P1 (#2): turn each signal's forward-return relationship into a persisted, queryable track record that recomputes automatically and lets the UI gate honestly.

## What's here
- **`models/validation.py`** — `SignalScorecard` table (signal, horizon, as_of, n, ic, hit_rate, mean_fwd_high/base, HAC `t_stat`, `p_value`, `confident`). Auto-created by `create_all`; new table needs no migration.
- **`analytics/validation/scorecards.py`** — recompute each continuous signal (disruption_score, tonne_miles, freight_proxy) × horizon {1,7,30}: one obs/day, rank IC, Newey-West HAC t-stat, top-tercile event study, two-sided p-value (stdlib `erf`). Upsert per (signal, horizon, as_of). `n<30` never confident.
- **`routes/validation.py`** — `GET /api/validation/scorecards` (public, latest as_of) and `GET /api/validation/disruption-weights` (Pro, live weight backtest).
- **scheduler** — weekly Monday 05:00 UTC recompute job.

## Verification
- 8 unit tests: per-day dedup, recompute writes/upserts all signal×horizon cards, planted predictive signal → positive IC + significant HAC t + high hit rate, p-value vs known z-values, API latest / empty-graceful / Pro-gated
- Full suite **98 → 106**, ruff clean, both routes registered

## First real run (manual, against a prod snapshot)
None of the three continuous signals shows a statistically significant forward-Brent relationship in the current ~3-month sample (all `p > 0.14`, `|HAC t| < 1.5`). Negative ICs at 7/30d are a single-regime artifact (Brent drifted ~-4.9%/30d while signals stayed elevated), not a contrarian edge. `confident` (n≥30) is met but `confident ≠ significant` — exactly why the scorecard separates the two. This is the honest "situational-awareness, not alpha" result the framework is meant to surface.

Note: disruption_score history is still pre-#3 (backwardation fix not yet deployed), so its numbers are on biased data until deploy.

## Follow-ups
P3 (generalize event-study from `alert_outcomes`) · P4 (frontend track-record badges + `/validation` methodology page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)