### PR TITLE
feat: cross-border physical flows (ENTSO-E A11) in ENERGY tab

### DIFF
--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -188,6 +188,15 @@ async def _run_power_daily():
             except Exception as exc:
                 logger.error("power daily ingest_grid [%s] failed: %s", zone_key, exc)
 
+        # Cross-border physical flows (A11) — all POWER_BORDERS.
+        try:
+            from backend.power.entsoe_flows import ingest_flows as ingest_border_flows
+
+            result = await ingest_border_flows(db, days, overwrite=True)
+            logger.info("power daily cross-border flows: %s", result)
+        except Exception as exc:
+            logger.error("power daily ingest_flows (A11) failed: %s", exc)
+
         # Spark spread uses POWER_DE (DE-LU) only — SparkSpreadHistory has no zone column.
         try:
             result = await collect_spark_spreads()

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -67,6 +67,10 @@ def run_migrations() -> None:
             ))
         logger.info("migrations: backfilled power_grid.residual_mw from load_mw/wind_mw/solar_mw")
 
+    # 2026-06-24: cross-border physical flows (A11) table
+    # Base.metadata.create_all handles new tables, so no ALTER needed here.
+    # This note documents the addition for the audit trail.
+
     if applied:
         logger.info("migrations applied: %s", ", ".join(applied))
     else:

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -110,6 +110,36 @@ class PowerGenMix(Base):
     )
 
 
