### PR TITLE
Honest track-record badges on signal panels (P4)

### DIFF
--- a/frontend/src/components/DisruptionScorePanel.jsx
+++ b/frontend/src/components/DisruptionScorePanel.jsx
@@ -1,4 +1,5 @@
 import Panel from './Panel'
+import TrackRecordBadge from './TrackRecordBadge'
 import useFetchWithError from '../hooks/useFetchWithError'
 import {
   ResponsiveContainer,
@@ -154,6 +155,7 @@ export default function DisruptionScorePanel() {
           )}
         </>
       )}
+      <TrackRecordBadge signal="disruption_score" />
     </Panel>
   )
 }

--- a/frontend/src/components/FreightProxyPanel.jsx
+++ b/frontend/src/components/FreightProxyPanel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { createChart, ColorType } from 'lightweight-charts'
 import Panel from './Panel'
+import TrackRecordBadge from './TrackRecordBadge'
 
 const API = '/api'
 
@@ -186,6 +187,7 @@ export default function FreightProxyPanel() {
           {data?.history?.length > 1 && <div ref={containerRef} className="px-2 pb-2" />}
         </>
       )}
+      <TrackRecordBadge signal="freight_proxy" />
     </Panel>
   )
 }

--- a/frontend/src/components/TonneMilesPanel.jsx
+++ b/frontend/src/components/TonneMilesPanel.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import Panel from './Panel'
+import TrackRecordBadge from './TrackRecordBadge'
 import useFetchWithError from '../hooks/useFetchWithError'
 import {
   ResponsiveContainer,
@@ -153,6 +154,7 @@ export default function TonneMilesPanel() {
           )}
         </>
       )}
+      <TrackRecordBadge signal="tonne_miles" />
     </Panel>
   )
 }

--- a/frontend/src/components/TrackRecordBadge.jsx
+++ b/frontend/src/components/TrackRecordBadge.jsx
@@ -1,0 +1,54 @@
+import { InfoPopover } from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+
+const API = '/api'
+
+// Honest-by-design: this never shows a green "edge" unless the forward-return
+// relationship is statistically significant. Sufficient data with no signal
+// reads as "no measured edge", not a win.
+const METHOD =
+  'Track record: rank correlation (IC) between this signal and the forward ' +
+  'Brent return, with Newey-West HAC significance for overlapping windows. ' +
+  '"No measured edge" means enough data but not statistically significant ' +
+  '(p > 0.05). Single-regime sample — informational, not a forecast.'
+
+/**
+ * Compact, honest track-record strip for a signal panel.
+ * Reads /api/validation/scorecards (shared SWR cache, fetched once) and renders
+ * the card for `signal` at `horizon`. Renders nothing until scorecards exist.
+ */
+export default function TrackRecordBadge({ signal, horizon = 7 }) {
+  const { data } = useFetchWithError(`${API}/validation/scorecards`)
+  if (!data?.available) return null
+
+  const cards = data.signals?.[signal]
+  if (!cards) return null
+  const card = cards.find((c) => c.horizon_days === horizon)
+  if (!card) return null
+
+  const minN = data.min_confident_n ?? 30
+  let label
+  let tone
+
+  if (!card.confident) {
+    label = `Track record: building — n=${card.n}/${minN}`
+    tone = 'text-neutral-600 border-neutral-700/50'
+  } else {
+    const significant = card.p_value != null && card.p_value <= 0.05
+    if (significant && card.ic != null) {
+      const sign = card.ic >= 0 ? '+' : ''
+      label = `Track record: IC ${sign}${card.ic.toFixed(2)} · ${horizon}d · n=${card.n} · p=${card.p_value.toFixed(2)}`
+      tone = card.ic >= 0 ? 'text-green-glow border-green-glow/30' : 'text-orange-400 border-orange-400/30'
+    } else {
+      label = `No measured edge · ${horizon}d · n=${card.n}`
+      tone = 'text-neutral-500 border-neutral-700/50'
+    }
+  }
+
+  return (
+    <div className="px-4 py-1.5 border-t border-border/30 flex items-center gap-1.5">
+      <span className={`font-mono text-[9px] px-1.5 py-0.5 rounded border ${tone}`}>{label}</span>
+      <InfoPopover text={METHOD} />
+    </div>
+  )
+}


### PR DESCRIPTION
Surfaces the P2 scorecards (#5) in the UI. A compact strip on the disruption-score, tonne-miles and freight-proxy panels reads `/api/validation/scorecards` (shared SWR cache, fetched once) and shows the signal's measured forward-Brent relationship — honestly.

## Behaviour
| State | Badge |
|---|---|
| n < 30 | `Track record: building — n/30` (grey) |
| n ok, p > 0.05 | **`No measured edge · 7d · n=84`** (neutral) — current real state |
| significant | `IC +0.31 · 7d · n=84 · p=0.03` (green) — only when earned |

Never shows a green edge unless the HAC-robust p-value clears 0.05, so a sufficient-but-insignificant signal reads as "no measured edge", not a win. An inline InfoPopover explains IC / Newey-West / the single-regime caveat.

## Safe to ship before deploy
Renders nothing until scorecards exist (the endpoint returns `available:false` until the weekly job runs), so there's no broken state pre-population.

## Verification
New files eslint-clean; `vite build` OK.

## Follow-up
Full `/validation` methodology page (P4b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)