### PR TITLE
feat(radar): cross-vertical descriptive anomaly radar (Phase 1)

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -71,6 +71,12 @@ def run_migrations() -> None:
     # Base.metadata.create_all handles new tables, so no ALTER needed here.
     # This note documents the addition for the audit trail.
 
+    # 2026-06-24: cross-vertical anomaly radar — tag each Alert with its data
+    # vertical. SQLite ADD COLUMN ... DEFAULT 'oil' backfills existing rows, all
+    # of which are oil/maritime detectors, so no separate UPDATE is needed.
+    if _add_column_if_missing("alerts", "vertical", "VARCHAR DEFAULT 'oil'"):
+        applied.append("alerts.vertical")
+
     if applied:
         logger.info("migrations applied: %s", ", ".join(applied))
     else:
@@ -87,4 +93,6 @@ def list_pending() -> Iterable[str]:
         pending.append("subscriptions.drip_stage")
     if "residual_mw" not in _existing_columns("power_grid"):
         pending.append("power_grid.residual_mw")
+    if "vertical" not in _existing_columns("alerts"):
+        pending.append("alerts.vertical")
     return pending

--- a/backend/models/alerts.py
+++ b/backend/models/alerts.py
@@ -13,6 +13,10 @@ class Alert(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     rule: Mapped[str] = mapped_column(String, index=True)  # e.g. "floating_storage"
     zone: Mapped[str] = mapped_column(String, default="")
+    # Which data vertical the alert belongs to, for the cross-vertical anomaly
+    # radar feed: "oil" | "gas" | "power" | "metals" | "sentiment". Defaults to
+    # "oil" so all pre-existing rows + the legacy maritime detectors stay valid.
+    vertical: Mapped[str] = mapped_column(String, default="oil", index=True)
     severity: Mapped[str] = mapped_column(String)  # "info", "warning", "critical"
     title: Mapped[str] = mapped_column(String)
     detail: Mapped[str] = mapped_column(Text, default="")

--- a/backend/models/sentiment.py
+++ b/backend/models/sentiment.py
@@ -19,7 +19,7 @@ class GDELTVolume(Base):
 
 
 class SentimentScore(Base):
-    """AI-generated sentiment risk score (BYOK LLM)."""
+    """Rule-based news-risk score (1-10), derived from GDELT tone — no LLM."""
     __tablename__ = "sentiment_scores"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/backend/routes/alerts.py
+++ b/backend/routes/alerts.py
@@ -7,36 +7,58 @@ from backend.signals.portwatch_alerts import check_chokepoint_anomalies
 
 router = APIRouter(prefix="/api/alerts", tags=["alerts"])
 
+# Sort order for the radar feed: most urgent first, then most recent.
+_SEVERITY_RANK = {"critical": 0, "warning": 1, "info": 2}
+
+
+def _serialize(r: Alert) -> dict:
+    return {
+        "id": r.id,
+        "rule": r.rule,
+        "zone": r.zone,
+        "vertical": r.vertical,
+        "severity": r.severity,
+        "title": r.title,
+        "detail": r.detail,
+        "created_at": r.created_at.isoformat(),
+    }
+
 
 @router.get("")
 async def get_alerts(
     rule: str = Query(None, description="Filter by rule name"),
     zone: str = Query(None, description="Filter by zone"),
+    vertical: str = Query(None, description="Filter by vertical (oil/gas/power/metals/sentiment)"),
     severity: str = Query(None, description="Filter by severity"),
+    group_by_vertical: bool = Query(False, description="Return alerts grouped by vertical, severity-sorted"),
     limit: int = Query(50, ge=1, le=500),
     db: Session = Depends(get_db),
 ):
-    """Get generated alerts, newest first."""
+    """Get generated alerts, newest first (or grouped by vertical, severity-sorted)."""
     query = db.query(Alert).order_by(Alert.created_at.desc())
     if rule:
         query = query.filter(Alert.rule == rule)
     if zone:
         query = query.filter(Alert.zone == zone)
+    if vertical:
+        query = query.filter(Alert.vertical == vertical)
     if severity:
         query = query.filter(Alert.severity == severity)
     rows = query.limit(limit).all()
-    return [
-        {
-            "id": r.id,
-            "rule": r.rule,
-            "zone": r.zone,
-            "severity": r.severity,
-            "title": r.title,
-            "detail": r.detail,
-            "created_at": r.created_at.isoformat(),
-        }
-        for r in rows
-    ]
+    items = [_serialize(r) for r in rows]
+
+    if not group_by_vertical:
+        return items
+
+    # Group by vertical, each group severity-sorted (critical→warning→info), then newest.
+    groups: dict[str, list[dict]] = {}
+    for item in items:
+        groups.setdefault(item["vertical"], []).append(item)
+    for group in groups.values():
+        # Stable sort: newest first, then promote by severity → severity primary, recency secondary.
+        group.sort(key=lambda a: a["created_at"], reverse=True)
+        group.sort(key=lambda a: _SEVERITY_RANK.get(a["severity"], 9))
+    return {"verticals": groups, "total": len(items)}
 
 
 @router.get("/portwatch")

--- a/backend/signals/detectors/__init__.py
+++ b/backend/signals/detectors/__init__.py
@@ -1,0 +1,71 @@
+"""Cross-vertical anomaly radar — curated detector registry + runner.
+
+IMPORTANT — do not confuse with the Pro user rule-builder. There are two alert
+subsystems in this codebase:
+
+  * ANONYMOUS radar (this package) — curated, always-on detectors that write to
+    the anonymous ``Alert`` table and surface on the on-site feed. No owner, no
+    Pro gate, no email.
+  * Pro RULE-BUILDER (``backend/signals/user_alert_rules.py`` +
+    ``backend/notifications/alert_runner.py``, the ALERTS tab) — per-user
+    configured rules with their own inbox + email. NOT touched here.
+
+Each detector is a pure ``(db) -> list[DetectorResult]`` (DB reads only, no
+network, descriptive not predictive). ``run_all_detectors`` is the only writer:
+it runs each detector defensively and upserts results into the ``Alert``
+backbone via ``_upsert_alert``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from backend.signals.detectors.gas import detect_gas_balance
+from backend.signals.detectors.oil import (
+    detect_days_of_supply,
+    detect_floating_storage,
+    detect_freight_divergence,
+    detect_supply_demand_divergence,
+)
+from backend.signals.detectors.power import detect_negative_prices
+from backend.signals.detectors.sentiment import detect_sentiment_risk
+from backend.signals.rules import _upsert_alert
+
+logger = logging.getLogger(__name__)
+
+# Phase 1 registry — detectors whose flags are already persisted.
+DETECTORS = [
+    detect_gas_balance,
+    detect_days_of_supply,
+    detect_supply_demand_divergence,
+    detect_freight_divergence,
+    detect_floating_storage,
+    detect_negative_prices,
+    detect_sentiment_risk,
+]
+
+
+def run_all_detectors(db: Session) -> int:
+    """Run every detector and upsert its results. Returns the number of alerts upserted.
+
+    Each detector is isolated: one raising never suppresses the others.
+    """
+    emitted = 0
+    for detector in DETECTORS:
+        try:
+            for result in detector(db):
+                _upsert_alert(
+                    db,
+                    rule=result.rule,
+                    zone=result.zone,
+                    severity=result.severity,
+                    title=result.title,
+                    detail=result.detail,
+                    vertical=result.vertical,
+                )
+                emitted += 1
+        except Exception:
+            logger.exception("anomaly detector %s failed", getattr(detector, "__name__", detector))
+    return emitted

--- a/backend/signals/detectors/base.py
+++ b/backend/signals/detectors/base.py
@@ -1,0 +1,63 @@
+"""Shared contract + helpers for the cross-vertical anomaly radar.
+
+A *detector* is a pure, side-effect-free function ``(db) -> list[DetectorResult]``
+that reads the latest PERSISTED flag rows for one data vertical, decides what is
+"abnormal vs history", and returns descriptive results. The registry runner
+(``detectors/__init__.py``) is the only thing that writes to the DB, via the
+existing ``_upsert_alert`` backbone.
+
+Two hard rules for every detector:
+  1. **DB reads only** — no recompute, no network. The runner is on a 5-minute
+     cron, so detectors must be cheap and deterministic.
+  2. **Descriptive, never predictive** — describe the physical state / deviation
+     ("residual +3.1σ vs 90d, dominant mover supply↑"), never a price call.
+
+The shared contract is the three severity levels + the descriptive tone, NOT a
+single numeric transform: each vertical keeps its own validated thresholds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DetectorResult:
+    """One anomaly emitted by a detector. Maps 1:1 onto an Alert row."""
+
+    rule: str          # stable, globally-unique key per detector (dedup key with zone)
+    zone: str          # geographic / market scope, "" if global
+    vertical: str      # "oil" | "gas" | "power" | "metals" | "sentiment"
+    severity: str      # "info" | "warning" | "critical"
+    title: str
+    detail: str = ""
+
+
+# Valid verticals — kept here so the API/frontend and tests share one source.
+VERTICALS = ("oil", "gas", "power", "metals", "sentiment")
+
+
+def severity_from_zscore(z: float) -> str:
+    """|z|>=3 → critical, >=2 → warning, else info. Mirrors gas WATCH/SIGNAL bands."""
+    az = abs(z)
+    if az >= 3.0:
+        return "critical"
+    if az >= 2.0:
+        return "warning"
+    return "info"
+
+
+def severity_from_count(n: int, warn_at: int, crit_at: int) -> str:
+    """Count-based escalation: >=crit_at → critical, >=warn_at → warning, else info."""
+    if n >= crit_at:
+        return "critical"
+    if n >= warn_at:
+        return "warning"
+    return "info"
+
+
+def severity_from_enum(value: str | None, mapping: dict[str, str], default: str = "info") -> str:
+    """Map a categorical state to a severity. Unknown/None → default."""
+    if value is None:
+        return default
+    return mapping.get(value, default)

--- a/backend/signals/detectors/gas.py
+++ b/backend/signals/detectors/gas.py
@@ -1,0 +1,47 @@
+"""Gas vertical detector — EU gas balance residual WATCH/SIGNAL flags.
+
+This is the gold-standard pattern: the flag already carries the level plus a
+dominant-mover attribution (e.g. "SIGNAL:supply↑"), computed and persisted in
+``backend/gas/balance.py``. We just surface it descriptively.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from backend.models.gas import GasBalance
+from backend.signals.detectors.base import DetectorResult
+
+# flag level → severity. Anything else ("OK"/None) emits no alert.
+_LEVEL_SEVERITY = {"SIGNAL": "critical", "WATCH": "warning"}
+
+
+def detect_gas_balance(db: Session) -> list[DetectorResult]:
+    # Use the LATEST day's state, not the most recent historically-flagged day —
+    # otherwise an old WATCH would resurface after conditions normalised.
+    row = db.query(GasBalance).order_by(GasBalance.date.desc()).first()
+    if row is None or not row.flag:
+        return []
+
+    # flag is "LEVEL" or "LEVEL:mover" (e.g. "SIGNAL:supply↑").
+    level, _, mover = row.flag.partition(":")
+    severity = _LEVEL_SEVERITY.get(level)
+    if severity is None:
+        return []
+
+    z = row.z_score if row.z_score is not None else 0.0
+    resid = row.residual_7d if row.residual_7d is not None else 0.0
+    mover_txt = f", dominant mover {mover}" if mover else ""
+    return [
+        DetectorResult(
+            rule="gas_balance",
+            zone="EU",
+            vertical="gas",
+            severity=severity,
+            title=f"EU gas balance {level.lower()}: residual {z:+.1f}σ vs 90d",
+            detail=(
+                f"7d residual {resid:+.0f} GWh/d, z-score {z:+.2f} vs trailing 90 days"
+                f"{mover_txt} (as of {row.date})."
+            ),
+        )
+    ]

--- a/backend/signals/detectors/oil.py
+++ b/backend/signals/detectors/oil.py
@@ -1,0 +1,104 @@
+"""Oil/maritime vertical detectors that wrap persisted analytics flags.
+
+These read the persisted output of the analytics layer (days-of-supply,
+supply-demand balance, freight proxy) and the floating-storage event table.
+They complement — they do NOT replace — the legacy in-line maritime checks in
+``evaluator.py`` (anchored vessels, flow anomaly, cushing, crack, convergence).
+"""
+
+from __future__ import annotations
+
+from backend.models.analytics import (
+    DaysOfSupplyHistory,
+    FreightProxyHistory,
+    SupplyDemandBalance,
+)
+from backend.models.vessels import FloatingStorageEvent
+from backend.signals.detectors.base import DetectorResult, severity_from_count
+
+# Days-of-supply: both extremes are notable for a radar; tight is the urgent one.
+_DOS_SEVERITY = {"TIGHT": "warning", "COMFORTABLE": "info"}  # IN_LINE → suppress
+
+
+def detect_days_of_supply(db) -> list[DetectorResult]:
+    row = db.query(DaysOfSupplyHistory).order_by(DaysOfSupplyHistory.date.desc()).first()
+    if row is None:
+        return []
+    severity = _DOS_SEVERITY.get(row.assessment or "")
+    if severity is None:
+        return []
+    dev = row.deviation if row.deviation is not None else 0.0
+    days = row.commercial_days if row.commercial_days is not None else 0.0
+    return [
+        DetectorResult(
+            rule="days_of_supply",
+            zone="us",
+            vertical="oil",
+            severity=severity,
+            title=f"US crude days-of-supply {row.assessment.lower()}",
+            detail=f"{days:.1f} days cover, {dev:+.1f}d vs 5-year seasonal average (as of {row.date}).",
+        )
+    ]
+
+
+def detect_supply_demand_divergence(db) -> list[DetectorResult]:
+    row = db.query(SupplyDemandBalance).order_by(SupplyDemandBalance.date.desc()).first()
+    if row is None or not row.divergence_type:
+        return []
+    # Only a genuine divergence is anomalous; "CONFIRMED" means the sources agree.
+    if "DIVERGENCE" not in row.divergence_type:
+        return []
+    return [
+        DetectorResult(
+            rule="supply_demand_divergence",
+            zone="us",
+            vertical="oil",
+            severity="warning",
+            title="EIA balance vs AIS divergence",
+            detail=(row.divergence_detail or row.divergence_type) + f" (as of {row.date}).",
+        )
+    ]
+
+
+def detect_freight_divergence(db) -> list[DetectorResult]:
+    row = db.query(FreightProxyHistory).order_by(FreightProxyHistory.date.desc()).first()
+    if row is None or not row.divergence_flag:
+        return []
+    return [
+        DetectorResult(
+            rule="freight_divergence",
+            zone="tanker",
+            vertical="oil",
+            severity="info",
+            title=f"Freight proxy {row.divergence_flag.lower()}",
+            detail=f"Tanker-equity freight proxy diverging from rerouting / Brent (as of {row.date}).",
+        )
+    ]
+
+
+def detect_floating_storage(db) -> list[DetectorResult]:
+    """One alert per zone with an elevated count of active floating-storage events."""
+    rows = (
+        db.query(FloatingStorageEvent.zone)
+        .filter(FloatingStorageEvent.status == "active")
+        .all()
+    )
+    counts: dict[str, int] = {}
+    for (zone,) in rows:
+        counts[zone or "global"] = counts.get(zone or "global", 0) + 1
+
+    results: list[DetectorResult] = []
+    for zone, n in counts.items():
+        if n < 3:
+            continue
+        results.append(
+            DetectorResult(
+                rule="floating_storage",
+                zone=zone,
+                vertical="oil",
+                severity=severity_from_count(n, warn_at=6, crit_at=12),
+                title=f"{n} tankers in floating-storage pattern in {zone}",
+                detail=f"{n} tankers stationary 7+ days (potential floating storage) in {zone}.",
+            )
+        )
+    return results

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -1,0 +1,38 @@
+"""Power vertical detector — negative day-ahead price hours per zone.
+
+Negative prices flag renewable oversupply (the grid pays to offload power). The
+hour count is persisted per (date, zone) in ``PowerPriceDaily.negative_hours``.
+"""
+
+from __future__ import annotations
+
+from backend.models.energy import PowerPriceDaily
+from backend.signals.detectors.base import DetectorResult, severity_from_count
+
+
+def detect_negative_prices(db) -> list[DetectorResult]:
+    zones = [z for (z,) in db.query(PowerPriceDaily.zone).distinct().all()]
+    results: list[DetectorResult] = []
+    for zone in zones:
+        row = (
+            db.query(PowerPriceDaily)
+            .filter(PowerPriceDaily.zone == zone)
+            .order_by(PowerPriceDaily.date.desc())
+            .first()
+        )
+        if row is None or row.negative_hours <= 0:
+            continue
+        results.append(
+            DetectorResult(
+                rule="negative_prices",
+                zone=zone,
+                vertical="power",
+                severity=severity_from_count(row.negative_hours, warn_at=6, crit_at=12),
+                title=f"{zone}: {row.negative_hours}h of negative day-ahead prices",
+                detail=(
+                    f"{row.negative_hours} hour(s) below 0 EUR/MWh on {row.date} "
+                    f"(renewable oversupply / inflexible generation)."
+                ),
+            )
+        )
+    return results

--- a/backend/signals/detectors/sentiment.py
+++ b/backend/signals/detectors/sentiment.py
@@ -1,0 +1,39 @@
+"""Sentiment vertical detector — elevated news-risk score.
+
+The 1-10 risk score is rule-based (derived from GDELT tone, no LLM) and
+persisted in ``SentimentScore.risk_score``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from backend.models.sentiment import SentimentScore
+from backend.signals.detectors.base import DetectorResult
+
+
+def detect_sentiment_risk(db) -> list[DetectorResult]:
+    row = db.query(SentimentScore).order_by(SentimentScore.date.desc()).first()
+    if row is None or row.risk_score < 6:
+        return []
+    severity = "warning" if row.risk_score >= 8 else "info"
+
+    top_factor = ""
+    if row.risk_factors:
+        try:
+            factors = json.loads(row.risk_factors)
+            if isinstance(factors, list) and factors:
+                top_factor = f" Top factor: {factors[0]}"
+        except (ValueError, TypeError):
+            top_factor = ""
+
+    return [
+        DetectorResult(
+            rule="sentiment_risk",
+            zone="",
+            vertical="sentiment",
+            severity=severity,
+            title=f"News risk {row.risk_score:.0f}/10 — elevated media negativity",
+            detail=f"GDELT-derived geopolitical/energy news risk at {row.risk_score:.0f}/10 ({row.date}).{top_factor}",
+        )
+    ]

--- a/backend/signals/evaluator.py
+++ b/backend/signals/evaluator.py
@@ -104,6 +104,17 @@ async def evaluate_signals():
         except Exception as e:
             logger.warning(f"Convergence alert check failed: {e}")
 
+        # 7. Cross-vertical anomaly radar — curated detectors over the
+        #    gas/power/oil-analytics/sentiment persisted flags. Each detector is
+        #    isolated inside run_all_detectors, so a vertical failing is contained.
+        try:
+            from backend.signals.detectors import run_all_detectors
+
+            n = run_all_detectors(db)
+            logger.info("Anomaly radar: %d alerts upserted", n)
+        except Exception as e:
+            logger.warning(f"Anomaly radar detectors failed: {e}")
+
         logger.info("Signal evaluation complete")
     except Exception as e:
         logger.error(f"Signal evaluation failed: {e}")

--- a/backend/signals/rules.py
+++ b/backend/signals/rules.py
@@ -38,11 +38,22 @@ ZONE_ANCHOR_BASELINES = {
 DEDUP_HOURS = 24  # suppress duplicate alerts within this window
 
 
-def _upsert_alert(db: Session, rule: str, zone: str, severity: str, title: str, detail: str):
+def _upsert_alert(
+    db: Session,
+    rule: str,
+    zone: str,
+    severity: str,
+    title: str,
+    detail: str,
+    vertical: str = "oil",
+):
     """Create a new alert or update the most recent existing one within the dedup window.
 
     If multiple duplicates exist (same rule + zone within DEDUP_HOURS), keeps only the
     most recent and deletes the rest to prevent duplicate buildup.
+
+    `vertical` tags the alert for the cross-vertical radar feed and defaults to
+    "oil" so the legacy maritime call sites stay correct without changes.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(hours=DEDUP_HOURS)
     existing = (
@@ -59,13 +70,14 @@ def _upsert_alert(db: Session, rule: str, zone: str, severity: str, title: str, 
         latest.title = title
         latest.detail = detail
         latest.severity = severity
+        latest.vertical = vertical
         # Delete any older duplicates
         for old in existing[1:]:
             db.delete(old)
         db.commit()
         return
 
-    db.add(Alert(rule=rule, zone=zone, severity=severity, title=title, detail=detail))
+    db.add(Alert(rule=rule, zone=zone, severity=severity, title=title, detail=detail, vertical=vertical))
     db.commit()
 
 

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -1,0 +1,238 @@
+"""Tests for the cross-vertical anomaly radar (anonymous Alert backbone).
+
+Covers the detector layer + run_all_detectors + the /api/alerts vertical
+exposure/grouping. This is a different subsystem from test_alert_rules.py
+(which covers the Pro user rule-builder) — keep them separate.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import inspect
+
+from backend.main import app
+from backend.models.alerts import Alert
+from backend.models.analytics import (
+    DaysOfSupplyHistory,
+    FreightProxyHistory,
+    SupplyDemandBalance,
+)
+from backend.models.energy import PowerPriceDaily
+from backend.models.gas import GasBalance
+from backend.models.sentiment import SentimentScore
+from backend.models.vessels import FloatingStorageEvent
+from backend.signals.detectors import DETECTORS, run_all_detectors
+from backend.signals.detectors.gas import detect_gas_balance
+from backend.signals.detectors.oil import (
+    detect_days_of_supply,
+    detect_floating_storage,
+    detect_freight_divergence,
+    detect_supply_demand_divergence,
+)
+from backend.signals.detectors.power import detect_negative_prices
+from backend.signals.detectors.sentiment import detect_sentiment_risk
+
+
+@pytest.fixture
+def client(db_session):
+    return TestClient(app)
+
+
+# ─── Gas ──────────────────────────────────────────────────────────────────────
+
+
+def test_gas_balance_signal_is_critical(db_session):
+    db_session.add(GasBalance(date="2026-06-24", residual_7d=-820, z_score=3.4, flag="SIGNAL:supply↑"))
+    db_session.commit()
+    results = detect_gas_balance(db_session)
+    assert len(results) == 1
+    r = results[0]
+    assert r.vertical == "gas" and r.rule == "gas_balance" and r.severity == "critical"
+    assert "signal" in r.title.lower()
+    assert "supply↑" in r.detail
+
+
+def test_gas_balance_ok_flag_suppressed(db_session):
+    db_session.add(GasBalance(date="2026-06-24", residual_7d=-10, z_score=-0.2, flag="OK"))
+    db_session.commit()
+    assert detect_gas_balance(db_session) == []
+
+
+def test_gas_balance_watch_is_warning(db_session):
+    db_session.add(GasBalance(date="2026-06-24", residual_7d=400, z_score=2.3, flag="WATCH:demand↓"))
+    db_session.commit()
+    assert detect_gas_balance(db_session)[0].severity == "warning"
+
+
+def test_gas_balance_uses_latest_day_not_stale_flag(db_session):
+    # Old flagged day + a newer normal (unflagged) day → current state wins → suppress.
+    db_session.add(GasBalance(date="2026-06-01", residual_7d=900, z_score=3.2, flag="SIGNAL:supply↑"))
+    db_session.add(GasBalance(date="2026-06-24", residual_7d=-20, z_score=-0.17, flag=None))
+    db_session.commit()
+    assert detect_gas_balance(db_session) == []
+
+
+# ─── Oil analytics ──────────────────────────────────────────────────────────
+
+
+def test_days_of_supply_tight_warns(db_session):
+    db_session.add(DaysOfSupplyHistory(date="2026-06-24", assessment="TIGHT", deviation=-4.5, commercial_days=21.0))
+    db_session.commit()
+    r = detect_days_of_supply(db_session)[0]
+    assert r.vertical == "oil" and r.severity == "warning"
+
+
+def test_days_of_supply_in_line_suppressed(db_session):
+    db_session.add(DaysOfSupplyHistory(date="2026-06-24", assessment="IN_LINE", deviation=0.2, commercial_days=27.0))
+    db_session.commit()
+    assert detect_days_of_supply(db_session) == []
+
+
+def test_supply_demand_divergence_warns(db_session):
+    db_session.add(
+        SupplyDemandBalance(date="2026-06-24", divergence_type="EIA_AIS_DIVERGENCE", divergence_detail="Forecast vs AIS gap.")
+    )
+    db_session.commit()
+    r = detect_supply_demand_divergence(db_session)[0]
+    assert r.severity == "warning" and "gap" in r.detail.lower()
+
+
+def test_supply_demand_confirmed_suppressed(db_session):
+    db_session.add(SupplyDemandBalance(date="2026-06-24", divergence_type="EIA_AIS_CONFIRMED", divergence_detail="Agree."))
+    db_session.commit()
+    assert detect_supply_demand_divergence(db_session) == []
+
+
+def test_freight_divergence_info(db_session):
+    db_session.add(FreightProxyHistory(date="2026-06-24", proxy_index=104.0, divergence_flag="FREIGHT_PROXY_DIVERGENCE"))
+    db_session.commit()
+    r = detect_freight_divergence(db_session)[0]
+    assert r.severity == "info" and r.vertical == "oil"
+
+
+def test_floating_storage_threshold(db_session):
+    # 2 active in a zone → below threshold (suppress); add a 3rd → info.
+    for i in range(2):
+        db_session.add(_fs_event(f"20000000{i}", "hormuz"))
+    db_session.commit()
+    assert detect_floating_storage(db_session) == []
+
+    db_session.add(_fs_event("200000099", "hormuz"))
+    db_session.commit()
+    r = detect_floating_storage(db_session)[0]
+    assert r.severity == "info" and r.zone == "hormuz"
+
+
+def _fs_event(mmsi: str, zone: str) -> FloatingStorageEvent:
+    from datetime import datetime
+
+    return FloatingStorageEvent(
+        mmsi=mmsi, zone=zone, first_seen=datetime.utcnow(), last_seen=datetime.utcnow(),
+        duration_days=9.0, status="active",
+    )
+
+
+# ─── Power ────────────────────────────────────────────────────────────────────
+
+
+def test_negative_prices_warns(db_session):
+    db_session.add(PowerPriceDaily(date="2026-06-24", zone="DE_LU", mean_price=20, min_price=-30, max_price=80, negative_hours=8))
+    db_session.commit()
+    r = detect_negative_prices(db_session)[0]
+    assert r.vertical == "power" and r.severity == "warning" and r.zone == "DE_LU"
+
+
+def test_negative_prices_zero_suppressed(db_session):
+    db_session.add(PowerPriceDaily(date="2026-06-24", zone="DE_LU", mean_price=50, min_price=10, max_price=80, negative_hours=0))
+    db_session.commit()
+    assert detect_negative_prices(db_session) == []
+
+
+# ─── Sentiment ──────────────────────────────────────────────────────────────
+
+
+def test_sentiment_high_risk_warns(db_session):
+    db_session.add(SentimentScore(date="2026-06-24", risk_score=9.0, risk_factors='["Strait of Hormuz tension"]'))
+    db_session.commit()
+    r = detect_sentiment_risk(db_session)[0]
+    assert r.vertical == "sentiment" and r.severity == "warning"
+    assert "Hormuz" in r.detail
+
+
+def test_sentiment_low_risk_suppressed(db_session):
+    db_session.add(SentimentScore(date="2026-06-24", risk_score=4.0, risk_factors="[]"))
+    db_session.commit()
+    assert detect_sentiment_risk(db_session) == []
+
+
+# ─── Runner (loop) ────────────────────────────────────────────────────────────
+
+
+def test_run_all_detectors_multi_vertical(db_session):
+    db_session.add(GasBalance(date="2026-06-24", residual_7d=-800, z_score=3.5, flag="SIGNAL:supply↑"))
+    db_session.add(SentimentScore(date="2026-06-24", risk_score=9.0, risk_factors="[]"))
+    db_session.commit()
+
+    n = run_all_detectors(db_session)
+    assert n == 2
+    verticals = {a.vertical for a in db_session.query(Alert).all()}
+    assert verticals == {"gas", "sentiment"}
+
+
+def test_run_all_detectors_isolates_failures(db_session, monkeypatch):
+    """One detector raising must not suppress the others."""
+    def boom(db):
+        raise RuntimeError("detector exploded")
+
+    monkeypatch.setattr("backend.signals.detectors.DETECTORS", [boom, detect_gas_balance])
+    db_session.add(GasBalance(date="2026-06-24", residual_7d=-800, z_score=3.5, flag="SIGNAL:supply↑"))
+    db_session.commit()
+
+    n = run_all_detectors(db_session)  # must not raise
+    assert n == 1
+    assert db_session.query(Alert).filter(Alert.vertical == "gas").count() == 1
+
+
+def test_detector_registry_has_seven(db_session):
+    assert len(DETECTORS) == 7
+
+
+# ─── API exposure + grouping ──────────────────────────────────────────────────
+
+
+def test_api_exposes_vertical_and_filters(client, db_session):
+    db_session.add(Alert(rule="gas_balance", zone="EU", vertical="gas", severity="critical", title="g", detail="d"))
+    db_session.add(Alert(rule="negative_prices", zone="DE_LU", vertical="power", severity="warning", title="p", detail="d"))
+    db_session.commit()
+
+    body = client.get("/api/alerts?vertical=gas").json()
+    assert len(body) == 1 and body[0]["vertical"] == "gas"
+
+
+def test_api_group_by_vertical_severity_sorted(client, db_session):
+    db_session.add(Alert(rule="freight_divergence", zone="t", vertical="oil", severity="info", title="i", detail=""))
+    db_session.add(Alert(rule="cushing_drawdown", zone="c", vertical="oil", severity="critical", title="c", detail=""))
+    db_session.add(Alert(rule="gas_balance", zone="EU", vertical="gas", severity="warning", title="g", detail=""))
+    db_session.commit()
+
+    body = client.get("/api/alerts?group_by_vertical=true").json()
+    assert body["total"] == 3
+    assert set(body["verticals"].keys()) == {"oil", "gas"}
+    # oil group: critical before info
+    oil_sev = [a["severity"] for a in body["verticals"]["oil"]]
+    assert oil_sev == ["critical", "info"]
+
+
+# ─── Migration ────────────────────────────────────────────────────────────────
+
+
+def test_alerts_vertical_column_present(db_session):
+    # The column is part of the schema the app actually binds to.
+    cols = {c["name"] for c in inspect(db_session.get_bind()).get_columns("alerts")}
+    assert "vertical" in cols
+
+
+def test_alert_defaults_to_oil(db_session):
+    db_session.add(Alert(rule="cushing_drawdown", zone="cushing", severity="critical", title="t", detail="d"))
+    db_session.commit()
+    row = db_session.query(Alert).filter(Alert.rule == "cushing_drawdown").first()
+    assert row.vertical == "oil"

--- a/frontend/src/components/AlertsPanel.jsx
+++ b/frontend/src/components/AlertsPanel.jsx
@@ -12,7 +12,12 @@ const SEVERITY_STYLES = {
   Minor: { dot: 'bg-green-glow', text: 'text-green-glow', border: 'border-green-500/30' },
 }
 
+// Sort order: most urgent first. Unknown severities sink to the bottom.
+const SEVERITY_RANK = { critical: 0, Extreme: 0, Severe: 0, warning: 1, Moderate: 1, info: 2, Minor: 2 }
+const sevRank = (s) => SEVERITY_RANK[s] ?? 3
+
 const RULE_ICONS = {
+  // legacy oil/maritime
   anchored_vessels: 'ANCHR',
   floating_storage: 'ANCHR',
   flow_anomaly: 'FLOW',
@@ -24,7 +29,19 @@ const RULE_ICONS = {
   rerouting_high: 'ROUTE',
   convergence: 'CONV',
   weather: 'WX',
+  // cross-vertical radar detectors
+  gas_balance: 'GASBAL',
+  days_of_supply: 'DOS',
+  supply_demand_divergence: 'DIVRG',
+  freight_divergence: 'FRGT',
+  negative_prices: 'NEGP',
+  sentiment_risk: 'SENT',
 }
+
+// Which dashboard tab holds the evidence chart for each vertical (drill-down).
+const VERTICAL_TAB = { gas: 'gas', power: 'energy', metals: 'metals', sentiment: 'sentiment', oil: 'overview' }
+const VERTICAL_LABELS = { gas: 'GAS', power: 'POWER', oil: 'OIL / MARITIME', metals: 'METALS', sentiment: 'SENTIMENT' }
+const VERTICAL_ORDER = ['gas', 'power', 'oil', 'metals', 'sentiment']
 
 const CONVERGENCE_STYLE = { dot: 'bg-amber-400', text: 'text-amber-400', border: 'border-amber-500/30' }
 
@@ -35,6 +52,7 @@ const RULE_GROUP_LABELS = {
   floating_storage: 'floating storage alerts',
   weather: 'weather alerts',
   refinery_thermal: 'thermal alerts',
+  negative_prices: 'zones with negative prices',
 }
 
 function timeAgo(isoStr) {
@@ -50,6 +68,12 @@ function timeAgo(isoStr) {
   } catch { return '' }
 }
 
+// Drill-down: jump to the vertical's evidence tab via the existing hash router.
+function goToVertical(vertical) {
+  const tab = VERTICAL_TAB[vertical] || 'overview'
+  window.location.hash = tab
+}
+
 export default function AlertsPanel({ weatherAlerts = [] }) {
   const [alerts, setAlerts] = useState([])
   const [chokeAlerts, setChokeAlerts] = useState([])
@@ -60,7 +84,7 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
     // hiding the loading state — otherwise the panel briefly renders an
     // incomplete merge and re-shuffles a second later.
     Promise.allSettled([
-      fetch(`${API}/alerts?limit=20`)
+      fetch(`${API}/alerts?limit=50`)
         .then((r) => (r.ok ? r.json() : []))
         .then(setAlerts)
         .catch((e) => console.error('AlertsPanel alerts:', e)),
@@ -73,11 +97,13 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
     ]).finally(() => setLoading(false))
   }, [])
 
-  // Merge signal alerts, weather alerts, and chokepoint alerts
-  const combined = [
+  // Merge signal alerts (carry their own `vertical`), weather + chokepoint
+  // (oil/maritime). Everything without an explicit vertical defaults to "oil".
+  const combined = useMemo(() => [
     ...chokeAlerts.map((c) => ({
       id: `choke-${c.portid}`,
       rule: 'chokepoint_anomaly',
+      vertical: 'oil',
       severity: c.alert_level,
       title: `${c.chokepoint || '?'}: ${c.anomaly_pct > 0 ? '+' : ''}${c.anomaly_pct ?? 0}% ${c.direction || ''}`,
       detail: `${c.n_total ?? '?'} vessels (${c.baseline_type === 'yoy' ? 'YoY' : '30d'}: ${c.baseline_avg ?? '?'})${c.disruption_name ? ` // ${c.disruption_name}` : ''}`,
@@ -88,6 +114,7 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
     ...weatherAlerts.map((w) => ({
       id: `wx-${w.id}`,
       rule: 'weather',
+      vertical: 'oil',
       severity: w.severity,
       title: w.headline || w.event,
       detail: w.area,
@@ -95,40 +122,60 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
       created_at: w.onset || new Date().toISOString(),
       isWeather: true,
     })),
-    ...alerts.map((a) => ({ ...a, isWeather: false })),
-  ]
+    ...alerts.map((a) => ({ ...a, vertical: a.vertical || 'oil', isWeather: false })),
+  ], [alerts, chokeAlerts, weatherAlerts])
 
   const totalCount = combined.length
 
-  // Group alerts by rule — collapse >2 of the same type into one expandable row
-  const displayItems = useMemo(() => {
-    const groups = {}
+  // Group by vertical → within each vertical, severity-sort and collapse >2 of
+  // the same rule into one expandable row.
+  const verticalSections = useMemo(() => {
+    const byVertical = {}
     for (const a of combined) {
-      if (!groups[a.rule]) groups[a.rule] = []
-      groups[a.rule].push(a)
+      const v = a.vertical || 'oil'
+      if (!byVertical[v]) byVertical[v] = []
+      byVertical[v].push(a)
     }
-    const items = []
-    for (const [rule, ruleAlerts] of Object.entries(groups)) {
-      if (ruleAlerts.length > 2) {
-        const zones = ruleAlerts.map((a) => (a.zone || '').toUpperCase()).filter(Boolean)
-        const label = RULE_GROUP_LABELS[rule] || rule
-        const summary = zones.length > 0
-          ? `${ruleAlerts.length} ${label}: ${zones.join(', ')}`
-          : `${ruleAlerts.length} ${label}`
-        items.push({ type: 'group', rule, id: `group-${rule}`, severity: ruleAlerts[0].severity, summary, alerts: ruleAlerts })
-      } else {
-        items.push(...ruleAlerts.map((a) => ({ type: 'single', ...a })))
+
+    const sections = []
+    for (const vertical of VERTICAL_ORDER) {
+      const vAlerts = byVertical[vertical]
+      if (!vAlerts || vAlerts.length === 0) continue
+
+      // collapse >2 same-rule
+      const groups = {}
+      for (const a of vAlerts) {
+        if (!groups[a.rule]) groups[a.rule] = []
+        groups[a.rule].push(a)
       }
+      const items = []
+      for (const [rule, ruleAlerts] of Object.entries(groups)) {
+        if (ruleAlerts.length > 2) {
+          const zones = ruleAlerts.map((a) => (a.zone || '').toUpperCase()).filter(Boolean)
+          const label = RULE_GROUP_LABELS[rule] || rule
+          const summary = zones.length > 0
+            ? `${ruleAlerts.length} ${label}: ${zones.join(', ')}`
+            : `${ruleAlerts.length} ${label}`
+          items.push({ type: 'group', rule, vertical, id: `group-${vertical}-${rule}`, severity: ruleAlerts[0].severity, summary, alerts: ruleAlerts })
+        } else {
+          items.push(...ruleAlerts.map((a) => ({ type: 'single', ...a })))
+        }
+      }
+      items.sort((a, b) => sevRank(a.severity) - sevRank(b.severity))
+      const topRank = Math.min(...items.map((i) => sevRank(i.severity)))
+      sections.push({ vertical, items, count: vAlerts.length, topRank })
     }
-    return items
+    // Verticals with the most urgent anomaly bubble up.
+    sections.sort((a, b) => a.topRank - b.topRank)
+    return sections
   }, [combined])
 
   const [expandedGroups, setExpandedGroups] = useState(new Set())
 
-  const toggleGroup = (rule) => {
+  const toggleGroup = (id) => {
     setExpandedGroups((prev) => {
       const next = new Set(prev)
-      next.has(rule) ? next.delete(rule) : next.add(rule)
+      next.has(id) ? next.delete(id) : next.add(id)
       return next
     })
   }
@@ -138,9 +185,12 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
     const icon = RULE_ICONS[a.rule] || 'SIG'
     const isWx = a.isWeather
     return (
-      <div
+      <button
         key={a.id}
-        className={`px-4 py-3 border-b border-border last:border-b-0 ${sev.border}`}
+        type="button"
+        onClick={() => goToVertical(a.vertical)}
+        title="Open evidence"
+        className={`w-full text-left px-4 py-3 border-b border-border last:border-b-0 hover:bg-white/[0.02] transition-colors ${sev.border}`}
       >
         <div className="flex items-start gap-2.5">
           <div className={`font-mono text-[10px] font-bold mt-0.5 px-1.5 py-0.5 border rounded ${a.isChoke ? 'text-cyan-glow border-cyan-glow/30' : (isWx || a.rule === 'refinery_thermal') ? 'text-orange-400 border-orange-500/30' : `${sev.text} ${sev.border}`}`}>
@@ -168,7 +218,7 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
             )}
           </div>
         </div>
-      </div>
+      </button>
     )
   }
 
@@ -176,7 +226,7 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
     return (
       <div className="border border-border bg-surface rounded">
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
-          <span className="font-mono text-xs text-neutral-500">SIGNAL ALERTS</span>
+          <span className="font-mono text-xs text-neutral-500">ANOMALY RADAR</span>
           <span className="font-mono text-[10px] text-neutral-600 animate-pulse">LOADING ...</span>
         </div>
         <div className="px-4 py-4 space-y-3 animate-pulse">
@@ -198,7 +248,7 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
     <div className="border border-border bg-surface rounded">
       <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
         <span className="font-mono text-xs text-neutral-500">
-          SIGNAL ALERTS
+          ANOMALY RADAR
         </span>
         <span className="font-mono text-[10px] text-neutral-600">
           {totalCount} active
@@ -206,44 +256,54 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
       </div>
 
       <div className="max-h-[300px] md:max-h-[400px] overflow-y-auto scrollbar-hidden">
-        {displayItems.length === 0 ? (
+        {verticalSections.length === 0 ? (
           <div className="px-4 py-6 text-center font-mono text-xs text-neutral-600">
-            No alerts generated yet
+            Nothing abnormal right now
           </div>
         ) : (
-          displayItems.map((item) => {
-            if (item.type === 'group') {
-              const sev = SEVERITY_STYLES[item.severity] || SEVERITY_STYLES.info
-              const icon = RULE_ICONS[item.rule] || 'SIG'
-              const isExpanded = expandedGroups.has(item.rule)
-              return (
-                <div key={item.id}>
-                  <button
-                    onClick={() => toggleGroup(item.rule)}
-                    className={`w-full text-left px-4 py-3 border-b border-border ${sev.border} hover:bg-white/[0.02] transition-colors`}
-                  >
-                    <div className="flex items-start gap-2.5">
-                      <div className={`font-mono text-[10px] font-bold mt-0.5 px-1.5 py-0.5 border rounded ${sev.text} ${sev.border}`}>
-                        {icon}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center justify-between gap-2">
-                          <span className="font-mono text-xs text-neutral-300">
-                            {item.summary}
-                          </span>
-                          <span className="font-mono text-[10px] text-neutral-600 shrink-0">
-                            {isExpanded ? '▾' : '▸'} {item.alerts.length}
-                          </span>
+          verticalSections.map((section) => (
+            <div key={section.vertical}>
+              <div className="flex items-center justify-between px-4 py-1.5 bg-white/[0.02] border-b border-border">
+                <span className="font-mono text-[10px] tracking-wider text-neutral-500">
+                  {VERTICAL_LABELS[section.vertical] || section.vertical.toUpperCase()}
+                </span>
+                <span className="font-mono text-[9px] text-neutral-600">{section.count}</span>
+              </div>
+              {section.items.map((item) => {
+                if (item.type === 'group') {
+                  const sev = SEVERITY_STYLES[item.severity] || SEVERITY_STYLES.info
+                  const icon = RULE_ICONS[item.rule] || 'SIG'
+                  const isExpanded = expandedGroups.has(item.id)
+                  return (
+                    <div key={item.id}>
+                      <button
+                        onClick={() => toggleGroup(item.id)}
+                        className={`w-full text-left px-4 py-3 border-b border-border ${sev.border} hover:bg-white/[0.02] transition-colors`}
+                      >
+                        <div className="flex items-start gap-2.5">
+                          <div className={`font-mono text-[10px] font-bold mt-0.5 px-1.5 py-0.5 border rounded ${sev.text} ${sev.border}`}>
+                            {icon}
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center justify-between gap-2">
+                              <span className="font-mono text-xs text-neutral-300">
+                                {item.summary}
+                              </span>
+                              <span className="font-mono text-[10px] text-neutral-600 shrink-0">
+                                {isExpanded ? '▾' : '▸'} {item.alerts.length}
+                              </span>
+                            </div>
+                          </div>
                         </div>
-                      </div>
+                      </button>
+                      {isExpanded && item.alerts.map(renderAlert)}
                     </div>
-                  </button>
-                  {isExpanded && item.alerts.map(renderAlert)}
-                </div>
-              )
-            }
-            return renderAlert(item)
-          })
+                  )
+                }
+                return renderAlert(item)
+              })}
+            </div>
+          ))
         )}
       </div>
     </div>

--- a/frontend/src/components/TrackRecordBadge.jsx
+++ b/frontend/src/components/TrackRecordBadge.jsx
@@ -3,15 +3,18 @@ import useFetchWithError from '../hooks/useFetchWithError'
 
 const API = '/api'
 
-// Honest-by-design: this never shows a green "edge" unless the forward-return
-// relationship is statistically significant. Sufficient data with no signal
-// reads as "no measured edge", not a win. `targetLabel` names the forward-return
-// target (Brent for oil/maritime signals, TTF for the gas residual).
+// Descriptive-by-design: OBSYD is an anomaly radar, not a predictor. This badge
+// reports the HISTORICAL co-movement between a signal and a market series as
+// transparency/context — never as a forecast or trade edge. A significant
+// relationship is shown for honesty (including negative/inverse ones), not as a
+// recommendation. `targetLabel` names the reference series (Brent for
+// oil/maritime, TTF for the gas residual).
 const method = (targetLabel) =>
-  `Track record: rank correlation (IC) between this signal and the forward ` +
-  `${targetLabel} return, with Newey-West HAC significance for overlapping windows. ` +
-  '"No measured edge" means enough data but not statistically significant ' +
-  '(p > 0.05). Single-regime sample — informational, not a forecast.'
+  `Historical co-movement: rank correlation between this signal and the ` +
+  `subsequent ${targetLabel} move, with Newey-West HAC significance for overlapping ` +
+  'windows. "No historical association" means enough data but no statistically ' +
+  'significant relationship (p > 0.05). This is descriptive context from a single ' +
+  'historical regime — NOT a forecast, signal, or recommendation.'
 
 /**
  * Compact, honest track-record strip for a signal panel.
@@ -32,16 +35,16 @@ export default function TrackRecordBadge({ signal, horizon = 7, targetLabel = 'B
   let tone
 
   if (!card.confident) {
-    label = `Track record: building — n=${card.n}/${minN}`
+    label = `Historical context: building — n=${card.n}/${minN}`
     tone = 'text-neutral-600 border-neutral-700/50'
   } else {
     const significant = card.p_value != null && card.p_value <= 0.05
     if (significant && card.ic != null) {
       const sign = card.ic >= 0 ? '+' : ''
-      label = `Track record: IC ${sign}${card.ic.toFixed(2)} · ${horizon}d · n=${card.n} · p=${card.p_value.toFixed(2)}`
+      label = `Historical co-movement ${sign}${card.ic.toFixed(2)} · ${horizon}d · n=${card.n} · context, not a forecast`
       tone = card.ic >= 0 ? 'text-green-glow border-green-glow/30' : 'text-orange-400 border-orange-400/30'
     } else {
-      label = `No measured edge · ${horizon}d · n=${card.n}`
+      label = `No historical association · ${horizon}d · n=${card.n}`
       tone = 'text-neutral-500 border-neutral-700/50'
     }
   }


### PR DESCRIPTION
## Was

Phase 1 des deskriptiven, kuratierten **Anomalie-Radars** (Posture B — kein Prognose-Anspruch). Verdrahtet die längst berechneten, persistierten Pro-Vertikal-Flags in den bestehenden anonymen `Alert`-Backbone über kuratierte Detektoren im 5-Min-`evaluate_signals`-Job.

**7 Detektoren** (`backend/signals/detectors/`): gas_balance, days_of_supply, supply_demand_divergence, freight_divergence, floating_storage, negative_prices, sentiment_risk. Reine DB-Reads, deskriptiv, template-basiert (kein LLM), fehler-isoliert.

- `Alert.vertical` + idempotente Migration
- `GET /api/alerts`: `vertical`-Filter + `group_by_vertical` (severity-sortiert), ungated
- `AlertsPanel` → Cross-Vertical „ANOMALY RADAR"-Feed (nach Vertikal gruppiert, kritisch zuerst, Drill-down zum Evidenz-Tab)
- `TrackRecordBadge` deskriptiv umgedeutet („historical co-movement", context not a forecast)
- 21 neue Tests

Rührt den Pro-Regel-Baukasten (`AlertRule` / ALERTS-Tab) **nicht** an.

## Verifikation
ruff sauber · 337 Backend-Tests grün · eslint sauber · vite build OK · End-to-End gegen lokale DB (0 Anomalien, passt zum aktuellen OK-Zustand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)