### PR TITLE
Close the domestic-production gap in gas supply

### DIFF
--- a/backend/gas/balance.py
+++ b/backend/gas/balance.py
@@ -68,7 +68,9 @@ def _export_ua_by_day(db: Session, date_from: str, date_to: str) -> dict[str, fl
 
 def compute_balance(db: Session, date_from: str, date_to: str) -> list[dict]:
     """Build the daily balance + residual + z-score + flag series."""
-    supply_rows = {r["date"]: r for r in validation.compute_daily_supply(db, date_from, date_to)}
+    # The balance's Supply_in includes EU domestic production (unlike the
+    # Bruegel imports validation).
+    supply_rows = {r["date"]: r for r in validation.compute_daily_supply(db, date_from, date_to, include_production=True)}
     export_ua = _export_ua_by_day(db, date_from, date_to)
 
     demand_h = {r.date: r for r in db.query(GasDemandModel).filter(GasDemandModel.date >= date_from, GasDemandModel.date <= date_to).all()}

--- a/backend/gas/classification.py
+++ b/backend/gas/classification.py
@@ -102,10 +102,15 @@ def classify_point(row: dict) -> PointClass | None:
     if "lng" in label_l and direction == "entry":
         return PointClass("lng_entry", "LNG terminal")
 
-    # 5. Pipeline imports: EU entry from a non-EU supplier on a Non-EU border.
+    # 5. Domestic production: ENTSOG has a dedicated point type for it
+    #    ("Aggregated production point - TP"; the ExtEU variant is already
+    #    excluded by the EU-side guard above).
+    if direction == "entry" and (row.get("pointType") or "").startswith("Aggregated production point"):
+        return PointClass("production_entry", f"Domestic {tso}")
+
+    # 6. Pipeline imports: EU entry from a non-EU supplier on a Non-EU border.
     if direction == "entry" and "Non-EU" in xb and adj in SUPPLIER_LABELS:
         return PointClass("import_pipeline", SUPPLIER_LABELS[adj])
 
-    # 6. Out of scope (in-country transit, EU-EU interconnectors, production
-    #    handled as a documented gap in Phase 1 — not on the Bruegel-imports path).
+    # 7. Out of scope (in-country transit, EU-EU interconnectors).
     return None

--- a/backend/gas/validation.py
+++ b/backend/gas/validation.py
@@ -34,8 +34,13 @@ def _physical(name: str) -> str:
     return re.sub(r"\s*\([^)]*\)\s*$", "", name or "").strip()
 
 
-def compute_daily_supply(db: Session, date_from: str, date_to: str) -> list[dict]:
-    """Per-day supply (GWh/d) = pipeline imports + LNG send-out + max(0, net UK).
+def compute_daily_supply(db: Session, date_from: str, date_to: str, *, include_production: bool = False) -> list[dict]:
+    """Per-day supply (GWh/d) = pipeline imports + LNG + max(0, net UK)
+    [+ domestic production, for the balance].
+
+    `include_production=False` (default) matches Bruegel's *imports* definition
+    for the validation milestone; the balance passes True to add EU domestic
+    production (the spec's Supply_in).
 
     Multi-operator double-reporting: several TSOs report the SAME physical entry
     (e.g. Emden EPT1) under different pointKeys, often with near-identical
@@ -43,11 +48,14 @@ def compute_daily_supply(db: Session, date_from: str, date_to: str) -> list[dict
     point is the SINGLE LARGEST operator report (sub-reports are ≤ the total),
     so we take the max per (physical point, direction, day), then sum.
     """
+    classes = ["import_pipeline", "interconnector_uk"]
+    if include_production:
+        classes.append("production_entry")
     rows = (
         db.query(GasPoint.name, GasPoint.point_class, GasFlow.date, GasFlow.direction, GasFlow.value_gwh)
         .join(GasFlow, GasFlow.point_id == GasPoint.point_id)
         .filter(GasFlow.date >= date_from, GasFlow.date <= date_to, GasPoint.active == 1)
-        .filter(GasPoint.point_class.in_(["import_pipeline", "interconnector_uk"]))
+        .filter(GasPoint.point_class.in_(classes))
         .all()
     )
 
@@ -61,9 +69,11 @@ def compute_daily_supply(db: Session, date_from: str, date_to: str) -> list[dict
 
     by_day: dict[str, dict] = {}
     for (d, _phys, direction), (pclass, value) in best.items():
-        agg = by_day.setdefault(d, {"pipeline": 0.0, "uk_entry": 0.0, "uk_exit": 0.0})
+        agg = by_day.setdefault(d, {"pipeline": 0.0, "production": 0.0, "uk_entry": 0.0, "uk_exit": 0.0})
         if pclass == "import_pipeline":
             agg["pipeline"] += value
+        elif pclass == "production_entry":
+            agg["production"] += value
         elif pclass == "interconnector_uk":
             agg["uk_entry" if direction == "entry" else "uk_exit"] += value
 
@@ -74,15 +84,17 @@ def compute_daily_supply(db: Session, date_from: str, date_to: str) -> list[dict
 
     out = []
     for d in sorted(set(by_day) | set(lng)):
-        agg = by_day.get(d, {"pipeline": 0.0, "uk_entry": 0.0, "uk_exit": 0.0})
+        agg = by_day.get(d, {"pipeline": 0.0, "production": 0.0, "uk_entry": 0.0, "uk_exit": 0.0})
         uk_net = agg["uk_entry"] - agg["uk_exit"]
         pipeline = agg["pipeline"]
+        production = agg["production"]
         lng_gwh = lng.get(d, 0.0)
-        supply = pipeline + lng_gwh + max(0.0, uk_net)
+        supply = pipeline + production + lng_gwh + max(0.0, uk_net)
         out.append(
             {
                 "date": d,
                 "pipeline_gwh": round(pipeline, 1),
+                "production_gwh": round(production, 1),
                 "lng_gwh": round(lng_gwh, 1),
                 "uk_net_gwh": round(uk_net, 1),
                 "supply_gwh": round(supply, 1),

--- a/backend/tests/test_gas_classification.py
+++ b/backend/tests/test_gas_classification.py
@@ -74,6 +74,17 @@ def test_lng_terminal_entry_is_lng_class():
     assert c and c.point_class == "lng_entry"
 
 
+def test_domestic_production_via_point_type():
+    c = classify_point(_row(pointLabel="Production (NL)", tSOCountry="NL", adjacentCountry="NL", crossBorderPointType="In-country EU", directionKey="entry", pointType="Aggregated production point - TP"))
+    assert c and c.point_class == "production_entry" and c.counterparty == "Domestic NL"
+
+
+def test_ext_eu_production_is_out_of_scope():
+    # Non-EU production (ExtEU) must not be classified as EU domestic.
+    c = classify_point(_row(pointLabel="Production (RS)", tSOCountry="RS", adjacentCountry="RS", crossBorderPointType="In-country Non-EU", directionKey="entry", pointType="Aggregated production point - TP ExtEU"))
+    assert c is None
+
+
 def test_in_country_transit_is_out_of_scope():
     c = classify_point(_row(pointLabel="Some VTP", tSOCountry="DE", adjacentCountry="DE", crossBorderPointType="In-country EU", directionKey="entry"))
     assert c is None

--- a/backend/tests/test_gas_validation.py
+++ b/backend/tests/test_gas_validation.py
@@ -50,7 +50,7 @@ def test_net_uk_export_does_not_subtract_from_supply(db_session):
     assert r["supply_gwh"] == 1000.0  # export not counted as supply
 
 
-def test_production_and_export_excluded(db_session):
+def test_production_excluded_by_default_included_for_balance(db_session):
     db = db_session
     _seed_point(db, "IMP", "import_pipeline")
     _seed_point(db, "PROD", "production_entry")
@@ -59,8 +59,14 @@ def test_production_and_export_excluded(db_session):
     _flow(db, "2026-06-01", "PROD", "entry", 300.0)
     _flow(db, "2026-06-01", "UA", "exit", 200.0)
     db.commit()
-    r = validation.compute_daily_supply(db, "2026-06-01", "2026-06-01")[0]
-    assert r["supply_gwh"] == 1000.0  # only imports
+    # Bruegel imports view: production + exports excluded.
+    imports_only = validation.compute_daily_supply(db, "2026-06-01", "2026-06-01")[0]
+    assert imports_only["supply_gwh"] == 1000.0
+    assert imports_only["production_gwh"] == 0.0
+    # Balance view: domestic production added.
+    with_prod = validation.compute_daily_supply(db, "2026-06-01", "2026-06-01", include_production=True)[0]
+    assert with_prod["production_gwh"] == 300.0
+    assert with_prod["supply_gwh"] == 1300.0
 
 
 def test_multi_operator_physical_point_takes_max_not_sum(db_session):


### PR DESCRIPTION
Phase 1–4 left EU domestic production (NL/RO/DK/DE fields) out of supply — a constant **~570 GWh/d bias** in the residual. ENTSOG has a dedicated point type for it, so the classification is clean (no guessing).

## Change
- **classification**: `pointType "Aggregated production point - TP"` + EU-side entry → `production_entry` (the ExtEU variant is excluded by the EU guard). 35 active production points classified live.
- **compute_daily_supply** gains `include_production` (default False): the Bruegel **imports** validation stays imports-only; the **balance** passes True so Supply_in includes production (per the spec). New `production_gwh` output field.
- **balance**: supply now includes production.

## Live verification (April–May 2026)
Production ~571 GWh/d (constant); the residual mean shifts **+332 → −239 GWh/d** (exactly the production added) with **unchanged stdev** (906→904) — the known constant bias is now physically explained instead of unaccounted. The remaining offset is the preliminary-demand state (no power split), which the ENTSO-E token resolves.

## Verification
+2 tests (production classification, ExtEU excluded) + include_production on/off. Suite **183 → 185**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)