### PR TITLE
feat: residual load + Dunkelflaute (ENERGY Strom-Lagebild, Phase 2.1)

### DIFF
--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -56,3 +56,29 @@ class SparkSpreadHistory(Base):
     co2_price: Mapped[Optional[float]] = mapped_column(Float, nullable=True)          # EUR/tCO₂
     clean_spark_spread: Mapped[Optional[float]] = mapped_column(Float, nullable=True) # EUR/MWh
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class PowerGrid(Base):
+    """Daily-mean electricity grid metrics for residual-load analysis.
+
+    One row per (date, zone). load_mw, wind_mw, solar_mw are daily means
+    in MW (not totals); residual_load = load − wind − solar is derived on
+    read, never stored.
+
+    Sources:
+      load_mw  — ENTSO-E A65 (Actual Total Load), processType A16
+      wind_mw  — ENTSO-E A75 (Actual Generation), psrType B18+B19
+      solar_mw — ENTSO-E A75 (Actual Generation), psrType B16
+    """
+
+    __tablename__ = "power_grid"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    date: Mapped[str] = mapped_column(String, nullable=False, index=True)   # YYYY-MM-DD
+    zone: Mapped[str] = mapped_column(String, nullable=False, index=True)   # e.g. "DE_LU"
+    load_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)   # daily mean MW
+    wind_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)   # daily mean MW (B18+B19)
+    solar_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # daily mean MW (B16)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (UniqueConstraint("date", "zone", name="uq_power_grid_date_zone"),)

