### PR TITLE
feat: gas residual track record (TTF series + scorecard)

### DIFF
--- a/backend/analytics/validation/prices.py
+++ b/backend/analytics/validation/prices.py
@@ -14,10 +14,12 @@ from datetime import datetime, timedelta
 
 import numpy as np
 
+from backend.models.energy import EnergyPrice
 from backend.models.prices import FREDSeries
 
 BRENT_SERIES = "DCOILBRENTEU"
 WTI_SERIES = "DCOILWTICO"
+TTF_SYMBOL = "TTF"  # forward-return target for gas-side signals (EnergyPrice)
 
 
 def load_price_map(db, series_id: str = BRENT_SERIES) -> dict[str, float]:
@@ -29,6 +31,17 @@ def load_price_map(db, series_id: str = BRENT_SERIES) -> dict[str, float]:
         .all()
     )
     return {r.date: float(r.value) for r in rows if r.value is not None}
+
+
+def load_energy_price_map(db, symbol: str = TTF_SYMBOL) -> dict[str, float]:
+    """date(YYYY-MM-DD) -> close for an EnergyPrice symbol (e.g. TTF), ascending."""
+    rows = (
+        db.query(EnergyPrice.date, EnergyPrice.close)
+        .filter(EnergyPrice.symbol == symbol)
+        .order_by(EnergyPrice.date.asc())
+        .all()
+    )
+    return {r.date: float(r.close) for r in rows if r.close is not None}
 
 
 def _on_or_before(sorted_dates: list[str], price_map: dict[str, float], target: str) -> float | None:

--- a/backend/analytics/validation/scorecards.py
+++ b/backend/analytics/validation/scorecards.py
@@ -18,7 +18,13 @@ import math
 import numpy as np
 
 from backend.analytics.validation import metrics
-from backend.analytics.validation.prices import BRENT_SERIES, forward_log_returns, load_price_map
+from backend.analytics.validation.prices import (
+    BRENT_SERIES,
+    TTF_SYMBOL,
+    forward_log_returns,
+    load_energy_price_map,
+    load_price_map,
+)
 from backend.analytics.validation.weights import MIN_CONFIDENT_N
 
 logger = logging.getLogger(__name__)
@@ -26,13 +32,23 @@ logger = logging.getLogger(__name__)
 HORIZONS = (1, 7, 30)
 TOP_TERCILE_Q = 2 / 3  # "signal high" = top third of its own distribution
 
-# Continuous signals: a history table + the scalar column to evaluate.
-# Imported lazily inside the loader to avoid import cycles at module load.
+# Continuous signals: (name, history-table, scalar column, forward-return target).
+# target ∈ {"brent" (FRED oil), "ttf" (EnergyPrice gas)}. Models are resolved
+# lazily inside the loader to avoid import cycles at module load.
 SIGNAL_SPECS = (
-    ("disruption_score", "DisruptionScoreHistory", "composite_score"),
-    ("tonne_miles", "TonneMilesHistory", "tonne_miles_index"),
-    ("freight_proxy", "FreightProxyHistory", "proxy_index"),
+    ("disruption_score", "DisruptionScoreHistory", "composite_score", "brent"),
+    ("tonne_miles", "TonneMilesHistory", "tonne_miles_index", "brent"),
+    ("freight_proxy", "FreightProxyHistory", "proxy_index", "brent"),
+    # Gas residual predicts European GAS prices, not Brent → scored against TTF.
+    ("gas_residual", "GasBalance", "z_score", "ttf"),
 )
+
+
+def _load_target_map(db, target: str) -> dict[str, float]:
+    """Resolve a signal's forward-return target to a date→price map."""
+    if target == "ttf":
+        return load_energy_price_map(db, TTF_SYMBOL)
+    return load_price_map(db, BRENT_SERIES)  # default / "brent"
 
 
 def _two_sided_p(t_stat: float) -> float | None:
@@ -43,19 +59,36 @@ def _two_sided_p(t_stat: float) -> float | None:
     return float(2.0 * (1.0 - 0.5 * (1.0 + math.erf(abs(t_stat) / math.sqrt(2.0)))))
 
 
-def load_signal_series(db, table_name: str, value_col: str) -> tuple[list[str], np.ndarray]:
-    """Return (dates, values) for a signal, one observation per day (last row
-    of each day — dedupes sub-daily cadences like the 2-hourly disruption score)."""
+def _resolve_model(table_name: str):
+    """Find a history model class by name across the analytics + gas modules."""
     from backend.models import analytics as analytics_models
 
