### PR TITLE
docs(A0): EUA/coal data-source decision (clean/dark spread stays parked)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,12 @@ tägliche **TTF-Preisserie** (`EnergyPrice` + `energy_prices`-Collector, yfinanc
 - **Generation-Mix** (voller A75-Mix → `PowerGenMix`); `/api/power/generation-mix` (frei).
 - **Track-Record:** `power_residual` + `spark_spread` im Scorecard gegen **Strompreis** gescort
   (target-aware), Badges auf den Panels.
-- **Zurückgestellt (Slice 4):** Clean-Spark (− CO₂) + Dark-Spread (Kohle) — **keine freie,
-  redistributierbare EUA-/Kohle-Tagesquelle** (yfinance leer, EEX webshop-/lizenzgesperrt);
-  `co2_price`/`clean_spark_spread`-Spalten existieren, bleiben leer bis Quelle geklärt.
+- **Zurückgestellt (Slice 4) — A0-Spike abgeschlossen 2026-06-24:** Clean-Spark (− CO₂) +
+  Dark-Spread (Kohle) bleiben geparkt. **Entscheidung:** keine bestätigte freie, programmatisch
+  abrufbare, redistributierbare Tages-EUA-/Kohle-Quelle (yfinance leer, EEX lizenzgesperrt, ICAP
+  Terms-restricted, Energy-Charts CO₂ via API unbestätigt). Voller Befund + Unblock-Pfade:
+  `docs/findings/2026-06-24-eua-coal-data-source.md`. `co2_price`/`clean_spark_spread` bleiben null.
+  Bester Unblock-Pfad: Energy-Charts-CO₂-Code pinnen (CC BY 4.0) oder CSV-Stopgap (Bruegel-Muster).
 
 **Fehlt noch:** Exposure-Mapping (Signal→Ticker→Richtung), CO₂/EU-ETS-Feed + Clean-/Dark-Spread,
 Merit-Order, gas→power→CO₂-Synthese, Cross-Commodity-Fusion (Öl- und Gas/Energy-Vertikale siliert),
@@ -181,8 +184,10 @@ Metalle/Kupfer/Solar als Analytik-Knoten (nur Preis-Quotes).
    Scorecard, Gas-Residual gegen TTF, `TrackRecordBadge` am Balance-Panel.
 3. ~~**Gas→Energy: ENERGY-Vertikal**~~ — **erledigt (PRs #16–#22), live in Prod:** Day-Ahead-Preis
    + Negativpreise, Spark-Spread, Residuallast/Dunkelflaute, Generation-Mix, Energy-Track-Record.
-   **Offen (Slice 4, blockiert):** EUA/Clean-Spark + Dark-Spread — wartet auf freie EUA-/Kohle-Quelle.
-   **Weiter offen:** Merit-Order, gas→power→CO₂-Synthese, Cross-Commodity-Fusion.
+   **A1 erledigt (PRs #24/#25):** Multi-Zone (DE-LU/FR/NL) + Cross-Border-Flows.
+   **Slice 4 geparkt (A0-Spike abgeschlossen 2026-06-24):** EUA/Clean-Spark + Dark-Spread — keine
+   bestätigte freie Datenquelle, siehe `docs/findings/2026-06-24-eua-coal-data-source.md`.
+   **Weiter offen:** Merit-Order, gas→power→CO₂-Synthese, Cross-Commodity-Fusion, Exposure-Mapping.
 4. **Exposure-Mapping v1** (Premium-Kern) — strukturierte Signal→Ticker→Richtung-Tabelle statt
    statischer Liste + Prosa; als Hypothese durch die Validierungs-Schicht, **bevor** als Edge
    verkauft. Erst dann Preis-Diskussion 20–30 €.

--- a/docs/findings/2026-06-24-eua-coal-data-source.md
+++ b/docs/findings/2026-06-24-eua-coal-data-source.md
@@ -1,0 +1,44 @@
+# Findings: free daily EUA (CO₂) + coal price source — A0 research spike
+
+**Date:** 2026-06-24 · **Status:** CLOSED — decision: no clean free source today → A3 (clean/dark spread, merit-order fuel legs) stays parked.
+
+## Question
+Is there a **free, programmatically-ingestable, redistributable, daily** price series for EU ETS
+allowances (EUA, EUR/tCO₂) — and for coal (API2/ARA) — to power the deferred energy syntheses
+(clean-spark `power − gas·heatrate − CO₂·EF`, dark-spread, merit-order fuel legs)? Obsyd's data
+principle requires *freely redistributable* sources for the visible core (CLAUDE.md).
+
+## Sources evaluated
+
+| Source | EUA daily? | Free + programmatic? | Redistributable? | Verdict |
+|---|---|---|---|---|
+| **yfinance** | — | — | — | **Dead.** `ECF=F`/`CO2=F`/`EUA=F` (EUA) + `MTF=F`/`API2`/`ARA=F` (coal) all return empty/delisted. Only `KRBN` (a USD carbon ETF, wrong instrument/currency) works. |
+| **EEX EU ETS auctions** | yes (auction days) | no | **no** | Authoritative, but webshop/permission-gated; ToS: *"systematic republication … only with express permission"* — blocks redistribution. |
+| **ICAP Allowance Price Explorer** | yes | partly (JS UI download) | restricted | Download exists but JS-driven, not a stable file/API; Terms-of-Use restrict reuse. Sandbag's viewer sources from here. |
+| **Databento** (ICE EUA futures) | yes | API | paid | Commercial. |
+| **Fraunhofer Energy-Charts API** (`api.energy-charts.info`) | **electricity yes; CO₂ unconfirmed** | **yes — free, no token, CC BY 4.0** | **yes (CC BY 4.0)** | Best general source. `/price` (day-ahead) + `/cbpf` (cross-border flows) confirmed. Fraunhofer's press release says the "prices" category *includes CO₂ certificate prices*, but the public `/price?bzn=CO2` is **invalid** and the exact CO₂ API code could not be confirmed (not in the OpenAPI spec; likely website-UI-only). |
+| **EEA EU ETS data viewer** | no (annual/aggregate) | csv | yes | Verified emissions/allowances by year — not a daily price. |
+
+## Decision
+**No confirmed free + programmatic + redistributable *daily EUA* feed exists today** (and **no free
+daily coal/API2 feed at all**). Therefore the clean/dark-spread + merit-order fuel legs (A3 / Slice 4)
+**stay parked**; `SparkSpreadHistory.co2_price` / `clean_spark_spread` stay null. This is consistent
+with the open-data principle — we do not build the visible product on a license-restricted or
+unconfirmed feed.
+
+## Unblock paths (ranked, for when revisited)
+1. **Pin the Energy-Charts CO₂ code** (most promising; CC BY 4.0 = usable): inspect energy-charts.info's
+   network calls for the CO₂ chart, or email Fraunhofer (`leonhard.gandhi@ise.fraunhofer.de`). If a
+   public daily CO₂ series exists → wire `EnergyPrice(symbol="EUA")` via the existing collector
+   pattern and clean-spark ships immediately.
+2. **Periodic CSV stopgap** (Bruegel-pattern, `data/gas/bruegel_weekly.csv` precedent): ingest ICAP/
+   Sandbag EUA settlements into a CSV with explicit source + last-updated labeling. Manual freshness —
+   acceptable only with honest staleness display.
+3. **Paid feed** (Databento/ICE) — only if revenue justifies; conflicts with the free-core principle
+   for the *visible* layer (could be a Pro-only input).
+
+## Byproduct opportunity (not acted on here)
+**Energy-Charts (CC BY 4.0, free, no-auth)** is a clean source for European **day-ahead prices** and
+**cross-border physical flows** — it could cross-check/complement our ENTSO-E power data and notably
+may cover the **FR↔NL** cross-border flow that ENTSO-E's A11 endpoint returned empty for (PR #25).
+Worth considering as a secondary/redundancy source in a future power slice.


### PR DESCRIPTION
Closes the A0 research spike. No confirmed free + programmatic + redistributable daily EUA (or coal) feed today (yfinance dead, EEX license-gated, ICAP Terms-restricted, Energy-Charts CO₂-via-API unconfirmed). → clean/dark-spread + merit-order fuel legs stay parked. Full findings + ranked unblock paths in docs/findings/2026-06-24-eua-coal-data-source.md; CLAUDE.md updated. Byproduct: Energy-Charts (CC BY 4.0) flagged as a free cross-check source for power prices/flows (incl. the FR↔NL flow ENTSO-E lacked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)