--- a/backend/power/entsoe_grid.py
+++ b/backend/power/entsoe_grid.py
@@ -1,0 +1,346 @@
+"""ENTSO-E electricity grid data: total load (A65) + generation mix (A75).
+
+Fetches per bidding zone for the DE-LU area (EIC 10Y1001A1001A82H):
+  A65 documentType → Actual Total Load → daily mean MW
+  A75 documentType → Actual Generation per Production Type → daily mean MW
+    B16 = Solar PV
+    B18 = Wind Offshore
+    B19 = Wind Onshore
+
+wind_mw = B18 + B19 (combined onshore + offshore)
+solar_mw = B16
+
+Residual load = load − wind − solar is DERIVED on read, not stored.
+
+Shares token / base URL / XML helpers with backend.gas.entsoe to avoid
+duplication. Caches raw XML under 'entsoe_load' and 'entsoe_genmix' keys in
+the raw_cache filesystem store.
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from datetime import date, datetime, timedelta, timezone
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.gas import raw_cache
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
+from backend.models.energy import PowerGrid
+
+logger = logging.getLogger(__name__)
+
+# German-Luxembourg bidding zone EIC code (same as entsoe_prices.py)
+DE_LU_EIC = "10Y1001A1001A82H"
+
+# psrType codes for renewable generation (A75)
+PSR_SOLAR = "B16"
+PSR_WIND_OFFSHORE = "B18"
+PSR_WIND_ONSHORE = "B19"
+
+_RESOLUTION_HOURS = {"PT60M": 1.0, "PT30M": 0.5, "PT15M": 0.25}
+
+
+# ─── parsers ─────────────────────────────────────────────────────────────────
+
+
+def parse_load(xml_text: str) -> dict[str, float]:
+    """Parse an A65 GL_MarketDocument into {YYYY-MM-DD: daily_mean_mw}.
+
+    Walks TimeSeries → Period → Point, reads <quantity> (MW), buckets each
+    hourly value to its UTC calendar day, and returns the daily MEAN in MW.
+
+    Namespace-agnostic (matches local tag names only). Unlike the gas B04
+    parser (which SUMS energy = MW × hours → GWh), here we collect raw MW
+    values and average them to get daily-mean load in MW.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A65 XML parse error: {exc}") from exc
+
+    by_day: dict[str, list[float]] = {}
+
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            start_el = next(
+                (e for e in period.iter() if _localname(e.tag) == "start"), None
+            )
+            res_el = next(
+                (e for e in period.iter() if _localname(e.tag) == "resolution"), None
+            )
+            if start_el is None or res_el is None:
+                continue
+            start = _parse_utc(start_el.text)
+            res_hours = _RESOLUTION_HOURS.get((res_el.text or "").strip())
+            if start is None or res_hours is None:
+                continue
+            for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+                pos = next(
+                    (e.text for e in point if _localname(e.tag) == "position"), None
+                )
+                qty = next(
+                    (e.text for e in point if _localname(e.tag) == "quantity"), None
+                )
+                if pos is None or qty is None:
+                    continue
+                try:
+                    ts_time = start + timedelta(hours=res_hours * (int(pos) - 1))
+                    mw = float(qty)
+                except (ValueError, TypeError):
+                    continue
+                day = ts_time.astimezone(timezone.utc).strftime("%Y-%m-%d")
+                by_day.setdefault(day, []).append(mw)
+
+    return {day: sum(vals) / len(vals) for day, vals in by_day.items() if vals}
+
+
+def parse_generation_by_type(xml_text: str) -> dict[str, dict[str, float]]:
+    """Parse an A75 GL_MarketDocument into {YYYY-MM-DD: {psrType: daily_mean_mw}}.
+
+    Walks every TimeSeries, reads its <psrType>, then walks its Periods/Points
+    collecting hourly MW quantities. Buckets per UTC day per psrType.
+    Returns the DAILY MEAN in MW for each psrType found.
+
+    Key differences from gas.entsoe.parse_generation (B04 parser):
+      1. Does NOT filter to a single psrType — collects ALL types present in
+         the XML and keys results by psrType string (B16, B18, B19, etc.).
+      2. Aggregation is MEAN (not SUM): load/renewable capacity is measured
+         in instantaneous MW, not energy volume.
+      3. Returns a nested dict {date: {psr: mean_mw}} instead of {date: gwh}.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A75 XML parse error: {exc}") from exc
+
+    # by_day[date][psr] = list[float]  (MW readings)
+    by_day: dict[str, dict[str, list[float]]] = {}
+
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        psr = next(
+            (e.text for e in ts.iter() if _localname(e.tag) == "psrType"), None
+        )
+        if psr is None:
+            continue
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            start_el = next(
+                (e for e in period.iter() if _localname(e.tag) == "start"), None
+            )
+            res_el = next(
+                (e for e in period.iter() if _localname(e.tag) == "resolution"), None
+            )
+            if start_el is None or res_el is None:
+                continue
+            start = _parse_utc(start_el.text)
+            res_hours = _RESOLUTION_HOURS.get((res_el.text or "").strip())
+            if start is None or res_hours is None:
+                continue
+            for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+                pos = next(
+                    (e.text for e in point if _localname(e.tag) == "position"), None
+                )
+                qty = next(
+                    (e.text for e in point if _localname(e.tag) == "quantity"), None
+                )
+                if pos is None or qty is None:
+                    continue
+                try:
+                    ts_time = start + timedelta(hours=res_hours * (int(pos) - 1))
+                    mw = float(qty)
+                except (ValueError, TypeError):
+                    continue
+                day = ts_time.astimezone(timezone.utc).strftime("%Y-%m-%d")
+                by_day.setdefault(day, {}).setdefault(psr, []).append(mw)
+
+    return {
+        day: {psr: sum(vals) / len(vals) for psr, vals in psr_map.items() if vals}
+        for day, psr_map in by_day.items()
+    }
+
+
+# ─── fetch ────────────────────────────────────────────────────────────────────
+
+
+async def _fetch_zone_month(
+    eic: str,
+    month_start: date,
+    doctype: str,
+    extra_params: dict,
+    *,
+    overwrite: bool = False,
+) -> str:
+    """Fetch one zone's XML for a calendar month (raw XML, cached).
+
+    `doctype` is "A65" or "A75"; `extra_params` carries doctype-specific
+    params (e.g. outBiddingZone_Domain for A65, processType for A75).
+    Cache keys are scoped by doctype so A65 and A75 don't collide.
+
+    Cache sources:
+      A65 → "entsoe_load"
+      A75 → "entsoe_genmix"
+    """
+    nxt = (month_start.replace(day=28) + timedelta(days=4)).replace(day=1)
+    period_start = f"{month_start:%Y%m%d}0000"
+    period_end = f"{nxt:%Y%m%d}0000"
+
+    cache_source = "entsoe_load" if doctype == "A65" else "entsoe_genmix"
+    cache_key = f"{eic}_{month_start:%Y-%m}"
+
+    async def _do() -> dict:
+        params = {
+            "securityToken": _token(),
+            "documentType": doctype,
+            "periodStart": period_start,
+            "periodEnd": period_end,
+        }
+        params.update(extra_params)
+        async with httpx.AsyncClient(timeout=90) as client:
+            resp = await client.get(ENTSOE_BASE, params=params)
+            resp.raise_for_status()
+            return {"xml": resp.text}
+
+    payload = await raw_cache.fetch_or_cache(
+        cache_source, cache_key, month_start, _do, overwrite=overwrite
+    )
+    return payload.get("xml", "")
+
+
+# ─── ingest ───────────────────────────────────────────────────────────────────
+
+
+async def ingest_grid(
+    db: Session,
+    days: list[str],
+    *,
+    eic: str = DE_LU_EIC,
+    zone: str = "DE_LU",
+    overwrite: bool = False,
+) -> dict:
+    """Fetch A65 (total load) + A75 (generation mix) for the month(s) spanning
+    `days`, compute per-day daily-mean MW for load / wind / solar, and upsert
+    into PowerGrid.
+
+    wind_mw = B18 (offshore) + B19 (onshore) combined daily mean.
+    solar_mw = B16 (solar PV) daily mean.
+
+    Returns {"days": n, "written": n} on success, or {"skipped": "no token"}
+    if ENTSOE_API_TOKEN is not configured.
+    """
+    if not days:
+        return {"days": 0, "written": 0}
+    if not settings.entsoe_api_token:
+        logger.warning("entsoe_grid.ingest_grid: ENTSOE_API_TOKEN not set — skipping")
+        return {"skipped": "no token"}
+
+    wanted = set(days)
+    months = sorted(
+        {datetime.strptime(d, "%Y-%m-%d").date().replace(day=1) for d in days}
+    )
+
+    # Accumulate per-day values across month fetches
+    load_by_day: dict[str, float] = {}
+    gen_by_day: dict[str, dict[str, float]] = {}  # date → {psr: mean_mw}
+
+    for month_start in months:
+        # ── A65 Total Load ──────────────────────────────────────────────────
+        try:
+            load_xml = await _fetch_zone_month(
+                eic,
+                month_start,
+                "A65",
+                {
+                    "processType": "A16",
+                    "outBiddingZone_Domain": eic,
+                },
+                overwrite=overwrite,
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("entsoe_grid: A65 %s fetch failed: %s", month_start, exc)
+            load_xml = ""
+
+        if load_xml:
+            for day, mean_mw in parse_load(load_xml).items():
+                if day in wanted:
+                    load_by_day[day] = mean_mw
+
+        # ── A75 Generation Mix ──────────────────────────────────────────────
+        try:
+            gen_xml = await _fetch_zone_month(
+                eic,
+                month_start,
+                "A75",
+                {
+                    "processType": "A16",
+                    "in_Domain": eic,
+                },
+                overwrite=overwrite,
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("entsoe_grid: A75 %s fetch failed: %s", month_start, exc)
+            gen_xml = ""
+
+        if gen_xml:
+            for day, psr_map in parse_generation_by_type(gen_xml).items():
+                if day in wanted:
+                    gen_by_day[day] = psr_map
+
+    # ── Upsert ─────────────────────────────────────────────────────────────
+    all_days = wanted & (load_by_day.keys() | gen_by_day.keys())
+    written = 0
+    for day in sorted(all_days):
+        psr_map = gen_by_day.get(day, {})
+        wind_mw = psr_map.get(PSR_WIND_OFFSHORE, 0.0) + psr_map.get(PSR_WIND_ONSHORE, 0.0)
+        solar_mw = psr_map.get(PSR_SOLAR, 0.0)
+        load_mw = load_by_day.get(day)
+
+        _upsert_grid(db, day, zone, load_mw, wind_mw or None, solar_mw or None)
+        written += 1
+
+    db.commit()
+    logger.info(
+        "entsoe_grid.ingest_grid: %d/%d days written (zone=%s)",
+        written,
+        len(days),
+        zone,
+    )
+    return {"days": len(days), "written": written}
+
+
+def _upsert_grid(
+    db: Session,
+    day: str,
+    zone: str,
+    load_mw: float | None,
+    wind_mw: float | None,
+    solar_mw: float | None,
+) -> None:
+    existing = (
+        db.query(PowerGrid)
+        .filter(PowerGrid.date == day, PowerGrid.zone == zone)
+        .first()
+    )
+    if existing:
+        if load_mw is not None:
+            existing.load_mw = load_mw
+        if wind_mw is not None:
+            existing.wind_mw = wind_mw
+        if solar_mw is not None:
+            existing.solar_mw = solar_mw
+    else:
+        db.add(
+            PowerGrid(
+                date=day,
+                zone=zone,
+                load_mw=load_mw,
+                wind_mw=wind_mw,
+                solar_mw=solar_mw,
+            )
+        )

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -8,7 +8,11 @@ GET /api/power/spark-spread?days=120  — PRO
     Historical spark spread (power − gas × heat_rate).
     Returns SparkSpreadHistory rows with a `latest` summary object.
 
-Both endpoints follow the `{"available": bool, "data": [...]}` envelope used
+GET /api/power/grid?days=120  — FREE
+    ENTSO-E A65 (load) + A75 (wind + solar) for DE-LU.
+    Returns PowerGrid rows with residual_mw, renewable_share, dunkelflaute flag.
+
+All endpoints follow the `{"available": bool, "data": [...]}` envelope used
 throughout the gas vertical (see backend/routes/gas.py).
 """
 