-    model = getattr(analytics_models, table_name)
-    rows = (
-        db.query(model.date, getattr(model, value_col), model.created_at)
-        .order_by(model.date.asc(), model.created_at.asc())
-        .all()
-    )
+    if hasattr(analytics_models, table_name):
+        return getattr(analytics_models, table_name)
+    from backend.models import gas as gas_models
+
+    return getattr(gas_models, table_name)
+
+
+def load_signal_series(db, table_name: str, value_col: str) -> tuple[list[str], np.ndarray]:
+    """Return (dates, values) for a signal, one observation per day (last row
+    of each day — dedupes sub-daily cadences like the 2-hourly disruption score).
+
+    Tables with a `created_at` (the analytics history tables) are ordered by it
+    so the last write per day wins; tables keyed one-row-per-day (GasBalance,
+    whose `date` is the PK) are read directly."""
+    model = _resolve_model(table_name)
+    has_created = hasattr(model, "created_at")
+    cols = [model.date, getattr(model, value_col)]
+    order = [model.date.asc()]
+    if has_created:
+        cols.append(model.created_at)
+        order.append(model.created_at.asc())
+    rows = db.query(*cols).order_by(*order).all()
+
     by_day: dict[str, float] = {}
-    for date_str, value, _created in rows:
+    for row in rows:
+        date_str, value = row[0], row[1]
         if value is not None:
             by_day[date_str] = float(value)  # last write per day wins
     dates = sorted(by_day)
@@ -117,10 +150,11 @@ def recompute_scorecards(db, as_of: str) -> list[dict]:
     `as_of` (YYYY-MM-DD). Returns the computed cards."""
     from backend.models.validation import SignalScorecard
 
-    price_map = load_price_map(db, BRENT_SERIES)
+    # Build one price map per distinct target (Brent via FRED, TTF via EnergyPrice).
+    price_maps = {target: _load_target_map(db, target) for target in {s[3] for s in SIGNAL_SPECS}}
     cards: list[dict] = []
 
-    for name, table_name, value_col in SIGNAL_SPECS:
+    for name, table_name, value_col, target in SIGNAL_SPECS:
         try:
             dates, values = load_signal_series(db, table_name, value_col)
         except Exception as e:
@@ -128,6 +162,7 @@ def recompute_scorecards(db, as_of: str) -> list[dict]:
             continue
         if len(dates) == 0:
             continue
+        price_map = price_maps[target]
         for horizon in HORIZONS:
             card = score_signal(name, dates, values, price_map, horizon)
             cards.append(card)

--- a/backend/collectors/energy_prices.py
+++ b/backend/collectors/energy_prices.py
@@ -1,0 +1,89 @@
+"""Energy price collector — daily close history via yfinance into `EnergyPrice`.
+
+Mirrors `crack_spreads.py`: first run backfills a long window, thereafter only
+the last few days. Upsert keyed on (date, symbol). Currently ingests TTF
+(Dutch gas front-month); EUA / power day-ahead slot in via SYMBOLS later.
+
+Scheduled daily at 22:15 UTC (after US close, like the crack/equity jobs).
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+import yfinance as yf
+
+from backend.database import SessionLocal
+from backend.models.energy import EnergyPrice
+
+logger = logging.getLogger(__name__)
+
+_executor = ThreadPoolExecutor(max_workers=1)
+
+# db_symbol -> yfinance ticker. Add "EUA"/"POWER_*" here as the energy vertical grows.
+SYMBOLS = {
+    "TTF": "TTF=F",  # Dutch TTF natural gas front-month (EUR/MWh)
+}
+
+
+def _store_symbol(db, db_symbol: str, ticker: str) -> int:
+    """Fetch one ticker's daily closes and upsert into EnergyPrice. Returns rows inserted."""
+    import pandas as pd
+
+    have_any = (
+        db.query(EnergyPrice).filter(EnergyPrice.symbol == db_symbol).first() is not None
+    )
+    period = "5d" if have_any else "max"
+    if not have_any:
+        logger.info("Energy prices: backfilling full history for %s (%s)", db_symbol, ticker)
+
+    hist = yf.download(ticker, period=period, progress=False, auto_adjust=True)
+    if hist.empty:
+        logger.warning("Energy prices: %s (%s) returned empty data", db_symbol, ticker)
+        return 0
+    if isinstance(hist.columns, pd.MultiIndex):
+        hist.columns = hist.columns.get_level_values(0)
+
+    closes = hist["Close"].dropna()
+    inserted = 0
+    for idx, value in closes.items():
+        date_str = idx.strftime("%Y-%m-%d") if hasattr(idx, "strftime") else str(idx)[:10]
+        close = round(float(value), 4)
+        existing = (
+            db.query(EnergyPrice)
+            .filter(EnergyPrice.date == date_str, EnergyPrice.symbol == db_symbol)
+            .first()
+        )
+        if existing:
+            existing.close = close
+        else:
+            db.add(EnergyPrice(date=date_str, symbol=db_symbol, close=close))
+            inserted += 1
+    return inserted
+
+
+def _fetch_and_store():
+    """Sync entry: fetch every configured symbol and upsert."""
+    db = SessionLocal()
+    try:
+        total_new = 0
+        for db_symbol, ticker in SYMBOLS.items():
+            try:
+                total_new += _store_symbol(db, db_symbol, ticker)
+            except Exception as e:  # one bad ticker must not abort the rest
+                logger.error("Energy prices: %s failed: %s", db_symbol, e)
+        db.commit()
+        total = db.query(EnergyPrice).count()
+        logger.info("Energy prices: inserted %d new rows (total: %d)", total_new, total)
+    except Exception as e:
+        db.rollback()
+        logger.error("Energy price collection failed: %s", e)
+    finally:
+        db.close()
+
+
+async def collect_energy_prices():
+    """Async entry point for the scheduler."""
+    import asyncio
+
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(_executor, _fetch_and_store)

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -27,6 +27,7 @@ from backend.analytics.supply_demand import compute_supply_demand
 from backend.analytics.tonne_miles import compute_tonne_miles
 from backend.analytics.validation.scorecards import recompute_scorecards_job
 from backend.collectors.crack_spreads import collect_crack_spreads
