### PR TITLE
feat: energy signals in track record (residual load + spark vs power price)

### DIFF
--- a/backend/analytics/validation/scorecards.py
+++ b/backend/analytics/validation/scorecards.py
@@ -33,21 +33,29 @@ HORIZONS = (1, 7, 30)
 TOP_TERCILE_Q = 2 / 3  # "signal high" = top third of its own distribution
 
 # Continuous signals: (name, history-table, scalar column, forward-return target).
-# target ∈ {"brent" (FRED oil), "ttf" (EnergyPrice gas)}. Models are resolved
-# lazily inside the loader to avoid import cycles at module load.
+# target ∈ {"brent" (FRED oil), "ttf" (EnergyPrice gas), "power" (EnergyPrice POWER_DE)}.
+# Models are resolved lazily inside the loader to avoid import cycles at module load.
 SIGNAL_SPECS = (
     ("disruption_score", "DisruptionScoreHistory", "composite_score", "brent"),
     ("tonne_miles", "TonneMilesHistory", "tonne_miles_index", "brent"),
     ("freight_proxy", "FreightProxyHistory", "proxy_index", "brent"),
     # Gas residual predicts European GAS prices, not Brent → scored against TTF.
     ("gas_residual", "GasBalance", "z_score", "ttf"),
+    # Energy signals: residual load + spark spread both scored against day-ahead power price.
+    ("power_residual", "PowerGrid", "residual_mw", "power"),
+    ("spark_spread", "SparkSpreadHistory", "spark_spread", "power"),
 )
+
+
+POWER_DE_SYMBOL = "POWER_DE"
 
 
 def _load_target_map(db, target: str) -> dict[str, float]:
     """Resolve a signal's forward-return target to a date→price map."""
     if target == "ttf":
         return load_energy_price_map(db, TTF_SYMBOL)
+    if target == "power":
+        return load_energy_price_map(db, POWER_DE_SYMBOL)
     return load_price_map(db, BRENT_SERIES)  # default / "brent"
 
 
@@ -60,14 +68,18 @@ def _two_sided_p(t_stat: float) -> float | None:
 
 
 def _resolve_model(table_name: str):
-    """Find a history model class by name across the analytics + gas modules."""
+    """Find a history model class by name across the analytics, gas, and energy modules."""
     from backend.models import analytics as analytics_models
 
     if hasattr(analytics_models, table_name):
         return getattr(analytics_models, table_name)
     from backend.models import gas as gas_models
 
-    return getattr(gas_models, table_name)
+    if hasattr(gas_models, table_name):
+        return getattr(gas_models, table_name)
+    from backend.models import energy as energy_models
+
+    return getattr(energy_models, table_name)
 
 
 def load_signal_series(db, table_name: str, value_col: str) -> tuple[list[str], np.ndarray]:

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -54,6 +54,19 @@ def run_migrations() -> None:
     if _add_column_if_missing("subscriptions", "drip_stage", "INTEGER"):
         applied.append("subscriptions.drip_stage")
 
+    # 2026-06-24: store residual_mw on PowerGrid for signal-scorecard use
+    if _add_column_if_missing("power_grid", "residual_mw", "REAL"):
+        applied.append("power_grid.residual_mw")
+        # One-time idempotent backfill: compute residual for all existing rows
+        # where load_mw is known but residual_mw is still NULL.
+        with engine.begin() as conn:
+            conn.execute(text(
+                "UPDATE power_grid "
+                "SET residual_mw = load_mw - COALESCE(wind_mw, 0) - COALESCE(solar_mw, 0) "
+                "WHERE residual_mw IS NULL AND load_mw IS NOT NULL"
+            ))
+        logger.info("migrations: backfilled power_grid.residual_mw from load_mw/wind_mw/solar_mw")
+
     if applied:
         logger.info("migrations applied: %s", ", ".join(applied))
     else:
@@ -68,4 +81,6 @@ def list_pending() -> Iterable[str]:
         pending.append("subscriptions.trial_ends_at")
     if "drip_stage" not in cols:
         pending.append("subscriptions.drip_stage")