@@ -19,7 +23,7 @@ from sqlalchemy.orm import Session
 
 from backend.auth.dependencies import require_pro
 from backend.database import get_db
-from backend.models.energy import EnergyPrice, SparkSpreadHistory
+from backend.models.energy import EnergyPrice, PowerGrid, SparkSpreadHistory
 
 router = APIRouter(prefix="/api/power", tags=["power"])
 
@@ -122,4 +126,80 @@ async def get_spark_spread(
         "from": date_from,
         "to": date_to,
         "data": [_row_dict(r) for r in rows],
+    }
+
+
+# ─── Grid load + renewables (free) ───────────────────────────────────────────
+
+#: Renewable share threshold below which a day is flagged as Dunkelflaute.
+DUNKELFLAUTE_THRESHOLD = 0.15
+
+
+def _compute_grid_row(r: PowerGrid) -> dict:
+    """Derive residual_mw, renewable_share, and dunkelflaute flag for one row.
+
+    None wind_mw / solar_mw are treated as 0 (they can be stored None when
+    genuinely near-zero during ingest failures).
+    """
+    wind = r.wind_mw or 0.0
+    solar = r.solar_mw or 0.0
+    load = r.load_mw or 0.0
+
+    residual_mw = load - wind - solar
+    renewable_share = (wind + solar) / load if load > 0 else 0.0
+    dunkelflaute = renewable_share < DUNKELFLAUTE_THRESHOLD
+
+    return {
+        "date": r.date,
+        "load_mw": r.load_mw,
+        "wind_mw": r.wind_mw,
+        "solar_mw": r.solar_mw,
+        "residual_mw": round(residual_mw, 2),
+        "renewable_share": round(renewable_share, 4),
+        "dunkelflaute": dunkelflaute,
+    }
+
+
+@router.get("/grid")
+async def get_grid(
+    days: int = Query(120, ge=1, le=1500),
+    db: Session = Depends(get_db),
+):
+    """ENTSO-E grid load + wind + solar for DE-LU (daily mean MW). Free tier.
+
+    Returns residual_mw (load − wind − solar), renewable_share, and a
+    Dunkelflaute flag (renewable_share < 15%) per day.  `latest` contains
+    the most recent row; `dunkelflaute_days` is the count within the window.
+    """
+    date_from, date_to = _window(days)
+    rows = (
+        db.query(PowerGrid)
+        .filter(
+            PowerGrid.zone == "DE_LU",
+            PowerGrid.date >= date_from,
+            PowerGrid.date <= date_to,
+        )
+        .order_by(PowerGrid.date.asc())
+        .all()
+    )
+    if not rows:
+        return {
+            "available": False,
+            "reason": "no grid data yet — run power grid backfill (ingest_grid)",
+        }
+
+    data = [_compute_grid_row(r) for r in rows]
+    latest = data[-1]
+    dunkelflaute_days = sum(1 for d in data if d["dunkelflaute"])
+
+    return {
+        "available": True,
+        "zone": "DE_LU",
+        "unit": "MW",
+        "threshold_note": f"dunkelflaute = renewable_share < {DUNKELFLAUTE_THRESHOLD:.0%}",
+        "latest": latest,
+        "dunkelflaute_days": dunkelflaute_days,
+        "from": date_from,
+        "to": date_to,
+        "data": data,
     }