+from backend.collectors.energy_prices import collect_energy_prices
 from backend.collectors.eia import collect_eia
 from backend.collectors.equities import collect_equities
 from backend.collectors.finnhub_news import collect_finnhub_news
@@ -299,6 +300,14 @@ def start_scheduler():
         collect_crack_spreads,
         CronTrigger(hour=22, minute=0),
         id="crack_spreads_daily",
+        **JOB_DEFAULTS,
+    )
+
+    # Energy prices (TTF, later EUA/power): daily 22:15 UTC
+    scheduler.add_job(
+        collect_energy_prices,
+        CronTrigger(hour=22, minute=15),
+        id="energy_prices_daily",
         **JOB_DEFAULTS,
     )
 

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -27,8 +27,8 @@ from backend.analytics.supply_demand import compute_supply_demand
 from backend.analytics.tonne_miles import compute_tonne_miles
 from backend.analytics.validation.scorecards import recompute_scorecards_job
 from backend.collectors.crack_spreads import collect_crack_spreads
-from backend.collectors.energy_prices import collect_energy_prices
 from backend.collectors.eia import collect_eia
+from backend.collectors.energy_prices import collect_energy_prices
 from backend.collectors.equities import collect_equities
 from backend.collectors.finnhub_news import collect_finnhub_news
 from backend.collectors.firms import collect_firms

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -1,0 +1,27 @@
+"""Energy price + spread models.
+
+`EnergyPrice` is a generic daily close store keyed by `(date, symbol)`. It is
+the shared substrate for the energy vertical: TTF (gas), later EUA (carbon) and
+electricity day-ahead prices. The signal-validation scorecard reads it as the
+forward-return target for gas-side signals (TTF), the same way it reads FRED
+for Brent.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class EnergyPrice(Base):
+    __tablename__ = "energy_prices"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    date: Mapped[str] = mapped_column(String, nullable=False, index=True)  # YYYY-MM-DD
+    symbol: Mapped[str] = mapped_column(String, nullable=False, index=True)  # e.g. "TTF", "EUA", "POWER_DE"
+    close: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (UniqueConstraint("date", "symbol", name="uq_energy_price_date_symbol"),)

--- a/backend/tests/test_energy_prices.py
+++ b/backend/tests/test_energy_prices.py
@@ -1,0 +1,42 @@
+"""Energy price collector — exercise the upsert path with yfinance mocked."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from backend.collectors import energy_prices
+from backend.models.energy import EnergyPrice
+
+
+def _frame(rows):
+    """rows: list[(date_str, close)] -> a yfinance-style DataFrame."""
+    idx = pd.to_datetime([d for d, _ in rows])
+    return pd.DataFrame({"Close": [c for _, c in rows]}, index=idx)
+
+
+def test_store_symbol_inserts_then_upserts_idempotently(db_session, monkeypatch):
+    monkeypatch.setattr(
+        energy_prices.yf,
+        "download",
+        lambda *a, **k: _frame([("2024-01-02", 30.0), ("2024-01-03", 31.5)]),
+    )
+
+    # First run: both dates inserted.
+    n1 = energy_prices._store_symbol(db_session, "TTF", "TTF=F")
+    db_session.commit()
+    assert n1 == 2
+    assert db_session.query(EnergyPrice).filter_by(symbol="TTF").count() == 2
+
+    # Second run: same dates -> no new rows (update in place), still 2.
+    n2 = energy_prices._store_symbol(db_session, "TTF", "TTF=F")
+    db_session.commit()
+    assert n2 == 0
+    assert db_session.query(EnergyPrice).filter_by(symbol="TTF").count() == 2
+    row = db_session.query(EnergyPrice).filter_by(date="2024-01-02", symbol="TTF").first()
+    assert row.close == 30.0
+
+
+def test_store_symbol_handles_empty(db_session, monkeypatch):
+    monkeypatch.setattr(energy_prices.yf, "download", lambda *a, **k: pd.DataFrame())
+    assert energy_prices._store_symbol(db_session, "TTF", "TTF=F") == 0
+    assert db_session.query(EnergyPrice).count() == 0