+    if "residual_mw" not in _existing_columns("power_grid"):
+        pending.append("power_grid.residual_mw")
     return pending

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -62,8 +62,8 @@ class PowerGrid(Base):
     """Daily-mean electricity grid metrics for residual-load analysis.
 
     One row per (date, zone). load_mw, wind_mw, solar_mw are daily means
-    in MW (not totals); residual_load = load − wind − solar is derived on
-    read, never stored.
+    in MW (not totals); residual_mw = load − wind − solar is stored for
+    direct use in signal scorecards (scored against POWER_DE forward price).
 
     Sources:
       load_mw  — ENTSO-E A65 (Actual Total Load), processType A16
@@ -79,6 +79,7 @@ class PowerGrid(Base):
     load_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)   # daily mean MW
     wind_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)   # daily mean MW (B18+B19)
     solar_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # daily mean MW (B16)
+    residual_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # load − wind − solar (MW)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     __table_args__ = (UniqueConstraint("date", "zone", name="uq_power_grid_date_zone"),)

--- a/backend/power/entsoe_grid.py
+++ b/backend/power/entsoe_grid.py
@@ -301,7 +301,12 @@ async def ingest_grid(
         solar_mw = psr_map.get(PSR_SOLAR, 0.0)
         load_mw = load_by_day.get(day)
 
-        _upsert_grid(db, day, zone, load_mw, wind_mw or None, solar_mw or None)
+        # Residual = dispatchable demand (load − renewables); None if load unknown.
+        residual_mw: float | None = None
+        if load_mw is not None:
+            residual_mw = load_mw - (wind_mw or 0.0) - (solar_mw or 0.0)
+
+        _upsert_grid(db, day, zone, load_mw, wind_mw or None, solar_mw or None, residual_mw)
         written += 1
 
     db.commit()
@@ -321,6 +326,7 @@ def _upsert_grid(
     load_mw: float | None,
     wind_mw: float | None,
     solar_mw: float | None,
+    residual_mw: float | None = None,
 ) -> None:
     existing = (
         db.query(PowerGrid)
@@ -334,6 +340,8 @@ def _upsert_grid(
             existing.wind_mw = wind_mw
         if solar_mw is not None:
             existing.solar_mw = solar_mw
+        if residual_mw is not None:
+            existing.residual_mw = residual_mw
     else:
         db.add(
             PowerGrid(
@@ -342,5 +350,6 @@ def _upsert_grid(
                 load_mw=load_mw,
                 wind_mw=wind_mw,
                 solar_mw=solar_mw,
+                residual_mw=residual_mw,
             )
         )

--- a/backend/power/entsoe_grid.py
+++ b/backend/power/entsoe_grid.py
@@ -301,10 +301,12 @@ async def ingest_grid(
         solar_mw = psr_map.get(PSR_SOLAR, 0.0)
         load_mw = load_by_day.get(day)
 
-        # Residual = dispatchable demand (load − renewables); None if load unknown.
+        # Residual = dispatchable demand (load − renewables). Only when generation
+        # was actually fetched for this day — otherwise wind/solar default to 0 and
+        # we'd store load−0−0 (inflated), clobbering a previously-correct residual.
         residual_mw: float | None = None
-        if load_mw is not None:
-            residual_mw = load_mw - (wind_mw or 0.0) - (solar_mw or 0.0)
+        if load_mw is not None and day in gen_by_day:
+            residual_mw = load_mw - wind_mw - solar_mw
 
         _upsert_grid(db, day, zone, load_mw, wind_mw or None, solar_mw or None, residual_mw)
         written += 1

--- a/backend/tests/test_validation_scorecards.py
+++ b/backend/tests/test_validation_scorecards.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 from backend.analytics.validation import scorecards
 from backend.main import app
 from backend.models.analytics import DisruptionScoreHistory
-from backend.models.energy import EnergyPrice
+from backend.models.energy import EnergyPrice, PowerGrid, SparkSpreadHistory
 from backend.models.gas import GasBalance
 from backend.models.prices import FREDSeries
 from backend.models.validation import SignalScorecard
@@ -157,3 +157,119 @@ def test_gas_residual_scores_against_ttf_not_brent(db_session):
     assert card_7d["n"] >= 30 and card_7d["confident"] == 1  # scored despite no Brent
     # Planted z->TTF relationship is positive → IC has the right sign.
     assert card_7d["ic"] is not None and card_7d["ic"] > 0
+
+
+# ── Energy signals: power_residual + spark_spread ────────────────────────────
+
+
+def _seed_power(db, n_days=80, seed=13):
+    """Plant PowerGrid rows with residual_mw that predicts the 7d-forward
+    POWER_DE move, plus a matching EnergyPrice POWER_DE series.
+
+    PowerGrid has one row per (date, zone) — no created_at — mirroring the
+    GasBalance seeding pattern.
+
+    A positive planted relationship (high residual → gas/coal plants must run
+    → tighter supply → higher power price next week) is used to assert IC sign.
+    """
+    rng = np.random.default_rng(seed)
+    start = date(2026, 1, 1)
+    residual = rng.uniform(20000, 50000, size=n_days)  # MW range realistic for DE-LU
+    price = [80.0]
+    for i in range(1, n_days + 12):
+        # High residual load → more thermal generation needed → upward price pressure
+        drift = 0.0002 * (residual[i - 7] - 35000) if 0 <= i - 7 < n_days else 0.0
+        price.append(price[-1] + drift + rng.normal(scale=0.5))
+    for i in range(n_days):
+        d = (start + timedelta(days=i)).strftime("%Y-%m-%d")
+        db.add(
+            PowerGrid(
+                date=d,
+                zone="DE_LU",
+                load_mw=float(residual[i]) + 10000.0,  # load > residual
+                wind_mw=5000.0,
+                solar_mw=5000.0,
+                residual_mw=float(residual[i]),
+            )
+        )
+    for i in range(n_days + 12):
+        d = (start + timedelta(days=i)).strftime("%Y-%m-%d")
+        db.add(EnergyPrice(date=d, symbol="POWER_DE", close=float(price[i])))
+    db.commit()
+
+
+def _seed_spark(db, n_days=80, seed=17):
+    """Plant SparkSpreadHistory rows where spark_spread predicts the 7d-forward
+    POWER_DE move, plus a matching EnergyPrice POWER_DE series.
+
+    Note on circularity: spark_spread = power − gas × heat_rate, so it is a
+    *linear function* of POWER_DE on the signal date. The IC measures whether
+    today's level predicts the *forward return* (7d-ahead log price change), not
+    whether high spark_spread correlates with a high absolute price — so there
+    is a meaningful (though partially circular) signal here. Tests simply assert
+    the mechanical plumbing (n≥30, IC not None), not a specific sign.
+    """
+    rng = np.random.default_rng(seed)
+    start = date(2026, 1, 1)
+    spark = rng.uniform(-10, 30, size=n_days)  # EUR/MWh realistic range
+    price = [80.0]
+    for i in range(1, n_days + 12):
+        drift = 0.05 * spark[i - 7] if 0 <= i - 7 < n_days else 0.0
+        price.append(price[-1] + drift + rng.normal(scale=0.5))
+    for i in range(n_days):
+        d = (start + timedelta(days=i)).strftime("%Y-%m-%d")
+        db.add(
+            SparkSpreadHistory(
+                date=d,
+                power_price=float(price[i]),
+                gas_price=float(price[i]) - float(spark[i]) * 2.0,
+                heat_rate=2.0,
+                spark_spread=float(spark[i]),
+            )
+        )
+    for i in range(n_days + 12):
+        d = (start + timedelta(days=i)).strftime("%Y-%m-%d")
+        db.add(EnergyPrice(date=d, symbol="POWER_DE", close=float(price[i])))
+    db.commit()
+
+
+def test_resolve_model_finds_energy_classes(db_session):
+    """_resolve_model must return the right classes for energy-vertical tables."""
+    assert scorecards._resolve_model("PowerGrid") is PowerGrid
+    assert scorecards._resolve_model("SparkSpreadHistory") is SparkSpreadHistory
+
+
+def test_power_residual_scores_against_power_price(db_session):
+    """power_residual is scored against POWER_DE (not Brent, not TTF)."""
+    _seed_power(db_session)
+    cards = scorecards.recompute_scorecards(db_session, as_of="2026-06-11")
+    pr = [c for c in cards if c["signal"] == "power_residual"]
+    assert {c["horizon_days"] for c in pr} == set(scorecards.HORIZONS)
+    card_7d = next(c for c in pr if c["horizon_days"] == 7)
+    assert card_7d["n"] >= 30 and card_7d["confident"] == 1
+    # Planted positive residual→power relationship: IC should be positive.
+    assert card_7d["ic"] is not None and card_7d["ic"] > 0
+
+
+def test_spark_spread_scores_against_power_price(db_session):
+    """spark_spread card exists with n≥30 and a non-None IC when seeded."""
+    _seed_spark(db_session)
+    cards = scorecards.recompute_scorecards(db_session, as_of="2026-06-11")
+    ss = [c for c in cards if c["signal"] == "spark_spread"]
+    assert {c["horizon_days"] for c in ss} == set(scorecards.HORIZONS)
+    card_7d = next(c for c in ss if c["horizon_days"] == 7)
+    assert card_7d["n"] >= 30 and card_7d["confident"] == 1
+    assert card_7d["ic"] is not None
+
+
+def test_existing_brent_ttf_signals_not_broken(db_session):
+    """Regression: adding energy targets must not break Brent or TTF signals."""
+    _seed(db_session)
+    _seed_gas(db_session)
+    cards = scorecards.recompute_scorecards(db_session, as_of="2026-06-11")
+    signals = {c["signal"] for c in cards}
+    assert "disruption_score" in signals
+    assert "gas_residual" in signals
+    # Both scored at all horizons
+    assert {c["horizon_days"] for c in cards if c["signal"] == "disruption_score"} == set(scorecards.HORIZONS)
+    assert {c["horizon_days"] for c in cards if c["signal"] == "gas_residual"} == set(scorecards.HORIZONS)

--- a/backend/tests/test_validation_scorecards.py
+++ b/backend/tests/test_validation_scorecards.py
@@ -166,8 +166,7 @@ def _seed_power(db, n_days=80, seed=13):
     """Plant PowerGrid rows with residual_mw that predicts the 7d-forward
     POWER_DE move, plus a matching EnergyPrice POWER_DE series.
 
