### PR TITLE
feat: generation-mix panel (full A75) in ENERGY tab

### DIFF
--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -83,3 +83,28 @@ class PowerGrid(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     __table_args__ = (UniqueConstraint("date", "zone", name="uq_power_grid_date_zone"),)
+
+
+class PowerGenMix(Base):
+    """Full ENTSO-E A75 generation mix in long format.
+
+    One row per (date, zone, psr_type). gen_mw is the daily-mean MW for that
+    production type. psr_type uses readable labels (e.g. "Nuclear", "Solar")
+    mapped from raw ENTSO-E psrType codes (B01–B20).
+
+    Source: ENTSO-E A75 (Actual Generation per Production Type), processType A16.
+    Idempotent upsert by (date, zone, psr_type).
+    """
+
+    __tablename__ = "power_gen_mix"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    date: Mapped[str] = mapped_column(String, nullable=False, index=True)     # YYYY-MM-DD
+    zone: Mapped[str] = mapped_column(String, nullable=False, index=True)     # e.g. "DE_LU"
+    psr_type: Mapped[str] = mapped_column(String, nullable=False, index=True) # readable label or raw code
+    gen_mw: Mapped[float] = mapped_column(Float, nullable=False)              # daily mean MW
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("date", "zone", "psr_type", name="uq_power_gen_mix_date_zone_psr"),
+    )

--- a/backend/power/entsoe_grid.py
+++ b/backend/power/entsoe_grid.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm import Session
 from backend.config import settings
 from backend.gas import raw_cache
 from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
-from backend.models.energy import PowerGrid
+from backend.models.energy import PowerGenMix, PowerGrid
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +40,26 @@ DE_LU_EIC = "10Y1001A1001A82H"
 PSR_SOLAR = "B16"
 PSR_WIND_OFFSHORE = "B18"
 PSR_WIND_ONSHORE = "B19"
+
+# ENTSO-E psrType code → readable label (A75 generation types)
+PSR_LABELS: dict[str, str] = {
+    "B01": "Biomass",
+    "B02": "Lignite",
+    "B04": "Fossil Gas",
+    "B05": "Hard Coal",
+    "B06": "Oil",
+    "B09": "Geothermal",
+    "B10": "Hydro Pumped Storage",
+    "B11": "Hydro Run-of-river",
+    "B12": "Hydro Reservoir",
+    "B14": "Nuclear",
+    "B15": "Other Renewable",
+    "B16": "Solar",
+    "B17": "Waste",
+    "B18": "Wind Offshore",
+    "B19": "Wind Onshore",
+    "B20": "Other",
+}
 
 _RESOLUTION_HOURS = {"PT60M": 1.0, "PT30M": 0.5, "PT15M": 0.25}
 