--- a/backend/tests/test_validation_scorecards.py
+++ b/backend/tests/test_validation_scorecards.py
@@ -11,6 +11,8 @@ from fastapi.testclient import TestClient
 from backend.analytics.validation import scorecards
 from backend.main import app
 from backend.models.analytics import DisruptionScoreHistory
+from backend.models.energy import EnergyPrice
+from backend.models.gas import GasBalance
 from backend.models.prices import FREDSeries
 from backend.models.validation import SignalScorecard
 
@@ -115,3 +117,43 @@ def test_scorecards_api_empty_is_graceful(client, db_session):
 def test_disruption_weights_api_requires_pro(client, db_session):
     resp = client.get("/api/validation/disruption-weights")
     assert resp.status_code == 401
+
+
+def _seed_gas(db, n_days=80, seed=7):
+    """Plant a gas residual z_score that predicts the 7d-forward TTF move, plus a
+    matching EnergyPrice TTF series. GasBalance has no created_at + date is PK."""
+    rng = np.random.default_rng(seed)
+    start = date(2026, 1, 1)
+    z = rng.uniform(-2, 2, size=n_days)
+    price = [40.0]
+    for i in range(1, n_days + 12):
+        drift = 0.5 * z[i - 7] if 0 <= i - 7 < n_days else 0.0
+        price.append(price[-1] + drift + rng.normal(scale=0.3))
+    for i in range(n_days):
+        d = (start + timedelta(days=i)).strftime("%Y-%m-%d")
+        db.add(GasBalance(date=d, z_score=float(z[i]), residual=float(z[i]), residual_7d=float(z[i])))
+    for i in range(n_days + 12):
+        d = (start + timedelta(days=i)).strftime("%Y-%m-%d")
+        db.add(EnergyPrice(date=d, symbol="TTF", close=float(price[i])))
+    db.commit()
+
+
+def test_gas_residual_loads_without_created_at(db_session):
+    # GasBalance lacks created_at and date is the PK (one row/day) — the loader
+    # must read it directly rather than ordering by created_at.
+    _seed_gas(db_session, n_days=40)
+    dates, values = scorecards.load_signal_series(db_session, "GasBalance", "z_score")
+    assert len(dates) == 40 and len(values) == 40
+
+
+def test_gas_residual_scores_against_ttf_not_brent(db_session):
+    # Seed gas + TTF but NO FRED Brent. gas_residual must still score (uses the
+    # per-target TTF map); the planted z->TTF relationship is significant.
+    _seed_gas(db_session)
+    cards = scorecards.recompute_scorecards(db_session, as_of="2026-06-11")
+    gas = [c for c in cards if c["signal"] == "gas_residual"]
+    assert {c["horizon_days"] for c in gas} == set(scorecards.HORIZONS)
+    card_7d = next(c for c in gas if c["horizon_days"] == 7)
+    assert card_7d["n"] >= 30 and card_7d["confident"] == 1  # scored despite no Brent
+    # Planted z->TTF relationship is positive → IC has the right sign.
+    assert card_7d["ic"] is not None and card_7d["ic"] > 0