-    PowerGrid has one row per (date, zone) — no created_at — mirroring the
-    GasBalance seeding pattern.
+    PowerGrid has one row per (date, zone), so the loader reads it directly.
 
     A positive planted relationship (high residual → gas/coal plants must run
     → tighter supply → higher power price next week) is used to assert IC sign.

--- a/frontend/src/components/PowerGridPanel.jsx
+++ b/frontend/src/components/PowerGridPanel.jsx
@@ -4,6 +4,7 @@ import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
 import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import TrackRecordBadge from './TrackRecordBadge'
 
 const API = '/api'
 
@@ -164,6 +165,7 @@ export default function PowerGridPanel() {
           )}
         </>
       )}
+      <TrackRecordBadge signal="power_residual" targetLabel="Power" />
     </Panel>
   )
 }

--- a/frontend/src/components/SparkSpreadPanel.jsx
+++ b/frontend/src/components/SparkSpreadPanel.jsx
@@ -4,6 +4,7 @@ import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
 import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import TrackRecordBadge from './TrackRecordBadge'
 
 const API = '/api'
 
@@ -125,6 +126,7 @@ export default function SparkSpreadPanel() {
           )}
         </>
       )}
+      <TrackRecordBadge signal="spark_spread" targetLabel="Power" />
     </Panel>
   )
 }