--- a/backend/tests/test_power_grid.py
+++ b/backend/tests/test_power_grid.py
@@ -1,0 +1,259 @@
+"""ENTSO-E grid load + generation mix: parse + ingest tests."""
+from __future__ import annotations
+
+import backend.power.entsoe_grid as grid_mod
+from backend.models.energy import PowerGrid
+
+
+def test_power_grid_model_importable():
+    """Smoke-test: model class exists with the expected columns."""
+    cols = {c.name for c in PowerGrid.__table__.columns}
+    assert {"date", "zone", "load_mw", "wind_mw", "solar_mw", "created_at"} <= cols
+
+
+# ── A65 XML helpers ───────────────────────────────────────────────────────────
+
+
+def _a65(
+    ts_blocks: str,
+    ns: str = "urn:iec62325.351:tc57wg16:451-6:generationloaddocument:3:0",
+) -> str:
+    return (
+        f'<?xml version="1.0"?>'
+        f'<GL_MarketDocument xmlns="{ns}"><type>A65</type>'
+        f"{ts_blocks}"
+        f"</GL_MarketDocument>"
+    )
+
+
+def _load_ts(start: str, mw_per_hour: float, n: int = 24, res: str = "PT60M") -> str:
+    pts = "".join(
+        f"<Point><position>{i + 1}</position><quantity>{mw_per_hour}</quantity></Point>"
+        for i in range(n)
+    )
+    return (
+        f"<TimeSeries>"
+        f"<Period>"
+        f"<timeInterval><start>{start}</start></timeInterval>"
+        f"<resolution>{res}</resolution>"
+        f"{pts}"
+        f"</Period>"
+        f"</TimeSeries>"
+    )
+
+
+# ── parse_load tests ──────────────────────────────────────────────────────────
+
+
+def test_parse_load_daily_mean():
+    """24 hourly points of 50_000 MW → mean = 50_000 MW for that UTC day."""
+    xml = _a65(_load_ts("2026-04-01T00:00Z", 50_000.0, n=24))
+    result = grid_mod.parse_load(xml)
+    assert result == {"2026-04-01": 50_000.0}
+
+
+def test_parse_load_two_days():
+    """Two separate 24-point periods → two daily means."""
+    xml = _a65(
+        _load_ts("2026-04-01T00:00Z", 60_000.0)
+        + _load_ts("2026-04-02T00:00Z", 40_000.0)
+    )
+    result = grid_mod.parse_load(xml)
+    assert result == {"2026-04-01": 60_000.0, "2026-04-02": 40_000.0}
+
+
+def test_parse_load_mixed_values():
+    """Mean of 23 hours at 50_000 and 1 hour at 70_000 → correct mean."""
+    pts = "".join(
+        f"<Point><position>{i + 1}</position><quantity>50000.0</quantity></Point>"
+        for i in range(23)
+    ) + "<Point><position>24</position><quantity>70000.0</quantity></Point>"
+    ts = (
+        f"<TimeSeries>"
+        f"<Period>"
+        f"<timeInterval><start>2026-04-01T00:00Z</start></timeInterval>"
+        f"<resolution>PT60M</resolution>"
+        f"{pts}"
+        f"</Period>"
+        f"</TimeSeries>"
+    )
+    xml = _a65(ts)
+    result = grid_mod.parse_load(xml)
+    expected = (23 * 50_000 + 70_000) / 24
+    assert abs(result["2026-04-01"] - expected) < 0.01
+
+
+def test_parse_load_malformed_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        grid_mod.parse_load("<not-xml")
+
+
+# ── A75 XML helpers ───────────────────────────────────────────────────────────
+
+
+def _a75_gen(
+    ts_blocks: str,
+    ns: str = "urn:iec62325.351:tc57wg16:451-6:generationloaddocument:3:0",
+) -> str:
+    return (
+        f'<?xml version="1.0"?>'
+        f'<GL_MarketDocument xmlns="{ns}"><type>A75</type>'
+        f"{ts_blocks}"
+        f"</GL_MarketDocument>"
+    )
+
+
+def _gen_ts(psr: str, start: str, mw: float, n: int = 24, res: str = "PT60M") -> str:
+    pts = "".join(
+        f"<Point><position>{i + 1}</position><quantity>{mw}</quantity></Point>"
+        for i in range(n)
+    )
+    return (
+        f"<TimeSeries>"
+        f"<MktPSRType><psrType>{psr}</psrType></MktPSRType>"
+        f"<Period>"
+        f"<timeInterval><start>{start}</start></timeInterval>"
+        f"<resolution>{res}</resolution>"
+        f"{pts}"
+        f"</Period>"
+        f"</TimeSeries>"
+    )
+
+
+# ── parse_generation_by_type tests ───────────────────────────────────────────
+
+
+def test_parse_genmix_single_type():
+    """24 points of 8000 MW for B16 (solar) → mean = 8000.0 MW."""
+    xml = _a75_gen(_gen_ts("B16", "2026-04-01T00:00Z", 8_000.0))
+    result = grid_mod.parse_generation_by_type(xml)
+    assert result == {"2026-04-01": {"B16": 8_000.0}}
+
+
+def test_parse_genmix_multiple_types_same_day():
+    """B16 + B18 + B19 on same day all parsed independently."""
+    xml = _a75_gen(
+        _gen_ts("B16", "2026-04-01T00:00Z", 5_000.0)   # solar
+        + _gen_ts("B18", "2026-04-01T00:00Z", 2_000.0)  # wind offshore
+        + _gen_ts("B19", "2026-04-01T00:00Z", 15_000.0)  # wind onshore
+    )
+    result = grid_mod.parse_generation_by_type(xml)
+    day = result["2026-04-01"]
+    assert day["B16"] == 5_000.0
+    assert day["B18"] == 2_000.0
+    assert day["B19"] == 15_000.0
+
+
+def test_parse_genmix_two_days():
+    """B19 across two separate 24-point periods → two day entries."""
+    xml = _a75_gen(
+        _gen_ts("B19", "2026-04-01T00:00Z", 12_000.0)
+        + _gen_ts("B19", "2026-04-02T00:00Z", 9_000.0)
+    )
+    result = grid_mod.parse_generation_by_type(xml)
+    assert result["2026-04-01"]["B19"] == 12_000.0
+    assert result["2026-04-02"]["B19"] == 9_000.0
+
+
+def test_parse_genmix_ignores_unknown_types():
+    """Unknown psrTypes (e.g. B04 gas, B14 nuclear) are included as-is — no filter."""
+    xml = _a75_gen(
+        _gen_ts("B04", "2026-04-01T00:00Z", 3_000.0)
+        + _gen_ts("B16", "2026-04-01T00:00Z", 7_000.0)
+    )
+    result = grid_mod.parse_generation_by_type(xml)
+    # B04 is collected too (caller decides which types to use)
+    assert "B04" in result["2026-04-01"]
+    assert result["2026-04-01"]["B16"] == 7_000.0
+
+
+def test_parse_genmix_malformed_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        grid_mod.parse_generation_by_type("<not-xml")
+
+
+# ── ingest_grid tests ─────────────────────────────────────────────────────────
+
+
+async def test_ingest_grid_upserts_load_wind_solar(db_session, monkeypatch):
+    """ingest_grid fetches A65 + A75 and upserts PowerGrid rows correctly."""
+    from pydantic import SecretStr
+
+    load_xml = _a65(_load_ts("2026-04-01T00:00Z", 55_000.0))  # 55 GW load
+    gen_xml = _a75_gen(
+        _gen_ts("B16", "2026-04-01T00:00Z", 8_000.0)   # solar
+        + _gen_ts("B18", "2026-04-01T00:00Z", 3_000.0)  # wind offshore
+        + _gen_ts("B19", "2026-04-01T00:00Z", 18_000.0)  # wind onshore
+    )
+
+    async def fake_fetch_zone_month(eic, month_start, doctype, extra_params, *, overwrite=False):
+        if doctype == "A65":
+            return load_xml
+        if doctype == "A75":
+            return gen_xml
+        return ""
+
+    monkeypatch.setattr(grid_mod, "_fetch_zone_month", fake_fetch_zone_month)
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", SecretStr("test-token"))
+
+    result = await grid_mod.ingest_grid(db_session, ["2026-04-01"])
+    assert result["written"] == 1
+    assert result["days"] == 1
+
+    row = (
+        db_session.query(PowerGrid)
+        .filter_by(date="2026-04-01", zone="DE_LU")
+        .first()
+    )
+    assert row is not None
+    assert row.load_mw == 55_000.0
+    assert row.solar_mw == 8_000.0
+    assert row.wind_mw == 21_000.0  # B18(3000) + B19(18000)
+
+
+async def test_ingest_grid_upserts_existing_row(db_session, monkeypatch):
+    """Second ingest of same date updates values in place (no duplicate row)."""
+    from pydantic import SecretStr
+
+    load_xml_v1 = _a65(_load_ts("2026-04-01T00:00Z", 50_000.0))
+    load_xml_v2 = _a65(_load_ts("2026-04-01T00:00Z", 52_000.0))
+    gen_xml = _a75_gen(_gen_ts("B16", "2026-04-01T00:00Z", 5_000.0))
+
+    call_count = {"n": 0}
+
+    async def fake_fetch(eic, month_start, doctype, extra_params, *, overwrite=False):
+        if doctype == "A65":
+            call_count["n"] += 1
+            return load_xml_v1 if call_count["n"] == 1 else load_xml_v2
+        return gen_xml
+
+    monkeypatch.setattr(grid_mod, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", SecretStr("test-token"))
+
+    await grid_mod.ingest_grid(db_session, ["2026-04-01"])
+    await grid_mod.ingest_grid(db_session, ["2026-04-01"])
+
+    rows = db_session.query(PowerGrid).filter_by(date="2026-04-01", zone="DE_LU").all()
+    assert len(rows) == 1  # no duplicate
+    assert rows[0].load_mw == 52_000.0  # updated value
+
+
+async def test_ingest_grid_skips_without_token(db_session, monkeypatch):
+    """Returns {"skipped": "no token"} when ENTSOE_API_TOKEN is not configured."""
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", None)
+    result = await grid_mod.ingest_grid(db_session, ["2026-04-01"])
+    assert result == {"skipped": "no token"}
+    assert db_session.query(PowerGrid).count() == 0
+
+
+async def test_ingest_grid_empty_days(db_session, monkeypatch):
+    """Empty days list returns immediately with zero counts."""
+    from pydantic import SecretStr
+
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", SecretStr("test-token"))
+    result = await grid_mod.ingest_grid(db_session, [])
+    assert result == {"days": 0, "written": 0}

--- a/backend/tests/test_power_grid_route.py
+++ b/backend/tests/test_power_grid_route.py
@@ -1,0 +1,193 @@
+"""Tests for GET /api/power/grid (residual load + Dunkelflaute)."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from backend.models.energy import PowerGrid
+from backend.routes.power import DUNKELFLAUTE_THRESHOLD, _compute_grid_row
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+# Dates well within the last 120 days so route window tests find them.
+_TODAY = date.today()
+_D1 = (_TODAY - timedelta(days=3)).isoformat()
+_D2 = (_TODAY - timedelta(days=2)).isoformat()
+_D3 = (_TODAY - timedelta(days=1)).isoformat()
+
+
+def _make_row(**kwargs) -> SimpleNamespace:
+    """Return a plain object that mimics a PowerGrid row (no SQLAlchemy state)."""
+    return SimpleNamespace(
+        date=kwargs.get("date", "2026-01-01"),
+        zone="DE_LU",
+        load_mw=kwargs.get("load_mw", None),
+        wind_mw=kwargs.get("wind_mw", None),
+        solar_mw=kwargs.get("solar_mw", None),
+    )
+
+
+# ─── unit tests for _compute_grid_row ────────────────────────────────────────
+
+
+def test_compute_residual_basic():
+    """residual_mw = load − wind − solar."""
+    row = _make_row(load_mw=50_000.0, wind_mw=10_000.0, solar_mw=5_000.0)
+    d = _compute_grid_row(row)
+    assert d["residual_mw"] == pytest.approx(35_000.0)
+
+
+def test_compute_renewable_share():
+    """renewable_share = (wind + solar) / load."""
+    row = _make_row(load_mw=40_000.0, wind_mw=4_000.0, solar_mw=4_000.0)
+    d = _compute_grid_row(row)
+    assert d["renewable_share"] == pytest.approx(0.2)
+
+
+def test_dunkelflaute_flag_below_threshold():
+    """Day with renewable_share < 0.15 → dunkelflaute = True."""
+    # 5 GW renewables on 50 GW load = 10% share
+    row = _make_row(load_mw=50_000.0, wind_mw=3_000.0, solar_mw=2_000.0)
+    d = _compute_grid_row(row)
+    assert d["renewable_share"] == pytest.approx(0.1)
+    assert d["dunkelflaute"] is True
+
+
+def test_dunkelflaute_flag_above_threshold():
+    """Day with renewable_share >= 0.15 → dunkelflaute = False."""
+    # 10 GW renewables on 50 GW load = 20% share
+    row = _make_row(load_mw=50_000.0, wind_mw=6_000.0, solar_mw=4_000.0)
+    d = _compute_grid_row(row)
+    assert d["renewable_share"] == pytest.approx(0.2)
+    assert d["dunkelflaute"] is False
+
+
+def test_dunkelflaute_threshold_value():
+    """Threshold is exactly 15%."""
+    assert DUNKELFLAUTE_THRESHOLD == pytest.approx(0.15)
+
+
+def test_null_wind_treated_as_zero():
+    """wind_mw=None → treated as 0 in all calculations."""
+    row = _make_row(load_mw=50_000.0, wind_mw=None, solar_mw=5_000.0)
+    d = _compute_grid_row(row)
+    assert d["residual_mw"] == pytest.approx(45_000.0)
+    assert d["renewable_share"] == pytest.approx(0.1)  # 5k / 50k
+    assert d["dunkelflaute"] is True
+
+
+def test_null_solar_treated_as_zero():
+    """solar_mw=None → treated as 0 in all calculations."""
+    row = _make_row(load_mw=50_000.0, wind_mw=15_000.0, solar_mw=None)
+    d = _compute_grid_row(row)
+    assert d["residual_mw"] == pytest.approx(35_000.0)
+    assert d["renewable_share"] == pytest.approx(0.3)  # 15k / 50k
+
+
+def test_null_wind_and_solar_treated_as_zero():
+    """Both wind_mw=None and solar_mw=None → residual = load, share = 0."""
+    row = _make_row(load_mw=50_000.0, wind_mw=None, solar_mw=None)
+    d = _compute_grid_row(row)
+    assert d["residual_mw"] == pytest.approx(50_000.0)
+    assert d["renewable_share"] == pytest.approx(0.0)
+    assert d["dunkelflaute"] is True
+
+
+def test_zero_load_no_division_error():
+    """load_mw=0 → renewable_share = 0.0, no ZeroDivisionError."""
+    row = _make_row(load_mw=0.0, wind_mw=0.0, solar_mw=0.0)
+    d = _compute_grid_row(row)
+    assert d["renewable_share"] == pytest.approx(0.0)
+    assert d["residual_mw"] == pytest.approx(0.0)
+
+
+# ─── route integration tests ──────────────────────────────────────────────────
+
+
+def _seed_grid(db: Session, rows: list[dict]) -> None:
+    for r in rows:
+        db.add(
+            PowerGrid(
+                date=r["date"],
+                zone="DE_LU",
+                load_mw=r.get("load_mw"),
+                wind_mw=r.get("wind_mw"),
+                solar_mw=r.get("solar_mw"),
+            )
+        )
+    db.commit()
+
+
+def _make_client(db: Session) -> TestClient:
+    """Build a TestClient with the test DB injected via dependency_overrides."""
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    client = TestClient(app, raise_server_exceptions=True)
+    return client
+
+
+def test_route_available_true(db_session):
+    """Seeded rows within window → available=True, data non-empty, fields present."""
+    _seed_grid(db_session, [
+        {"date": _D1, "load_mw": 50_000.0, "wind_mw": 10_000.0, "solar_mw": 5_000.0},
+        {"date": _D2, "load_mw": 45_000.0, "wind_mw": 2_000.0, "solar_mw": 1_000.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/grid?days=120")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert len(body["data"]) == 2
+    # Check derived fields on the earlier row
+    row = next(r for r in body["data"] if r["date"] == _D1)
+    assert row["residual_mw"] == pytest.approx(35_000.0)
+    assert row["renewable_share"] == pytest.approx(0.3)
+    assert row["dunkelflaute"] is False
+
+
+def test_route_available_false_when_empty(db_session):
+    """No rows → available=False."""
+    client = _make_client(db_session)
+    resp = client.get("/api/power/grid?days=120")
+    assert resp.status_code == 200
+    assert resp.json()["available"] is False
+
+
+def test_route_latest_and_dunkelflaute_count(db_session):
+    """latest reflects the most recent row; dunkelflaute_days counts flagged days."""
+    _seed_grid(db_session, [
+        # 10% renewables → Dunkelflaute
+        {"date": _D1, "load_mw": 50_000.0, "wind_mw": 3_000.0, "solar_mw": 2_000.0},
+        # 20% renewables → not Dunkelflaute
+        {"date": _D2, "load_mw": 50_000.0, "wind_mw": 8_000.0, "solar_mw": 2_000.0},
+        # 8% renewables → Dunkelflaute
+        {"date": _D3, "load_mw": 50_000.0, "wind_mw": 3_000.0, "solar_mw": 1_000.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/grid?days=120")
+    body = resp.json()
+    assert body["dunkelflaute_days"] == 2
+    assert body["latest"]["date"] == _D3
+    assert body["latest"]["residual_mw"] == pytest.approx(46_000.0)
+    assert body["latest"]["dunkelflaute"] is True
+
+
+def test_route_null_wind_solar_treated_as_zero(db_session):
+    """Rows with null wind/solar are handled gracefully."""
+    _seed_grid(db_session, [
+        {"date": _D1, "load_mw": 50_000.0, "wind_mw": None, "solar_mw": None},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/grid?days=120")
+    body = resp.json()
+    assert body["available"] is True
+    row = body["data"][0]
+    assert row["residual_mw"] == pytest.approx(50_000.0)
+    assert row["renewable_share"] == pytest.approx(0.0)
+    assert row["dunkelflaute"] is True

--- a/backend/tests/test_power_grid_route.py
+++ b/backend/tests/test_power_grid_route.py
@@ -11,6 +11,17 @@ from sqlalchemy.orm import Session
 from backend.models.energy import PowerGrid
 from backend.routes.power import DUNKELFLAUTE_THRESHOLD, _compute_grid_row
 
+
+@pytest.fixture(autouse=True)
+def _clear_dependency_overrides():
+    """_make_client installs an app.dependency_overrides[get_db]; clear it after
+    every test so the override never leaks into other test files' TestClients."""
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
 # ─── helpers ─────────────────────────────────────────────────────────────────
 
 # Dates well within the last 120 days so route window tests find them.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,7 @@ import GasStoragePanel from './components/GasStoragePanel'
 import GasSupplyPanel from './components/GasSupplyPanel'
 import GasDemandPanel from './components/GasDemandPanel'
 import PowerDayAheadPanel from './components/PowerDayAheadPanel'
+import PowerGridPanel from './components/PowerGridPanel'
 import SparkSpreadPanel from './components/SparkSpreadPanel'
 import Landing from './components/Landing'
 import { useAuth } from './context/AuthContext'
@@ -520,6 +521,13 @@ function Dashboard() {
             <div className="mt-3">
               <ErrorBoundary name="power-dayahead">
                 <PowerDayAheadPanel />
+              </ErrorBoundary>
+            </div>
+
+            {/* Row 3: Residual Load + Dunkelflaute (free) */}
+            <div className="mt-3">
+              <ErrorBoundary name="power-grid">
+                <PowerGridPanel />
               </ErrorBoundary>
             </div>
           </>

--- a/frontend/src/components/PowerGridPanel.jsx
+++ b/frontend/src/components/PowerGridPanel.jsx
@@ -1,0 +1,169 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import {
+  ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
+} from 'recharts'
+import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+// Color palette for the stacked areas
+const COLOR_WIND   = '#22d3ee' // cyan
+const COLOR_SOLAR  = '#fbbf24' // amber
+const COLOR_RESID  = '#94a3b8' // slate (dispatchable)
+const COLOR_DUNKEL = '#f87171' // red-400
+
+// Custom dot: renders a small marker on Dunkelflaute days, nothing otherwise.
+function DunkelDot({ cx, cy, payload }) {
+  if (!payload?.dunkelflaute || cx == null || cy == null) return null
+  return <circle cx={cx} cy={cy} r={3} fill={COLOR_DUNKEL} stroke="none" />
+}
+
+export default function PowerGridPanel() {
+  const { data, loading, error } = useFetchWithError(`${API}/power/grid?days=120`)
+
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">RESIDUAL LOAD // FETCH ERROR</div>
+      </div>
+    )
+  if (!data?.available && !loading) return null
+
+  const rows = data?.data ?? []
+  const latest = data?.latest
+  const dunkelflaute_days = data?.dunkelflaute_days ?? 0
+
+  // Residual in GW for the headline
+  const residualGW = latest?.residual_mw != null
+    ? (latest.residual_mw / 1000).toFixed(1)
+    : null
+  const sharePercent = latest?.renewable_share != null
+    ? (latest.renewable_share * 100).toFixed(1)
+    : null
+
+  const isDunkel = latest?.dunkelflaute === true
+  const headerColor = isDunkel ? COLOR_DUNKEL : '#22d3ee'
+
+  return (
+    <Panel
+      id="power-grid"
+      title="RESIDUAL LOAD · DE-LU"
+      info="Residual load = total electricity demand − wind − solar (MW daily mean). This is the demand that dispatchable plants (gas, coal, nuclear, hydro) must cover. Dunkelflaute = day when renewable share < 15% of total load — a physical stress signal, not a price forecast."
+      collapsible
+      headerRight={
+        residualGW != null && (
+          <span className="font-mono text-[10px] font-bold" style={{ color: headerColor }}>
+            {residualGW} GW residual
+          </span>
+        )
+      }
+    >
+      {loading && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Loading grid data…
+        </div>
+      )}
+      {!loading && data?.available && latest && (
+        <>
+          {/* ── Hero numbers ── */}
+          <div className="px-4 py-3 border-b border-border/30">
+            <div className="flex items-baseline gap-3 flex-wrap">
+              <span className="font-mono text-3xl font-bold" style={{ color: headerColor }}>
+                {residualGW != null ? `${residualGW} GW` : '—'}
+              </span>
+              <span className="font-mono text-[10px] text-neutral-600">residual load</span>
+              {sharePercent != null && (
+                <span className="font-mono text-[10px] text-neutral-300">
+                  {sharePercent}% renewables
+                </span>
+              )}
+              {isDunkel && (
+                <span
+                  className="font-mono text-[9px] tracking-wider px-1.5 py-0.5 rounded border"
+                  style={{ color: COLOR_DUNKEL, borderColor: `${COLOR_DUNKEL}40` }}
+                >
+                  DUNKELFLAUTE
+                </span>
+              )}
+            </div>
+            <div className="font-mono text-[10px] text-neutral-600 mt-1">
+              {dunkelflaute_days} Dunkelflaute days / {rows.length} · ENTSO-E A65 + A75 · {latest.date}
+            </div>
+          </div>
+
+          {/* ── Stacked area chart ── */}
+          {rows.length > 1 && (
+            <div className="px-2 py-2">
+              <ResponsiveContainer width="100%" height={120}>
+                <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tickFormatter={fmtDate}
+                    interval="preserveStartEnd"
+                    minTickGap={60}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                    width={36}
+                    tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
+                  />
+                  <Tooltip
+                    contentStyle={CHART_TOOLTIP_STYLE}
+                    formatter={(v, name) => [`${Math.round(v).toLocaleString()} MW`, name]}
+                    labelFormatter={fmtDate}
+                  />
+                  {/* Stack: wind + solar + residual = total load */}
+                  <Area
+                    type="monotone"
+                    dataKey="wind_mw"
+                    name="wind"
+                    stackId="load"
+                    stroke={COLOR_WIND}
+                    fill={COLOR_WIND}
+                    fillOpacity={0.18}
+                    strokeWidth={1}
+                    dot={false}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="solar_mw"
+                    name="solar"
+                    stackId="load"
+                    stroke={COLOR_SOLAR}
+                    fill={COLOR_SOLAR}
+                    fillOpacity={0.18}
+                    strokeWidth={1}
+                    dot={false}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="residual_mw"
+                    name="residual"
+                    stackId="load"
+                    stroke={COLOR_RESID}
+                    fill={COLOR_RESID}
+                    fillOpacity={0.12}
+                    strokeWidth={1.5}
+                    dot={<DunkelDot />}
+                    activeDot={{ r: 3 }}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+
+              {/* Legend */}
+              <div className="flex items-center justify-center gap-4 mt-1 font-mono text-[8px] text-neutral-600">
+                <span style={{ color: COLOR_WIND }}>▬ wind</span>
+                <span style={{ color: COLOR_SOLAR }}>▬ solar</span>
+                <span style={{ color: COLOR_RESID }}>▬ residual (dispatchable)</span>
+                <span style={{ color: COLOR_DUNKEL }}>● Dunkelflaute</span>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
## Summary
First Phase-2 slice: the physical electricity picture (free) in the ENERGY tab.

- **`backend/power/entsoe_grid.py`** — ENTSO-E **A65 total load** + **A75 generation mix** (wind B18/B19, solar B16) → daily-mean MW into new `PowerGrid(date, zone, load_mw, wind_mw, solar_mw)`. Reuses the gas/power ENTSO-E plumbing (token, raw_cache, TimeSeries/Period/Point walker; generalized to group by psrType + daily mean).
- **`GET /api/power/grid`** (free) — per-day `residual_mw = load − wind − solar`, `renewable_share`, and a **Dunkelflaute** flag (renewables < 15% of load), plus `dunkelflaute_days` count.
- **`PowerGridPanel`** (free) in the ENERGY tab — stacked wind/solar/residual area (totals to load) + Dunkelflaute day markers.

Negative-price detection deferred (needs hourly price retention; the A44 store is daily-mean). CO₂/clean-spark + dark-spread still deferred (EUA feed).

## Test Plan
- [x] `ruff check backend/` clean; `pytest` **237 passed** (A65/A75 parser + ingest + route/compute tests; fixed a test-isolation leak from `app.dependency_overrides`)
- [x] frontend `npm run build` clean; `PowerGridPanel` eslint-clean
- [x] Local backfill: 121 PowerGrid rows; `/api/power/grid` returns residual ~37 GW, renewable_share, dunkelflaute flags
- [ ] After merge + prod backfill (`ingest_grid`): residual-load panel live on obsyd.dev ENERGY tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)