### PR TITLE
Gas balance Phase 3: HDD demand model (heating + industrial)

### DIFF
--- a/backend/gas/demand.py
+++ b/backend/gas/demand.py
@@ -1,0 +1,136 @@
+"""EU gas demand model (Phase 3): heating + industrial.
+
+Total gas demand = power burn (measured, Phase 2) + heating (HDD-driven) +
+industrial (flat). We calibrate the heating/industrial split on Eurostat
+monthly consumption:
+
+    net_month = Eurostat_total_month − power_burn_month
+    regress   net_month = a + b · HDD_month   (EU aggregate, OLS)
+    heating_day    = b · HDD_day              (integrates to b·HDD_month)
+    industrial_day = a / days_in_month        (flat, temperature-independent)
+
+Industrial is explicitly the weakest component — a constant monthly residual.
+When the residual signal moves, this assumption is usually what breaks (real
+industrial demand destruction/recovery shows up here first); that is intended.
+
+Calibration needs power burn (ENTSO-E, Phase 2). Without a token, power is
+absent → net = total, which conflates power into heating/industrial: the model
+runs but the split is PRELIMINARY (flagged in model_version).
+"""
+
+from __future__ import annotations
+
+import calendar
+import logging
+
+import numpy as np
+from sqlalchemy.orm import Session
+
+from backend.gas import eurostat
+from backend.gas.weather import CITY_BASKETS
+from backend.models.gas import GasDemandModel, GasPowerBurn, GasWeather
+
+logger = logging.getLogger(__name__)
+
+MIN_CALIBRATION_MONTHS = 6
+
+
+def _month(day: str) -> str:
+    return day[:7]
+
+
+def eu_daily_hdd(db: Session, country_weights: dict[str, float]) -> dict[str, float]:
+    """Consumption-weighted mean HDD across basket countries, per day."""
+    rows = db.query(GasWeather.date, GasWeather.country, GasWeather.hdd).all()
+    acc: dict[str, list[tuple[float, float]]] = {}
+    for d, country, hdd in rows:
+        w = country_weights.get(country)
+        if w and hdd is not None:
+            acc.setdefault(d, []).append((hdd, w))
+    out: dict[str, float] = {}
+    for d, pairs in acc.items():
+        wsum = sum(w for _, w in pairs)
+        if wsum:
+            out[d] = sum(h * w for h, w in pairs) / wsum
+    return out
+
+
+def _power_monthly(db: Session) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for date_, implied in db.query(GasPowerBurn.date, GasPowerBurn.implied_gas_gwh).all():
+        if implied is not None:
+            out[_month(date_)] = out.get(_month(date_), 0.0) + implied
+    return out
+
+
+def calibrate(net_monthly: dict[str, float], hdd_monthly: dict[str, float]) -> tuple[float, float, int]:
+    """OLS net = a + b·HDD over months present in both. Returns (a, b, n)."""
+    months = sorted(set(net_monthly) & set(hdd_monthly))
+    if len(months) < MIN_CALIBRATION_MONTHS:
+        return (float("nan"), float("nan"), len(months))
+    x = np.array([hdd_monthly[m] for m in months], dtype=float)
+    y = np.array([net_monthly[m] for m in months], dtype=float)
+    A = np.vstack([np.ones_like(x), x]).T
+    (a, b), *_ = np.linalg.lstsq(A, y, rcond=None)
+    return (float(a), float(b), len(months))
+
+
+def compute_demand(db: Session, eurostat_per_country: dict[str, dict[str, float]]) -> dict:
+    """Calibrate and write daily gas_demand_model for every day with HDD."""
+    # country weight = its annual Eurostat consumption (basket countries only)
+    weights = {
+        c: sum(eurostat_per_country.get(c, {}).values())
+        for c in CITY_BASKETS
+        if eurostat_per_country.get(c)
+    }
+    if not weights:
+        return {"written": 0, "note": "no eurostat data for basket countries"}
+
+    daily_hdd = eu_daily_hdd(db, weights)
+    if not daily_hdd:
+        return {"written": 0, "note": "no weather/HDD data — run weather ingest"}
+
+    hdd_monthly: dict[str, float] = {}
+    for d, h in daily_hdd.items():
+        hdd_monthly[_month(d)] = hdd_monthly.get(_month(d), 0.0) + h
+
+    eu_total = eurostat.eu_monthly_total(eurostat_per_country)
+    power = _power_monthly(db)
+    has_power = bool(power)
+    net_monthly = {m: eu_total[m] - power.get(m, 0.0) for m in eu_total}
+
+    a, b, n = calibrate(net_monthly, hdd_monthly)
+    if not np.isfinite(a):
+        return {"written": 0, "note": f"insufficient calibration data (n={n}, need {MIN_CALIBRATION_MONTHS})"}
+
+    version = f"v1{'+power' if has_power else '+nopower(prelim)'};a={a:.0f};b={b:.1f};n={n}"
+    days_in = {}
+    written = 0
+    for d, hdd in sorted(daily_hdd.items()):
+        y, mo = int(d[:4]), int(d[5:7])
+        dim = days_in.setdefault((y, mo), calendar.monthrange(y, mo)[1])
+        heat = max(0.0, b * hdd)
+        industrial = max(0.0, a / dim)
+        _upsert(db, d, round(heat, 1), round(industrial, 1), version)
+        written += 1
+    db.commit()
+    logger.info("demand.compute: %d days, a=%.0f b=%.1f n=%d power=%s", written, a, b, n, has_power)
+    return {"written": written, "a_industrial_monthly": round(a, 1), "b_heating_per_hdd": round(b, 1), "calibration_months": n, "has_power": has_power}
+
+
+def _upsert(db: Session, day: str, heat: float, industrial: float, version: str) -> None:
+    existing = db.get(GasDemandModel, day)
+    if existing:
+        existing.heat_gwh = heat
+        existing.industrial_gwh = industrial
+        existing.model_version = version
+    else:
+        db.add(GasDemandModel(date=day, heat_gwh=heat, industrial_gwh=industrial, model_version=version))
+
+
+async def compute_demand_model(db: Session, *, since: str = "2023-01") -> dict:
+    """Load Eurostat then calibrate + write. Entry point for backfill/scheduler."""
+    eurostat_per_country = await eurostat.load_monthly_consumption(since=since)
+    if not eurostat_per_country:
+        return {"written": 0, "note": "eurostat unavailable"}
+    return compute_demand(db, eurostat_per_country)

