### PR TITLE
feat: multi-zone ENERGY (DE-LU / FR / NL) with zone selector

### DIFF
--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -150,32 +150,45 @@ def _power_recent_days(n: int = 7) -> list[str]:
 
 
 async def _run_power_daily():
-    """Daily electricity + spark spread refresh.
+    """Daily electricity + spark spread refresh for all supported bidding zones.
 
-    (a) Ingest ENTSO-E A44 day-ahead prices for the last 7 days into
-        EnergyPrice(symbol="POWER_DE") — re-fetches to catch any revisions.
-    (b) Ingest ENTSO-E A65 load + A75 wind/solar for the last 7 days into
-        PowerGrid (keeps the residual-load / Dunkelflaute view current).
-    (c) Recompute SparkSpreadHistory for all aligned POWER_DE + TTF dates.
+    For each zone in POWER_ZONES (DE_LU, FR, NL):
+      (a) Ingest ENTSO-E A44 day-ahead prices for the last 7 days into
+          EnergyPrice(symbol=zone_cfg["price_symbol"]) + PowerPriceDaily(zone=zone).
+      (b) Ingest ENTSO-E A65 load + A75 wind/solar for the last 7 days into
+          PowerGrid + PowerGenMix keyed by zone.
+
+    Then:
+      (c) Recompute SparkSpreadHistory — DE-LU only (no zone column; intentional).
     """
     from backend.power.entsoe_grid import ingest_grid
     from backend.power.entsoe_prices import ingest_day_ahead
+    from backend.power.zones import POWER_ZONES
 
     db = SessionLocal()
     try:
         days = _power_recent_days(7)
-        try:
-            result = await ingest_day_ahead(db, days, overwrite=True)
-            logger.info("power daily ingest: %s", result)
-        except Exception as exc:
-            logger.error("power daily ingest_day_ahead failed: %s", exc)
 
-        try:
-            result = await ingest_grid(db, days, overwrite=True)
-            logger.info("power daily grid ingest: %s", result)
-        except Exception as exc:
-            logger.error("power daily ingest_grid failed: %s", exc)
+        for zone_key, zone_cfg in POWER_ZONES.items():
+            try:
+                result = await ingest_day_ahead(
+                    db, days,
+                    eic=zone_cfg["eic"],
+                    symbol=zone_cfg["price_symbol"],
+                    zone=zone_key,
+                    overwrite=True,
+                )
+                logger.info("power daily ingest [%s]: %s", zone_key, result)
+            except Exception as exc:
+                logger.error("power daily ingest_day_ahead [%s] failed: %s", zone_key, exc)
 
+            try:
+                result = await ingest_grid(db, days, eic=zone_cfg["eic"], zone=zone_key, overwrite=True)
+                logger.info("power daily grid ingest [%s]: %s", zone_key, result)
+            except Exception as exc:
+                logger.error("power daily ingest_grid [%s] failed: %s", zone_key, exc)
+
+        # Spark spread uses POWER_DE (DE-LU) only — SparkSpreadHistory has no zone column.
         try:
             result = await collect_spark_spreads()
             logger.info("power daily spark spreads: %s", result)

--- a/backend/power/entsoe_prices.py
+++ b/backend/power/entsoe_prices.py
@@ -190,10 +190,11 @@ async def ingest_day_ahead(
     *,
     eic: str = DE_LU_EIC,
     symbol: str = POWER_DE_SYMBOL,
+    zone: str = "DE_LU",
     overwrite: bool = False,
 ) -> dict:
     """Fetch A44 day-ahead prices for the month(s) spanning `days`, parse, and
-    upsert daily means into EnergyPrice(symbol=symbol).
+    upsert daily means into EnergyPrice(symbol=symbol) and PowerPriceDaily(zone=zone).
 
     Returns {"days": n, "written": n} on success, or {"skipped": "no token"}
     if ENTSOE_API_TOKEN is not configured.
