### PR TITLE
feat: ENERGY tab — day-ahead power price + spark spread (Gas→Energy bridge)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 > (Abschnitt „Build-Stand") ist zum Datum unten verifiziert und veraltet schneller — bei Konflikt
 > gewinnt der Code.
 >
-> **Stand: 2026-06-24** · Gas-Vertikal-UI (PR #14) + ENTSO-E/GIE-Keys lokal eingebaut + Backfill 2023→heute
+> **Stand: 2026-06-24** · Gas-UI (PR #14) + Gas-Track-Record/TTF (PR #15) + ENERGY-Tab/Spark-Spread (PR #16); Keys lokal, Prod-Deploy offen
 
 ---
 
@@ -132,11 +132,24 @@ product"*). Seit 2026-06-24 (PR #14): **GAS-Tab im Frontend** — Pro-Residual-H
 Gating: **Rohdaten frei, Residual Pro**. ENTSO-E-Token + GIE-Key sind **lokal eingebaut &
 validiert**, voller Backfill 2023→heute gelaufen → Power-Burn/Demand/Balance laufen **real,
 nicht mehr PRELIMINARY** (`/api/gas/*` liefert ~121 Zeilen @ days=120). ⚠️ **Prod-Caveat:**
-beide Keys müssen noch in die Prod-`.env` auf dem VPS + dort ein Backfill, sonst ist das
-Vertikal in Production leer.
+beide Keys (ENTSO-E + GIE) müssen noch in die Prod-`.env` auf dem VPS + dort ein Backfill,
+sonst sind Gas **und** Energy in Production leer.
 
-**Fehlt komplett:** Exposure-Mapping (Signal→Ticker→Richtung), CO₂/EU-ETS (0 Treffer im Code),
-Spark/Dark-Spread, Merit-Order, gas→power→CO₂-Synthese, Cross-Commodity-Fusion (Öl- und
+**Gas-Track-Record (PR #15):** der Gas-Residual ist im Validierungs-Scorecard, **gegen TTF**
+gescort (nicht Brent — der Scorecard ist jetzt target-aware, `SIGNAL_SPECS` 4-Tupel). Neue
+tägliche **TTF-Preisserie** (`EnergyPrice` + `energy_prices`-Collector, yfinance `TTF=F`).
+`TrackRecordBadge` am Balance-Hero. Gemessen: IC −0,17 @ 7d, p=0,001, n=1226 (signifikant).
+
+**ENERGY-Vertikal — erste Slice live (PR #16, Gas→Energy-Brücke):** neues `backend/power/`
+mit ENTSO-E **A44 Day-Ahead-Strompreis** (DE-LU) → `EnergyPrice(POWER_DE)`; **Spark-Spread**
+(`spark = power − gas·heat_rate`, heat_rate=1/`gas_ccgt_efficiency`) in `SparkSpreadHistory`;
+`/api/power/{day-ahead(frei),spark-spread(Pro)}`; **ENERGY-Tab** (PowerDayAhead frei +
+SparkSpread Pro). **Clean-Spark (− CO₂) zurückgestellt** — kein verlässlicher EUA-Ticker;
+`co2_price`/`clean_spark_spread`-Spalten existieren, bleiben leer.
+
+**Fehlt komplett:** Exposure-Mapping (Signal→Ticker→Richtung), CO₂/EU-ETS (kein EUA-Feed),
+Dark/Clean-Spread, Merit-Order/Residuallast/Dunkelflaute, Strom-Last/Generation-Mix,
+gas→power→CO₂-Synthese, Cross-Commodity-Fusion (Öl- und
 Gas-Vertikal siliert; Gas-Residual **nicht** in den Scorecards → kein Track Record fürs
 Gas-Vertikal), Metalle/Kupfer/Solar als Analytik-Knoten (nur Preis-Quotes).
 
@@ -154,14 +167,16 @@ Gas-Vertikal), Metalle/Kupfer/Solar als Analytik-Knoten (nur Preis-Quotes).
 1. ~~**Gas-Vertikal sichtbar machen**~~ — **erledigt 2026-06-24 (PR #14):** GAS-Tab mit
    Residual-Hero + freien Treiber-Panels; ENTSO-E-Token + GIE-Key live (lokal), Backfill
    2023→heute. Rest-Aufgabe: Keys + Backfill in **Prod** (siehe Build-Stand-Caveat).
-2. **Gas-Residual in die Validierungs-Schicht** — `SIGNAL_SPECS` (`backend/analytics/validation/
-   scorecards.py:31`) um das Gas-Signal erweitern → Track Record + `TrackRecordBadge` auf dem
-   Balance-Panel. **← nächster Schritt.**
-3. **Exposure-Mapping v1** (Premium-Kern) — strukturierte Signal→Ticker→Richtung-Tabelle statt
-   statischer Liste + Prosa; als Hypothese durch die bestehende Validierungs-Schicht laufen
-   lassen, **bevor** sie als Edge verkauft wird. Erst dann Preis-Diskussion 20–30 €.
-4. **Danach** neue Knoten — CO₂/EU-ETS (vervollständigt die gas→power→CO₂-Kette), Metall/Kupfer,
-   Solar; jeder als fokussierter Zusatz, Engine wiederverwendet.
+2. ~~**Gas-Residual in die Validierungs-Schicht**~~ — **erledigt (PR #15):** target-aware
+   Scorecard, Gas-Residual gegen TTF, `TrackRecordBadge` am Balance-Panel.
+3. ~~**Gas→Energy erste Slice (Spark-Spread)**~~ — **erledigt (PR #16):** ENERGY-Tab,
+   Strompreis (A44) + Spark-Spread. **Energy-Fortsetzung (Phase 2, ← nächster Schritt):**
+   Strom-Last (A65) + Generation-Mix (A75) → Residuallast/Merit-Order/Dunkelflaute/Negativpreise;
+   EUA/Clean-Spark + Dark-Spread; Energy-Signale in den Track-Record; gas→power→CO₂-Synthese.
+4. **Exposure-Mapping v1** (Premium-Kern) — strukturierte Signal→Ticker→Richtung-Tabelle statt
+   statischer Liste + Prosa; als Hypothese durch die Validierungs-Schicht, **bevor** als Edge
+   verkauft. Erst dann Preis-Diskussion 20–30 €.
+5. **Danach** weitere Rohstoff-Knoten — Metall/Kupfer, Solar; jeder als fokussierter Zusatz.
 
 ---
 

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -29,7 +29,6 @@ from backend.analytics.validation.scorecards import recompute_scorecards_job
 from backend.collectors.crack_spreads import collect_crack_spreads
 from backend.collectors.eia import collect_eia
 from backend.collectors.energy_prices import collect_energy_prices
-from backend.collectors.spark_spreads import collect_spark_spreads
 from backend.collectors.equities import collect_equities
 from backend.collectors.finnhub_news import collect_finnhub_news
 from backend.collectors.firms import collect_firms
@@ -42,6 +41,7 @@ from backend.collectors.noaa import collect_noaa_alerts
 from backend.collectors.portwatch import collect_portwatch
 from backend.collectors.portwatch_store import fetch_chokepoint_data, store_chokepoint_data
 from backend.collectors.retention import run_retention
+from backend.collectors.spark_spreads import collect_spark_spreads
 from backend.collectors.sts_collector import collect_sts_events
 from backend.database import SessionLocal
 from backend.notifications.alert_runner import process_alert_rules

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -29,6 +29,7 @@ from backend.analytics.validation.scorecards import recompute_scorecards_job
 from backend.collectors.crack_spreads import collect_crack_spreads
 from backend.collectors.eia import collect_eia
 from backend.collectors.energy_prices import collect_energy_prices
+from backend.collectors.spark_spreads import collect_spark_spreads
 from backend.collectors.equities import collect_equities
 from backend.collectors.finnhub_news import collect_finnhub_news
 from backend.collectors.firms import collect_firms
@@ -136,6 +137,43 @@ async def _run_gas_daily():
         logger.info("gas daily: refreshed %s..%s + recomputed demand/balance", days[0], days[-1])
     except Exception as e:
         logger.error("gas daily failed: %s", e)
+    finally:
+        db.close()
+
+
+def _power_recent_days(n: int = 7) -> list[str]:
+    """The last n days ending yesterday for ENTSO-E A44 ingestion."""
+    from datetime import datetime, timedelta, timezone
+
+    end = datetime.now(timezone.utc).date() - timedelta(days=1)
+    return [(end - timedelta(days=i)).isoformat() for i in range(n)][::-1]
+
+
+async def _run_power_daily():
+    """Daily electricity + spark spread refresh.
+
+    (a) Ingest ENTSO-E A44 day-ahead prices for the last 7 days into
+        EnergyPrice(symbol="POWER_DE") — re-fetches to catch any revisions.
+    (b) Recompute SparkSpreadHistory for all aligned POWER_DE + TTF dates.
+    """
+    from backend.power.entsoe_prices import ingest_day_ahead
+
+    db = SessionLocal()
+    try:
+        days = _power_recent_days(7)
+        try:
+            result = await ingest_day_ahead(db, days, overwrite=True)
+            logger.info("power daily ingest: %s", result)
+        except Exception as exc:
+            logger.error("power daily ingest_day_ahead failed: %s", exc)
+
+        try:
+            result = await collect_spark_spreads()
+            logger.info("power daily spark spreads: %s", result)
+        except Exception as exc:
+            logger.error("power daily collect_spark_spreads failed: %s", exc)
+    except Exception as exc:
+        logger.error("_run_power_daily outer failed: %s", exc)
     finally:
         db.close()
 
@@ -469,6 +507,16 @@ def start_scheduler():
         _run_gas_registry_weekly,
         CronTrigger(day_of_week="mon", hour=3, minute=30),
         id="gas_registry_weekly",
+        **JOB_DEFAULTS,
+    )
+
+    # Power day-ahead + spark spread: daily 22:30 UTC.
+    # (a) Ingest ENTSO-E A44 for DE-LU last 7 days into POWER_DE.
+    # (b) Recompute SparkSpreadHistory for all aligned POWER_DE + TTF dates.
+    scheduler.add_job(
+        _run_power_daily,
+        CronTrigger(hour=22, minute=30),
+        id="power_spark_daily",
         **JOB_DEFAULTS,
     )
 

--- a/backend/collectors/spark_spreads.py
+++ b/backend/collectors/spark_spreads.py
@@ -1,0 +1,130 @@
+"""Spark spread collector — daily EUR/MWh margin for gas-fired power generation.
+
+Computes the clean (CO₂-free) spark spread:
+    spark_spread = power_price − gas_price × heat_rate
+where:
+    power_price — EnergyPrice symbol POWER_DE (daily mean EUR/MWh, ENTSO-E A44)
+    gas_price   — EnergyPrice symbol TTF (daily close EUR/MWh, yfinance)
+    heat_rate   — 1 / settings.gas_ccgt_efficiency  (default: 1/0.50 = 2.0 MWh_gas/MWh_el)
+
+CO₂ / clean-spark spread is deferred: `co2_price` and `clean_spark_spread` are
+always stored as None until a reliable EUA ticker is confirmed.
+
+One idempotent upsert per calendar day: if both POWER_DE and TTF have a row for
+the same date, a SparkSpreadHistory row is created or updated.  Dates where either
+price is missing are silently skipped (inner-join semantics).
+
+Scheduled as part of `_run_power_daily` in backend/collectors/scheduler.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.database import SessionLocal
+from backend.models.energy import EnergyPrice, SparkSpreadHistory
+
+logger = logging.getLogger(__name__)
+
+
+def _compute_and_upsert(db: Session) -> dict:
+    """Inner sync function: align POWER_DE + TTF on date, compute spread, upsert.
+
+    Returns {"computed": n, "written": n} where `written` counts new rows and
+    updated rows combined.
+    """
+    heat_rate = 1.0 / settings.gas_ccgt_efficiency
+
+    # Pull both price series as dicts keyed by date string
+    power_rows = (
+        db.query(EnergyPrice)
+        .filter(EnergyPrice.symbol == "POWER_DE")
+        .all()
+    )
+    ttf_rows = (
+        db.query(EnergyPrice)
+        .filter(EnergyPrice.symbol == "TTF")
+        .all()
+    )
+
+    power_by_date: dict[str, float] = {r.date: r.close for r in power_rows}
+    ttf_by_date: dict[str, float] = {r.date: r.close for r in ttf_rows}
+
+    # Inner join: only dates where both prices exist
+    common_dates = sorted(set(power_by_date) & set(ttf_by_date))
+
+    if not common_dates:
+        logger.info("spark_spreads: no overlapping POWER_DE/TTF dates — nothing to compute")
+        return {"computed": 0, "written": 0}
+
+    written = 0
+    for date_str in common_dates:
+        power_price = power_by_date[date_str]
+        gas_price = ttf_by_date[date_str]
+        spark = round(power_price - gas_price * heat_rate, 4)
+
+        existing = (
+            db.query(SparkSpreadHistory)
+            .filter(SparkSpreadHistory.date == date_str)
+            .first()
+        )
+        if existing:
+            # Update only if something changed (prices may be revised)
+            if (
+                existing.power_price != power_price
+                or existing.gas_price != gas_price
+                or existing.heat_rate != heat_rate
+                or existing.spark_spread != spark
+            ):
+                existing.power_price = power_price
+                existing.gas_price = gas_price
+                existing.heat_rate = heat_rate
+                existing.spark_spread = spark
+                written += 1
+        else:
+            db.add(
+                SparkSpreadHistory(
+                    date=date_str,
+                    power_price=power_price,
+                    gas_price=gas_price,
+                    heat_rate=heat_rate,
+                    spark_spread=spark,
+                    co2_price=None,          # deferred
+                    clean_spark_spread=None,  # deferred
+                )
+            )
+            written += 1
+
+    db.commit()
+
+    total = db.query(SparkSpreadHistory).count()
+    logger.info(
+        "spark_spreads: %d common dates, %d rows written (total: %d, heat_rate=%.4f)",
+        len(common_dates),
+        written,
+        total,
+        heat_rate,
+    )
+    return {"computed": len(common_dates), "written": written}
+
+
+async def collect_spark_spreads() -> dict:
+    """Async entry point for the scheduler and one-off backfill calls.
+
+    Opens its own DB session so it can be awaited directly from a coroutine
+    or from `_run_power_daily` in the scheduler.
+    """
+    db = SessionLocal()
+    try:
+        result = _compute_and_upsert(db)
+        return result
+    except Exception as exc:
+        db.rollback()
+        logger.error("spark_spreads: collection failed: %s", exc)
+        raise
+    finally:
+        db.close()

--- a/backend/collectors/spark_spreads.py
+++ b/backend/collectors/spark_spreads.py
@@ -20,7 +20,6 @@ Scheduled as part of `_run_power_daily` in backend/collectors/scheduler.py.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,7 @@ from backend.routes import auth as auth_routes
 from backend.routes import briefing as briefing_routes
 from backend.routes import email as email_routes
 from backend.routes import gas as gas_routes
+from backend.routes import power as power_routes
 from backend.routes import jodi as jodi_routes
 from backend.routes import portwatch as portwatch_routes
 from backend.routes import settings as settings_routes
@@ -211,3 +212,4 @@ app.include_router(voyages.router)
 app.include_router(analytics_routes.router)
 app.include_router(validation_routes.router)
 app.include_router(gas_routes.router)
+app.include_router(power_routes.router)

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,9 +28,9 @@ from backend.routes import auth as auth_routes
 from backend.routes import briefing as briefing_routes
 from backend.routes import email as email_routes
 from backend.routes import gas as gas_routes
-from backend.routes import power as power_routes
 from backend.routes import jodi as jodi_routes
 from backend.routes import portwatch as portwatch_routes
+from backend.routes import power as power_routes
 from backend.routes import settings as settings_routes
 from backend.routes import signals as signals_routes
 from backend.routes import thermal as thermal_routes

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -5,9 +5,16 @@ the shared substrate for the energy vertical: TTF (gas), later EUA (carbon) and
 electricity day-ahead prices. The signal-validation scorecard reads it as the
 forward-return target for gas-side signals (TTF), the same way it reads FRED
 for Brent.
+
+`SparkSpreadHistory` stores the daily clean-gas-power generation margin:
+  spark_spread = power_price − gas_price × heat_rate
+where heat_rate = 1 / CCGT_efficiency (default 2.0 for 50% fleet efficiency).
+CO₂/clean-spark columns exist but are nullable and unpopulated — EUA ticker
+is deferred until a reliable free source is confirmed.
 """
 
 from datetime import datetime
+from typing import Optional
 
 from sqlalchemy import DateTime, Float, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
@@ -25,3 +32,27 @@ class EnergyPrice(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     __table_args__ = (UniqueConstraint("date", "symbol", name="uq_energy_price_date_symbol"),)
+
+
+class SparkSpreadHistory(Base):
+    """Daily spark spread: power − gas × heat_rate (EUR/MWh).
+
+    One row per calendar day, computed from EnergyPrice POWER_DE (day-ahead
+    electricity) and TTF (Dutch gas front-month). heat_rate = 1 / CCGT_efficiency.
+
+    CO₂/clean-spark columns are reserved for when EUA data becomes reliably
+    available; they are always NULL until then.
+    """
+
+    __tablename__ = "spark_spread_history"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    date: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)  # YYYY-MM-DD
+    power_price: Mapped[float] = mapped_column(Float, nullable=False)   # EUR/MWh (POWER_DE)
+    gas_price: Mapped[float] = mapped_column(Float, nullable=False)     # EUR/MWh (TTF)
+    heat_rate: Mapped[float] = mapped_column(Float, nullable=False)     # MWh_gas / MWh_el  (1/efficiency)
+    spark_spread: Mapped[float] = mapped_column(Float, nullable=False)  # EUR/MWh  (power − gas × heat_rate)
+    # CO₂ / clean-spark — deferred (EUA ticker TBD)
+    co2_price: Mapped[Optional[float]] = mapped_column(Float, nullable=True)          # EUR/tCO₂
+    clean_spark_spread: Mapped[Optional[float]] = mapped_column(Float, nullable=True) # EUR/MWh
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/power/entsoe_prices.py
+++ b/backend/power/entsoe_prices.py
@@ -1,0 +1,191 @@
+"""ENTSO-E day-ahead electricity prices: A44 → daily mean EUR/MWh per bidding zone.
+
+Fetches documentType A44 (Day-Ahead Prices) for a bidding zone via the ENTSO-E
+Transparency Platform RESTful API (XML), parses each PT60M Point's <price.amount>
+(EUR/MWh), buckets hourly values to UTC calendar days, and stores the daily mean
+into EnergyPrice(symbol="POWER_DE").
+
+The key difference from the A75/power-burn parser:
+  - Tag name: `price.amount`  (not `quantity`)
+  - No unit conversion: values are already EUR/MWh (not MW → MWh)
+  - Aggregation: MEAN of hourly prices (not SUM of energy quantities)
+  - No psrType filter (A44 documents don't carry psrType)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta, timezone
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.gas import raw_cache
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
+
+import xml.etree.ElementTree as ET
+
+from backend.models.energy import EnergyPrice
+
+logger = logging.getLogger(__name__)
+
+# German-Luxembourg bidding zone EIC code (lead zone for the energy vertical)
+DE_LU_EIC = "10Y1001A1001A82H"
+POWER_DE_SYMBOL = "POWER_DE"
+
+_RESOLUTION_HOURS = {"PT60M": 1.0, "PT30M": 0.5, "PT15M": 0.25}
+
+
+# ─── parse ───────────────────────────────────────────────────────────────────
+
+
+def parse_day_ahead_prices(xml_text: str) -> dict[str, float]:
+    """Parse an A44 Publication_MarketDocument into {YYYY-MM-DD: mean_eur_per_mwh}.
+
+    Walks TimeSeries → Period → Point, reads <price.amount> (EUR/MWh), buckets
+    each hourly value to its UTC calendar day, and returns the daily MEAN.
+
+    Namespace-agnostic (matches local tag names only).  Differs from
+    parse_generation() in three ways:
+      1. Reads `price.amount` instead of `quantity`.
+      2. No psrType filter (A44 has no generation-type classification).
+      3. Returns MEAN over hourly prices, not SUM of energies.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A44 XML parse error: {exc}") from exc
+
+    # Collect raw hourly prices per UTC day: {day: [price, ...]}
+    by_day: dict[str, list[float]] = {}
+
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            start_el = next((e for e in period.iter() if _localname(e.tag) == "start"), None)
+            res_el = next((e for e in period.iter() if _localname(e.tag) == "resolution"), None)
+            if start_el is None or res_el is None:
+                continue
+            start = _parse_utc(start_el.text)
+            res_hours = _RESOLUTION_HOURS.get((res_el.text or "").strip())
+            if start is None or res_hours is None:
+                continue
+            for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+                pos = next((e.text for e in point if _localname(e.tag) == "position"), None)
+                # A44 uses <price.amount>, NOT <quantity>
+                price_str = next((e.text for e in point if _localname(e.tag) == "price.amount"), None)
+                if pos is None or price_str is None:
+                    continue
+                try:
+                    ts_time = start + timedelta(hours=res_hours * (int(pos) - 1))
+                    price = float(price_str)
+                except (ValueError, TypeError):
+                    continue
+                day = ts_time.astimezone(timezone.utc).strftime("%Y-%m-%d")
+                by_day.setdefault(day, []).append(price)
+
+    # Daily mean of all hourly prices (in-day hours, not across days)
+    return {day: sum(prices) / len(prices) for day, prices in by_day.items() if prices}
+
+
+# ─── fetch ────────────────────────────────────────────────────────────────────
+
+
+async def _fetch_zone_month(eic: str, month_start: date, *, overwrite: bool = False) -> str:
+    """Fetch one zone's A44 day-ahead prices for a month (raw XML, cached)."""
+    nxt = (month_start.replace(day=28) + timedelta(days=4)).replace(day=1)
+    period_start = f"{month_start:%Y%m%d}0000"
+    period_end = f"{nxt:%Y%m%d}0000"
+
+    async def _do() -> dict:
+        async with httpx.AsyncClient(timeout=90) as client:
+            resp = await client.get(
+                ENTSOE_BASE,
+                params={
+                    "securityToken": _token(),
+                    "documentType": "A44",
+                    "in_Domain": eic,
+                    "out_Domain": eic,
+                    "periodStart": period_start,
+                    "periodEnd": period_end,
+                },
+            )
+            resp.raise_for_status()
+            return {"xml": resp.text}
+
+    payload = await raw_cache.fetch_or_cache(
+        "entsoe_prices", f"{eic}_{month_start:%Y-%m}", month_start, _do, overwrite=overwrite
+    )
+    return payload.get("xml", "")
+
+
+# ─── ingest ───────────────────────────────────────────────────────────────────
+
+
+async def ingest_day_ahead(
+    db: Session,
+    days: list[str],
+    *,
+    eic: str = DE_LU_EIC,
+    symbol: str = POWER_DE_SYMBOL,
+    overwrite: bool = False,
+) -> dict:
+    """Fetch A44 day-ahead prices for the month(s) spanning `days`, parse, and
+    upsert daily means into EnergyPrice(symbol=symbol).
+
+    Returns {"days": n, "written": n} on success, or {"skipped": "no token"}
+    if ENTSOE_API_TOKEN is not configured.
+    """
+    if not days:
+        return {"days": 0, "written": 0}
+    if not settings.entsoe_api_token:
+        logger.warning(
+            "entsoe_prices.ingest_day_ahead: ENTSOE_API_TOKEN not set — skipping"
+        )
+        return {"skipped": "no token"}
+
+    wanted = set(days)
+    # Determine the unique months needed
+    months = sorted(
+        {datetime.strptime(d, "%Y-%m-%d").date().replace(day=1) for d in days}
+    )
+
+    prices_by_day: dict[str, float] = {}
+    for month_start in months:
+        try:
+            xml = await _fetch_zone_month(eic, month_start, overwrite=overwrite)
+        except httpx.HTTPError as exc:
+            logger.warning("entsoe_prices: %s fetch failed: %s", month_start, exc)
+            continue
+        if not xml:
+            continue
+        for day, mean_price in parse_day_ahead_prices(xml).items():
+            if day in wanted:
+                prices_by_day[day] = mean_price
+
+    written = 0
+    for day, mean_price in prices_by_day.items():
+        _upsert(db, day, symbol, mean_price)
+        written += 1
+    db.commit()
+    logger.info(
+        "entsoe_prices.ingest_day_ahead: %d/%d days written (symbol=%s)",
+        written,
+        len(days),
+        symbol,
+    )
+    return {"days": len(days), "written": written}
+
+
+def _upsert(db: Session, day: str, symbol: str, close: float) -> None:
+    existing = (
+        db.query(EnergyPrice)
+        .filter(EnergyPrice.date == day, EnergyPrice.symbol == symbol)
+        .first()
+    )
+    if existing:
+        existing.close = close
+    else:
+        db.add(EnergyPrice(date=day, symbol=symbol, close=close))

--- a/backend/power/entsoe_prices.py
+++ b/backend/power/entsoe_prices.py
@@ -15,6 +15,7 @@ The key difference from the A75/power-burn parser:
 from __future__ import annotations
 
 import logging
+import xml.etree.ElementTree as ET
 from datetime import date, datetime, timedelta, timezone
 
 import httpx
@@ -23,9 +24,6 @@ from sqlalchemy.orm import Session
 from backend.config import settings
 from backend.gas import raw_cache
 from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
-
-import xml.etree.ElementTree as ET
-
 from backend.models.energy import EnergyPrice
 
 logger = logging.getLogger(__name__)

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1,0 +1,125 @@
+"""Electricity + spark spread read endpoints.
+
+GET /api/power/day-ahead?days=120  — FREE
+    ENTSO-E A44 daily mean EUR/MWh series for DE-LU bidding zone.
+    Returns EnergyPrice(symbol="POWER_DE") rows, newest first, then reversed.
+
+GET /api/power/spark-spread?days=120  — PRO
+    Historical spark spread (power − gas × heat_rate).
+    Returns SparkSpreadHistory rows with a `latest` summary object.
+
+Both endpoints follow the `{"available": bool, "data": [...]}` envelope used
+throughout the gas vertical (see backend/routes/gas.py).
+"""
+
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from backend.auth.dependencies import require_pro
+from backend.database import get_db
+from backend.models.energy import EnergyPrice, SparkSpreadHistory
+
+router = APIRouter(prefix="/api/power", tags=["power"])
+
+
+def _window(days: int) -> tuple[str, str]:
+    """Return (start_iso, end_iso) for the last `days` calendar days (UTC)."""
+    end = datetime.utcnow().date()
+    start = end - timedelta(days=days)
+    return start.isoformat(), end.isoformat()
+
+
+# ─── Day-ahead prices (free) ──────────────────────────────────────────────────
+
+
+@router.get("/day-ahead")
+async def get_day_ahead(
+    days: int = Query(120, ge=1, le=1500),
+    db: Session = Depends(get_db),
+):
+    """ENTSO-E day-ahead electricity prices for DE-LU (EUR/MWh). Free tier."""
+    date_from, date_to = _window(days)
+    rows = (
+        db.query(EnergyPrice)
+        .filter(
+            EnergyPrice.symbol == "POWER_DE",
+            EnergyPrice.date >= date_from,
+            EnergyPrice.date <= date_to,
+        )
+        .order_by(EnergyPrice.date.asc())
+        .all()
+    )
+    if not rows:
+        return {
+            "available": False,
+            "reason": "no POWER_DE data yet — run power backfill (ingest_day_ahead)",
+        }
+    return {
+        "available": True,
+        "symbol": "POWER_DE",
+        "unit": "EUR/MWh",
+        "from": date_from,
+        "to": date_to,
+        "data": [{"date": r.date, "close": r.close} for r in rows],
+    }
+
+
+# ─── Spark spread (Pro) ───────────────────────────────────────────────────────
+
+
+@router.get("/spark-spread")
+async def get_spark_spread(
+    days: int = Query(120, ge=7, le=1500),
+    db: Session = Depends(get_db),
+    _user=Depends(require_pro),
+):
+    """Spark spread history (power − gas × heat_rate, EUR/MWh). Pro only.
+
+    `latest` contains the most recent row for dashboard widgets.
+    `data` is the full window sorted ascending for charting.
+    CO₂ and clean-spark fields are included in the schema but will be null
+    until EUA data ingestion is implemented.
+    """
+    date_from, date_to = _window(days)
+    rows = (
+        db.query(SparkSpreadHistory)
+        .filter(
+            SparkSpreadHistory.date >= date_from,
+            SparkSpreadHistory.date <= date_to,
+        )
+        .order_by(SparkSpreadHistory.date.asc())
+        .all()
+    )
+    if not rows:
+        return {
+            "available": False,
+            "reason": (
+                "no spark spread data yet — "
+                "ingest POWER_DE via ingest_day_ahead, then run collect_spark_spreads"
+            ),
+        }
+
+    def _row_dict(r: SparkSpreadHistory) -> dict:
+        return {
+            "date": r.date,
+            "power_price": r.power_price,
+            "gas_price": r.gas_price,
+            "heat_rate": r.heat_rate,
+            "spark_spread": r.spark_spread,
+            "co2_price": r.co2_price,
+            "clean_spark_spread": r.clean_spark_spread,
+        }
+
+    latest = _row_dict(rows[-1])
+    return {
+        "available": True,
+        "unit": "EUR/MWh",
+        "heat_rate_note": "1 / CCGT_efficiency; default efficiency = 0.50",
+        "co2_note": "co2_price and clean_spark_spread are deferred (EUA ticker TBD)",
+        "latest": latest,
+        "from": date_from,
+        "to": date_to,
+        "data": [_row_dict(r) for r in rows],
+    }

--- a/backend/tests/test_power_prices.py
+++ b/backend/tests/test_power_prices.py
@@ -1,0 +1,208 @@
+"""ENTSO-E A44 day-ahead price parser tests — no network.
+
+Tests the parse_day_ahead_prices() function against minimal hand-crafted XML
+that mirrors the real A44 schema (Publication_MarketDocument), and exercises
+the ingest_day_ahead() upsert path with a mocked fetch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.power.entsoe_prices import parse_day_ahead_prices
+from backend.models.energy import EnergyPrice
+
+
+# ─── XML helpers ─────────────────────────────────────────────────────────────
+
+_NS = "urn:iec62325.351:tc57wg16:451-6:publicationdocument:7:0"
+
+
+def _a44(ts_blocks: str, ns: str = _NS) -> str:
+    return (
+        f'<?xml version="1.0"?>'
+        f'<Publication_MarketDocument xmlns="{ns}">'
+        f"<type>A44</type>"
+        f"{ts_blocks}"
+        f"</Publication_MarketDocument>"
+    )
+
+
+def _ts(start: str, end: str, prices: list[float], res: str = "PT60M") -> str:
+    """Build a single TimeSeries/Period block with the given hourly prices."""
+    pts = "".join(
+        f"<Point><position>{i + 1}</position><price.amount>{p}</price.amount></Point>"
+        for i, p in enumerate(prices)
+    )
+    return (
+        f"<TimeSeries>"
+        f"<Period>"
+        f"<timeInterval><start>{start}</start><end>{end}</end></timeInterval>"
+        f"<resolution>{res}</resolution>"
+        f"{pts}"
+        f"</Period>"
+        f"</TimeSeries>"
+    )
+
+
+# ─── parse tests ─────────────────────────────────────────────────────────────
+
+
+def test_parse_single_day_exact_mean():
+    """24 identical hourly prices → daily mean equals that price."""
+    prices = [50.0] * 24
+    xml = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", prices))
+    result = parse_day_ahead_prices(xml)
+    assert result == {"2026-05-01": 50.0}
+
+
+def test_parse_single_day_varying_prices():
+    """Daily mean of [40, 60] over 2 hours = 50.0."""
+    prices = [40.0, 60.0]
+    xml = _a44(_ts("2026-05-01T00:00Z", "2026-05-01T02:00Z", prices))
+    result = parse_day_ahead_prices(xml)
+    assert result == {"2026-05-01": 50.0}
+
+
+def test_parse_two_days_separate():
+    """Two separate Period blocks on consecutive days → two dict entries."""
+    xml = _a44(
+        _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [100.0] * 24)
+        + _ts("2026-05-02T00:00Z", "2026-05-03T00:00Z", [200.0] * 24)
+    )
+    result = parse_day_ahead_prices(xml)
+    assert result == {"2026-05-01": 100.0, "2026-05-02": 200.0}
+
+
+def test_parse_two_days_in_one_period():
+    """A 48-hour Period spanning two days; hours bucket to UTC day correctly."""
+    # 24 hours at 30 EUR + 24 hours at 70 EUR → two days with distinct means
+    prices = [30.0] * 24 + [70.0] * 24
+    xml = _a44(_ts("2026-05-01T00:00Z", "2026-05-03T00:00Z", prices))
+    result = parse_day_ahead_prices(xml)
+    assert result == {"2026-05-01": 30.0, "2026-05-02": 70.0}
+
+
+def test_parse_no_price_amount_returns_empty():
+    """A Point that uses <quantity> (A75-style) instead of <price.amount> is skipped."""
+    xml = _a44(
+        f"<TimeSeries><Period>"
+        f"<timeInterval><start>2026-05-01T00:00Z</start><end>2026-05-02T00:00Z</end></timeInterval>"
+        f"<resolution>PT60M</resolution>"
+        f"<Point><position>1</position><quantity>5000</quantity></Point>"
+        f"</Period></TimeSeries>"
+    )
+    result = parse_day_ahead_prices(xml)
+    assert result == {}
+
+
+def test_parse_half_hourly_resolution():
+    """PT30M: 48 half-hour slots of 80 EUR → mean = 80.0."""
+    prices = [80.0] * 48
+    xml = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", prices, res="PT30M"))
+    result = parse_day_ahead_prices(xml)
+    assert result == {"2026-05-01": 80.0}
+
+
+def test_parse_malformed_xml_raises():
+    with pytest.raises(ValueError):
+        parse_day_ahead_prices("<not-xml")
+
+
+def test_parse_empty_document():
+    xml = _a44("")
+    assert parse_day_ahead_prices(xml) == {}
+
+
+def test_parse_namespace_agnostic():
+    """Parser must work even with a different (or no) XML namespace."""
+    prices = [55.5] * 24
+    xml = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", prices), ns="some:other:ns")
+    result = parse_day_ahead_prices(xml)
+    assert result == {"2026-05-01": 55.5}
+
+
+# ─── ingest tests ─────────────────────────────────────────────────────────────
+
+
+async def test_ingest_upserts_daily_mean(db_session, monkeypatch):
+    """ingest_day_ahead writes a POWER_DE row for each requested day."""
+    from backend.power import entsoe_prices
+    from pydantic import SecretStr
+
+    prices = [100.0] * 24
+    xml = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", prices))
+
+    async def fake_fetch(eic, month_start, *, overwrite=False):
+        return xml
+
+    monkeypatch.setattr(entsoe_prices, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(entsoe_prices.settings, "entsoe_api_token", SecretStr("tok"))
+
+    result = await entsoe_prices.ingest_day_ahead(db_session, ["2026-05-01"])
+    assert result == {"days": 1, "written": 1}
+
+    row = (
+        db_session.query(EnergyPrice)
+        .filter_by(date="2026-05-01", symbol="POWER_DE")
+        .first()
+    )
+    assert row is not None
+    assert row.close == 100.0
+
+
+async def test_ingest_skips_when_no_token(db_session, monkeypatch):
+    from backend.power import entsoe_prices
+
+    monkeypatch.setattr(entsoe_prices.settings, "entsoe_api_token", None)
+    result = await entsoe_prices.ingest_day_ahead(db_session, ["2026-05-01"])
+    assert result == {"skipped": "no token"}
+    assert db_session.query(EnergyPrice).count() == 0
+
+
+async def test_ingest_idempotent_upsert(db_session, monkeypatch):
+    """Running ingest twice doesn't duplicate rows; close is updated."""
+    from backend.power import entsoe_prices
+    from pydantic import SecretStr
+
+    xml_v1 = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [100.0] * 24))
+    xml_v2 = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [120.0] * 24))
+    fetch_results = [xml_v1, xml_v2]
+
+    call_count = {"n": 0}
+
+    async def fake_fetch(eic, month_start, *, overwrite=False):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        return fetch_results[min(idx, len(fetch_results) - 1)]
+
+    monkeypatch.setattr(entsoe_prices, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(entsoe_prices.settings, "entsoe_api_token", SecretStr("tok"))
+
+    await entsoe_prices.ingest_day_ahead(db_session, ["2026-05-01"])
+    await entsoe_prices.ingest_day_ahead(db_session, ["2026-05-01"], overwrite=True)
+
+    rows = db_session.query(EnergyPrice).filter_by(symbol="POWER_DE").all()
+    assert len(rows) == 1
+    assert rows[0].close == 120.0
+
+
+async def test_ingest_filters_to_requested_days(db_session, monkeypatch):
+    """Days outside `days` list are not written even if present in the XML."""
+    from backend.power import entsoe_prices
+    from pydantic import SecretStr
+
+    xml = _a44(
+        _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [100.0] * 24)
+        + _ts("2026-05-02T00:00Z", "2026-05-03T00:00Z", [200.0] * 24)
+    )
+
+    async def fake_fetch(eic, month_start, *, overwrite=False):
+        return xml
+
+    monkeypatch.setattr(entsoe_prices, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(entsoe_prices.settings, "entsoe_api_token", SecretStr("tok"))
+
+    result = await entsoe_prices.ingest_day_ahead(db_session, ["2026-05-01"])
+    assert result == {"days": 1, "written": 1}
+    assert db_session.query(EnergyPrice).filter_by(date="2026-05-02").first() is None

--- a/backend/tests/test_power_prices.py
+++ b/backend/tests/test_power_prices.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 import pytest
 
-from backend.power.entsoe_prices import parse_day_ahead_prices
 from backend.models.energy import EnergyPrice
-
+from backend.power.entsoe_prices import parse_day_ahead_prices
 
 # ─── XML helpers ─────────────────────────────────────────────────────────────
 
@@ -86,11 +85,11 @@ def test_parse_two_days_in_one_period():
 def test_parse_no_price_amount_returns_empty():
     """A Point that uses <quantity> (A75-style) instead of <price.amount> is skipped."""
     xml = _a44(
-        f"<TimeSeries><Period>"
-        f"<timeInterval><start>2026-05-01T00:00Z</start><end>2026-05-02T00:00Z</end></timeInterval>"
-        f"<resolution>PT60M</resolution>"
-        f"<Point><position>1</position><quantity>5000</quantity></Point>"
-        f"</Period></TimeSeries>"
+        "<TimeSeries><Period>"
+        "<timeInterval><start>2026-05-01T00:00Z</start><end>2026-05-02T00:00Z</end></timeInterval>"
+        "<resolution>PT60M</resolution>"
+        "<Point><position>1</position><quantity>5000</quantity></Point>"
+        "</Period></TimeSeries>"
     )
     result = parse_day_ahead_prices(xml)
     assert result == {}
@@ -127,8 +126,9 @@ def test_parse_namespace_agnostic():
 
 async def test_ingest_upserts_daily_mean(db_session, monkeypatch):
     """ingest_day_ahead writes a POWER_DE row for each requested day."""
-    from backend.power import entsoe_prices
     from pydantic import SecretStr
+
+    from backend.power import entsoe_prices
 
     prices = [100.0] * 24
     xml = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", prices))
@@ -162,8 +162,9 @@ async def test_ingest_skips_when_no_token(db_session, monkeypatch):
 
 async def test_ingest_idempotent_upsert(db_session, monkeypatch):
     """Running ingest twice doesn't duplicate rows; close is updated."""
-    from backend.power import entsoe_prices
     from pydantic import SecretStr
+
+    from backend.power import entsoe_prices
 
     xml_v1 = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [100.0] * 24))
     xml_v2 = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [120.0] * 24))