### PR DESCRIPTION
## Summary
Phase 2, Slice 1: the ENERGY signals get an honest track record, scored against the forward **electricity price** (POWER_DE) — same pattern as the gas residual vs TTF.

- `PowerGrid.residual_mw` now **stored** (computed `load − wind − solar` in `ingest_grid`, only when generation was actually fetched). Idempotent migration adds the column + backfills existing rows.
- Scorecard `_load_target_map` adds a `"power"` target; `_resolve_model` resolves `backend.models.energy`; `SIGNAL_SPECS` += `power_residual` (PowerGrid) + `spark_spread` (SparkSpreadHistory), both target `power`.
- `TrackRecordBadge` (targetLabel="Power") on `PowerGridPanel` + `SparkSpreadPanel`.

Measured on local data: `power_residual` IC −0.56 (p=0.0001, n=82), `spark_spread` IC −0.59 (p=0.004). Honest by construction (building n/30 → IC/p). Spark's partial circularity (it contains the power price) is on forward *returns*, not levels — disclosed.

## Test Plan
- [x] `ruff` clean; `pytest` **241 passed** (energy scorecard + resolve-model + brent/ttf regression tests)
- [x] frontend eslint + `npm run build` clean
- [x] Review fix applied: residual not clobbered on A75 fetch failure
- [ ] After merge + prod deploy (migration runs on restart): badges render on ENERGY panels after the weekly scorecard recompute

🤖 Generated with [Claude Code](https://claude.com/claude-code)