--- a/backend/gas/eurostat.py
+++ b/backend/gas/eurostat.py
@@ -1,0 +1,89 @@
+"""Eurostat monthly gas consumption (nrg_cb_gasm) — demand-model calibration.
+
+Not part of the daily pipeline; used only to calibrate the heating/industrial
+split. Gross inland consumption (IC_CAL_MG), natural gas (G3000), in TJ_GCV →
+GWh. Per EU27 country, monthly. Free API, no key. JSON-stat decoded the easy
+way: the query fixes every dimension except time, so value indices map 1:1 to
+the time category.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+import httpx
+
+from backend.gas import raw_cache
+
+logger = logging.getLogger(__name__)
+
+BASE = "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/nrg_cb_gasm"
+TJ_TO_GWH = 0.277778  # 1 TJ = 0.27778 GWh
+
+EU27 = (
+    "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "EL",  # EL = Greece in Eurostat
+    "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE",
+)
+
+
+async def fetch_country(geo: str, since: str, *, overwrite: bool = False) -> dict:
+    """Raw JSON-stat for one country (cached, monthly bucket)."""
+
+    async def _do() -> dict:
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.get(
+                BASE,
+                params={
+                    "format": "JSON",
+                    "geo": geo,
+                    "nrg_bal": "IC_CAL_MG",
+                    "siec": "G3000",
+                    "unit": "TJ_GCV",
+                    "sinceTimePeriod": since,
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    return await raw_cache.fetch_or_cache("eurostat", f"nrg_cb_gasm_{geo}", date.today().replace(day=1), _do, overwrite=overwrite)
+
+
+def parse_consumption(payload: dict) -> dict[str, float]:
+    """JSON-stat → {YYYY-MM: GWh}. Empty dict on missing data / error shape."""
+    try:
+        time_index = payload["dimension"]["time"]["category"]["index"]
+        values = payload["value"]
+    except (KeyError, TypeError):
+        return {}
+    inv = {idx: month for month, idx in time_index.items()}
+    out: dict[str, float] = {}
+    for flat_idx, tj in values.items():
+        month = inv.get(int(flat_idx))
+        if month is not None and tj is not None:
+            out[month] = float(tj) * TJ_TO_GWH
+    return out
+
+
+async def load_monthly_consumption(since: str = "2023-01", *, countries=EU27, overwrite: bool = False) -> dict[str, dict[str, float]]:
+    """{country: {YYYY-MM: GWh}} of gross inland gas consumption."""
+    out: dict[str, dict[str, float]] = {}
+    for geo in countries:
+        try:
+            payload = await fetch_country(geo, since, overwrite=overwrite)
+        except httpx.HTTPError as exc:
+            logger.warning("eurostat: %s fetch failed: %s", geo, exc)
+            continue
+        series = parse_consumption(payload)
+        if series:
+            out[geo] = series
+    return out
+
+
+def eu_monthly_total(per_country: dict[str, dict[str, float]]) -> dict[str, float]:
+    """Sum to an EU monthly total {YYYY-MM: GWh}."""
+    total: dict[str, float] = {}
+    for series in per_country.values():
+        for month, gwh in series.items():
+            total[month] = total.get(month, 0.0) + gwh
+    return total

--- a/backend/gas/weather.py
+++ b/backend/gas/weather.py
@@ -1,0 +1,122 @@
+"""Open-Meteo HDD ingestion (free, no key).
+
+Heating-degree-days drive the temperature-sensitive part of gas demand. For
+each country we take a small population-weighted basket of cities, fetch daily
+mean temperature from the Open-Meteo historical archive, compute the
+population-weighted national mean, then HDD = max(0, base - T_mean). The 8
+basket countries are ~85% of EU heating-gas demand.
+
+  HDD = max(0, HDD_BASE - T_mean),  HDD_BASE = 15.5 °C (configurable)
+
+Stored per (date, country) in gas_weather.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.gas import raw_cache
+from backend.models.gas import GasWeather
+
+logger = logging.getLogger(__name__)
+
+ARCHIVE_URL = "https://archive-api.open-meteo.com/v1/archive"
+HDD_BASE = 15.5  # °C
+
+# Population-weighted city baskets per country (lat, lon, weight). Weights are
+# rough metro populations (millions); only relative weights matter.
+CITY_BASKETS: dict[str, list[tuple[float, float, float]]] = {
+    "DE": [(52.52, 13.41, 3.7), (53.55, 9.99, 1.9), (48.14, 11.58, 1.5), (50.94, 6.96, 1.1), (50.11, 8.68, 0.8)],
+    "FR": [(48.85, 2.35, 11.0), (45.76, 4.84, 1.7), (43.30, 5.37, 1.6), (43.60, 1.44, 1.0), (50.63, 3.06, 1.0)],
+    "IT": [(41.90, 12.50, 4.3), (45.46, 9.19, 3.2), (40.85, 14.27, 3.1), (45.07, 7.69, 1.8), (44.49, 11.34, 1.0)],
+    "NL": [(52.37, 4.90, 2.5), (51.92, 4.48, 1.0), (52.08, 4.30, 1.0), (51.44, 5.47, 0.8)],
+    "ES": [(40.42, -3.70, 6.7), (41.39, 2.17, 5.6), (39.47, -0.38, 1.6), (37.39, -5.98, 1.5)],
+    "BE": [(50.85, 4.35, 2.1), (51.22, 4.40, 1.0), (51.05, 3.72, 0.5)],
+    "AT": [(48.21, 16.37, 2.8), (47.07, 15.44, 0.6), (48.30, 14.29, 0.5)],
+    "PL": [(52.23, 21.01, 3.1), (50.06, 19.95, 1.0), (51.11, 17.04, 0.9), (54.35, 18.65, 1.5)],
+}
+
+# Basket countries are ~85% of EU heating gas; scale the EU total up by this.
+COVERAGE_SCALE = 1.0 / 0.85
+
+
+async def fetch_city_temps(lat: float, lon: float, start: str, end: str, *, overwrite: bool = False) -> dict[str, float]:
+    """Daily mean temperature for one point over [start, end] (raw-cached)."""
+    dt = date.fromisoformat(start)
+
+    async def _do() -> dict:
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.get(
+                ARCHIVE_URL,
+                params={
+                    "latitude": lat,
+                    "longitude": lon,
+                    "start_date": start,
+                    "end_date": end,
+                    "daily": "temperature_2m_mean",
+                    "timezone": "UTC",
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    key = f"{lat:.2f}_{lon:.2f}_{start}_{end}"
+    payload = await raw_cache.fetch_or_cache("openmeteo", key, dt, _do, overwrite=overwrite)
+    daily = payload.get("daily", {})
+    times = daily.get("time", [])
+    temps = daily.get("temperature_2m_mean", [])
+    return {t: v for t, v in zip(times, temps) if v is not None}
+
+
+def hdd(t_mean: float, base: float = HDD_BASE) -> float:
+    return max(0.0, base - t_mean)
+
+
+async def ingest_country(db: Session, country: str, start: str, end: str, *, overwrite: bool = False) -> int:
+    """Population-weighted mean temp → HDD per day for one country."""
+    basket = CITY_BASKETS[country]
+    # date -> [(temp, weight), ...]
+    acc: dict[str, list[tuple[float, float]]] = {}
+    for lat, lon, weight in basket:
+        temps = await fetch_city_temps(lat, lon, start, end, overwrite=overwrite)
+        for d, t in temps.items():
+            acc.setdefault(d, []).append((t, weight))
+
+    written = 0
+    for d, pairs in acc.items():
+        wsum = sum(w for _, w in pairs)
+        if wsum == 0:
+            continue
+        t_mean = sum(t * w for t, w in pairs) / wsum
+        _upsert(db, d, country, round(t_mean, 2), round(hdd(t_mean), 2))
+        written += 1
+    db.commit()
+    return written
+
+
+async def ingest_weather(db: Session, days: list[str], *, overwrite: bool = False) -> dict:
+    """Ingest HDD for every basket country over the span of `days`."""
+    if not days:
+        return {"days": 0, "countries": 0, "written": 0}
+    start, end = min(days), max(days)
+    total = 0
+    for country in CITY_BASKETS:
+        try:
+            total += await ingest_country(db, country, start, end, overwrite=overwrite)
+        except httpx.HTTPError as exc:
+            logger.warning("weather: %s fetch failed: %s", country, exc)
+    logger.info("weather.ingest: %d country-days over %s..%s", total, start, end)
+    return {"days": len(days), "countries": len(CITY_BASKETS), "written": total}
+
+
+def _upsert(db: Session, day: str, country: str, t_mean: float, hdd_val: float) -> None:
+    existing = db.get(GasWeather, (day, country))
+    if existing:
+        existing.t_mean = t_mean
+        existing.hdd = hdd_val
+    else:
+        db.add(GasWeather(date=day, country=country, t_mean=t_mean, hdd=hdd_val))

--- a/backend/routes/gas.py
+++ b/backend/routes/gas.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from backend.database import get_db
 from backend.gas import validation
-from backend.models.gas import GasLng, GasPowerBurn, GasStorage
+from backend.models.gas import GasDemandModel, GasLng, GasPowerBurn, GasStorage
 
 router = APIRouter(prefix="/api/gas", tags=["gas"])
 
@@ -89,6 +89,28 @@ async def get_power_burn(days: int = Query(90, ge=1, le=1500), db: Session = Dep
         "note": "implied_gas_gwh = gen_gwh_el / efficiency; efficiency ~0.50 carries ~±5% systematic error",
         "data": [
             {"date": r.date, "gen_gwh_el": r.gen_gwh_el, "implied_gas_gwh": r.implied_gas_gwh, "efficiency": r.efficiency}
+            for r in rows
+        ],
+    }
+
+
+@router.get("/demand")
+async def get_demand(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
+    """Modeled gas demand: HDD-driven heating + flat industrial baseline (Phase 3)."""
+    date_from, date_to = _window(days)
+    rows = (
+        db.query(GasDemandModel)
+        .filter(GasDemandModel.date >= date_from, GasDemandModel.date <= date_to)
+        .order_by(GasDemandModel.date.asc())
+        .all()
+    )
+    if not rows:
+        return {"available": False, "reason": "no demand model yet — run gas_backfill --sources weather,demand"}
+    return {
+        "available": True,
+        "note": "industrial baseline is flat/month and (without ENTSO-E power burn) absorbs power — see model_version",
+        "data": [
+            {"date": r.date, "heat_gwh": r.heat_gwh, "industrial_gwh": r.industrial_gwh, "model_version": r.model_version}
             for r in rows
         ],
     }

--- a/backend/scripts/gas_backfill.py
+++ b/backend/scripts/gas_backfill.py
@@ -18,15 +18,18 @@ import sys
 from datetime import date, datetime
 
 from backend.database import SessionLocal
+from backend.gas.demand import compute_demand_model
 from backend.gas.entsoe import ingest_power_burn
 from backend.gas.entsog import ingest_flows, sync_points
 from backend.gas.gie import daterange, ingest_lng, ingest_storage
+from backend.gas.weather import ingest_weather
 
 logger = logging.getLogger("gas_backfill")
 
 BACKFILL_START = date(2023, 1, 1)
-# entsoe skips gracefully if no token is configured, so it's safe in the default set.
-ALL_SOURCES = ("entsog", "agsi", "alsi", "entsoe")
+# entsoe skips gracefully if no token is configured, so it's safe in the default
+# set. "demand" runs once after the loop (it calibrates over the whole period).
+ALL_SOURCES = ("entsog", "agsi", "alsi", "entsoe", "weather", "demand")
 
 
 async def _with_retry(coro_factory, label: str, attempts: int = 3, base: float = 1.0):
@@ -73,7 +76,14 @@ async def run_backfill(db, start: date, end: date, sources: set[str], overwrite:
             await _with_retry(lambda d=days: ingest_lng(db, d, overwrite=overwrite), f"alsi {tag}")
         if "entsoe" in sources:
             await _with_retry(lambda d=days: ingest_power_burn(db, d, overwrite=overwrite), f"entsoe {tag}")
+        if "weather" in sources:
+            await _with_retry(lambda d=days: ingest_weather(db, d, overwrite=overwrite), f"weather {tag}")
         logger.info("backfill: %s done", tag)
+
+    # Demand model calibrates over the whole period, so it runs once at the end.
+    if "demand" in sources:
+        result = await compute_demand_model(db)
+        logger.info("backfill: demand model %s", result)
 
 
 def main(argv: list[str]) -> int:
@@ -81,7 +91,7 @@ def main(argv: list[str]) -> int:
     p = argparse.ArgumentParser(description="EU gas balance backfill")
     p.add_argument("--start", default=BACKFILL_START.isoformat())
     p.add_argument("--end", default=date.today().isoformat())
-    p.add_argument("--sources", default=",".join(ALL_SOURCES), help="comma list: entsog,agsi,alsi")
+    p.add_argument("--sources", default=",".join(ALL_SOURCES), help="comma list: entsog,agsi,alsi,entsoe,weather,demand")
     p.add_argument("--overwrite", action="store_true", help="re-fetch cached days (provisional→confirmed)")
     args = p.parse_args(argv[1:])
 

--- a/backend/tests/test_gas_demand.py
+++ b/backend/tests/test_gas_demand.py
@@ -1,0 +1,81 @@
+"""Demand-model tests: calibration + daily heating/industrial split."""
+
+from __future__ import annotations
+
+import calendar
+
+import numpy as np
+
+from backend.gas import demand, weather
+from backend.models.gas import GasDemandModel, GasPowerBurn, GasWeather
+
+
+def test_calibrate_recovers_known_coefficients():
+    # net = 50000 + 200·HDD over 8 months → OLS recovers a≈50000, b≈200.
+    hdd = {f"2026-{m:02d}": 50.0 + 10 * m for m in range(1, 9)}
+    net = {m: 50000.0 + 200.0 * h for m, h in hdd.items()}
+    a, b, n = demand.calibrate(net, hdd)
+    assert n == 8
+    assert abs(a - 50000.0) < 1.0
+    assert abs(b - 200.0) < 0.1
+
+
+def test_calibrate_insufficient_months_is_nan():
+    hdd = {"2026-01": 100.0, "2026-02": 90.0}
+    net = {"2026-01": 1000.0, "2026-02": 900.0}
+    a, b, n = demand.calibrate(net, hdd)
+    assert n == 2 and np.isnan(a)
+
+
+def _seed_weather(db, country, day_to_hdd):
+    for d, h in day_to_hdd.items():
+        db.add(GasWeather(date=d, country=country, t_mean=15.5 - h, hdd=h))
+
+
+def test_compute_demand_end_to_end(db_session, monkeypatch):
+    db = db_session
+    # Single basket country so weighting is trivial.
+    monkeypatch.setattr(weather, "CITY_BASKETS", {"DE": [(1.0, 1.0, 1.0)]})
+    monkeypatch.setattr(demand, "CITY_BASKETS", {"DE": [(1.0, 1.0, 1.0)]})
+
+    # 8 months, ~4 days each, HDD declining; net (eurostat-power) = 50000 + 200·HDD_month
+    eurostat_pc = {"DE": {}}
+    for m in range(1, 9):
+        month = f"2026-{m:02d}"
+        days = [f"{month}-{dd:02d}" for dd in (1, 2, 3, 4)]
+        hdd_each = 20.0 - m  # per-day HDD this month
+        _seed_weather(db, "DE", {d: hdd_each for d in days})
+        hdd_month = hdd_each * len(days)
+        net_month = 50000.0 + 200.0 * hdd_month
+        # power = 3000/month, so eurostat total = net + power
+        db.add(GasPowerBurn(date=f"{month}-15", gen_gwh_el=1500.0, implied_gas_gwh=3000.0, efficiency=0.5))
+        eurostat_pc["DE"][month] = net_month + 3000.0
+    db.commit()
+
+    res = demand.compute_demand(db, eurostat_pc)
+    assert res["has_power"] is True
+    assert abs(res["b_heating_per_hdd"] - 200.0) < 1.0
+    assert abs(res["a_industrial_monthly"] - 50000.0) < 5.0
+
+    # A sample day: heating = b·HDD; industrial = a/days_in_month
+    row = db.get(GasDemandModel, "2026-03-01")
+    hdd_mar = 20.0 - 3
+    assert abs(row.heat_gwh - 200.0 * hdd_mar) < 5.0
+    assert abs(row.industrial_gwh - 50000.0 / calendar.monthrange(2026, 3)[1]) < 5.0
+    assert "+power" in row.model_version
+
+
+def test_compute_demand_without_power_is_flagged_preliminary(db_session, monkeypatch):
+    db = db_session
+    monkeypatch.setattr(demand, "CITY_BASKETS", {"DE": [(1.0, 1.0, 1.0)]})
+    eurostat_pc = {"DE": {}}
+    for m in range(1, 9):
+        month = f"2026-{m:02d}"
+        days = [f"{month}-{dd:02d}" for dd in (1, 2, 3, 4)]
+        _seed_weather(db, "DE", {d: 20.0 - m for d in days})
+        eurostat_pc["DE"][month] = 60000.0 + 200.0 * (20.0 - m) * 4
+    db.commit()
+    res = demand.compute_demand(db, eurostat_pc)  # no GasPowerBurn rows
+    assert res["has_power"] is False
+    row = db.query(GasDemandModel).first()
+    assert "nopower(prelim)" in row.model_version

--- a/backend/tests/test_gas_eurostat.py
+++ b/backend/tests/test_gas_eurostat.py
@@ -1,0 +1,42 @@
+"""Eurostat nrg_cb_gasm JSON-stat parsing tests."""
+
+from __future__ import annotations
+
+from backend.gas import eurostat
+
+
+def _payload(month_to_tj: dict[str, float]) -> dict:
+    months = list(month_to_tj)
+    return {
+        "value": {str(i): month_to_tj[m] for i, m in enumerate(months)},
+        "dimension": {"time": {"category": {"index": {m: i for i, m in enumerate(months)}}}},
+    }
+
+
+def test_parse_consumption_tj_to_gwh():
+    out = eurostat.parse_consumption(_payload({"2026-01": 100000.0, "2026-02": 50000.0}))
+    assert abs(out["2026-01"] - 27777.8) < 0.5   # 100000 TJ × 0.277778
+    assert abs(out["2026-02"] - 13888.9) < 0.5
+
+
+def test_parse_consumption_skips_nulls_and_bad_shape():
+    p = _payload({"2026-01": 100000.0})
+    p["value"]["1"] = None  # a null value at a nonexistent-time index is ignored
+    assert "2026-01" in eurostat.parse_consumption(p)
+    assert eurostat.parse_consumption({}) == {}
+    assert eurostat.parse_consumption({"value": {}}) == {}
+
+
+def test_eu_monthly_total_sums_countries():
+    per_country = {
+        "DE": {"2026-01": 1000.0, "2026-02": 800.0},
+        "FR": {"2026-01": 500.0, "2026-02": 400.0},
+    }
+    total = eurostat.eu_monthly_total(per_country)
+    assert total["2026-01"] == 1500.0
+    assert total["2026-02"] == 1200.0
+
+
+def test_eu27_uses_eurostat_greece_code():
+    assert "EL" in eurostat.EU27   # Eurostat uses EL, not GR
+    assert "GR" not in eurostat.EU27

--- a/backend/tests/test_gas_weather.py
+++ b/backend/tests/test_gas_weather.py
@@ -1,0 +1,40 @@
+"""Open-Meteo HDD ingestion tests."""
+
+from __future__ import annotations
+
+from backend.gas import weather
+from backend.models.gas import GasWeather
+
+
+def test_hdd_formula():
+    assert weather.hdd(5.5) == 10.0          # 15.5 - 5.5
+    assert weather.hdd(15.5) == 0.0
+    assert weather.hdd(20.0) == 0.0          # warm → no heating
+    assert weather.hdd(-4.5) == 20.0
+
+
+async def test_ingest_country_population_weights(db_session, monkeypatch):
+    # Two-city basket with weights 3 and 1 → weighted mean temp = (3*0 + 1*8)/4 = 2.0
+    monkeypatch.setattr(weather, "CITY_BASKETS", {"XX": [(1.0, 1.0, 3.0), (2.0, 2.0, 1.0)]})
+    temps = {(1.0, 1.0): {"2026-01-01": 0.0}, (2.0, 2.0): {"2026-01-01": 8.0}}
+
+    async def fake(lat, lon, start, end, *, overwrite=False):
+        return temps[(lat, lon)]
+
+    monkeypatch.setattr(weather, "fetch_city_temps", fake)
+    await weather.ingest_country(db_session, "XX", "2026-01-01", "2026-01-01")
+    row = db_session.get(GasWeather, ("2026-01-01", "XX"))
+    assert row.t_mean == 2.0
+    assert row.hdd == 13.5  # 15.5 - 2.0
+
+
+async def test_ingest_country_is_idempotent(db_session, monkeypatch):
+    monkeypatch.setattr(weather, "CITY_BASKETS", {"XX": [(1.0, 1.0, 1.0)]})
+
+    async def fake(lat, lon, start, end, *, overwrite=False):
+        return {"2026-01-01": 0.0}
+
+    monkeypatch.setattr(weather, "fetch_city_temps", fake)
+    await weather.ingest_country(db_session, "XX", "2026-01-01", "2026-01-01")
+    await weather.ingest_country(db_session, "XX", "2026-01-01", "2026-01-01")
+    assert db_session.query(GasWeather).count() == 1


### PR DESCRIPTION
Completes the demand side (bar power burn, Phase 2). Two new **key-free, live-verified** data sources + the heating/industrial demand model.

## What's here
- **gas/weather.py** — Open-Meteo HDD: population-weighted city baskets for the 8 countries that are ~85% of EU heating gas; daily mean temp → `HDD = max(0, 15.5 − T_mean)`; per (date, country). Verified live (DE Jan 2026: HDD 22→11 across a cold snap).
- **gas/eurostat.py** — `nrg_cb_gasm` gross inland consumption (IC_CAL_MG / G3000 / TJ_GCV → GWh), monthly per EU27; calibration reference only (cached, no DB table). JSON-stat decoded. Verified live (27 countries).
- **gas/demand.py** — EU-aggregate OLS: `net_month = Eurostat_total − power_burn`; `net = a + b·HDD`. `heating_day = b·HDD_day`, `industrial_day = a/days_in_month` (flat — the explicitly weakest component). Subtracts power burn when present; without an ENTSO-E token it runs but the split is flagged **preliminary** in `model_version`.
- backfill: `weather` (per-month) + `demand` (once, calibrates over the period). routes/gas.py: `/api/gas/demand`.

## Live calibration (the verification)
2024–2025, 24 months, 27 Eurostat countries, 5,848 HDD country-days → realistic EU total demand: **winter ~16,200 GWh/d, summer ~6,000 GWh/d** (~2.7× seasonal swing), squarely the published EU27 range, with correct HDD-driven seasonality.

## Verification
+11 tests (HDD formula + weighting, JSON-stat parse, calibration recovers known a/b, end-to-end split, no-power preliminary flag). Suite **166 → 177**, ruff clean.

## Note
The heating/industrial split is **preliminary** until Phase 2 power burn is live (needs the ENTSO-E token) — then `net = total − power` separates them properly. Phase 4 (residual engine) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)