### PR TITLE
fix(radar): show only current alerts in the feed + prune old alerts

### DIFF
--- a/backend/collectors/retention.py
+++ b/backend/collectors/retention.py
@@ -42,8 +42,22 @@ async def run_retention():
         """))
         deleted = r2.rowcount
 
+        # Phase 3: Prune old anomaly alerts so the table stays bounded. 45 days is past the
+        # 30-day AlertOutcome research horizon, so outcome capture is unaffected. Drop the
+        # linked outcomes first (FK), then the alerts. (The radar feed itself only shows the
+        # last ~48h via /api/alerts; this is pure housekeeping for DB size.)
+        db.execute(text("""
+            DELETE FROM alert_outcomes
+            WHERE alert_id IN (SELECT id FROM alerts WHERE created_at < datetime('now', '-45 days'))
+        """))
+        r3 = db.execute(text("DELETE FROM alerts WHERE created_at < datetime('now', '-45 days')"))
+        pruned_alerts = r3.rowcount
+
         db.commit()
-        logger.info(f"Retention: thinned {thinned} rows (7-30d), deleted {deleted} rows (>30d)")
+        logger.info(
+            f"Retention: thinned {thinned} rows (7-30d), deleted {deleted} positions (>30d), "
+            f"pruned {pruned_alerts} alerts (>45d)"
+        )
 
     except Exception as e:
         db.rollback()

--- a/backend/routes/alerts.py
+++ b/backend/routes/alerts.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
@@ -31,11 +33,18 @@ async def get_alerts(
     vertical: str = Query(None, description="Filter by vertical (oil/gas/power/metals/sentiment)"),
     severity: str = Query(None, description="Filter by severity"),
     group_by_vertical: bool = Query(False, description="Return alerts grouped by vertical, severity-sorted"),
+    max_age_hours: int = Query(48, ge=1, le=720, description="Only alerts refreshed within this window (radar = what's abnormal NOW)"),
     limit: int = Query(50, ge=1, le=500),
     db: Session = Depends(get_db),
 ):
-    """Get generated alerts, newest first (or grouped by vertical, severity-sorted)."""
-    query = db.query(Alert).order_by(Alert.created_at.desc())
+    """Get current alerts, newest first (or grouped by vertical, severity-sorted).
+
+    Alerts are deduped on (rule, zone) within 24h and their timestamp is bumped on every
+    re-fire, so a still-active anomaly always falls inside `max_age_hours` while a resolved
+    one ages out — keeping the radar feed to what is currently abnormal, not weeks of history.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
+    query = db.query(Alert).filter(Alert.created_at > cutoff).order_by(Alert.created_at.desc())
     if rule:
         query = query.filter(Alert.rule == rule)
     if zone:

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -316,6 +316,21 @@ def test_api_group_by_vertical_severity_sorted(client, db_session):
     assert oil_sev == ["critical", "info"]
 
 
+def test_api_excludes_stale_alerts(client, db_session):
+    # The radar feed shows only current anomalies: a re-fired alert stays fresh, a resolved
+    # one ages out of the default 48h window so weeks of history don't pile up.
+    db_session.add(Alert(rule="gas_balance", zone="EU", vertical="gas", severity="critical", title="fresh", detail=""))
+    db_session.add(Alert(rule="flow_anomaly", zone="houston", vertical="oil", severity="warning", title="stale",
+                         detail="", created_at=datetime.utcnow() - timedelta(days=3)))
+    db_session.commit()
+
+    titles = [a["title"] for a in client.get("/api/alerts").json()]
+    assert "fresh" in titles and "stale" not in titles
+    # An explicit wider window can still reach it.
+    titles_wide = [a["title"] for a in client.get("/api/alerts?max_age_hours=168").json()]
+    assert "stale" in titles_wide
+
+
 # ─── Migration ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Der Feed stapelte veraltete Alerts: `_upsert_alert` dedupt nur 24h, und `GET /api/alerts` hatte keinen Aktualitäts-Filter → tägliche Re-Fires summierten sich (flow_anomaly: 48 Zeilen über nur 6 Zonen ≈ 14 Tage Houston). Das vergräbt „was ist *gerade* abnormal".

- **`/api/alerts`**: `max_age_hours` (Default 48). Ein re-gefeuerter Alert behält frischen Timestamp → aktive Anomalien immer sichtbar; aufgelöste altern raus.
- **retention**: Alerts (+ verknüpfte alert_outcomes) > 45 Tage prunen — jenseits des 30d-AlertOutcome-Horizonts, Research-Capture unberührt; Tabelle bleibt bounded.
- Test: stale Alert per Default ausgeschlossen, mit breiterem Fenster erreichbar.

ruff sauber, 350 Backend-Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)