### PR TITLE
feat(metals): copper price history + copper scorecard target (A4.1)

### DIFF
--- a/backend/analytics/validation/scorecards.py
+++ b/backend/analytics/validation/scorecards.py
@@ -56,6 +56,8 @@ def _load_target_map(db, target: str) -> dict[str, float]:
         return load_energy_price_map(db, TTF_SYMBOL)
     if target == "power":
         return load_energy_price_map(db, POWER_DE_SYMBOL)
+    if target == "copper":
+        return load_energy_price_map(db, "COPPER")  # A4 metals node (yfinance HG=F)
     return load_price_map(db, BRENT_SERIES)  # default / "brent"
 
 

--- a/backend/collectors/energy_prices.py
+++ b/backend/collectors/energy_prices.py
@@ -22,6 +22,7 @@ _executor = ThreadPoolExecutor(max_workers=1)
 # db_symbol -> yfinance ticker. Add "EUA"/"POWER_*" here as the energy vertical grows.
 SYMBOLS = {
     "TTF": "TTF=F",  # Dutch TTF natural gas front-month (EUR/MWh)
+    "COPPER": "HG=F",  # COMEX copper front-month (USD/lb) — A4 metals node price target
 }
 
 

--- a/backend/tests/test_validation_scorecards.py
+++ b/backend/tests/test_validation_scorecards.py
@@ -272,3 +272,12 @@ def test_existing_brent_ttf_signals_not_broken(db_session):
     # Both scored at all horizons
     assert {c["horizon_days"] for c in cards if c["signal"] == "disruption_score"} == set(scorecards.HORIZONS)
     assert {c["horizon_days"] for c in cards if c["signal"] == "gas_residual"} == set(scorecards.HORIZONS)
+
+
+def test_copper_target_reads_energy_price(db_session):
+    """A4.1: the 'copper' scorecard target resolves to the EnergyPrice COPPER series."""
+    db_session.add(EnergyPrice(date="2026-06-01", symbol="COPPER", close=4.5))
+    db_session.add(EnergyPrice(date="2026-06-02", symbol="COPPER", close=4.6))
+    db_session.commit()
+    pm = scorecards._load_target_map(db_session, "copper")
+    assert pm == {"2026-06-01": 4.5, "2026-06-02": 4.6}


### PR DESCRIPTION
First slice of the A4 copper node: groundwork for the metals vertical.
- `energy_prices.SYMBOLS += COPPER: HG=F` → daily copper close history in the generic `EnergyPrice` table (backfilled 6482 rows, 2000→now).
- `scorecards._load_target_map`: new `"copper"` target → `load_energy_price_map("COPPER")` (sets up A4.3 scoring).

## Test Plan
- [x] `ruff` clean; `pytest` **293 passed** (new: copper target resolves to EnergyPrice COPPER)
- [ ] prod: COPPER history backfilled (daily energy_prices job keeps it fresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)