+class PowerFlow(Base):
+    """Daily net cross-border physical electricity flow (ENTSO-E A11).
+
+    One row per (date, from_zone, to_zone). net_mw is the daily-mean MW
+    averaged over all hourly quantities in the A11 document.
+
+    Sign convention: net_mw > 0 means net physical flow goes from_zone → to_zone;
+    net_mw < 0 means the reverse net direction.
+
+    Computed as:
+        net_mw = mean(A11 where out_Domain=from_zone, in_Domain=to_zone)
+               − mean(A11 where out_Domain=to_zone,   in_Domain=from_zone)
+
+    Source: ENTSO-E A11 (Actual Cross-Border Physical Flows).
+    """
+
+    __tablename__ = "power_flow"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    date: Mapped[str] = mapped_column(String, nullable=False, index=True)        # YYYY-MM-DD
+    from_zone: Mapped[str] = mapped_column(String, nullable=False, index=True)   # e.g. "DE_LU"
+    to_zone: Mapped[str] = mapped_column(String, nullable=False, index=True)     # e.g. "FR"
+    net_mw: Mapped[float] = mapped_column(Float, nullable=False)                 # daily mean MW (signed)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("date", "from_zone", "to_zone", name="uq_power_flow_date_from_to"),
+    )
+
+
 class PowerPriceDaily(Base):
     """Rich per-day electricity price stats for negative-price detection.
 

--- a/backend/power/entsoe_flows.py
+++ b/backend/power/entsoe_flows.py
@@ -1,0 +1,262 @@
+"""ENTSO-E cross-border physical electricity flows (A11).
+
+Fetches Actual Cross-Border Physical Flow (documentType=A11) between
+pairs of bidding zones defined in POWER_BORDERS (zones.py).
+
+One A11 query covers one direction: out_Domain (exporter) → in_Domain
+(importer).  Net flow on a border is:
+
+    net_mw(A→B) = mean_mw(out=A, in=B) − mean_mw(out=B, in=A)
+
+Positive net_mw means net physical flow from_zone → to_zone.
+
+Caches raw XML under source "entsoe_flows", key
+"<in_eic>_<out_eic>_<YYYY-MM>", month-bucketed.
+
+Shares token / base URL / XML helpers with backend.gas.entsoe to avoid
+duplication (same pattern as entsoe_grid.py).
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from datetime import date, datetime, timedelta, timezone
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.gas import raw_cache
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
+from backend.models.energy import PowerFlow
+from backend.power.zones import POWER_BORDERS, POWER_ZONES
+
+logger = logging.getLogger(__name__)
+
+_RESOLUTION_HOURS = {"PT60M": 1.0, "PT30M": 0.5, "PT15M": 0.25}
+
+
+# ─── parser ──────────────────────────────────────────────────────────────────
+
+
+def parse_physical_flow(xml_text: str) -> dict[str, float]:
+    """Parse an A11 GL_MarketDocument into {YYYY-MM-DD: daily_mean_mw}.
+
+    Walks TimeSeries → Period → Point, reads <quantity> (MW), buckets each
+    hourly value to its UTC calendar day, and returns the daily MEAN in MW.
+
+    The same walk as parse_load (A65) — the only difference is the document
+    type; the XML structure and <quantity> tag are identical.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A11 XML parse error: {exc}") from exc
+
+    by_day: dict[str, list[float]] = {}
+
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            start_el = next(
+                (e for e in period.iter() if _localname(e.tag) == "start"), None
+            )
+            res_el = next(
+                (e for e in period.iter() if _localname(e.tag) == "resolution"), None
+            )
+            if start_el is None or res_el is None:
+                continue
+            start = _parse_utc(start_el.text)
+            res_hours = _RESOLUTION_HOURS.get((res_el.text or "").strip())
+            if start is None or res_hours is None:
+                continue
+            for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+                pos = next(
+                    (e.text for e in point if _localname(e.tag) == "position"), None
+                )
+                qty = next(
+                    (e.text for e in point if _localname(e.tag) == "quantity"), None
+                )
+                if pos is None or qty is None:
+                    continue
+                try:
+                    ts_time = start + timedelta(hours=res_hours * (int(pos) - 1))
+                    mw = float(qty)
+                except (ValueError, TypeError):
+                    continue
+                day = ts_time.astimezone(timezone.utc).strftime("%Y-%m-%d")
+                by_day.setdefault(day, []).append(mw)
+
+    return {day: sum(vals) / len(vals) for day, vals in by_day.items() if vals}
+
+
+# ─── fetch ────────────────────────────────────────────────────────────────────
+
+
+async def _fetch_border_month(
+    in_eic: str,
+    out_eic: str,
+    month_start: date,
+    *,
+    overwrite: bool = False,
+) -> str:
+    """Fetch one directional border flow for a calendar month (raw XML, cached).
+
+    Cached under source "entsoe_flows", key "<in_eic>_<out_eic>_<YYYY-MM>".
+    Returns raw XML string (empty string on HTTP errors).
+    """
+    nxt = (month_start.replace(day=28) + timedelta(days=4)).replace(day=1)
+    period_start = f"{month_start:%Y%m%d}0000"
+    period_end = f"{nxt:%Y%m%d}0000"
+
+    cache_key = f"{in_eic}_{out_eic}_{month_start:%Y-%m}"
+
+    async def _do() -> dict:
+        params = {
+            "securityToken": _token(),
+            "documentType": "A11",
+            "in_Domain": in_eic,
+            "out_Domain": out_eic,
+            "periodStart": period_start,
+            "periodEnd": period_end,
+        }
+        async with httpx.AsyncClient(timeout=90) as client:
+            resp = await client.get(ENTSOE_BASE, params=params)
+            resp.raise_for_status()
+            return {"xml": resp.text}
+
+    payload = await raw_cache.fetch_or_cache(
+        "entsoe_flows", cache_key, month_start, _do, overwrite=overwrite
+    )
+    return payload.get("xml", "")
+
+
+# ─── ingest ───────────────────────────────────────────────────────────────────
+
+
+async def ingest_flows(
+    db: Session,
+    days: list[str],
+    *,
+    overwrite: bool = False,
+) -> dict:
+    """Ingest cross-border physical flows for all POWER_BORDERS.
+
+    For each (from_zone, to_zone) pair in POWER_BORDERS:
+      1. Fetch A11 with out_Domain=from_zone, in_Domain=to_zone (flow A→B).
+      2. Fetch A11 with out_Domain=to_zone,   in_Domain=from_zone (flow B→A).
+      3. Compute net_mw per day:
+           net_mw = flow_AB[day] − flow_BA[day]
+         Positive = net physical export from_zone → to_zone.
+         Missing direction treated as 0 for that day.
+      4. Upsert PowerFlow(from_zone, to_zone, net_mw) per day.
+
+    Returns {"days": n, "written": n} or {"skipped": "no token"}.
+    """
+    if not days:
+        return {"days": 0, "written": 0}
+    if not settings.entsoe_api_token:
+        logger.warning("entsoe_flows.ingest_flows: ENTSOE_API_TOKEN not set — skipping")
+        return {"skipped": "no token"}
+
+    wanted = set(days)
+    months = sorted(
+        {datetime.strptime(d, "%Y-%m-%d").date().replace(day=1) for d in days}
+    )
+
+    written = 0
+
+    for from_zone, to_zone in POWER_BORDERS:
+        from_eic = POWER_ZONES[from_zone]["eic"]
+        to_eic = POWER_ZONES[to_zone]["eic"]
+
+        # Accumulate both directions across month fetches
+        flow_ab: dict[str, float] = {}  # from_zone → to_zone (out=from, in=to)
+        flow_ba: dict[str, float] = {}  # to_zone → from_zone (out=to, in=from)
+
+        for month_start in months:
+            # Direction A→B: out=from_zone, in=to_zone
+            try:
+                xml_ab = await _fetch_border_month(
+                    in_eic=to_eic,
+                    out_eic=from_eic,
+                    month_start=month_start,
+                    overwrite=overwrite,
+                )
+            except httpx.HTTPError as exc:
+                logger.warning(
+                    "entsoe_flows: A11 %s→%s %s fetch failed: %s",
+                    from_zone, to_zone, month_start, exc,
+                )
+                xml_ab = ""
+
+            if xml_ab:
+                for day, mean_mw in parse_physical_flow(xml_ab).items():
+                    if day in wanted:
+                        flow_ab[day] = mean_mw
+
+            # Direction B→A: out=to_zone, in=from_zone
+            try:
+                xml_ba = await _fetch_border_month(
+                    in_eic=from_eic,
+                    out_eic=to_eic,
+                    month_start=month_start,
+                    overwrite=overwrite,
+                )
+            except httpx.HTTPError as exc:
+                logger.warning(
+                    "entsoe_flows: A11 %s→%s %s fetch failed: %s",
+                    to_zone, from_zone, month_start, exc,
+                )
+                xml_ba = ""
+
+            if xml_ba:
+                for day, mean_mw in parse_physical_flow(xml_ba).items():
+                    if day in wanted:
+                        flow_ba[day] = mean_mw
+
+        # Days that appear in either direction
+        all_days = wanted & (flow_ab.keys() | flow_ba.keys())
+        for day in sorted(all_days):
+            net_mw = flow_ab.get(day, 0.0) - flow_ba.get(day, 0.0)
+            _upsert_flow(db, day, from_zone, to_zone, net_mw)
+            written += 1
+
+    db.commit()
+    logger.info(
+        "entsoe_flows.ingest_flows: %d rows written across %d borders",
+        written,
+        len(POWER_BORDERS),
+    )
+    return {"days": len(days), "written": written}
+
+
+def _upsert_flow(
+    db: Session,
+    day: str,
+    from_zone: str,
+    to_zone: str,
+    net_mw: float,
+) -> None:
+    existing = (
+        db.query(PowerFlow)
+        .filter(
+            PowerFlow.date == day,
+            PowerFlow.from_zone == from_zone,
+            PowerFlow.to_zone == to_zone,
+        )
+        .first()
+    )
+    if existing:
+        existing.net_mw = net_mw
+    else:
+        db.add(
+            PowerFlow(
+                date=day,
+                from_zone=from_zone,
+                to_zone=to_zone,
+                net_mw=net_mw,
+            )
+        )

--- a/backend/power/zones.py
+++ b/backend/power/zones.py
@@ -40,3 +40,12 @@ POWER_ZONES: dict[str, dict] = {
 }
 
 DEFAULT_ZONE = "DE_LU"
+
+# Cross-border pairs for A11 physical flow ingestion.
+# Convention: net_mw is positive when flow goes from_zone → to_zone.
+# net_mw = dir(out=from_zone, in=to_zone) − dir(out=to_zone, in=from_zone)
+POWER_BORDERS: list[tuple[str, str]] = [
+    ("DE_LU", "FR"),
+    ("DE_LU", "NL"),
+    ("FR", "NL"),
+]

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -28,8 +28,8 @@ from sqlalchemy.orm import Session
 
 from backend.auth.dependencies import require_pro
 from backend.database import get_db
-from backend.models.energy import EnergyPrice, PowerGenMix, PowerGrid, PowerPriceDaily, SparkSpreadHistory
-from backend.power.zones import DEFAULT_ZONE, POWER_ZONES
+from backend.models.energy import EnergyPrice, PowerFlow, PowerGenMix, PowerGrid, PowerPriceDaily, SparkSpreadHistory
+from backend.power.zones import DEFAULT_ZONE, POWER_BORDERS, POWER_ZONES
 
 router = APIRouter(prefix="/api/power", tags=["power"])
 
@@ -294,6 +294,108 @@ async def get_grid(
         "threshold_note": f"dunkelflaute = renewable_share < {DUNKELFLAUTE_THRESHOLD:.0%}",
         "latest": latest,
         "dunkelflaute_days": dunkelflaute_days,
+        "from": date_from,
+        "to": date_to,
+        "data": data,
+    }
+
+
+# ─── Cross-border physical flows (free) ──────────────────────────────────────
+
+
+def _border_label(from_zone: str, to_zone: str) -> str:
+    """Human-readable border label, e.g. "DE-LU↔FR"."""
+    a = POWER_ZONES[from_zone]["label"]
+    b = POWER_ZONES[to_zone]["label"]
+    return f"{a}↔{b}"
+
+
+def _flow_direction(from_zone: str, to_zone: str, net_mw: float) -> str:
+    """Arrow label for current net direction.
+
+    Positive net_mw = from_zone → to_zone.
+    Negative net_mw = to_zone → from_zone.
+    """
+    a = POWER_ZONES[from_zone]["label"]
+    b = POWER_ZONES[to_zone]["label"]
+    return f"{a}→{b}" if net_mw >= 0 else f"{b}→{a}"
+
+
+@router.get("/flows")
+async def get_flows(
+    days: int = Query(30, ge=1, le=1500),
+    db: Session = Depends(get_db),
+):
+    """ENTSO-E A11 cross-border physical flows for all supported borders. Free tier.
+
+    Returns net daily mean MW per border (positive = from_zone→to_zone).
+    `borders` — latest snapshot per border with direction label.
+    `data`    — wide format: one row per date with one key per border arrow.
+    `latest`  — most recent date values keyed by border arrow.
+
+    Border convention: from_zone → to_zone as defined in POWER_BORDERS.
+    net_mw > 0 = net physical export from_zone to to_zone.
+    """
+    date_from, date_to = _window(days)
+
+    rows = (
+        db.query(PowerFlow)
+        .filter(
+            PowerFlow.date >= date_from,
+            PowerFlow.date <= date_to,
+        )
+        .order_by(PowerFlow.date.asc())
+        .all()
+    )
+
+    if not rows:
+        return {
+            "available": False,
+            "reason": "no cross-border flow data yet — run power backfill (ingest_flows)",
+        }
+
+    # Build wide format {date -> {border_arrow: net_mw}}
+    pivot: dict[str, dict[str, float]] = {}
+    for r in rows:
+        arrow = f"{POWER_ZONES[r.from_zone]['label']}→{POWER_ZONES[r.to_zone]['label']}"
+        pivot.setdefault(r.date, {})[arrow] = round(r.net_mw, 2)
+
+    data = [{"date": d, **pivot[d]} for d in sorted(pivot.keys())]
+    latest_date = sorted(pivot.keys())[-1]
+    latest = {"date": latest_date, **pivot[latest_date]}
+
+    # Per-border summary using the latest available row per (from_zone, to_zone)
+    borders: list[dict] = []
+    for from_zone, to_zone in POWER_BORDERS:
+        # Latest row for this border pair
+        border_row = (
+            db.query(PowerFlow)
+            .filter(
+                PowerFlow.from_zone == from_zone,
+                PowerFlow.to_zone == to_zone,
+                PowerFlow.date >= date_from,
+                PowerFlow.date <= date_to,
+            )
+            .order_by(PowerFlow.date.desc())
+            .first()
+        )
+        if border_row is None:
+            continue
+        net = round(border_row.net_mw, 2)
+        borders.append({
+            "from_zone": from_zone,
+            "to_zone": to_zone,
+            "label": _border_label(from_zone, to_zone),
+            "net_mw": net,
+            "direction": _flow_direction(from_zone, to_zone, net),
+        })
+
+    return {
+        "available": True,
+        "unit": "MW",
+        "note": "net_mw > 0 = net physical flow from_zone→to_zone (ENTSO-E A11 daily mean)",
+        "borders": borders,
+        "latest": latest,
         "from": date_from,
         "to": date_to,
         "data": data,

--- a/backend/tests/test_power_flows.py
+++ b/backend/tests/test_power_flows.py
@@ -1,0 +1,285 @@
+"""Tests for cross-border physical electricity flows (ENTSO-E A11).
+
+Covers:
+  - parse_physical_flow: unit test with crafted A11 XML for both directions
+  - ingest_flows: net computation + upsert idempotency
+  - GET /api/power/flows: route shape + available/unavailable cases
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from backend.models.energy import PowerFlow
+from backend.power.entsoe_flows import parse_physical_flow
+
+# ─── autouse: clear dependency overrides between tests ───────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_dependency_overrides():
+    """Prevent app.dependency_overrides leaking between test files."""
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+_TODAY = date.today()
+_D1 = (_TODAY - timedelta(days=3)).isoformat()
+_D2 = (_TODAY - timedelta(days=2)).isoformat()
+_D3 = (_TODAY - timedelta(days=1)).isoformat()
+
+
+def _a11_xml(day: str, quantity: float, resolution: str = "PT60M") -> str:
+    """Minimal valid A11 XML for a single day (24 hourly points at `quantity` MW).
+
+    The <start> element uses ISO 8601 UTC format (e.g. "2026-06-21T00:00Z") that
+    _parse_utc (datetime.fromisoformat) can consume.  The YYYYMMDD0000 format is
+    the ENTSO-E query parameter format, NOT the XML element format.
+    """
+    # Build 24 hourly points
+    points = "".join(
+        f"<Point><position>{i}</position><quantity>{quantity}</quantity></Point>"
+        for i in range(1, 25)
+    )
+    iso_start = f"{day}T00:00Z"
+    # Note: no leading whitespace before the XML declaration — ET.fromstring
+    # requires it to be at position 0.
+    return (
+        f'<?xml version="1.0" encoding="UTF-8"?>'
+        f'<GL_MarketDocument xmlns="urn:iec62325.351:tc57wg16:451-6:generationloaddocument:3:0">'
+        f"<TimeSeries>"
+        f"<Period>"
+        f"<timeInterval><start>{iso_start}</start></timeInterval>"
+        f"<resolution>{resolution}</resolution>"
+        f"{points}"
+        f"</Period>"
+        f"</TimeSeries>"
+        f"</GL_MarketDocument>"
+    )
+
+
+def _seed_flows(db: Session, rows: list[dict]) -> None:
+    for r in rows:
+        db.add(
+            PowerFlow(
+                date=r["date"],
+                from_zone=r.get("from_zone", "DE_LU"),
+                to_zone=r.get("to_zone", "FR"),
+                net_mw=r["net_mw"],
+            )
+        )
+    db.commit()
+
+
+def _make_client(db: Session) -> TestClient:
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ─── parse_physical_flow unit tests ──────────────────────────────────────────
+
+
+def test_parse_returns_daily_mean():
+    """24 hourly points of 1000 MW → daily mean 1000.0 MW."""
+    xml = _a11_xml(_D1, 1000.0)
+    result = parse_physical_flow(xml)
+    assert _D1 in result
+    assert result[_D1] == pytest.approx(1000.0)
+
+
+def test_parse_two_days():
+    """Points spanning midnight produce two date buckets."""
+    # Build a 24-h block starting at midnight of d2 (so all in d2)
+    xml_d2 = _a11_xml(_D2, 3000.0)
+    result = parse_physical_flow(xml_d2)
+    assert _D2 in result
+    assert result[_D2] == pytest.approx(3000.0)
+
+
+def test_parse_empty_xml_returns_empty():
+    """An XML with no TimeSeries → empty dict (no crash)."""
+    xml = '<?xml version="1.0"?><GL_MarketDocument></GL_MarketDocument>'
+    result = parse_physical_flow(xml)
+    assert result == {}
+
+
+def test_parse_invalid_xml_raises():
+    """Malformed XML → ValueError."""
+    with pytest.raises(ValueError, match="A11 XML parse error"):
+        parse_physical_flow("not xml at all <<>>")
+
+
+def test_net_flow_convention():
+    """Net = AB − BA: positive = A→B, negative = B→A."""
+    xml_ab = _a11_xml(_D1, 2000.0)  # from A to B: 2 GW
+    xml_ba = _a11_xml(_D1, 500.0)   # from B to A: 0.5 GW
+    flow_ab = parse_physical_flow(xml_ab)
+    flow_ba = parse_physical_flow(xml_ba)
+    net = flow_ab[_D1] - flow_ba[_D1]
+    assert net == pytest.approx(1500.0)  # net 1.5 GW A→B
+
+
+# ─── ingest_flows integration tests ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ingest_skips_without_token(db_session):
+    """ingest_flows returns {"skipped": "no token"} when ENTSOE_API_TOKEN is unset."""
+    from backend.power.entsoe_flows import ingest_flows
+
+    with patch("backend.power.entsoe_flows.settings") as mock_settings:
+        mock_settings.entsoe_api_token = None
+        result = await ingest_flows(db_session, [_D1])
+    assert result == {"skipped": "no token"}
+
+
+@pytest.mark.asyncio
+async def test_ingest_empty_days(db_session):
+    """Empty day list → {days: 0, written: 0}."""
+    from backend.power.entsoe_flows import ingest_flows
+
+    result = await ingest_flows(db_session, [])
+    assert result == {"days": 0, "written": 0}
+
+
+@pytest.mark.asyncio
+async def test_ingest_upsert_idempotent(db_session):
+    """Ingesting the same day twice with overwrite=True updates net_mw in place."""
+    from backend.power.entsoe_flows import _upsert_flow
+
+    _upsert_flow(db_session, _D1, "DE_LU", "FR", 1500.0)
+    db_session.commit()
+    row1 = db_session.query(PowerFlow).filter(PowerFlow.date == _D1).first()
+    assert row1.net_mw == pytest.approx(1500.0)
+
+    # Second upsert with different value
+    _upsert_flow(db_session, _D1, "DE_LU", "FR", 800.0)
+    db_session.commit()
+    rows = db_session.query(PowerFlow).filter(PowerFlow.date == _D1).all()
+    assert len(rows) == 1
+    assert rows[0].net_mw == pytest.approx(800.0)
+
+
+@pytest.mark.asyncio
+async def test_ingest_net_computation(db_session):
+    """ingest_flows computes net = AB − BA for each border day and writes PowerFlow rows."""
+    from backend.power.entsoe_flows import ingest_flows
+
+    xml_ab = _a11_xml(_D1, 2000.0)   # DE_LU → FR: 2000 MW
+    xml_ba = _a11_xml(_D1, 500.0)    # FR → DE_LU: 500 MW
+
+    call_count = {}
+
+    async def mock_fetch(in_eic, out_eic, month_start, *, overwrite=False):
+        key = (in_eic, out_eic)
+        call_count[key] = call_count.get(key, 0) + 1
+        # Identify direction: DE_LU EIC = "10Y1001A1001A82H", FR EIC = "10YFR-RTE------C"
+        de_eic = "10Y1001A1001A82H"
+        fr_eic = "10YFR-RTE------C"
+        if out_eic == de_eic and in_eic == fr_eic:
+            return xml_ab  # out=DE_LU (from_zone), in=FR (to_zone)
+        if out_eic == fr_eic and in_eic == de_eic:
+            return xml_ba  # out=FR, in=DE_LU
+        return ""
+
+    with (
+        patch("backend.power.entsoe_flows.settings") as mock_settings,
+        patch("backend.power.entsoe_flows._fetch_border_month", side_effect=mock_fetch),
+    ):
+        mock_settings.entsoe_api_token = "fake-token"
+        result = await ingest_flows(db_session, [_D1])
+
+    # Should have written rows (1 per border per day; 3 borders but mock only
+    # covers DE_LU↔FR, others return empty → 0 for those)
+    assert result["days"] == 1
+    assert result["written"] >= 1
+
+    # Check the DE_LU↔FR border specifically
+    row = (
+        db_session.query(PowerFlow)
+        .filter(
+            PowerFlow.date == _D1,
+            PowerFlow.from_zone == "DE_LU",
+            PowerFlow.to_zone == "FR",
+        )
+        .first()
+    )
+    assert row is not None
+    assert row.net_mw == pytest.approx(1500.0)  # 2000 − 500
+
+
+# ─── route tests ─────────────────────────────────────────────────────────────
+
+
+def test_route_flows_available_false_when_empty(db_session):
+    """No PowerFlow rows → available=False."""
+    client = _make_client(db_session)
+    resp = client.get("/api/power/flows?days=30")
+    assert resp.status_code == 200
+    assert resp.json()["available"] is False
+
+
+def test_route_flows_available_true(db_session):
+    """Seeded rows → available=True, borders list, data list, latest."""
+    _seed_flows(db_session, [
+        {"date": _D1, "from_zone": "DE_LU", "to_zone": "FR",  "net_mw": 1200.0},
+        {"date": _D1, "from_zone": "DE_LU", "to_zone": "NL",  "net_mw": -800.0},
+        {"date": _D2, "from_zone": "DE_LU", "to_zone": "FR",  "net_mw": 1500.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/flows?days=30")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert len(body["borders"]) >= 1
+    assert "data" in body
+    assert "latest" in body
+    assert "unit" in body
+
+
+def test_route_flows_border_direction(db_session):
+    """Positive net_mw → direction arrow A→B; negative → B→A."""
+    _seed_flows(db_session, [
+        {"date": _D1, "from_zone": "DE_LU", "to_zone": "FR", "net_mw":  2000.0},
+        {"date": _D2, "from_zone": "DE_LU", "to_zone": "NL", "net_mw": -1500.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/flows?days=30")
+    body = resp.json()
+    borders = {f"{b['from_zone']}-{b['to_zone']}": b for b in body["borders"]}
+
+    de_fr = borders.get("DE_LU-FR")
+    assert de_fr is not None
+    assert de_fr["net_mw"] == pytest.approx(2000.0)
+    assert "DE-LU" in de_fr["direction"] and "FR" in de_fr["direction"]
+
+    de_nl = borders.get("DE_LU-NL")
+    assert de_nl is not None
+    assert de_nl["net_mw"] == pytest.approx(-1500.0)
+    # Negative → NL→DE-LU direction
+    assert "NL" in de_nl["direction"]
+
+
+def test_route_flows_data_wide_format(db_session):
+    """data rows are wide-format dicts with date + border arrow keys."""
+    _seed_flows(db_session, [
+        {"date": _D1, "from_zone": "DE_LU", "to_zone": "FR", "net_mw": 1200.0},
+        {"date": _D1, "from_zone": "FR",    "to_zone": "NL", "net_mw":  300.0},
+    ])
+    client = _make_client(db_session)
+    resp = client.get("/api/power/flows?days=30")
+    body = resp.json()
+    d1_row = next((r for r in body["data"] if r["date"] == _D1), None)
+    assert d1_row is not None
+    assert "DE-LU→FR" in d1_row or "DE_LU→FR" in str(d1_row)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,7 @@ import PowerDayAheadPanel from './components/PowerDayAheadPanel'
 import PowerGridPanel from './components/PowerGridPanel'
 import SparkSpreadPanel from './components/SparkSpreadPanel'
 import GenerationMixPanel from './components/GenerationMixPanel'
+import CrossBorderFlowPanel from './components/CrossBorderFlowPanel'
 import ZoneSelector from './components/ZoneSelector'
 import Landing from './components/Landing'
 import { useAuth } from './context/AuthContext'
@@ -547,6 +548,13 @@ function Dashboard() {
             <div className="mt-3">
               <ErrorBoundary name="generation-mix">
                 <GenerationMixPanel zone={energyZone} />
+              </ErrorBoundary>
+            </div>
+
+            {/* Row 5: Cross-Border Physical Flows (free) */}
+            <div className="mt-3">
+              <ErrorBoundary name="cross-border-flows">
+                <CrossBorderFlowPanel />
               </ErrorBoundary>
             </div>
           </>

--- a/frontend/src/components/CrossBorderFlowPanel.jsx
+++ b/frontend/src/components/CrossBorderFlowPanel.jsx
@@ -1,0 +1,175 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ReferenceLine,
+} from 'recharts'
+import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+// Color palette: green = export, orange = import, neutral = near-zero
+const COLOR_EXPORT = '#22d3ee'  // cyan – net exporter
+const COLOR_IMPORT = '#fb923c'  // orange – net importer
+const COLOR_ZERO   = '#94a3b8'  // slate – near-zero or missing
+
+function borderColor(netMw) {
+  if (netMw == null) return COLOR_ZERO
+  if (netMw > 0) return COLOR_EXPORT
+  if (netMw < 0) return COLOR_IMPORT
+  return COLOR_ZERO
+}
+
+// Each border = one sparkline + headline bar
+function BorderRow({ border, data }) {
+  const { label, net_mw: netMw, direction, from_zone, to_zone } = border
+
+  // Pick the column key for this border: "DE-LU→FR" or similar
+  // The API builds arrows like "DE-LU→FR" from zone labels.
+  // `direction` is the ACTUAL direction for the latest day.
+  // For the sparkline we want the signed net_mw values.
+  const fromLabel = from_zone === 'DE_LU' ? 'DE-LU' : from_zone
+  const toLabel   = to_zone   === 'DE_LU' ? 'DE-LU' : to_zone
+  const arrowKey  = `${fromLabel}→${toLabel}`
+
+  const sparkData = data
+    .filter((d) => d[arrowKey] != null)
+    .map((d) => ({ date: d.date, net_mw: d[arrowKey] }))
+
+  const absGW = netMw != null ? Math.abs(netMw / 1000).toFixed(2) : '—'
+  const color = borderColor(netMw)
+
+  // Bar width: scale relative to ±5 GW max visible
+  const MAX_BAR_GW = 5
+  const barPct = netMw != null
+    ? Math.min(Math.abs(netMw) / (MAX_BAR_GW * 1000), 1) * 100
+    : 0
+  const barLeft = netMw != null && netMw < 0  // bar grows left from center
+
+  return (
+    <div className="px-4 py-2.5 border-b border-border/30 last:border-0">
+      {/* Label + headline */}
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <span className="font-mono text-[10px] text-neutral-500 shrink-0">{label}</span>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px]" style={{ color }}>
+            {absGW} GW
+          </span>
+          <span className="font-mono text-[9px] text-neutral-600">
+            {direction}
+          </span>
+        </div>
+      </div>
+
+      {/* Signed horizontal bar */}
+      <div className="flex items-center gap-1 mb-1.5">
+        {/* Left half */}
+        <div className="flex-1 h-1.5 bg-neutral-900 rounded-l overflow-hidden flex justify-end">
+          {barLeft && (
+            <div
+              className="h-full rounded-l transition-all"
+              style={{ width: `${barPct}%`, background: color }}
+            />
+          )}
+        </div>
+        {/* Centre tick */}
+        <div className="w-px h-2.5 bg-neutral-700 shrink-0" />
+        {/* Right half */}
+        <div className="flex-1 h-1.5 bg-neutral-900 rounded-r overflow-hidden">
+          {!barLeft && netMw != null && netMw > 0 && (
+            <div
+              className="h-full rounded-r transition-all"
+              style={{ width: `${barPct}%`, background: color }}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Sparkline */}
+      {sparkData.length > 1 && (
+        <ResponsiveContainer width="100%" height={36}>
+          <LineChart data={sparkData} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+            <XAxis dataKey="date" hide />
+            <YAxis hide />
+            <ReferenceLine y={0} stroke="#2a2a3a" strokeDasharray="2 2" />
+            <Tooltip
+              contentStyle={CHART_TOOLTIP_STYLE}
+              formatter={(v) => [`${(v / 1000).toFixed(2)} GW`, 'net']}
+              labelFormatter={fmtDate}
+            />
+            <Line
+              type="monotone"
+              dataKey="net_mw"
+              stroke={color}
+              strokeWidth={1}
+              dot={false}
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}
+
+export default function CrossBorderFlowPanel() {
+  const url = `${API}/power/flows?days=30`
+  const { data, loading, error } = useFetchWithError(url)
+
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">
+          CROSS-BORDER FLOWS // FETCH ERROR
+        </div>
+      </div>
+    )
+  }
+
+  if (!data?.available && !loading) return null
+
+  const borders = data?.borders ?? []
+  const rows = data?.data ?? []
+
+  return (
+    <Panel
+      id="cross-border-flows"
+      title="CROSS-BORDER FLOWS"
+      info="Net physical electricity flows between bidding zones (ENTSO-E A11, Actual Cross-Border Physical Flow). Daily mean MW — positive = net export in the shown direction. Green = net exporter, orange = net importer. Sparkline shows the last 30 days signed."
+      collapsible
+      headerRight={
+        borders.length > 0 && (
+          <span className="font-mono text-[9px] text-neutral-600">
+            {borders.length} borders · A11
+          </span>
+        )
+      }
+    >
+      {loading && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Loading cross-border flows…
+        </div>
+      )}
+
+      {!loading && data?.available && (
+        <>
+          {borders.map((border) => (
+            <BorderRow
+              key={`${border.from_zone}-${border.to_zone}`}
+              border={border}
+              data={rows}
+            />
+          ))}
+          <div className="px-4 py-2 font-mono text-[9px] text-neutral-700">
+            ENTSO-E A11 · daily mean MW · latest {data?.latest?.date}
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
## Summary
A1.2: net cross-border physical electricity flows (the "physical flow intelligence" angle) for DE-LU↔FR and DE-LU↔NL (FR↔NL has no ENTSO-E A11 data → skipped gracefully).

- `PowerFlow(date, from_zone, to_zone, net_mw)`; `entsoe_flows.py` fetches A11 both directions, nets daily-mean MW (positive = from→to). `POWER_BORDERS` config; wired into `_run_power_daily`.
- `GET /api/power/flows` (free) → per-border net + direction + time series.
- `CrossBorderFlowPanel` (free) — signed bars per border in the ENERGY tab.

## Test Plan
- [x] `ruff` clean; `pytest` **285 passed** (new `test_power_flows.py`: net-flow parse both directions, ingest, route, autouse override-clear)
- [x] eslint + `npm run build` clean
- [x] local backfill: 240 rows (120d × 2 active borders); FR→DE −1.5 GW, DE→NL +0.6 GW plausible
- [ ] After merge + prod deploy + flow backfill: cross-border panel live

🤖 Generated with [Claude Code](https://claude.com/claude-code)