@@ -189,8 +190,9 @@ async def test_ingest_idempotent_upsert(db_session, monkeypatch):
 
 async def test_ingest_filters_to_requested_days(db_session, monkeypatch):
     """Days outside `days` list are not written even if present in the XML."""
-    from backend.power import entsoe_prices
     from pydantic import SecretStr
+
+    from backend.power import entsoe_prices
 
     xml = _a44(
         _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [100.0] * 24)

--- a/backend/tests/test_spark_spreads.py
+++ b/backend/tests/test_spark_spreads.py
@@ -15,7 +15,6 @@ import pytest
 
 from backend.models.energy import EnergyPrice, SparkSpreadHistory
 
-
 # ─── helpers ─────────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_spark_spreads.py
+++ b/backend/tests/test_spark_spreads.py
@@ -1,0 +1,192 @@
+"""Spark spread collector tests — no network, no ENTSO-E token required.
+
+Seeds EnergyPrice rows directly into the in-memory DB, runs the collector's
+compute+upsert logic, and verifies:
+  - spark_spread == power − gas / efficiency  (formula correctness)
+  - inner-join semantics (missing-price dates are skipped)
+  - idempotent upsert (second run doesn't duplicate rows)
+  - heat_rate respects settings.gas_ccgt_efficiency
+  - co2_price and clean_spark_spread are always None (deferred)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.models.energy import EnergyPrice, SparkSpreadHistory
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _seed(db, symbol: str, rows: list[tuple[str, float]]) -> None:
+    """Insert EnergyPrice rows for the given symbol."""
+    for date_str, close in rows:
+        db.add(EnergyPrice(date=date_str, symbol=symbol, close=close))
+    db.commit()
+
+
+def _run_compute(db):
+    """Run the sync inner compute function directly (avoids async overhead)."""
+    from backend.collectors.spark_spreads import _compute_and_upsert
+
+    return _compute_and_upsert(db)
+
+
+# ─── tests ────────────────────────────────────────────────────────────────────
+
+
+def test_spark_formula_default_efficiency(db_session, monkeypatch):
+    """spark_spread = power − gas × (1/0.50) = power − 2 × gas."""
+    from backend.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "gas_ccgt_efficiency", 0.50)
+
+    power, gas = 80.0, 30.0
+    _seed(db_session, "POWER_DE", [("2025-01-10", power)])
+    _seed(db_session, "TTF", [("2025-01-10", gas)])
+
+    result = _run_compute(db_session)
+    assert result["computed"] == 1
+    assert result["written"] == 1
+
+    row = db_session.query(SparkSpreadHistory).filter_by(date="2025-01-10").first()
+    assert row is not None
+    expected = round(power - gas * (1.0 / 0.50), 4)
+    assert row.spark_spread == pytest.approx(expected)
+    assert row.power_price == power
+    assert row.gas_price == gas
+    assert row.heat_rate == pytest.approx(2.0)
+
+
+def test_spark_formula_custom_efficiency(db_session, monkeypatch):
+    """heat_rate = 1 / 0.60 ≈ 1.667 with custom efficiency."""
+    from backend.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "gas_ccgt_efficiency", 0.60)
+
+    power, gas = 100.0, 40.0
+    _seed(db_session, "POWER_DE", [("2025-02-01", power)])
+    _seed(db_session, "TTF", [("2025-02-01", gas)])
+
+    _run_compute(db_session)
+
+    row = db_session.query(SparkSpreadHistory).filter_by(date="2025-02-01").first()
+    assert row is not None
+    expected_heat_rate = 1.0 / 0.60
+    expected_spark = round(power - gas * expected_heat_rate, 4)
+    assert row.spark_spread == pytest.approx(expected_spark, rel=1e-5)
+    assert row.heat_rate == pytest.approx(expected_heat_rate, rel=1e-5)
+
+
+def test_inner_join_skips_missing_dates(db_session, monkeypatch):
+    """Dates with only one price (no matching counterpart) are skipped."""
+    from backend.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "gas_ccgt_efficiency", 0.50)
+
+    _seed(db_session, "POWER_DE", [
+        ("2025-03-01", 90.0),
+        ("2025-03-03", 95.0),  # no TTF on 03-03
+    ])
+    _seed(db_session, "TTF", [
+        ("2025-03-01", 35.0),
+        ("2025-03-02", 36.0),  # no POWER_DE on 03-02
+    ])
+
+    result = _run_compute(db_session)
+    assert result["computed"] == 1  # only 2025-03-01 aligns
+
+    rows = db_session.query(SparkSpreadHistory).all()
+    assert len(rows) == 1
+    assert rows[0].date == "2025-03-01"
+
+
+def test_idempotent_upsert_no_duplicate(db_session, monkeypatch):
+    """Running compute twice yields exactly 1 row, not 2."""
+    from backend.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "gas_ccgt_efficiency", 0.50)
+
+    _seed(db_session, "POWER_DE", [("2025-04-05", 70.0)])
+    _seed(db_session, "TTF", [("2025-04-05", 25.0)])
+
+    _run_compute(db_session)
+    _run_compute(db_session)
+
+    assert db_session.query(SparkSpreadHistory).count() == 1
+
+
+def test_upsert_updates_on_price_revision(db_session, monkeypatch):
+    """If the underlying price changes (provisional→confirmed), the spread is revised."""
+    from backend.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "gas_ccgt_efficiency", 0.50)
+
+    _seed(db_session, "POWER_DE", [("2025-05-10", 80.0)])
+    _seed(db_session, "TTF", [("2025-05-10", 30.0)])
+
+    _run_compute(db_session)
+
+    # Simulate price revision
+    power_row = (
+        db_session.query(EnergyPrice)
+        .filter_by(date="2025-05-10", symbol="POWER_DE")
+        .first()
+    )
+    power_row.close = 85.0
+    db_session.commit()
+
+    result2 = _run_compute(db_session)
+    assert result2["written"] == 1  # updated
+
+    row = db_session.query(SparkSpreadHistory).filter_by(date="2025-05-10").first()
+    assert row.power_price == 85.0
+    expected = round(85.0 - 30.0 * 2.0, 4)
+    assert row.spark_spread == pytest.approx(expected)
+
+
+def test_co2_columns_are_null(db_session, monkeypatch):
+    """co2_price and clean_spark_spread are always None (deferred)."""
+    from backend.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "gas_ccgt_efficiency", 0.50)
+
+    _seed(db_session, "POWER_DE", [("2025-06-01", 75.0)])
+    _seed(db_session, "TTF", [("2025-06-01", 28.0)])
+
+    _run_compute(db_session)
+
+    row = db_session.query(SparkSpreadHistory).filter_by(date="2025-06-01").first()
+    assert row.co2_price is None
+    assert row.clean_spark_spread is None
+
+
+def test_no_data_returns_zero_counts(db_session):
+    """With no EnergyPrice rows, compute returns computed=0, written=0."""
+    result = _run_compute(db_session)
+    assert result == {"computed": 0, "written": 0}
+
+
+def test_multiple_dates(db_session, monkeypatch):
+    """Multiple aligned dates all get their own row."""
+    from backend.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "gas_ccgt_efficiency", 0.50)
+
+    dates = ["2025-07-01", "2025-07-02", "2025-07-03"]
+    power_prices = [80.0, 85.0, 90.0]
+    gas_prices = [30.0, 32.0, 31.0]
+
+    _seed(db_session, "POWER_DE", list(zip(dates, power_prices)))
+    _seed(db_session, "TTF", list(zip(dates, gas_prices)))
+
+    result = _run_compute(db_session)
+    assert result["computed"] == 3
+    assert result["written"] == 3
+
+    rows = {r.date: r for r in db_session.query(SparkSpreadHistory).all()}
+    for date_str, p, g in zip(dates, power_prices, gas_prices):
+        assert date_str in rows
+        expected = round(p - g * 2.0, 4)
+        assert rows[date_str].spark_spread == pytest.approx(expected)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -35,6 +35,8 @@ import GasBalancePanel from './components/GasBalancePanel'
 import GasStoragePanel from './components/GasStoragePanel'
 import GasSupplyPanel from './components/GasSupplyPanel'
 import GasDemandPanel from './components/GasDemandPanel'
+import PowerDayAheadPanel from './components/PowerDayAheadPanel'
+import SparkSpreadPanel from './components/SparkSpreadPanel'
 import Landing from './components/Landing'
 import { useAuth } from './context/AuthContext'
 
@@ -45,6 +47,7 @@ const TABS = [
   { key: 'market', label: 'MARKET' },
   { key: 'signals', label: 'SIGNALS' },
   { key: 'gas', label: 'GAS' },
+  { key: 'energy', label: 'ENERGY' },
   { key: 'sentiment', label: 'SENTIMENT' },
   { key: 'alerts', label: 'ALERTS' },
 ]
@@ -498,6 +501,25 @@ function Dashboard() {
               </ErrorBoundary>
               <ErrorBoundary name="gas-demand">
                 <GasDemandPanel />
+              </ErrorBoundary>
+            </div>
+          </>
+        )}
+
+        {/* ENERGY TAB */}
+        {activeTab === 'energy' && (
+          <>
+            {/* Row 1: Spark Spread hero (Pro) */}
+            <ErrorBoundary name="power-spark">
+              <ProGate feature="Spark Spread">
+                <SparkSpreadPanel />
+              </ProGate>
+            </ErrorBoundary>
+
+            {/* Row 2: Day-Ahead price (free) */}
+            <div className="mt-3">
+              <ErrorBoundary name="power-dayahead">
+                <PowerDayAheadPanel />
               </ErrorBoundary>
             </div>
           </>

--- a/frontend/src/components/PowerDayAheadPanel.jsx
+++ b/frontend/src/components/PowerDayAheadPanel.jsx
@@ -1,0 +1,96 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import {
+  ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
+} from 'recharts'
+import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+export default function PowerDayAheadPanel() {
+  const { data, loading, error } = useFetchWithError(`${API}/power/day-ahead?days=120`)
+
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">POWER DAY-AHEAD // FETCH ERROR</div>
+      </div>
+    )
+  if (!data?.available && !loading) return null
+
+  const rows = data?.data ?? []
+  const latest = rows[rows.length - 1]
+  const close = latest?.close
+
+  return (
+    <Panel
+      id="power-day-ahead"
+      title="POWER DAY-AHEAD · DE-LU"
+      info="ENTSO-E day-ahead electricity prices for the DE-LU bidding zone (EUR/MWh). Each point is the daily mean of 24 hourly auction results from the ENTSO-E Transparency Platform (A44). Free, official redistributable data."
+      collapsible
+      headerRight={
+        close != null && (
+          <span className="font-mono text-[10px] text-cyan-glow font-bold">
+            {close.toFixed(1)} €/MWh
+          </span>
+        )
+      }
+    >
+      {loading && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Loading power prices…
+        </div>
+      )}
+      {!loading && data?.available && latest && (
+        <>
+          <div className="px-4 py-3 border-b border-border/30">
+            <div className="flex items-baseline gap-3">
+              <span className="font-mono text-3xl font-bold text-cyan-glow">
+                {close?.toFixed(1)}
+              </span>
+              <span className="font-mono text-[10px] text-neutral-600">EUR/MWh</span>
+              <span className="font-mono text-[10px] text-neutral-600">{latest.date}</span>
+            </div>
+            <div className="font-mono text-[10px] text-neutral-600 mt-1">
+              ENTSO-E A44 · DE-LU bidding zone · daily mean of hourly prices
+            </div>
+          </div>
+          {rows.length > 1 && (
+            <div className="px-2 py-2">
+              <ResponsiveContainer width="100%" height={70}>
+                <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tickFormatter={fmtDate}
+                    interval="preserveStartEnd"
+                    minTickGap={60}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                    width={30}
+                  />
+                  <Tooltip
+                    contentStyle={CHART_TOOLTIP_STYLE}
+                    formatter={(v) => [`${Number(v).toFixed(1)} €/MWh`, 'Day-Ahead']}
+                    labelFormatter={fmtDate}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="close"
+                    stroke="#22d3ee"
+                    fill="#22d3ee"
+                    fillOpacity={0.06}
+                    strokeWidth={1.5}
+                    dot={false}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/SparkSpreadPanel.jsx
+++ b/frontend/src/components/SparkSpreadPanel.jsx
@@ -10,13 +10,17 @@ const API = '/api'
 export default function SparkSpreadPanel() {
   const { data, loading, error } = useFetchWithError(`${API}/power/spark-spread?days=120`)
 
-  if (error)
+  // This panel is Pro-gated at the call site (ProGate). The route is also
+  // require_pro, so an anon/free fetch returns 401/403 — treat that as "not
+  // available" (ProGate shows its upgrade overlay) rather than a red error box.
+  const authError = !!error && (error.includes('401') || error.includes('403'))
+  if (error && !authError)
     return (
       <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
         <div className="font-mono text-[10px] text-red-400">SPARK SPREAD // FETCH ERROR</div>
       </div>
     )
-  if (!data?.available && !loading) return null
+  if (authError || (!data?.available && !loading)) return null
 
   const rows = data?.data ?? []
   const latest = data?.latest

--- a/frontend/src/components/SparkSpreadPanel.jsx
+++ b/frontend/src/components/SparkSpreadPanel.jsx
@@ -1,0 +1,126 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import {
+  ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
+} from 'recharts'
+import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+export default function SparkSpreadPanel() {
+  const { data, loading, error } = useFetchWithError(`${API}/power/spark-spread?days=120`)
+
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">SPARK SPREAD // FETCH ERROR</div>
+      </div>
+    )
+  if (!data?.available && !loading) return null
+
+  const rows = data?.data ?? []
+  const latest = data?.latest
+  const spread = latest?.spark_spread
+  const spreadColor = spread == null ? '#737373' : spread >= 0 ? '#4ade80' : '#fb923c'
+
+  return (
+    <Panel
+      id="spark-spread"
+      title="SPARK SPREAD · CCGT GENERATION MARGIN"
+      info="Spark spread = power − gas × heat-rate (CCGT generation margin). Measures the theoretical profitability of gas-fired power generation. Positive = burning gas to generate electricity is profitable. Clean spark (− CO₂ cost) coming once EUA data is wired."
+      collapsible
+      headerRight={
+        spread != null && (
+          <span className="font-mono text-[10px] font-bold" style={{ color: spreadColor }}>
+            {spread >= 0 ? '+' : ''}{spread.toFixed(1)} €/MWh
+          </span>
+        )
+      }
+    >
+      {loading && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Computing spark spread…
+        </div>
+      )}
+      {!loading && data?.available && latest && (
+        <>
+          <div className="px-4 py-3 border-b border-border/30">
+            <div className="flex items-baseline gap-3 flex-wrap">
+              <span className="font-mono text-3xl font-bold" style={{ color: spreadColor }}>
+                {spread == null
+                  ? '—'
+                  : `${spread >= 0 ? '+' : ''}${spread.toFixed(1)}`}
+              </span>
+              <span className="font-mono text-[10px] text-neutral-600">EUR/MWh spark spread</span>
+            </div>
+            <div className="flex items-center gap-4 mt-2 flex-wrap">
+              <div className="font-mono text-[10px] text-neutral-500">
+                <span className="text-neutral-600">POWER</span>{' '}
+                <span className="text-neutral-300">
+                  {latest.power_price != null ? `${latest.power_price.toFixed(1)} €/MWh` : '—'}
+                </span>
+              </div>
+              <div className="font-mono text-[10px] text-neutral-500">
+                <span className="text-neutral-600">GAS</span>{' '}
+                <span className="text-neutral-300">
+                  {latest.gas_price != null ? `${latest.gas_price.toFixed(2)} €/MWh` : '—'}
+                </span>
+              </div>
+              <div className="font-mono text-[10px] text-neutral-500">
+                <span className="text-neutral-600">HEAT-RATE</span>{' '}
+                <span className="text-neutral-300">
+                  {latest.heat_rate != null ? latest.heat_rate.toFixed(3) : '—'}
+                </span>
+              </div>
+            </div>
+            <div className="font-mono text-[10px] text-neutral-700 mt-1.5">
+              Clean spark (− CO₂) coming once EUA data is wired.
+            </div>
+          </div>
+          {rows.length > 1 && (
+            <div className="px-2 py-2">
+              <ResponsiveContainer width="100%" height={120}>
+                <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tickFormatter={fmtDate}
+                    interval="preserveStartEnd"
+                    minTickGap={60}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                    width={30}
+                  />
+                  <Tooltip
+                    contentStyle={CHART_TOOLTIP_STYLE}
+                    formatter={(v) => [
+                      `${Number(v) >= 0 ? '+' : ''}${Number(v).toFixed(1)} €/MWh`,
+                      'Spark Spread',
+                    ]}
+                    labelFormatter={fmtDate}
+                  />
+                  <ReferenceLine y={0} stroke="#444" />
+                  <Area
+                    type="monotone"
+                    dataKey="spark_spread"
+                    stroke="#4ade80"
+                    fill="#4ade80"
+                    fillOpacity={0.06}
+                    strokeWidth={1.5}
+                    dot={false}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+              <div className="flex items-center justify-center gap-4 mt-1 font-mono text-[8px] text-neutral-600">
+                <span style={{ color: '#4ade80' }}>▬ spark spread</span>
+                <span className="text-neutral-600">— zero line</span>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
## Summary
First slice of the Gas→Energy expansion: a new ENERGY tab bridging the gas vertical to electricity.

- **`backend/power/`** — ENTSO-E **A44 day-ahead price** (DE-LU) → `EnergyPrice(POWER_DE)`, reusing the gas `entsoe.py` plumbing (token, raw_cache, TimeSeries/Period/Point parser; A44 reads `price.amount`, daily mean).
- **Spark spread** — `spark = power − gas × heat_rate` (heat_rate = 1/`gas_ccgt_efficiency`) → `SparkSpreadHistory` + `collect_spark_spreads` collector + `_run_power_daily` scheduler job.
- **Routes** `/api/power/day-ahead` (free) + `/api/power/spark-spread` (Pro, `require_pro`).
- **Frontend ENERGY tab** — `PowerDayAheadPanel` (free) + `SparkSpreadPanel` (Pro), mirroring the GAS tab (free data + Pro synthesis).
- **Clean-spark (CO₂) deferred** — no reliable EUA ticker; `co2_price`/`clean_spark_spread` columns exist but stay null; UI doesn't render them.

## Test Plan
- [x] `ruff check backend/` clean; `pytest` 210 passed (13 A44 parser + 8 spark tests added)
- [x] frontend `npm run build` clean; new panels eslint-clean
- [x] Live smoke: `/api/power/day-ahead` 91 real DE-LU rows; `/spark-spread` 401 for anon (gate); spark verified 80.56 = 164.59 − 42.01×2.0
- [x] Final review: READY TO MERGE (anon-401 UX fix applied: ProGate overlay, not error box)
- [ ] After merge + prod backfill: ENERGY tab live on obsyd.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)