@@ -292,7 +312,7 @@ async def ingest_grid(
                 if day in wanted:
                     gen_by_day[day] = psr_map
 
-    # ── Upsert ─────────────────────────────────────────────────────────────
+    # ── Upsert PowerGrid ───────────────────────────────────────────────────
     all_days = wanted & (load_by_day.keys() | gen_by_day.keys())
     written = 0
     for day in sorted(all_days):
@@ -311,6 +331,9 @@ async def ingest_grid(
         _upsert_grid(db, day, zone, load_mw, wind_mw or None, solar_mw or None, residual_mw)
         written += 1
 
+    # ── Upsert PowerGenMix (full A75 breakdown) ────────────────────────────
+    _upsert_generation_mix(db, gen_by_day, zone)
+
     db.commit()
     logger.info(
         "entsoe_grid.ingest_grid: %d/%d days written (zone=%s)",
@@ -319,6 +342,46 @@ async def ingest_grid(
         zone,
     )
     return {"days": len(days), "written": written}
+
+
+def _upsert_generation_mix(
+    db: Session,
+    gen_by_day: dict[str, dict[str, float]],
+    zone: str,
+) -> None:
+    """Upsert the full generation mix (all psrTypes) from a parsed A75 result.
+
+    `gen_by_day` maps {date_str: {psrType_code: mean_mw}}.  Each (date, zone,
+    label) triple is upserted idempotently — existing rows are updated in-place,
+    new rows are inserted. Readable labels from PSR_LABELS are used; unknown
+    codes fall back to the raw code string.
+
+    Note: does NOT call db.commit() — the caller (ingest_grid) commits once
+    after both _upsert_grid and _upsert_generation_mix complete.
+    """
+    for day, psr_map in gen_by_day.items():
+        for code, mean_mw in psr_map.items():
+            label = PSR_LABELS.get(code, code)
+            existing = (
+                db.query(PowerGenMix)
+                .filter(
+                    PowerGenMix.date == day,
+                    PowerGenMix.zone == zone,
+                    PowerGenMix.psr_type == label,
+                )
+                .first()
+            )
+            if existing:
+                existing.gen_mw = mean_mw
+            else:
+                db.add(
+                    PowerGenMix(
+                        date=day,
+                        zone=zone,
+                        psr_type=label,
+                        gen_mw=mean_mw,
+                    )
+                )
 
 
 def _upsert_grid(

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 
 from backend.auth.dependencies import require_pro
 from backend.database import get_db
-from backend.models.energy import EnergyPrice, PowerGrid, SparkSpreadHistory
+from backend.models.energy import EnergyPrice, PowerGenMix, PowerGrid, SparkSpreadHistory
 
 router = APIRouter(prefix="/api/power", tags=["power"])
 
@@ -199,6 +199,70 @@ async def get_grid(
         "threshold_note": f"dunkelflaute = renewable_share < {DUNKELFLAUTE_THRESHOLD:.0%}",
         "latest": latest,
         "dunkelflaute_days": dunkelflaute_days,
+        "from": date_from,
+        "to": date_to,
+        "data": data,
+    }
+
+
+# ─── Generation mix (free) ────────────────────────────────────────────────────
+
+
+@router.get("/generation-mix")
+async def get_generation_mix(
+    days: int = Query(30, ge=1, le=1500),
+    db: Session = Depends(get_db),
+):
+    """Full ENTSO-E A75 generation mix for DE-LU (daily mean MW). Free tier.
+
+    Returns data in wide/pivoted format: each row is one date with one key per
+    production type (readable labels like "Solar", "Nuclear", "Wind Onshore").
+    `types` lists all distinct production types present in the window.
+    `latest` is the most recent date's breakdown plus a `total_mw` sum.
+    """
+    date_from, date_to = _window(days)
+    rows = (
+        db.query(PowerGenMix)
+        .filter(
+            PowerGenMix.zone == "DE_LU",
+            PowerGenMix.date >= date_from,
+            PowerGenMix.date <= date_to,
+        )
+        .order_by(PowerGenMix.date.asc(), PowerGenMix.psr_type.asc())
+        .all()
+    )
+    if not rows:
+        return {
+            "available": False,
+            "reason": "no generation-mix data yet — run power grid backfill (ingest_grid)",
+        }
+
+    # Pivot: {date -> {psr_type -> gen_mw}}
+    pivot: dict[str, dict[str, float]] = {}
+    for r in rows:
+        pivot.setdefault(r.date, {})[r.psr_type] = r.gen_mw
+
+    # Collect all distinct types (sorted for stable output)
+    all_types: list[str] = sorted({r.psr_type for r in rows})
+
+    # Build wide-format data list
+    data = []
+    for date_str in sorted(pivot.keys()):
+        row_dict: dict = {"date": date_str}
+        row_dict.update(pivot[date_str])
+        data.append(row_dict)
+
+    # Latest: most recent date + total
+    latest_date = sorted(pivot.keys())[-1]
+    latest_vals = pivot[latest_date]
+    latest = {"date": latest_date, **latest_vals, "total_mw": round(sum(latest_vals.values()), 2)}
+
+    return {
+        "available": True,
+        "zone": "DE_LU",
+        "unit": "MW",
+        "types": all_types,
+        "latest": latest,
         "from": date_from,
         "to": date_to,
         "data": data,

--- a/backend/tests/test_generation_mix.py
+++ b/backend/tests/test_generation_mix.py
@@ -1,0 +1,175 @@
+"""Tests for PowerGenMix model + GET /api/power/generation-mix route."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from backend.models.energy import PowerGenMix
+
+
+@pytest.fixture(autouse=True)
+def _clear_dependency_overrides():
+    """Prevent dependency_overrides leaking into other test files."""
+    yield
+    from backend.main import app
+    app.dependency_overrides.clear()
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+_TODAY = date.today()
+_D1 = (_TODAY - timedelta(days=3)).isoformat()
+_D2 = (_TODAY - timedelta(days=2)).isoformat()
+_D3 = (_TODAY - timedelta(days=1)).isoformat()
+
+
+def _seed_mix(db: Session, rows: list[dict]) -> None:
+    for r in rows:
+        db.add(
+            PowerGenMix(
+                date=r["date"],
+                zone=r.get("zone", "DE_LU"),
+                psr_type=r["psr_type"],
+                gen_mw=r["gen_mw"],
+            )
+        )
+    db.commit()
+
+
+def _make_client(db: Session) -> TestClient:
+    from backend.database import get_db
+    from backend.main import app
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ─── model / upsert helpers ───────────────────────────────────────────────────
+
+
+def test_model_unique_constraint(db_session):
+    """Inserting duplicate (date, zone, psr_type) raises an integrity error."""
+    import sqlalchemy.exc
+
+    db_session.add(
+        PowerGenMix(date=_D1, zone="DE_LU", psr_type="Solar", gen_mw=5000.0)
+    )
+    db_session.commit()
+
+    db_session.add(
+        PowerGenMix(date=_D1, zone="DE_LU", psr_type="Solar", gen_mw=6000.0)
+    )
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        db_session.commit()
+
+
+# ─── route: available=False when empty ───────────────────────────────────────
+
+
+def test_route_empty_returns_available_false(db_session):
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=30")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is False
+
+
+# ─── route: pivot + types ─────────────────────────────────────────────────────
+
+
+def test_route_pivot_structure(db_session):
+    """Seeded rows are pivoted wide: each data row has per-type MW keys."""
+    _seed_mix(db_session, [
+        {"date": _D1, "psr_type": "Solar",        "gen_mw": 4000.0},
+        {"date": _D1, "psr_type": "Wind Onshore",  "gen_mw": 8000.0},
+        {"date": _D1, "psr_type": "Nuclear",        "gen_mw": 6000.0},
+        {"date": _D2, "psr_type": "Solar",         "gen_mw": 3500.0},
+        {"date": _D2, "psr_type": "Wind Onshore",   "gen_mw": 9000.0},
+        {"date": _D2, "psr_type": "Nuclear",         "gen_mw": 6100.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=30")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["available"] is True
+    assert set(body["types"]) == {"Nuclear", "Solar", "Wind Onshore"}
+    assert len(body["data"]) == 2
+
+    row = next(r for r in body["data"] if r["date"] == _D1)
+    assert row["Solar"] == pytest.approx(4000.0)
+    assert row["Wind Onshore"] == pytest.approx(8000.0)
+    assert row["Nuclear"] == pytest.approx(6000.0)
+
+
+def test_route_latest_total_mw(db_session):
+    """latest.total_mw = sum of all types for the most recent date."""
+    _seed_mix(db_session, [
+        {"date": _D1, "psr_type": "Solar",       "gen_mw": 5000.0},
+        {"date": _D1, "psr_type": "Wind Onshore", "gen_mw": 7000.0},
+        {"date": _D2, "psr_type": "Solar",        "gen_mw": 3000.0},
+        {"date": _D2, "psr_type": "Wind Onshore",  "gen_mw": 6000.0},
+        {"date": _D2, "psr_type": "Nuclear",        "gen_mw": 8000.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=30")
+    body = resp.json()
+
+    assert body["latest"]["date"] == _D2
+    assert body["latest"]["total_mw"] == pytest.approx(17000.0)
+
+
+def test_route_types_list_sorted(db_session):
+    """types list is alphabetically sorted for stable output."""
+    _seed_mix(db_session, [
+        {"date": _D1, "psr_type": "Wind Onshore", "gen_mw": 5000.0},
+        {"date": _D1, "psr_type": "Nuclear",       "gen_mw": 6000.0},
+        {"date": _D1, "psr_type": "Solar",         "gen_mw": 4000.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=30")
+    body = resp.json()
+    assert body["types"] == sorted(body["types"])
+
+
+def test_route_zone_and_unit(db_session):
+    """Response includes zone=DE_LU and unit=MW."""
+    _seed_mix(db_session, [
+        {"date": _D1, "psr_type": "Solar", "gen_mw": 1000.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=30")
+    body = resp.json()
+    assert body["zone"] == "DE_LU"
+    assert body["unit"] == "MW"
+
+
+def test_route_data_sorted_ascending(db_session):
+    """data rows are sorted by date ascending."""
+    _seed_mix(db_session, [
+        {"date": _D3, "psr_type": "Solar", "gen_mw": 1000.0},
+        {"date": _D1, "psr_type": "Solar", "gen_mw": 2000.0},
+        {"date": _D2, "psr_type": "Solar", "gen_mw": 3000.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=30")
+    body = resp.json()
+    dates = [r["date"] for r in body["data"]]
+    assert dates == sorted(dates)
+
+
+def test_route_days_window_filters(db_session):
+    """Only rows within the requested days window are returned."""
+    old_date = (_TODAY - timedelta(days=60)).isoformat()
+    _seed_mix(db_session, [
+        {"date": _D1,     "psr_type": "Solar", "gen_mw": 1000.0},
+        {"date": old_date, "psr_type": "Solar", "gen_mw": 2000.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=30")
+    body = resp.json()
+    assert body["available"] is True
+    assert len(body["data"]) == 1
+    assert body["data"][0]["date"] == _D1

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,6 +38,7 @@ import GasDemandPanel from './components/GasDemandPanel'
 import PowerDayAheadPanel from './components/PowerDayAheadPanel'
 import PowerGridPanel from './components/PowerGridPanel'
 import SparkSpreadPanel from './components/SparkSpreadPanel'
+import GenerationMixPanel from './components/GenerationMixPanel'
 import Landing from './components/Landing'
 import { useAuth } from './context/AuthContext'
 
@@ -528,6 +529,13 @@ function Dashboard() {
             <div className="mt-3">
               <ErrorBoundary name="power-grid">
                 <PowerGridPanel />
+              </ErrorBoundary>
+            </div>
+
+            {/* Row 4: Generation Mix (free) */}
+            <div className="mt-3">
+              <ErrorBoundary name="generation-mix">
+                <GenerationMixPanel />
               </ErrorBoundary>
             </div>
           </>

--- a/frontend/src/components/GenerationMixPanel.jsx
+++ b/frontend/src/components/GenerationMixPanel.jsx
@@ -1,0 +1,155 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import {
+  ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
+} from 'recharts'
+import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+// Color palette: darker for firm/dispatchable; brighter for renewables/hydro
+const TYPE_COLORS = {
+  'Nuclear':             '#c084fc', // violet
+  'Lignite':             '#78716c', // stone (dark)
+  'Hard Coal':           '#57534e', // stone (darker)
+  'Fossil Gas':          '#6b7280', // gray
+  'Oil':                 '#44403c', // very dark
+  'Biomass':             '#4ade80', // green
+  'Geothermal':          '#fb923c', // orange
+  'Hydro Pumped Storage':'#38bdf8', // sky
+  'Hydro Run-of-river':  '#0ea5e9', // sky darker
+  'Hydro Reservoir':     '#0284c7', // blue
+  'Other Renewable':     '#a3e635', // lime
+  'Solar':               '#fbbf24', // amber
+  'Waste':               '#a8a29e', // stone light
+  'Wind Offshore':       '#22d3ee', // cyan
+  'Wind Onshore':        '#67e8f9', // cyan lighter
+  'Other':               '#374151', // gray dark
+}
+
+const DEFAULT_COLOR = '#64748b'
+
+export default function GenerationMixPanel() {
+  const { data, loading, error } = useFetchWithError(`${API}/power/generation-mix?days=30`)
+
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">GENERATION MIX // FETCH ERROR</div>
+      </div>
+    )
+  if (!data?.available && !loading) return null
+
+  const rows = data?.data ?? []
+  const latest = data?.latest
+  const types = data?.types ?? []
+
+  // Top type by generation in latest snapshot
+  const topType = latest
+    ? Object.entries(latest)
+        .filter(([k]) => k !== 'date' && k !== 'total_mw')
+        .sort(([, a], [, b]) => b - a)[0]?.[0]
+    : null
+
+  const totalGW = latest?.total_mw != null
+    ? (latest.total_mw / 1000).toFixed(1)
+    : null
+
+  return (
+    <Panel
+      id="generation-mix"
+      title="GENERATION MIX · DE-LU"
+      info="Full ENTSO-E A75 generation breakdown by production type (daily mean MW). Covers nuclear, coal, gas, hydro, biomass, wind, solar and more. Source: ENTSO-E Transparency Platform, processType A16."
+      collapsible
+      headerRight={
+        totalGW != null && (
+          <span className="font-mono text-[10px] font-bold text-cyan-400">
+            {totalGW} GW total
+          </span>
+        )
+      }
+    >
+      {loading && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Loading generation mix…
+        </div>
+      )}
+      {!loading && data?.available && latest && (
+        <>
+          {/* ── Hero numbers ── */}
+          <div className="px-4 py-3 border-b border-border/30">
+            <div className="flex items-baseline gap-3 flex-wrap">
+              <span className="font-mono text-3xl font-bold text-cyan-400">
+                {totalGW != null ? `${totalGW} GW` : '—'}
+              </span>
+              <span className="font-mono text-[10px] text-neutral-600">total generation</span>
+              {topType && (
+                <span
+                  className="font-mono text-[10px] font-semibold"
+                  style={{ color: TYPE_COLORS[topType] ?? DEFAULT_COLOR }}
+                >
+                  top: {topType} ({((latest[topType] / latest.total_mw) * 100).toFixed(1)}%)
+                </span>
+              )}
+            </div>
+            <div className="font-mono text-[10px] text-neutral-600 mt-1">
+              {types.length} types · ENTSO-E A75 · {latest.date}
+            </div>
+          </div>
+
+          {/* ── Stacked area chart ── */}
+          {rows.length > 1 && (
+            <div className="px-2 py-2">
+              <ResponsiveContainer width="100%" height={160}>
+                <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tickFormatter={fmtDate}
+                    interval="preserveStartEnd"
+                    minTickGap={60}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                    width={36}
+                    tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
+                  />
+                  <Tooltip
+                    contentStyle={CHART_TOOLTIP_STYLE}
+                    formatter={(v, name) => [`${Math.round(v).toLocaleString()} MW`, name]}
+                    labelFormatter={fmtDate}
+                  />
+                  {types.map((type) => (
+                    <Area
+                      key={type}
+                      type="monotone"
+                      dataKey={type}
+                      name={type}
+                      stackId="mix"
+                      stroke={TYPE_COLORS[type] ?? DEFAULT_COLOR}
+                      fill={TYPE_COLORS[type] ?? DEFAULT_COLOR}
+                      fillOpacity={0.18}
+                      strokeWidth={1}
+                      dot={false}
+                      connectNulls
+                    />
+                  ))}
+                </AreaChart>
+              </ResponsiveContainer>
+
+              {/* Legend — two rows max, 8 per row */}
+              <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 mt-1 font-mono text-[8px] text-neutral-600">
+                {types.map((type) => (
+                  <span key={type} style={{ color: TYPE_COLORS[type] ?? DEFAULT_COLOR }}>
+                    ▬ {type}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
Phase 2 Slice 2: full ENTSO-E generation mix in the ENERGY tab. New PowerGenMix (long) + ingest extension (reuses parsed A75, no extra fetch) + /api/power/generation-mix (free) + stacked GenerationMixPanel. ruff clean, pytest 249 passed (autouse fixture clears dependency_overrides), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)