@@ -211,9 +212,6 @@ async def ingest_day_ahead(
     months = sorted(
         {datetime.strptime(d, "%Y-%m-%d").date().replace(day=1) for d in days}
     )
-
-    # Zone label for PowerPriceDaily (readable key matching PowerGrid convention)
-    zone = "DE_LU"
 
     stats_by_day: dict[str, dict] = {}
     for month_start in months:

--- a/backend/power/zones.py
+++ b/backend/power/zones.py
@@ -1,0 +1,42 @@
+"""Power-zone registry for the ENERGY vertical.
+
+POWER_ZONES maps zone key → metadata. EIC codes are sourced from
+backend.gas.entsoe.EU27_BIDDING_ZONES — do NOT invent or duplicate them.
+
+Supported zones:
+  DE_LU — German-Luxembourg bidding zone (lead zone, default)
+  FR    — France (RTE)
+  NL    — Netherlands (TenneT NL)
+
+Out of scope (left DE-only, intentional):
+  SparkSpreadHistory — no zone column; always uses POWER_DE (DE-LU) price.
+  Scorecard signals (power_residual, spark_spread) — target-aware but zoned
+    at DE-LU only; extending them is a future sprint.
+"""
+
+from __future__ import annotations
+
+# EIC codes from backend.gas.entsoe.EU27_BIDDING_ZONES (verified against that map):
+#   "DE-LU": "10Y1001A1001A82H"
+#   "FR":    "10YFR-RTE------C"
+#   "NL":    "10YNL----------L"
+
+POWER_ZONES: dict[str, dict] = {
+    "DE_LU": {
+        "eic": "10Y1001A1001A82H",
+        "price_symbol": "POWER_DE",
+        "label": "DE-LU",
+    },
+    "FR": {
+        "eic": "10YFR-RTE------C",
+        "price_symbol": "POWER_FR",
+        "label": "FR",
+    },
+    "NL": {
+        "eic": "10YNL----------L",
+        "price_symbol": "POWER_NL",
+        "label": "NL",
+    },
+}
+
+DEFAULT_ZONE = "DE_LU"

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1,16 +1,21 @@
 """Electricity + spark spread read endpoints.
 
-GET /api/power/day-ahead?days=120  — FREE
-    ENTSO-E A44 daily mean EUR/MWh series for DE-LU bidding zone.
-    Returns EnergyPrice(symbol="POWER_DE") rows, newest first, then reversed.
+GET /api/power/day-ahead?days=120&zone=DE_LU  — FREE
+    ENTSO-E A44 daily mean EUR/MWh series for the requested bidding zone.
+    Supported zones: DE_LU (default), FR, NL.
+    Returns EnergyPrice rows + richer PowerPriceDaily stats (negative prices etc.)
+    Each response includes `zone` (resolved) and `zones` (all supported zone keys).
 
 GET /api/power/spark-spread?days=120  — PRO
     Historical spark spread (power − gas × heat_rate).
-    Returns SparkSpreadHistory rows with a `latest` summary object.
+    DE-LU only (SparkSpreadHistory has no zone column); stays DE-only intentionally.
 
-GET /api/power/grid?days=120  — FREE
-    ENTSO-E A65 (load) + A75 (wind + solar) for DE-LU.
+GET /api/power/grid?days=120&zone=DE_LU  — FREE
+    ENTSO-E A65 (load) + A75 (wind + solar) for the requested bidding zone.
     Returns PowerGrid rows with residual_mw, renewable_share, dunkelflaute flag.
+
+GET /api/power/generation-mix?days=30&zone=DE_LU  — FREE
+    Full ENTSO-E A75 generation mix for the requested bidding zone.
 
 All endpoints follow the `{"available": bool, "data": [...]}` envelope used
 throughout the gas vertical (see backend/routes/gas.py).
@@ -24,8 +29,23 @@ from sqlalchemy.orm import Session
 from backend.auth.dependencies import require_pro
 from backend.database import get_db
 from backend.models.energy import EnergyPrice, PowerGenMix, PowerGrid, PowerPriceDaily, SparkSpreadHistory
+from backend.power.zones import DEFAULT_ZONE, POWER_ZONES
 
 router = APIRouter(prefix="/api/power", tags=["power"])
+
+_ZONE_KEYS = list(POWER_ZONES.keys())
+
+
+def _resolve_zone(zone: str) -> str:
+    """Validate zone against POWER_ZONES; fall back to DEFAULT_ZONE with a note.
+
+    Returns the resolved (canonical) zone key string.
+    """
+    if zone in POWER_ZONES:
+        return zone
+    # Unknown zone: fall back silently to default (400 is too loud for a
+    # missing backfill; the response `zones` list tells the caller what's valid).
+    return DEFAULT_ZONE
 
 
 def _window(days: int) -> tuple[str, str]:
@@ -41,28 +61,35 @@ def _window(days: int) -> tuple[str, str]:
 @router.get("/day-ahead")
 async def get_day_ahead(
     days: int = Query(120, ge=1, le=1500),
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     db: Session = Depends(get_db),
 ):
-    """ENTSO-E day-ahead electricity prices for DE-LU (EUR/MWh). Free tier.
+    """ENTSO-E day-ahead electricity prices for a bidding zone (EUR/MWh). Free tier.
+
+    `zone` defaults to DE_LU. Unknown zones fall back to DE_LU.
+    Each response includes `zone` (resolved) and `zones` (all supported zone keys).
 
     When PowerPriceDaily rows are available, each data point includes:
-      close         — daily mean EUR/MWh (identical to EnergyPrice.close)
-      min_price     — daily minimum EUR/MWh (can be negative)
-      max_price     — daily maximum EUR/MWh
+      close          — daily mean EUR/MWh (identical to EnergyPrice.close)
+      min_price      — daily minimum EUR/MWh (can be negative)
+      max_price      — daily maximum EUR/MWh
       negative_hours — hours where the auction price was < 0
-      negative      — true if negative_hours > 0
+      negative       — true if negative_hours > 0
     negative_days counts how many days in the window had at least one negative hour.
     latest contains the most recent row's fields.
 
     Falls back to EnergyPrice-only behaviour if PowerPriceDaily is empty.
     """
+    resolved_zone = _resolve_zone(zone)
+    zone_cfg = POWER_ZONES[resolved_zone]
+    symbol = zone_cfg["price_symbol"]
     date_from, date_to = _window(days)
 
     # Primary path: richer PowerPriceDaily table
     daily_rows = (
         db.query(PowerPriceDaily)
         .filter(
-            PowerPriceDaily.zone == "DE_LU",
+            PowerPriceDaily.zone == resolved_zone,
             PowerPriceDaily.date >= date_from,
             PowerPriceDaily.date <= date_to,
         )
@@ -86,7 +113,9 @@ async def get_day_ahead(
         negative_days = sum(1 for d in data if d["negative"])
         return {
             "available": True,
-            "symbol": "POWER_DE",
+            "zone": resolved_zone,
+            "zones": _ZONE_KEYS,
+            "symbol": symbol,
             "unit": "EUR/MWh",
             "from": date_from,
             "to": date_to,
@@ -99,7 +128,7 @@ async def get_day_ahead(
     rows = (
         db.query(EnergyPrice)
         .filter(
-            EnergyPrice.symbol == "POWER_DE",
+            EnergyPrice.symbol == symbol,
             EnergyPrice.date >= date_from,
             EnergyPrice.date <= date_to,
         )
@@ -109,12 +138,16 @@ async def get_day_ahead(
     if not rows:
         return {
             "available": False,
-            "reason": "no POWER_DE data yet — run power backfill (ingest_day_ahead)",
+            "zone": resolved_zone,
+            "zones": _ZONE_KEYS,
+            "reason": f"no {symbol} data yet — run power backfill (ingest_day_ahead)",
         }
     data = [{"date": r.date, "close": r.close} for r in rows]
     return {
         "available": True,
-        "symbol": "POWER_DE",
+        "zone": resolved_zone,
+        "zones": _ZONE_KEYS,
+        "symbol": symbol,
         "unit": "EUR/MWh",
         "from": date_from,
         "to": date_to,
@@ -217,19 +250,24 @@ def _compute_grid_row(r: PowerGrid) -> dict:
 @router.get("/grid")
 async def get_grid(
     days: int = Query(120, ge=1, le=1500),
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     db: Session = Depends(get_db),
 ):
-    """ENTSO-E grid load + wind + solar for DE-LU (daily mean MW). Free tier.
+    """ENTSO-E grid load + wind + solar for a bidding zone (daily mean MW). Free tier.
+
+    `zone` defaults to DE_LU. Unknown zones fall back to DE_LU.
+    Each response includes `zone` (resolved) and `zones` (all supported zone keys).
 
     Returns residual_mw (load − wind − solar), renewable_share, and a
     Dunkelflaute flag (renewable_share < 15%) per day.  `latest` contains
     the most recent row; `dunkelflaute_days` is the count within the window.
     """
+    resolved_zone = _resolve_zone(zone)
     date_from, date_to = _window(days)
     rows = (
         db.query(PowerGrid)
         .filter(
-            PowerGrid.zone == "DE_LU",
+            PowerGrid.zone == resolved_zone,
             PowerGrid.date >= date_from,
             PowerGrid.date <= date_to,
         )
@@ -239,7 +277,9 @@ async def get_grid(
     if not rows:
         return {
             "available": False,
-            "reason": "no grid data yet — run power grid backfill (ingest_grid)",
+            "zone": resolved_zone,
+            "zones": _ZONE_KEYS,
+            "reason": f"no grid data for zone {resolved_zone} — run power grid backfill (ingest_grid)",
         }
 
     data = [_compute_grid_row(r) for r in rows]
@@ -248,7 +288,8 @@ async def get_grid(
 
     return {
         "available": True,
-        "zone": "DE_LU",
+        "zone": resolved_zone,
+        "zones": _ZONE_KEYS,
         "unit": "MW",
         "threshold_note": f"dunkelflaute = renewable_share < {DUNKELFLAUTE_THRESHOLD:.0%}",
         "latest": latest,
@@ -265,20 +306,25 @@ async def get_grid(
 @router.get("/generation-mix")
 async def get_generation_mix(
     days: int = Query(30, ge=1, le=1500),
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     db: Session = Depends(get_db),
 ):
-    """Full ENTSO-E A75 generation mix for DE-LU (daily mean MW). Free tier.
+    """Full ENTSO-E A75 generation mix for a bidding zone (daily mean MW). Free tier.
+
+    `zone` defaults to DE_LU. Unknown zones fall back to DE_LU.
+    Each response includes `zone` (resolved) and `zones` (all supported zone keys).
 
     Returns data in wide/pivoted format: each row is one date with one key per
     production type (readable labels like "Solar", "Nuclear", "Wind Onshore").
     `types` lists all distinct production types present in the window.
     `latest` is the most recent date's breakdown plus a `total_mw` sum.
     """
+    resolved_zone = _resolve_zone(zone)
     date_from, date_to = _window(days)
     rows = (
         db.query(PowerGenMix)
         .filter(
-            PowerGenMix.zone == "DE_LU",
+            PowerGenMix.zone == resolved_zone,
             PowerGenMix.date >= date_from,
             PowerGenMix.date <= date_to,
         )
@@ -288,7 +334,9 @@ async def get_generation_mix(
     if not rows:
         return {
             "available": False,
-            "reason": "no generation-mix data yet — run power grid backfill (ingest_grid)",
+            "zone": resolved_zone,
+            "zones": _ZONE_KEYS,
+            "reason": f"no generation-mix data for zone {resolved_zone} — run power grid backfill (ingest_grid)",
         }
 
     # Pivot: {date -> {psr_type -> gen_mw}}
@@ -313,7 +361,8 @@ async def get_generation_mix(
 
     return {
         "available": True,
-        "zone": "DE_LU",
+        "zone": resolved_zone,
+        "zones": _ZONE_KEYS,
         "unit": "MW",
         "types": all_types,
         "latest": latest,

--- a/backend/tests/test_power_zones.py
+++ b/backend/tests/test_power_zones.py
@@ -1,0 +1,209 @@
+"""Multi-zone route tests for the ENERGY vertical.
+
+Tests:
+  - /api/power/grid returns correct zone, zones list, and available=True
+  - /api/power/day-ahead returns correct zone + zones list
+  - /api/power/generation-mix returns correct zone + zones list
+  - Unknown zone falls back to DE_LU
+  - Default zone (no param) is DE_LU
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Import models early so Base.metadata knows about these tables
+# before the db_session fixture calls create_all.
+from backend.models.energy import PowerGenMix, PowerGrid, PowerPriceDaily
+
+
+@pytest.fixture(autouse=True)
+def _clear_dependency_overrides():
+    """Clear app.dependency_overrides after every test."""
+    yield
+    from backend.main import app
+    app.dependency_overrides.clear()
+
+
+_TODAY = date.today()
+_D1 = (_TODAY - timedelta(days=3)).isoformat()
+_D2 = (_TODAY - timedelta(days=2)).isoformat()
+
+
+def _make_client(db):
+    from backend.database import get_db
+    from backend.main import app
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _seed_grid(db, zone: str):
+    db.add(PowerGrid(
+        date=_D1, zone=zone, load_mw=50_000.0, wind_mw=8_000.0, solar_mw=4_000.0
+    ))
+    db.add(PowerGrid(
+        date=_D2, zone=zone, load_mw=45_000.0, wind_mw=2_000.0, solar_mw=1_000.0
+    ))
+    db.commit()
+
+
+def _seed_price_daily(db, zone: str, symbol: str):
+    db.add(PowerPriceDaily(
+        date=_D1, zone=zone, mean_price=75.0, min_price=40.0, max_price=110.0, negative_hours=0.0
+    ))
+    db.add(PowerPriceDaily(
+        date=_D2, zone=zone, mean_price=-5.0, min_price=-20.0, max_price=30.0, negative_hours=3.0
+    ))
+    db.commit()
+
+
+def _seed_genmix(db, zone: str):
+    for date_str in (_D1, _D2):
+        db.add(PowerGenMix(date=date_str, zone=zone, psr_type="Solar", gen_mw=3_000.0))
+        db.add(PowerGenMix(date=date_str, zone=zone, psr_type="Wind Onshore", gen_mw=5_000.0))
+    db.commit()
+
+
+# ─── /api/power/grid ──────────────────────────────────────────────────────────
+
+def test_grid_de_lu_default(db_session):
+    """No zone param → default DE_LU."""
+    _seed_grid(db_session, "DE_LU")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/grid?days=120")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert body["zone"] == "DE_LU"
+    assert "FR" in body["zones"]
+    assert "NL" in body["zones"]
+    assert "DE_LU" in body["zones"]
+    assert len(body["data"]) == 2
+
+
+def test_grid_fr_zone(db_session):
+    """?zone=FR returns FR zone data."""
+    _seed_grid(db_session, "FR")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/grid?days=120&zone=FR")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert body["zone"] == "FR"
+    assert set(body["zones"]) == {"DE_LU", "FR", "NL"}
+    assert len(body["data"]) == 2
+
+
+def test_grid_nl_zone(db_session):
+    """?zone=NL returns NL zone data."""
+    _seed_grid(db_session, "NL")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/grid?days=120&zone=NL")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert body["zone"] == "NL"
+
+
+def test_grid_unknown_zone_falls_back_to_de_lu(db_session):
+    """Unknown zone falls back to DE_LU silently."""
+    _seed_grid(db_session, "DE_LU")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/grid?days=120&zone=XX_INVALID")
+    assert resp.status_code == 200
+    body = resp.json()
+    # Falls back to DE_LU
+    assert body["zone"] == "DE_LU"
+    assert body["available"] is True
+
+
+def test_grid_zone_isolation(db_session):
+    """FR zone data does not appear when querying DE_LU."""
+    _seed_grid(db_session, "FR")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/grid?days=120&zone=DE_LU")
+    assert resp.status_code == 200
+    body = resp.json()
+    # DE_LU has no data → unavailable
+    assert body["available"] is False
+    assert body["zone"] == "DE_LU"
+    assert "zones" in body
+
+
+# ─── /api/power/day-ahead ────────────────────────────────────────────────────
+
+def test_day_ahead_de_lu_default(db_session):
+    """No zone param → default DE_LU."""
+    _seed_price_daily(db_session, "DE_LU", "POWER_DE")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/day-ahead?days=120")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert body["zone"] == "DE_LU"
+    assert set(body["zones"]) == {"DE_LU", "FR", "NL"}
+
+
+def test_day_ahead_fr_zone(db_session):
+    """?zone=FR returns FR zone price data."""
+    _seed_price_daily(db_session, "FR", "POWER_FR")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/day-ahead?days=120&zone=FR")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert body["zone"] == "FR"
+    assert body["symbol"] == "POWER_FR"
+    # One negative day (D2 has negative_hours=3)
+    assert body["negative_days"] == 1
+    assert len(body["data"]) == 2
+
+
+def test_day_ahead_unknown_zone_falls_back(db_session):
+    """Unknown zone falls back to DE_LU."""
+    _seed_price_daily(db_session, "DE_LU", "POWER_DE")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/day-ahead?days=120&zone=BOGUS")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["zone"] == "DE_LU"
+
+
+# ─── /api/power/generation-mix ───────────────────────────────────────────────
+
+def test_generation_mix_fr_zone(db_session):
+    """?zone=FR returns FR generation mix."""
+    _seed_genmix(db_session, "FR")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=120&zone=FR")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert body["zone"] == "FR"
+    assert set(body["zones"]) == {"DE_LU", "FR", "NL"}
+    assert "Solar" in body["types"]
+    assert "Wind Onshore" in body["types"]
+
+
+def test_generation_mix_zone_isolation(db_session):
+    """NL mix data does not bleed into FR query."""
+    _seed_genmix(db_session, "NL")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=120&zone=FR")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is False
+    assert body["zone"] == "FR"
+
+
+def test_generation_mix_default_de_lu(db_session):
+    """No zone param → default DE_LU."""
+    _seed_genmix(db_session, "DE_LU")
+    client = _make_client(db_session)
+    resp = client.get("/api/power/generation-mix?days=120")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert body["zone"] == "DE_LU"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,7 @@ import PowerDayAheadPanel from './components/PowerDayAheadPanel'
 import PowerGridPanel from './components/PowerGridPanel'
 import SparkSpreadPanel from './components/SparkSpreadPanel'
 import GenerationMixPanel from './components/GenerationMixPanel'
+import ZoneSelector from './components/ZoneSelector'
 import Landing from './components/Landing'
 import { useAuth } from './context/AuthContext'
 
@@ -167,6 +168,10 @@ function Dashboard() {
     const hash = window.location.hash.replace('#', '')
     return TABS.find((t) => t.key === hash) ? hash : 'overview'
   })
+
+  // Selected bidding zone for the ENERGY tab (DE_LU / FR / NL).
+  // SparkSpreadHistory has no zone column and stays DE-LU only (intentional).
+  const [energyZone, setEnergyZone] = useState('DE_LU')
 
   // URL hash sync
   useEffect(() => {
@@ -511,7 +516,13 @@ function Dashboard() {
         {/* ENERGY TAB */}
         {activeTab === 'energy' && (
           <>
-            {/* Row 1: Spark Spread hero (Pro) */}
+            {/* Zone selector — applies to DayAhead, Grid, GenerationMix panels.
+                SparkSpreadHistory has no zone column → stays DE-LU only. */}
+            <div className="flex items-center justify-end mb-2">
+              <ZoneSelector zone={energyZone} onChange={setEnergyZone} />
+            </div>
+
+            {/* Row 1: Spark Spread hero (Pro) — DE-LU only, no zone param */}
             <ErrorBoundary name="power-spark">
               <ProGate feature="Spark Spread">
                 <SparkSpreadPanel />
@@ -521,21 +532,21 @@ function Dashboard() {
             {/* Row 2: Day-Ahead price (free) */}
             <div className="mt-3">
               <ErrorBoundary name="power-dayahead">
-                <PowerDayAheadPanel />
+                <PowerDayAheadPanel zone={energyZone} />
               </ErrorBoundary>
             </div>
 
             {/* Row 3: Residual Load + Dunkelflaute (free) */}
             <div className="mt-3">
               <ErrorBoundary name="power-grid">
-                <PowerGridPanel />
+                <PowerGridPanel zone={energyZone} />
               </ErrorBoundary>
             </div>
 
             {/* Row 4: Generation Mix (free) */}
             <div className="mt-3">
               <ErrorBoundary name="generation-mix">
-                <GenerationMixPanel />
+                <GenerationMixPanel zone={energyZone} />
               </ErrorBoundary>
             </div>
           </>

--- a/frontend/src/components/GenerationMixPanel.jsx
+++ b/frontend/src/components/GenerationMixPanel.jsx
@@ -29,8 +29,9 @@ const TYPE_COLORS = {
 
 const DEFAULT_COLOR = '#64748b'
 
-export default function GenerationMixPanel() {
-  const { data, loading, error } = useFetchWithError(`${API}/power/generation-mix?days=30`)
+export default function GenerationMixPanel({ zone = 'DE_LU' }) {
+  const url = `${API}/power/generation-mix?days=30&zone=${zone}`
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone] })
 
   if (error)
     return (
@@ -55,10 +56,13 @@ export default function GenerationMixPanel() {
     ? (latest.total_mw / 1000).toFixed(1)
     : null
 
+  // Readable label: prefer what the API returns, fall back to zone prop
+  const zoneLabel = data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)
+
   return (
     <Panel
       id="generation-mix"
-      title="GENERATION MIX · DE-LU"
+      title={`GENERATION MIX · ${zoneLabel}`}
       info="Full ENTSO-E A75 generation breakdown by production type (daily mean MW). Covers nuclear, coal, gas, hydro, biomass, wind, solar and more. Source: ENTSO-E Transparency Platform, processType A16."
       collapsible
       headerRight={
@@ -93,7 +97,7 @@ export default function GenerationMixPanel() {
               )}
             </div>
             <div className="font-mono text-[10px] text-neutral-600 mt-1">
-              {types.length} types · ENTSO-E A75 · {latest.date}
+              {types.length} types · ENTSO-E A75 · {zoneLabel} · {latest.date}
             </div>
           </div>
 

--- a/frontend/src/components/PowerDayAheadPanel.jsx
+++ b/frontend/src/components/PowerDayAheadPanel.jsx
@@ -14,8 +14,9 @@ function NegativeDot({ cx, cy, payload }) {
   return <circle cx={cx} cy={cy} r={3} fill="#f87171" stroke="none" />
 }
 
-export default function PowerDayAheadPanel() {
-  const { data, loading, error } = useFetchWithError(`${API}/power/day-ahead?days=120`)
+export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
+  const url = `${API}/power/day-ahead?days=120&zone=${zone}`
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone] })
 
   if (error)
     return (
@@ -29,12 +30,14 @@ export default function PowerDayAheadPanel() {
   const latest = data?.latest ?? rows[rows.length - 1]
   const close = latest?.close
   const negativeDays = data?.negative_days ?? 0
+  // Readable label: prefer what the API returns, fall back to the zone prop
+  const zoneLabel = data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)
 
   return (
     <Panel
       id="power-day-ahead"
-      title="POWER DAY-AHEAD · DE-LU"
-      info="ENTSO-E day-ahead electricity prices for the DE-LU bidding zone (EUR/MWh). Each point is the daily mean of 24 hourly auction results from the ENTSO-E Transparency Platform (A44). Red markers indicate days with at least one negative-price hour (renewable oversupply). Free, official redistributable data."
+      title={`POWER DAY-AHEAD · ${zoneLabel}`}
+      info="ENTSO-E day-ahead electricity prices for the selected bidding zone (EUR/MWh). Each point is the daily mean of 24 hourly auction results from the ENTSO-E Transparency Platform (A44). Red markers indicate days with at least one negative-price hour (renewable oversupply). Free, official redistributable data."
       collapsible
       headerRight={
         close != null && (
@@ -60,7 +63,7 @@ export default function PowerDayAheadPanel() {
               <span className="font-mono text-[10px] text-neutral-600">{latest.date}</span>
             </div>
             <div className="font-mono text-[10px] text-neutral-600 mt-1">
-              ENTSO-E A44 · DE-LU bidding zone · daily mean of hourly prices
+              ENTSO-E A44 · {zoneLabel} bidding zone · daily mean of hourly prices
               {negativeDays > 0 && (
                 <span className="ml-2 text-red-400">
                   · {negativeDays} negative-price {negativeDays === 1 ? 'day' : 'days'}

--- a/frontend/src/components/PowerGridPanel.jsx
+++ b/frontend/src/components/PowerGridPanel.jsx
@@ -20,8 +20,9 @@ function DunkelDot({ cx, cy, payload }) {
   return <circle cx={cx} cy={cy} r={3} fill={COLOR_DUNKEL} stroke="none" />
 }
 
-export default function PowerGridPanel() {
-  const { data, loading, error } = useFetchWithError(`${API}/power/grid?days=120`)
+export default function PowerGridPanel({ zone = 'DE_LU' }) {
+  const url = `${API}/power/grid?days=120&zone=${zone}`
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone] })
 
   if (error)
     return (
@@ -46,10 +47,13 @@ export default function PowerGridPanel() {
   const isDunkel = latest?.dunkelflaute === true
   const headerColor = isDunkel ? COLOR_DUNKEL : '#22d3ee'
 
+  // Readable label: prefer what the API returns, fall back to zone prop
+  const zoneLabel = data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)
+
   return (
     <Panel
       id="power-grid"
-      title="RESIDUAL LOAD · DE-LU"
+      title={`RESIDUAL LOAD · ${zoneLabel}`}
       info="Residual load = total electricity demand − wind − solar (MW daily mean). This is the demand that dispatchable plants (gas, coal, nuclear, hydro) must cover. Dunkelflaute = day when renewable share < 15% of total load — a physical stress signal, not a price forecast."
       collapsible
       headerRight={
@@ -89,7 +93,7 @@ export default function PowerGridPanel() {
               )}
             </div>
             <div className="font-mono text-[10px] text-neutral-600 mt-1">
-              {dunkelflaute_days} Dunkelflaute days / {rows.length} · ENTSO-E A65 + A75 · {latest.date}
+              {dunkelflaute_days} Dunkelflaute days / {rows.length} · ENTSO-E A65 + A75 · {zoneLabel} · {latest.date}
             </div>
           </div>
 

--- a/frontend/src/components/ZoneSelector.jsx
+++ b/frontend/src/components/ZoneSelector.jsx
@@ -1,0 +1,37 @@
+/**
+ * ZoneSelector — small pill-button group for the ENERGY tab.
+ *
+ * Props:
+ *   zone     {string}   — currently selected zone key (e.g. "DE_LU")
+ *   onChange {function} — called with the new zone key on click
+ *
+ * SparkSpreadHistory has no zone column and is intentionally DE-LU only;
+ * only the three multi-zone panels (DayAhead, Grid, GenerationMix) use this.
+ */
+
+const ZONES = [
+  { key: 'DE_LU', label: 'DE-LU' },
+  { key: 'FR',    label: 'FR'    },
+  { key: 'NL',    label: 'NL'    },
+]
+
+export default function ZoneSelector({ zone, onChange }) {
+  return (
+    <div className="flex items-center gap-1">
+      {ZONES.map(({ key, label }) => (
+        <button
+          key={key}
+          onClick={() => onChange(key)}
+          className={[
+            'font-mono text-[9px] tracking-wider px-2 py-0.5 rounded border transition-colors',
+            zone === key
+              ? 'border-cyan-500/60 text-cyan-300 bg-cyan-500/10'
+              : 'border-border/40 text-neutral-500 hover:text-neutral-300 hover:border-border/60 bg-transparent',
+          ].join(' ')}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
A1.1 of the follow-up plan: the ENERGY vertical goes multi-zone (DE-LU, France, Netherlands) for day-ahead price (+negative prices), residual-load/Dunkelflaute, and generation-mix.

- `POWER_ZONES` registry (EICs sourced from `EU27_BIDDING_ZONES`).
- `ingest_day_ahead`/`ingest_grid` thread `zone`; `_run_power_daily` loops all zones.
- `/api/power/{day-ahead,grid,generation-mix}?zone=` (default DE_LU, unknown→fallback); responses carry `zone` + `zones`.
- Frontend `ZoneSelector` (DE-LU/FR/NL) drives the three panels (refetch on change).
- **DE-only (documented):** spark-spread + scorecard signals (SparkSpreadHistory has no zone column — A1 follow-on).

## Test Plan
- [x] `ruff` clean; `pytest` **272 passed** (new `test_power_zones.py`: zone echo, fallback, zone isolation FR↛DE)
- [x] eslint + `npm run build` clean
- [x] local backfill FR/NL: PowerGrid/PriceDaily/GenMix populated per zone; `/api/power/grid?zone=FR|NL|DE_LU` return correct zone data
- [ ] After merge + prod deploy + zone backfill: zone selector live on ENERGY tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)