### PR TITLE
fix(radar): baseline-aware detectors to cut false alarms (Phase A)

### DIFF
--- a/backend/signals/detectors/base.py
+++ b/backend/signals/detectors/base.py
@@ -18,6 +18,7 @@ single numeric transform: each vertical keeps its own validated thresholds.
 
 from __future__ import annotations
 
+import statistics
 from dataclasses import dataclass
 
 
@@ -61,3 +62,25 @@ def severity_from_enum(value: str | None, mapping: dict[str, str], default: str 
     if value is None:
         return default
     return mapping.get(value, default)
+
+
+# Minimum history points before a trailing baseline is trustworthy.
+MIN_BASELINE_N = 14
+
+
+def trailing_zscore(current: float, history: list[float], *, min_n: int = MIN_BASELINE_N):
+    """z-score of `current` against a trailing `history` — "abnormal vs THIS series' own past".
+
+    This is the core of the descriptive radar: an anomaly is a statistical deviation from a
+    series' own recent norm, not a flat threshold (which misfires on structurally-high series
+    like a permanent anchorage). Returns (z, mean, std, n), or None if history is too short or
+    has zero variance (→ no trustworthy baseline → no alert).
+    """
+    n = len(history)
+    if n < min_n:
+        return None
+    mean = statistics.fmean(history)
+    std = statistics.pstdev(history)
+    if std == 0:
+        return None
+    return (current - mean) / std, mean, std, n

--- a/backend/signals/detectors/oil.py
+++ b/backend/signals/detectors/oil.py
@@ -8,16 +8,26 @@ They complement — they do NOT replace — the legacy in-line maritime checks i
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from backend.models.analytics import (
     DaysOfSupplyHistory,
     FreightProxyHistory,
     SupplyDemandBalance,
 )
 from backend.models.vessels import FloatingStorageEvent
-from backend.signals.detectors.base import DetectorResult, severity_from_count
+from backend.signals.detectors.base import DetectorResult, trailing_zscore
 
 # Days-of-supply: both extremes are notable for a radar; tight is the urgent one.
 _DOS_SEVERITY = {"TIGHT": "warning", "COMFORTABLE": "info"}  # IN_LINE → suppress
+
+# Floating storage: compare a zone's CURRENT count to its OWN trailing norm, not a flat
+# threshold — a permanent anchorage (Malacca/Singapore, Houston) is structurally high and a
+# flat count would cry wolf there. Only an unusual *buildup* vs the zone's own history alerts.
+FS_WINDOW_DAYS = 90      # trailing baseline length
+FS_MIN_NORMAL = 2.0      # skip zones that normally hold ~0-1 tankers (tiny-n noise)
+FS_WARN_Z = 2.0
+FS_CRIT_Z = 3.0
 
 
 def detect_days_of_supply(db) -> list[DetectorResult]:
@@ -77,28 +87,50 @@ def detect_freight_divergence(db) -> list[DetectorResult]:
 
 
 def detect_floating_storage(db) -> list[DetectorResult]:
-    """One alert per zone with an elevated count of active floating-storage events."""
-    rows = (
-        db.query(FloatingStorageEvent.zone)
-        .filter(FloatingStorageEvent.status == "active")
-        .all()
-    )
-    counts: dict[str, int] = {}
-    for (zone,) in rows:
-        counts[zone or "global"] = counts.get(zone or "global", 0) + 1
+    """Alert per zone with an UNUSUAL floating-storage buildup vs that zone's own history.
+
+    "Active on day D" = an event whose [first_seen, last_seen] window covers D — this is
+    reconstructable historically (unlike the current-only `status` flag, which also retains
+    stale 'active' rows whose last_seen is weeks old). The current count is taken on the latest
+    day present in the data and z-scored against the prior FS_WINDOW_DAYS days for that zone.
+    """
+    rows = db.query(
+        FloatingStorageEvent.zone, FloatingStorageEvent.first_seen, FloatingStorageEvent.last_seen
+    ).all()
+    if not rows:
+        return []
+
+    anchor = max(ls for _, _, ls in rows).date()
+    by_zone: dict[str, list[tuple]] = {}
+    for zone, first_seen, last_seen in rows:
+        by_zone.setdefault(zone or "global", []).append((first_seen.date(), last_seen.date()))
 
     results: list[DetectorResult] = []
-    for zone, n in counts.items():
-        if n < 3:
+    for zone, evs in by_zone.items():
+        def active_on(d):
+            return sum(1 for fs, ls in evs if fs <= d <= ls)
+
+        current = active_on(anchor)
+        baseline = [active_on(anchor - timedelta(days=o)) for o in range(1, FS_WINDOW_DAYS + 1)]
+        stat = trailing_zscore(current, baseline)
+        if stat is None:
+            continue
+        z, mean, std, n = stat
+        # Only an unusually HIGH buildup is an anomaly, and only in zones that normally hold a
+        # meaningful number (skip permanent near-empty zones where 1→3 looks like a big z).
+        if mean < FS_MIN_NORMAL or z < FS_WARN_Z:
             continue
         results.append(
             DetectorResult(
                 rule="floating_storage",
                 zone=zone,
                 vertical="oil",
-                severity=severity_from_count(n, warn_at=6, crit_at=12),
-                title=f"{n} tankers in floating-storage pattern in {zone}",
-                detail=f"{n} tankers stationary 7+ days (potential floating storage) in {zone}.",
+                severity="critical" if z >= FS_CRIT_Z else "warning",
+                title=f"Unusual floating-storage buildup in {zone}: {current} tankers ({z:+.1f}σ)",
+                detail=(
+                    f"{current} tankers in floating-storage pattern vs ~{mean:.0f} normal for {zone} "
+                    f"(z {z:+.2f} over {n}d, as of {anchor})."
+                ),
             )
         )
     return results

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -7,31 +7,50 @@ hour count is persisted per (date, zone) in ``PowerPriceDaily.negative_hours``.
 from __future__ import annotations
 
 from backend.models.energy import PowerPriceDaily
-from backend.signals.detectors.base import DetectorResult, severity_from_count
+from backend.signals.detectors.base import DetectorResult, trailing_zscore
+
+# Negative day-ahead hours happen routinely in solar/wind-heavy zones — so flag only when
+# TODAY is unusually high vs the zone's own recent norm (relative), not on a flat hour count.
+NP_WINDOW = 45           # trailing days of negative-hour history per zone
+NP_MIN_HOURS = 3         # ignore one or two negative hours (normal noise)
+NP_WARN_Z = 2.0
+NP_CRIT_Z = 3.0
 
 
 def detect_negative_prices(db) -> list[DetectorResult]:
     zones = [z for (z,) in db.query(PowerPriceDaily.zone).distinct().all()]
     results: list[DetectorResult] = []
     for zone in zones:
-        row = (
+        rows = (
             db.query(PowerPriceDaily)
             .filter(PowerPriceDaily.zone == zone)
             .order_by(PowerPriceDaily.date.desc())
-            .first()
+            .limit(NP_WINDOW + 1)
+            .all()
         )
-        if row is None or row.negative_hours <= 0:
+        if not rows:
+            continue
+        row = rows[0]
+        current = row.negative_hours
+        if current < NP_MIN_HOURS:
+            continue
+        baseline = [r.negative_hours for r in rows[1:]]
+        stat = trailing_zscore(current, baseline)
+        if stat is None:
+            continue  # too little history → no trustworthy "unusual" judgement yet
+        z, mean, _, n = stat
+        if z < NP_WARN_Z:
             continue
         results.append(
             DetectorResult(
                 rule="negative_prices",
                 zone=zone,
                 vertical="power",
-                severity=severity_from_count(row.negative_hours, warn_at=6, crit_at=12),
-                title=f"{zone}: {row.negative_hours}h of negative day-ahead prices",
+                severity="critical" if z >= NP_CRIT_Z else "warning",
+                title=f"{zone}: unusually many negative-price hours ({current}h, {z:+.1f}σ)",
                 detail=(
-                    f"{row.negative_hours} hour(s) below 0 EUR/MWh on {row.date} "
-                    f"(renewable oversupply / inflexible generation)."
+                    f"{current}h below 0 EUR/MWh on {row.date} vs ~{mean:.0f}h normal for {zone} "
+                    f"(z {z:+.2f}; renewable oversupply / inflexible generation)."
                 ),
             )
         )

--- a/backend/signals/detectors/sentiment.py
+++ b/backend/signals/detectors/sentiment.py
@@ -9,14 +9,27 @@ from __future__ import annotations
 import json
 
 from backend.models.sentiment import SentimentScore
-from backend.signals.detectors.base import DetectorResult
+from backend.signals.detectors.base import DetectorResult, trailing_zscore
+
+SENT_WINDOW = 30          # trailing days of risk-score history
+SENT_ABS_EXTREME = 8.0    # absolute ceiling: always notable regardless of baseline
+SENT_REL_FLOOR = 6.0      # for a relative "unusual jump", require at least moderate risk
+SENT_REL_Z = 2.0
 
 
 def detect_sentiment_risk(db) -> list[DetectorResult]:
-    row = db.query(SentimentScore).order_by(SentimentScore.date.desc()).first()
-    if row is None or row.risk_score < 6:
+    rows = db.query(SentimentScore).order_by(SentimentScore.date.desc()).limit(SENT_WINDOW + 1).all()
+    if not rows:
         return []
-    severity = "warning" if row.risk_score >= 8 else "info"
+    row = rows[0]
+
+    # Two ways to be notable: an absolute extreme, OR an unusual jump vs the recent norm.
+    elevated_abs = row.risk_score >= SENT_ABS_EXTREME
+    stat = trailing_zscore(row.risk_score, [r.risk_score for r in rows[1:]])
+    elevated_rel = stat is not None and stat[0] >= SENT_REL_Z and row.risk_score >= SENT_REL_FLOOR
+    if not (elevated_abs or elevated_rel):
+        return []
+    severity = "warning" if elevated_abs else "info"
 
     top_factor = ""
     if row.risk_factors:

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -5,6 +5,8 @@ exposure/grouping. This is a different subsystem from test_alert_rules.py
 (which covers the Pro user rule-builder) — keep them separate.
 """
 
+from datetime import date, datetime, time, timedelta
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import inspect
@@ -109,36 +111,68 @@ def test_freight_divergence_info(db_session):
     assert r.severity == "info" and r.vertical == "oil"
 
 
-def test_floating_storage_threshold(db_session):
-    # 2 active in a zone → below threshold (suppress); add a 3rd → info.
-    for i in range(2):
-        db_session.add(_fs_event(f"20000000{i}", "hormuz"))
-    db_session.commit()
+_FS_ANCHOR = date(2026, 6, 24)
+
+
+def _seed_fs_daily(db, zone, counts_by_offset):
+    """Create events so active_on(anchor - offset) == count for each offset (anchor = _FS_ANCHOR)."""
+    for off, c in counts_by_offset.items():
+        dt = datetime.combine(_FS_ANCHOR - timedelta(days=off), time(12, 0))
+        for i in range(c):
+            db.add(FloatingStorageEvent(
+                mmsi=f"{zone}-{off}-{i}", zone=zone,
+                first_seen=dt, last_seen=dt, duration_days=8.0, status="active",
+            ))
+    db.commit()
+
+
+def test_floating_storage_structural_high_no_alert(db_session):
+    # Malacca-like: structurally ~10 tankers every day, today 11 → normal vs its own history → no alert.
+    counts = {0: 11}
+    for o in range(1, 90):
+        counts[o] = 9 + (o % 3)  # 9/10/11 → mean ~10
+    _seed_fs_daily(db_session, "malacca", counts)
     assert detect_floating_storage(db_session) == []
 
-    db_session.add(_fs_event("200000099", "hormuz"))
-    db_session.commit()
-    r = detect_floating_storage(db_session)[0]
-    assert r.severity == "info" and r.zone == "hormuz"
+
+def test_floating_storage_spike_alerts(db_session):
+    # Normally ~2-3 tankers, today 22 → unusual buildup → critical.
+    counts = {0: 22}
+    for o in range(1, 90):
+        counts[o] = 2 + (o % 2)  # 2/3 → mean ~2.5
+    _seed_fs_daily(db_session, "suez", counts)
+    res = detect_floating_storage(db_session)
+    assert len(res) == 1 and res[0].zone == "suez" and res[0].severity == "critical"
 
 
-def _fs_event(mmsi: str, zone: str) -> FloatingStorageEvent:
-    from datetime import datetime
-
-    return FloatingStorageEvent(
-        mmsi=mmsi, zone=zone, first_seen=datetime.utcnow(), last_seen=datetime.utcnow(),
-        duration_days=9.0, status="active",
-    )
+def test_floating_storage_sparse_zone_no_alert(db_session):
+    # A zone that normally holds ~0 tankers must not alert on a small absolute count.
+    _seed_fs_daily(db_session, "hormuz", {0: 10, 1: 1, 2: 1})
+    assert detect_floating_storage(db_session) == []
 
 
 # ─── Power ────────────────────────────────────────────────────────────────────
 
 
 def test_negative_prices_warns(db_session):
-    db_session.add(PowerPriceDaily(date="2026-06-24", zone="DE_LU", mean_price=20, min_price=-30, max_price=80, negative_hours=8))
+    anchor = date(2026, 6, 24)
+    for o in range(1, 21):  # 20 prior days of low negative-hours (0/1/2)
+        d = (anchor - timedelta(days=o)).isoformat()
+        db_session.add(PowerPriceDaily(date=d, zone="DE_LU", mean_price=40, min_price=-5, max_price=80, negative_hours=o % 3))
+    db_session.add(PowerPriceDaily(date=anchor.isoformat(), zone="DE_LU", mean_price=10, min_price=-40, max_price=60, negative_hours=12))
     db_session.commit()
     r = detect_negative_prices(db_session)[0]
-    assert r.vertical == "power" and r.severity == "warning" and r.zone == "DE_LU"
+    assert r.vertical == "power" and r.zone == "DE_LU" and r.severity in ("warning", "critical")
+
+
+def test_negative_prices_normal_for_zone_suppressed(db_session):
+    # Zone routinely has ~8 negative hours; today 8 → normal vs its own history → no alert.
+    anchor = date(2026, 6, 24)
+    for o in range(0, 20):
+        d = (anchor - timedelta(days=o)).isoformat()
+        db_session.add(PowerPriceDaily(date=d, zone="DE_LU", mean_price=20, min_price=-20, max_price=70, negative_hours=7 + (o % 3)))
+    db_session.commit()
+    assert detect_negative_prices(db_session) == []
 
 
 def test_negative_prices_zero_suppressed(db_session):
@@ -162,6 +196,17 @@ def test_sentiment_low_risk_suppressed(db_session):
     db_session.add(SentimentScore(date="2026-06-24", risk_score=4.0, risk_factors="[]"))
     db_session.commit()
     assert detect_sentiment_risk(db_session) == []
+
+
+def test_sentiment_relative_jump_info(db_session):
+    # Calm baseline (~3), today jumps to 7 → unusual vs own norm (but below absolute 8) → info.
+    anchor = date(2026, 6, 24)
+    for o in range(1, 20):
+        db_session.add(SentimentScore(date=(anchor - timedelta(days=o)).isoformat(), risk_score=3.0 + (o % 2) * 0.5, risk_factors="[]"))
+    db_session.add(SentimentScore(date=anchor.isoformat(), risk_score=7.0, risk_factors="[]"))
+    db_session.commit()
+    r = detect_sentiment_risk(db_session)[0]
+    assert r.severity == "info" and r.vertical == "sentiment"
 
 
 # ─── Runner (loop) ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Phase A — Rauschen senken

Phase-1-Detektoren nutzten flache Schwellen → Fehlalarme auf strukturell hohen Serien. Konkret: `floating_storage` meldete *„21 Tanker Malacca = critical"*, aber Malacca ist ein Dauer-Ankerplatz (und der Count enthielt veraltete `active`-Rows mit altem `last_seen`).

- **`trailing_zscore()`** (base.py): Anomalie = Abweichung von der **eigenen** jüngsten Norm der Serie, nicht flache Schwelle.
- **floating_storage**: tägliche Aktiv-Zahl je Zone via `[first_seen,last_seen]`-Fenster rekonstruiert (historisch reproduzierbar, droppt veraltete Rows), z-Score des letzten Tages vs. 90d; nur ungewöhnlicher Buildup alarmiert. Gegen Prod validiert: Malacca/Houston/Suez/Hormuz alle z<2 → keine Fehl-Criticals mehr.
- **negative_prices**: nur wenn heutige Negativ-Stunden ungewöhnlich hoch vs. 45d-Norm der Zone (Negativstunden sind in Solar/Wind-Zonen Routine).
- **sentiment_risk**: absolutes Extrem (≥8) behalten + „ungewöhnlicher Sprung vs. eigene Baseline".
- gas_balance / days_of_supply / Divergenzen unverändert (schon baseline-aware).

Tests für Baseline-Verhalten inkl. Malacca-Normal-Regression. ruff sauber, 341 Backend-Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)