### PR TITLE
feat(radar): Phase B coverage — dunkelflaute/rerouting/chokepoint + thermal de-noise

### DIFF
--- a/backend/collectors/firms.py
+++ b/backend/collectors/firms.py
@@ -11,7 +11,7 @@ Free API key required (register at https://firms.modaps.eosdis.nasa.gov/api/).
 
 import logging
 import math
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import httpx
 
@@ -135,15 +135,40 @@ async def collect_firms():
         db.close()
 
 
-def _check_refinery_anomalies(db, hotspots: list[dict]):
-    """Check for abnormal thermal activity near known refineries.
+# Refineries run hot continuously (flaring is routine), so "any nearby hotspot = alert" floods
+# the feed. Alert only when today's nearby-hotspot count is unusually high vs the refinery's own
+# trailing daily norm — the same baseline-aware posture as the anomaly radar.
+THERMAL_WINDOW_DAYS = 45
+THERMAL_MIN_NEARBY = 2     # ignore 0-1 nearby hotspots (always-on refinery glow)
+THERMAL_WARN_Z = 2.0
+THERMAL_CRIT_Z = 3.0
 
-    Alerts when hotspots are detected within PROXIMITY_KM of a refinery,
-    indicating potential flaring, fire, or unusual thermal events.
-    No hotspots = no alert (satellite gaps are not actionable).
+
+def _refinery_nearby_by_date(db, ref: dict, window_days: int) -> dict:
+    """Trailing per-day count of stored hotspots within PROXIMITY_KM of a refinery."""
+    cutoff = (datetime.now(timezone.utc).date() - timedelta(days=window_days)).isoformat()
+    rows = (
+        db.query(ThermalHotspot.latitude, ThermalHotspot.longitude, ThermalHotspot.acq_date)
+        .filter(ThermalHotspot.area_name == ref["area"], ThermalHotspot.acq_date >= cutoff)
+        .all()
+    )
+    by_date: dict[str, int] = {}
+    for lat, lon, d in rows:
+        if d and _haversine_km(ref["lat"], ref["lon"], lat, lon) <= PROXIMITY_KM:
+            by_date[d] = by_date.get(d, 0) + 1
+    return by_date
+
+
+def _check_refinery_anomalies(db, hotspots: list[dict]):
+    """Alert only on UNUSUAL thermal activity near a refinery vs its own recent norm.
+
+    Compares today's nearby-hotspot count to the refinery's trailing daily baseline; a flat
+    "any hotspot = warning" is suppressed (refineries are always warm). No hotspots = no alert.
     """
     if not hotspots:
         return
+
+    from backend.signals.detectors.base import trailing_zscore
 
     for ref in REFINERIES:
         nearby = [
@@ -151,15 +176,26 @@ def _check_refinery_anomalies(db, hotspots: list[dict]):
             for h in hotspots
             if h["area"] == ref["area"] and _haversine_km(ref["lat"], ref["lon"], h["lat"], h["lon"]) <= PROXIMITY_KM
         ]
+        current = len(nearby)
+        if current < THERMAL_MIN_NEARBY:
+            continue
 
-        if len(nearby) > 0:
-            _create_refinery_alert(db, ref, len(nearby), max(h["brightness"] for h in nearby))
+        by_date = _refinery_nearby_by_date(db, ref, THERMAL_WINDOW_DAYS)
+        # Baseline = prior days only (drop the most recent acq_date so we don't compare today to itself).
+        dates = sorted(by_date)
+        baseline = [by_date[d] for d in dates[:-1]] if len(dates) > 1 else []
+        stat = trailing_zscore(current, baseline)
+        if stat is None:
+            continue
+        z, mean, _, _ = stat
+        if z < THERMAL_WARN_Z:
+            continue
+        severity = "critical" if z >= THERMAL_CRIT_Z else "warning"
+        _create_refinery_alert(db, ref, current, max(h["brightness"] for h in nearby), severity, z, mean)
 
 
-def _create_refinery_alert(db, ref: dict, count: int, peak_brightness: float):
-    """Create alert for abnormal thermal activity near a refinery (with dedup)."""
-    from datetime import timedelta
-
+def _create_refinery_alert(db, ref: dict, count: int, peak_brightness: float, severity: str, z: float, mean: float):
+    """Create alert for UNUSUAL thermal activity near a refinery (with dedup)."""
     cutoff = datetime.now(timezone.utc) - timedelta(hours=DEDUP_HOURS)
     existing = (
         db.query(Alert)
@@ -174,6 +210,7 @@ def _create_refinery_alert(db, ref: dict, count: int, peak_brightness: float):
 
     if existing:
         existing.created_at = datetime.now(timezone.utc)
+        existing.severity = severity
         db.commit()
         return
 
@@ -181,14 +218,13 @@ def _create_refinery_alert(db, ref: dict, count: int, peak_brightness: float):
         Alert(
             rule="refinery_thermal",
             zone=ref["area"],
-            severity="warning",
-            title=f"Thermal anomaly near {ref['name']}",
+            severity=severity,
+            title=f"Unusual thermal activity near {ref['name']} ({z:+.1f}σ)",
             detail=(
-                f"{count} hotspot(s) detected within {PROXIMITY_KM}km of "
-                f"{ref['name']} ({ref['lat']:.3f}, {ref['lon']:.3f}). "
-                f"Peak brightness: {peak_brightness:.1f}K. Possible flaring or fire."
+                f"{count} hotspot(s) within {PROXIMITY_KM}km of {ref['name']} vs ~{mean:.0f} normal "
+                f"(z {z:+.2f}, peak {peak_brightness:.0f}K). Possible elevated flaring or fire."
             ),
         )
     )
     db.commit()
-    logger.info(f"Alert: refinery_thermal — {ref['name']} ({count} hotspots, {peak_brightness:.1f}K)")
+    logger.info(f"Alert: refinery_thermal — {ref['name']} ({count} hotspots, z={z:+.2f})")

--- a/backend/signals/detectors/__init__.py
+++ b/backend/signals/detectors/__init__.py
@@ -24,18 +24,22 @@ from sqlalchemy.orm import Session
 
 from backend.signals.detectors.gas import detect_gas_balance
 from backend.signals.detectors.oil import (
+    detect_chokepoint,
     detect_days_of_supply,
     detect_floating_storage,
     detect_freight_divergence,
+    detect_rerouting,
     detect_supply_demand_divergence,
 )
-from backend.signals.detectors.power import detect_negative_prices
+from backend.signals.detectors.power import detect_dunkelflaute, detect_negative_prices
 from backend.signals.detectors.sentiment import detect_sentiment_risk
 from backend.signals.rules import _upsert_alert
 
 logger = logging.getLogger(__name__)
 
-# Phase 1 registry — detectors whose flags are already persisted.
+# Curated detector registry. Phase 1 = persisted-flag detectors; Phase 2 adds the
+# rerouting/chokepoint/dunkelflaute detectors (all pure local-DB reads — they wrap
+# already-baseline-aware computations, no new persistence needed).
 DETECTORS = [
     detect_gas_balance,
     detect_days_of_supply,
@@ -44,6 +48,9 @@ DETECTORS = [
     detect_floating_storage,
     detect_negative_prices,
     detect_sentiment_risk,
+    detect_rerouting,
+    detect_chokepoint,
+    detect_dunkelflaute,
 ]
 
 

--- a/backend/signals/detectors/oil.py
+++ b/backend/signals/detectors/oil.py
@@ -134,3 +134,68 @@ def detect_floating_storage(db) -> list[DetectorResult]:
             )
         )
     return results
+
+
+def detect_rerouting(db) -> list[DetectorResult]:
+    """Suez→Cape rerouting index above its normal state (consolidates the legacy evaluator check).
+
+    `compute_rerouting_index` is already baseline-aware (current vs 30d/365d) and a pure local
+    DB read, so we just surface its state descriptively.
+    """
+    from backend.signals.tonnage_proxy import compute_rerouting_index
+
+    data = compute_rerouting_index(days=365)
+    if not data.get("available"):
+        return []
+    cur = data.get("current", {})
+    severity = cur.get("severity")  # high_rerouting→warning, elevated→info, normal→None
+    if not severity:
+        return []
+    ratio_pct = cur.get("ratio_pct") or 0.0
+    base_30d = (cur.get("baseline_30d") or 0.0) * 100
+    return [
+        DetectorResult(
+            rule="rerouting_high",
+            zone="global",
+            vertical="oil",
+            severity=severity,
+            title=f"Rerouting index at {ratio_pct:.0f}% — {cur.get('state', '').replace('_', ' ').upper()}",
+            detail=(
+                f"Cape share {ratio_pct:.0f}% vs ~{base_30d:.0f}% 30d-norm; elevated Cape routing "
+                f"typically signals Suez/Red Sea avoidance (longer voyages, higher tanker demand)."
+            ),
+        )
+    ]
+
+
+def _chokepoint_zone(name: str) -> str:
+    skip = {"strait", "of", "the", "canal"}
+    words = [w for w in (name or "").lower().split() if w not in skip]
+    return words[0] if words else (name or "global").lower()
+
+
+def detect_chokepoint(db) -> list[DetectorResult]:
+    """PortWatch chokepoint transit anomalies (consolidates the live /api/alerts/portwatch route).
+
+    `check_chokepoint_anomalies` is already YoY-baseline-aware with seasonal-low suppression and a
+    ±30% threshold — a pure local DB read.
+    """
+    from backend.signals.portwatch_alerts import check_chokepoint_anomalies
+
+    results: list[DetectorResult] = []
+    for a in check_chokepoint_anomalies():
+        disruption = f" // {a['disruption_name']}" if a.get("disruption_name") else ""
+        results.append(
+            DetectorResult(
+                rule="chokepoint_anomaly",
+                zone=_chokepoint_zone(a.get("chokepoint", "")),
+                vertical="oil",
+                severity="critical" if a.get("alert_level") == "critical" else "warning",
+                title=f"{a['chokepoint']}: {a['anomaly_pct']:+.0f}% {a['direction']}",
+                detail=(
+                    f"{a['n_total']} vessels vs {a['baseline_avg']} ({a['baseline_type']} baseline)"
+                    f"{disruption}."
+                ),
+            )
+        )
+    return results

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -6,8 +6,13 @@ hour count is persisted per (date, zone) in ``PowerPriceDaily.negative_hours``.
 
 from __future__ import annotations
 
-from backend.models.energy import PowerPriceDaily
+from backend.models.energy import PowerGrid, PowerPriceDaily
 from backend.signals.detectors.base import DetectorResult, trailing_zscore
+
+# Dunkelflaute = renewables carry an unusually small share of load (wind+solar < 15%),
+# so conventional generation must cover the residual. A fixed physical threshold is
+# meaningful here (it is a defined grid condition, not a structurally-always-true count).
+DUNKELFLAUTE_THRESHOLD = 0.15
 
 # Negative day-ahead hours happen routinely in solar/wind-heavy zones — so flag only when
 # TODAY is unusually high vs the zone's own recent norm (relative), not on a flat hour count.
@@ -51,6 +56,38 @@ def detect_negative_prices(db) -> list[DetectorResult]:
                 detail=(
                     f"{current}h below 0 EUR/MWh on {row.date} vs ~{mean:.0f}h normal for {zone} "
                     f"(z {z:+.2f}; renewable oversupply / inflexible generation)."
+                ),
+            )
+        )
+    return results
+
+
+def detect_dunkelflaute(db) -> list[DetectorResult]:
+    """Latest day where wind+solar cover an unusually small share of load, per zone."""
+    zones = [z for (z,) in db.query(PowerGrid.zone).distinct().all()]
+    results: list[DetectorResult] = []
+    for zone in zones:
+        row = (
+            db.query(PowerGrid)
+            .filter(PowerGrid.zone == zone)
+            .order_by(PowerGrid.date.desc())
+            .first()
+        )
+        if row is None or not row.load_mw or row.load_mw <= 0:
+            continue
+        share = ((row.wind_mw or 0.0) + (row.solar_mw or 0.0)) / row.load_mw
+        if share >= DUNKELFLAUTE_THRESHOLD:
+            continue
+        results.append(
+            DetectorResult(
+                rule="dunkelflaute",
+                zone=zone,
+                vertical="power",
+                severity="warning",
+                title=f"{zone}: Dunkelflaute — renewables {share * 100:.0f}% of load",
+                detail=(
+                    f"Wind+solar only {share * 100:.1f}% of load on {row.date} (<15% threshold); "
+                    f"residual load carried by conventional generation."
                 ),
             )
         )

--- a/backend/signals/evaluator.py
+++ b/backend/signals/evaluator.py
@@ -92,11 +92,8 @@ async def evaluate_signals():
         except Exception as e:
             logger.warning(f"Crack spread alert check failed: {e}")
 
-        # 5. Rerouting alert
-        try:
-            _check_rerouting(db)
-        except Exception as e:
-            logger.warning(f"Rerouting alert check failed: {e}")
+        # 5. Rerouting alert — now handled by the anomaly radar (detect_rerouting),
+        #    see step 7. Legacy _check_rerouting removed to avoid duplicate alerts.
 
         # 6. Convergence alert — multi-signal
         try:
@@ -171,34 +168,6 @@ def _check_crack_spread(db: Session):
                 f"3:2:1 crack spread ${spread}/bbl is at the {pct}th percentile "
                 f"vs 1-year range. Low spread = weak refining margins = bearish crude demand. "
                 f"(data: {ts})"
-            ),
-        )
-
-
-def _check_rerouting(db: Session):
-    """Alert when rerouting index exceeds thresholds."""
-    from backend.signals.tonnage_proxy import compute_rerouting_index
-
-    data = compute_rerouting_index(days=365)
-    if not data.get("available"):
-        return
-
-    current = data.get("current", {})
-    state = current.get("state")
-    ratio_pct = current.get("ratio_pct")
-
-    if state == "high_rerouting" and ratio_pct is not None:
-        _upsert_alert(
-            db,
-            rule="rerouting_high",
-            zone="global",
-            severity="warning",
-            title=f"Rerouting index at {ratio_pct:.0f}% — HIGH",
-            detail=(
-                f"Cape share at {ratio_pct:.0f}%. "
-                f"High rerouting typically indicates Suez/Red Sea disruption. "
-                f"Tanker demand increases with longer voyages via Cape. "
-                f"(data: {datetime.now(timezone.utc).isoformat()})"
             ),
         )
 

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -18,19 +18,21 @@ from backend.models.analytics import (
     FreightProxyHistory,
     SupplyDemandBalance,
 )
-from backend.models.energy import PowerPriceDaily
+from backend.models.energy import PowerGrid, PowerPriceDaily
 from backend.models.gas import GasBalance
 from backend.models.sentiment import SentimentScore
 from backend.models.vessels import FloatingStorageEvent
 from backend.signals.detectors import DETECTORS, run_all_detectors
 from backend.signals.detectors.gas import detect_gas_balance
 from backend.signals.detectors.oil import (
+    detect_chokepoint,
     detect_days_of_supply,
     detect_floating_storage,
     detect_freight_divergence,
+    detect_rerouting,
     detect_supply_demand_divergence,
 )
-from backend.signals.detectors.power import detect_negative_prices
+from backend.signals.detectors.power import detect_dunkelflaute, detect_negative_prices
 from backend.signals.detectors.sentiment import detect_sentiment_risk
 
 
@@ -218,9 +220,9 @@ def test_run_all_detectors_multi_vertical(db_session):
     db_session.commit()
 
     n = run_all_detectors(db_session)
-    assert n == 2
-    verticals = {a.vertical for a in db_session.query(Alert).all()}
-    assert verticals == {"gas", "sentiment"}
+    assert n >= 2  # >= because store-backed detectors (rerouting/chokepoint) may also fire
+    rules = {a.rule for a in db_session.query(Alert).all()}
+    assert {"gas_balance", "sentiment_risk"} <= rules
 
 
 def test_run_all_detectors_isolates_failures(db_session, monkeypatch):
@@ -237,8 +239,55 @@ def test_run_all_detectors_isolates_failures(db_session, monkeypatch):
     assert db_session.query(Alert).filter(Alert.vertical == "gas").count() == 1
 
 
-def test_detector_registry_has_seven(db_session):
-    assert len(DETECTORS) == 7
+def test_detector_registry_count(db_session):
+    assert len(DETECTORS) == 10
+
+
+# ─── Phase B: dunkelflaute / rerouting / chokepoint ───────────────────────────
+
+
+def test_dunkelflaute_warns(db_session):
+    db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000, wind_mw=3000, solar_mw=2000))  # ~8%
+    db_session.commit()
+    r = detect_dunkelflaute(db_session)[0]
+    assert r.vertical == "power" and r.rule == "dunkelflaute" and r.severity == "warning"
+
+
+def test_dunkelflaute_high_renewables_suppressed(db_session):
+    db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000, wind_mw=30000, solar_mw=15000))  # 75%
+    db_session.commit()
+    assert detect_dunkelflaute(db_session) == []
+
+
+def test_rerouting_high_warns(db_session, monkeypatch):
+    monkeypatch.setattr(
+        "backend.signals.tonnage_proxy.compute_rerouting_index",
+        lambda days=365: {"available": True, "current": {"state": "high_rerouting", "severity": "warning", "ratio_pct": 58.0, "baseline_30d": 0.30}},
+    )
+    r = detect_rerouting(db_session)[0]
+    assert r.rule == "rerouting_high" and r.severity == "warning" and r.vertical == "oil"
+
+
+def test_rerouting_normal_suppressed(db_session, monkeypatch):
+    monkeypatch.setattr(
+        "backend.signals.tonnage_proxy.compute_rerouting_index",
+        lambda days=365: {"available": True, "current": {"state": "normal", "severity": None}},
+    )
+    assert detect_rerouting(db_session) == []
+
+
+def test_chokepoint_maps_alert(db_session, monkeypatch):
+    monkeypatch.setattr(
+        "backend.signals.portwatch_alerts.check_chokepoint_anomalies",
+        lambda: [{
+            "chokepoint": "Strait of Hormuz", "anomaly_pct": -42.0, "direction": "drop",
+            "n_total": 30, "baseline_avg": 52.0, "baseline_type": "yoy",
+            "alert_level": "critical", "disruption_name": "Red Sea crisis",
+        }],
+    )
+    r = detect_chokepoint(db_session)[0]
+    assert r.rule == "chokepoint_anomaly" and r.zone == "hormuz" and r.severity == "critical"
+    assert "Red Sea crisis" in r.detail
 
 
 # ─── API exposure + grouping ──────────────────────────────────────────────────

--- a/backend/tests/test_firms_thermal.py
+++ b/backend/tests/test_firms_thermal.py
@@ -1,0 +1,55 @@
+"""Tests for the baseline-aware refinery thermal anomaly check (collectors/firms.py).
+
+Refineries run hot continuously, so the check must alert only on activity that is unusual
+vs the refinery's own trailing daily norm — not on any hotspot at all.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from backend.collectors.firms import REFINERIES, _check_refinery_anomalies
+from backend.models.alerts import Alert
+from backend.models.thermal import ThermalHotspot
+
+_REF = next(r for r in REFINERIES if r["area"] == "gulf_coast")  # Baytown TX
+
+
+def _seed_hotspots(db, counts_by_offset):
+    """Seed `count` nearby hotspots on each (today - offset) day for the refinery."""
+    anchor = datetime.now(timezone.utc).date()
+    for off, c in counts_by_offset.items():
+        d = (anchor - timedelta(days=off)).isoformat()
+        for i in range(c):
+            db.add(ThermalHotspot(
+                latitude=_REF["lat"], longitude=_REF["lon"], brightness=320.0,
+                confidence="high", area_name=_REF["area"], acq_date=d,
+            ))
+    db.commit()
+
+
+def _batch(n):
+    return [{"area": _REF["area"], "lat": _REF["lat"], "lon": _REF["lon"], "brightness": 335.0} for _ in range(n)]
+
+
+def _thermal_alert_count(db):
+    return db.query(Alert).filter(Alert.rule == "refinery_thermal").count()
+
+
+def test_thermal_normal_activity_no_alert(db_session):
+    # ~3 nearby hotspots/day baseline; today also ~3 → normal → no alert.
+    _seed_hotspots(db_session, {o: 2 + (o % 3) for o in range(1, 31)})  # 2-4/day
+    _check_refinery_anomalies(db_session, _batch(3))
+    assert _thermal_alert_count(db_session) == 0
+
+
+def test_thermal_spike_alerts(db_session):
+    # Same calm baseline, but today 15 nearby hotspots → unusual → alert.
+    _seed_hotspots(db_session, {o: 2 + (o % 3) for o in range(1, 31)})
+    _check_refinery_anomalies(db_session, _batch(15))
+    assert _thermal_alert_count(db_session) == 1
+
+
+def test_thermal_single_hotspot_suppressed(db_session):
+    # One nearby hotspot is below THERMAL_MIN_NEARBY → never alerts (always-on refinery glow).
+    _seed_hotspots(db_session, {o: 3 for o in range(1, 31)})
+    _check_refinery_anomalies(db_session, _batch(1))
+    assert _thermal_alert_count(db_session) == 0

--- a/frontend/src/components/AlertsPanel.jsx
+++ b/frontend/src/components/AlertsPanel.jsx
@@ -36,6 +36,7 @@ const RULE_ICONS = {
   freight_divergence: 'FRGT',
   negative_prices: 'NEGP',
   sentiment_risk: 'SENT',
+  dunkelflaute: 'DUNKL',
 }
 
 // Which dashboard tab holds the evidence chart for each vertical (drill-down).
@@ -76,41 +77,21 @@ function goToVertical(vertical) {
 
 export default function AlertsPanel({ weatherAlerts = [] }) {
   const [alerts, setAlerts] = useState([])
-  const [chokeAlerts, setChokeAlerts] = useState([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    // Wait until both alert sources have responded (or failed) before
-    // hiding the loading state — otherwise the panel briefly renders an
-    // incomplete merge and re-shuffles a second later.
-    Promise.allSettled([
-      fetch(`${API}/alerts?limit=50`)
-        .then((r) => (r.ok ? r.json() : []))
-        .then(setAlerts)
-        .catch((e) => console.error('AlertsPanel alerts:', e)),
-      fetch(`${API}/alerts/portwatch`)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((data) => {
-          if (data?.alerts) setChokeAlerts(data.alerts)
-        })
-        .catch((e) => console.error('AlertsPanel portwatch:', e)),
-    ]).finally(() => setLoading(false))
+    // Chokepoint anomalies now flow through /api/alerts (the detect_chokepoint
+    // detector), so a single fetch covers the whole cross-vertical radar.
+    fetch(`${API}/alerts?limit=50`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then(setAlerts)
+      .catch((e) => console.error('AlertsPanel alerts:', e))
+      .finally(() => setLoading(false))
   }, [])
 
-  // Merge signal alerts (carry their own `vertical`), weather + chokepoint
-  // (oil/maritime). Everything without an explicit vertical defaults to "oil".
+  // Merge radar alerts (carry their own `vertical`) with weather (oil/maritime).
+  // Everything without an explicit vertical defaults to "oil".
   const combined = useMemo(() => [
-    ...chokeAlerts.map((c) => ({
-      id: `choke-${c.portid}`,
-      rule: 'chokepoint_anomaly',
-      vertical: 'oil',
-      severity: c.alert_level,
-      title: `${c.chokepoint || '?'}: ${c.anomaly_pct > 0 ? '+' : ''}${c.anomaly_pct ?? 0}% ${c.direction || ''}`,
-      detail: `${c.n_total ?? '?'} vessels (${c.baseline_type === 'yoy' ? 'YoY' : '30d'}: ${c.baseline_avg ?? '?'})${c.disruption_name ? ` // ${c.disruption_name}` : ''}`,
-      zone: (c.chokepoint || '').toLowerCase().split(' ').pop() || '',
-      created_at: `${c.date}T00:00:00Z`,
-      isChoke: true,
-    })),
     ...weatherAlerts.map((w) => ({
       id: `wx-${w.id}`,
       rule: 'weather',
@@ -123,7 +104,7 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
       isWeather: true,
     })),
     ...alerts.map((a) => ({ ...a, vertical: a.vertical || 'oil', isWeather: false })),
-  ], [alerts, chokeAlerts, weatherAlerts])
+  ], [alerts, weatherAlerts])
 
   const totalCount = combined.length
 


### PR DESCRIPTION
## Phase B — Coverage + Legacy-Thermal-Cleanup

Drei neue Detektoren, die schon baseline-bewusste, reine **lokale DB**-Berechnungen kapseln (**keine Migration** — die Daten lagen persistiert vor, nur die API-Routen rechneten on-read):
- **detect_dunkelflaute** (power): letzter Tag mit wind+solar < 15 % der Last, je Zone.
- **detect_rerouting** (oil): Suez→Cape-Rerouting-Index über Normal — **konsolidiert + ersetzt** das Legacy `evaluator._check_rerouting` (entfernt), keine Doppel-Alerts.
- **detect_chokepoint** (oil): PortWatch-Chokepoint-Anomalien (YoY-Baseline, ±30 %, Seasonal-Low-Suppression) → Alert-Tabelle. Frontend liest sie jetzt aus `/api/alerts` und holt `/api/alerts/portwatch` **nicht mehr doppelt**.

**Legacy-Thermal-Cleanup** (firms.py): `_check_refinery_anomalies` war „jeder Hotspot nahe Raffinerie = warning" → flutet den Feed (Raffinerien laufen immer heiß). Jetzt z-Score der heutigen Nähe-Hotspot-Zahl gegen die eigene 45-Tage-Baseline der Raffinerie; Alert nur bei signifikanter Erhöhung.

Registry = 10 Detektoren. Tests für alle drei + Thermal-Baseline. ruff sauber, 349 Backend-Tests grün, eslint + build grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)