--- a/frontend/src/components/GasBalancePanel.jsx
+++ b/frontend/src/components/GasBalancePanel.jsx
@@ -6,6 +6,7 @@ import {
   XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
 import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import TrackRecordBadge from './TrackRecordBadge'
 
 const API = '/api'
 
@@ -132,6 +133,7 @@ export default function GasBalancePanel() {
           </div>
         </>
       )}
+      <TrackRecordBadge signal="gas_residual" targetLabel="TTF" />
     </Panel>
   )
 }

--- a/frontend/src/components/TrackRecordBadge.jsx
+++ b/frontend/src/components/TrackRecordBadge.jsx
@@ -5,10 +5,11 @@ const API = '/api'
 
 // Honest-by-design: this never shows a green "edge" unless the forward-return
 // relationship is statistically significant. Sufficient data with no signal
-// reads as "no measured edge", not a win.
-const METHOD =
-  'Track record: rank correlation (IC) between this signal and the forward ' +
-  'Brent return, with Newey-West HAC significance for overlapping windows. ' +
+// reads as "no measured edge", not a win. `targetLabel` names the forward-return
+// target (Brent for oil/maritime signals, TTF for the gas residual).
+const method = (targetLabel) =>
+  `Track record: rank correlation (IC) between this signal and the forward ` +
+  `${targetLabel} return, with Newey-West HAC significance for overlapping windows. ` +
   '"No measured edge" means enough data but not statistically significant ' +
   '(p > 0.05). Single-regime sample — informational, not a forecast.'
 
@@ -17,7 +18,7 @@ const METHOD =
  * Reads /api/validation/scorecards (shared SWR cache, fetched once) and renders
  * the card for `signal` at `horizon`. Renders nothing until scorecards exist.
  */
-export default function TrackRecordBadge({ signal, horizon = 7 }) {
+export default function TrackRecordBadge({ signal, horizon = 7, targetLabel = 'Brent' }) {
   const { data } = useFetchWithError(`${API}/validation/scorecards`)
   if (!data?.available) return null
 
@@ -48,7 +49,7 @@ export default function TrackRecordBadge({ signal, horizon = 7 }) {
   return (
     <div className="px-4 py-1.5 border-t border-border/30 flex items-center gap-1.5">
       <span className={`font-mono text-[9px] px-1.5 py-0.5 rounded border ${tone}`}>{label}</span>
-      <InfoPopover text={METHOD} />
+      <InfoPopover text={method(targetLabel)} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Gives the EU gas residual a real, honest track record (Roadmap-Schritt 2).

- **0B — TTF daily series:** new `EnergyPrice(date, symbol, close)` table + `energy_prices` collector (yfinance `TTF=F` daily closes, upsert) + daily scheduler job. Shared substrate for the track record *and* the upcoming spark spread. Backfilled locally: 2179 rows (2017→now).
- **0C — Gas residual scored against TTF:** the scorecard layer is now **target-aware** (`SIGNAL_SPECS` 4-tuple, per-signal forward-return target). The gas residual predicts European gas, so it is scored against TTF — not Brent. `load_signal_series` generalized to resolve models across the analytics+gas modules and handle tables without `created_at` (GasBalance is one-row-per-day, `date` is PK). `TrackRecordBadge` parameterized with a `targetLabel` and added to `GasBalancePanel` (`signal="gas_residual" targetLabel="TTF"`). The 3 existing Brent signals are unchanged.

**Measured result on real local data:** gas residual vs forward TTF → **IC −0.17 at 7d, p=0.001, n=1226** (significant, negative — oversupplied storage = bearish forward gas). Honest by construction: shows "building n/30" until n≥30, "no measured edge" when not significant.

## Test Plan
- [x] `pytest`: 189 passed (incl. new tests: no-`created_at` load + TTF-target scoring + idempotency)
- [x] Frontend `npm run build` clean; `TrackRecordBadge`/`GasBalancePanel` eslint-clean
- [ ] After merge + a weekly scorecard run in prod: `gas_residual` appears in `/api/validation/scorecards`; badge renders on the GAS tab balance hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)