### PR TITLE
feat(metals): copper stocks signal → track record (A4.3)

### DIFF
--- a/backend/analytics/validation/scorecards.py
+++ b/backend/analytics/validation/scorecards.py
@@ -44,6 +44,8 @@ SIGNAL_SPECS = (
     # Energy signals: residual load + spark spread both scored against day-ahead power price.
     ("power_residual", "PowerGrid", "residual_mw", "power"),
     ("spark_spread", "SparkSpreadHistory", "spark_spread", "power"),
+    # Copper refined stocks (USGS, monthly) vs forward copper price — low stocks = tight supply.
+    ("copper_stocks", "CopperSupply", "us_refined_stocks", "copper"),
 )
 
 
@@ -70,7 +72,7 @@ def _two_sided_p(t_stat: float) -> float | None:
 
 
 def _resolve_model(table_name: str):
-    """Find a history model class by name across the analytics, gas, and energy modules."""
+    """Find a history model class by name across analytics, gas, energy, and metals modules."""
     from backend.models import analytics as analytics_models
 
     if hasattr(analytics_models, table_name):
@@ -81,7 +83,11 @@ def _resolve_model(table_name: str):
         return getattr(gas_models, table_name)
     from backend.models import energy as energy_models
 
-    return getattr(energy_models, table_name)
+    if hasattr(energy_models, table_name):
+        return getattr(energy_models, table_name)
+    from backend.models import metals as metals_models
+
+    return getattr(metals_models, table_name)
 
 
 def load_signal_series(db, table_name: str, value_col: str) -> tuple[list[str], np.ndarray]:

--- a/backend/tests/test_validation_scorecards.py
+++ b/backend/tests/test_validation_scorecards.py
@@ -13,6 +13,7 @@ from backend.main import app
 from backend.models.analytics import DisruptionScoreHistory
 from backend.models.energy import EnergyPrice, PowerGrid, SparkSpreadHistory
 from backend.models.gas import GasBalance
+from backend.models.metals import CopperSupply
 from backend.models.prices import FREDSeries
 from backend.models.validation import SignalScorecard
 
@@ -281,3 +282,25 @@ def test_copper_target_reads_energy_price(db_session):
     db_session.commit()
     pm = scorecards._load_target_map(db_session, "copper")
     assert pm == {"2026-06-01": 4.5, "2026-06-02": 4.6}
+
+
+def test_copper_stocks_signal_resolves_and_scores(db_session):
+    """A4.3: copper_stocks (CopperSupply) resolves via metals module + scores vs copper price."""
+    assert scorecards._resolve_model("CopperSupply") is CopperSupply
+    # 36 monthly stock obs + a daily copper price series covering them + the 30d horizon tail
+    months = [f"2023-{mm:02d}-01" for mm in range(1, 13)] + [f"2024-{mm:02d}-01" for mm in range(1, 13)] + [f"2025-{mm:02d}-01" for mm in range(1, 13)]
+    for i, mdate in enumerate(months):
+        db_session.add(CopperSupply(date=mdate, us_refined_stocks=100000.0 + i * 1000))
+    # daily copper price across the whole span + 30d horizon tail
+    d = date(2023, 1, 1)
+    px = 4.0
+    while d <= date(2026, 1, 31):
+        db_session.add(EnergyPrice(date=d.isoformat(), symbol="COPPER", close=px))
+        px += 0.001
+        d += timedelta(days=1)
+    db_session.commit()
+
+    cards = scorecards.recompute_scorecards(db_session, as_of="2026-06-11")
+    cs = [c for c in cards if c["signal"] == "copper_stocks"]
+    assert {c["horizon_days"] for c in cs} == set(scorecards.HORIZONS)
+    assert any(c["n"] > 0 for c in cs)  # scored against the COPPER price target

--- a/frontend/src/components/CopperPanel.jsx
+++ b/frontend/src/components/CopperPanel.jsx
@@ -11,6 +11,7 @@ import {
   Legend,
 } from 'recharts'
 import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import TrackRecordBadge from './TrackRecordBadge'
 
 const API = '/api'
 
@@ -208,6 +209,7 @@ export default function CopperPanel() {
       <div className="px-4 pb-3 font-mono text-[8px] text-neutral-700">
         Source: USGS Mineral Industry Surveys (public domain) · Price: COMEX HG=F via yfinance
       </div>
+      <TrackRecordBadge signal="copper_stocks" targetLabel="Copper" />
     </Panel>
   )
 }


### PR DESCRIPTION
A4.3 — final copper slice: the USGS refined-stocks series gets an honest track record vs the copper price.
- `SIGNAL_SPECS += ("copper_stocks","CopperSupply","us_refined_stocks","copper")`; `_resolve_model` now also resolves `backend.models.metals`.
- `TrackRecordBadge signal="copper_stocks" targetLabel="Copper"` on the CopperPanel.
- Monthly cadence → small n; badge honestly shows "building n/30" until enough history (local recompute: n=18, confident=0).

## Test Plan
- [x] `ruff` clean; `pytest` **316 passed** (new: copper_stocks resolves via metals + scores vs copper price)
- [x] eslint + `npm run build` clean
- [ ] After merge + prod deploy + weekly recompute: copper_stocks in /api/validation/scorecards, badge on METALS tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)