### PR TITLE
feat(radar): Phase C evidence loop — click an alert, land on its chart

### DIFF
--- a/frontend/src/components/AlertsPanel.jsx
+++ b/frontend/src/components/AlertsPanel.jsx
@@ -39,8 +39,24 @@ const RULE_ICONS = {
   dunkelflaute: 'DUNKL',
 }
 
-// Which dashboard tab holds the evidence chart for each vertical (drill-down).
+// Which dashboard tab holds the evidence chart for each vertical (drill-down fallback).
 const VERTICAL_TAB = { gas: 'gas', power: 'energy', metals: 'metals', sentiment: 'sentiment', oil: 'overview' }
+
+// Precise per-rule drill-down: which tab + which panel holds THE evidence for this anomaly,
+// so a click lands directly on the chart that explains it (not just somewhere on the tab).
+const RULE_TARGET = {
+  gas_balance: { tab: 'gas', panel: 'gas-balance' },
+  dunkelflaute: { tab: 'energy', panel: 'power-grid' },
+  negative_prices: { tab: 'energy', panel: 'power-day-ahead' },
+  sentiment_risk: { tab: 'sentiment', panel: 'sentiment' },
+  floating_storage: { tab: 'signals', panel: 'sts-detection' },
+  freight_divergence: { tab: 'signals', panel: 'freight-proxy' },
+  rerouting_high: { tab: 'overview', panel: 'rerouting' },
+  chokepoint_anomaly: { tab: 'overview', panel: 'chokepoint-monitor' },
+  flow_anomaly: { tab: 'overview', panel: 'chokepoint-monitor' },
+  days_of_supply: { tab: 'overview', panel: 'fundamentals' },
+  supply_demand_divergence: { tab: 'overview', panel: 'fundamentals' },
+}
 const VERTICAL_LABELS = { gas: 'GAS', power: 'POWER', oil: 'OIL / MARITIME', metals: 'METALS', sentiment: 'SENTIMENT' }
 const VERTICAL_ORDER = ['gas', 'power', 'oil', 'metals', 'sentiment']
 
@@ -69,10 +85,22 @@ function timeAgo(isoStr) {
   } catch { return '' }
 }
 
-// Drill-down: jump to the vertical's evidence tab via the existing hash router.
-function goToVertical(vertical) {
-  const tab = VERTICAL_TAB[vertical] || 'overview'
-  window.location.hash = tab
+// Drill-down: jump to the anomaly's evidence chart — switch tab, then scroll the specific
+// panel into view and briefly highlight it so it's obvious WHY this fired.
+function goToEvidence(rule, vertical) {
+  const target = RULE_TARGET[rule] || { tab: VERTICAL_TAB[vertical] || 'overview', panel: null }
+  window.location.hash = target.tab
+  if (!target.panel) return
+  // Wait for the tab content to mount, then locate the panel (Panel wraps id as `panel-<id>`;
+  // a couple of panels use a raw div id — try both).
+  setTimeout(() => {
+    const el = document.getElementById(`panel-${target.panel}`) || document.getElementById(target.panel)
+    if (!el) return
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    el.style.transition = 'box-shadow 0.3s ease'
+    el.style.boxShadow = '0 0 0 2px rgba(34, 211, 238, 0.8)'
+    setTimeout(() => { el.style.boxShadow = '' }, 1600)
+  }, 200)
 }
 
 export default function AlertsPanel({ weatherAlerts = [] }) {
@@ -169,7 +197,7 @@ export default function AlertsPanel({ weatherAlerts = [] }) {
       <button
         key={a.id}
         type="button"
-        onClick={() => goToVertical(a.vertical)}
+        onClick={() => goToEvidence(a.rule, a.vertical)}
         title="Open evidence"
         className={`w-full text-left px-4 py-3 border-b border-border last:border-b-0 hover:bg-white/[0.02] transition-colors ${sev.border}`}
       >

--- a/frontend/src/components/Panel.jsx
+++ b/frontend/src/components/Panel.jsx
@@ -45,11 +45,11 @@ export default function Panel({ id, title, info, collapsible = false, headerRigh
     if (!collapsible) return
     try {
       localStorage.setItem(`obsyd-panel-${id}`, collapsed ? '1' : '0')
-    } catch {}
+    } catch { /* localStorage unavailable */ }
   }, [collapsed, id, collapsible])
 
   return (
-    <div className="border border-border bg-surface rounded overflow-hidden">
+    <div id={id ? `panel-${id}` : undefined} className="border border-border bg-surface rounded overflow-hidden">
       <div
         className={`flex items-center justify-between px-4 py-2 ${
           !collapsed ? 'border-b border-border/50' : ''

--- a/frontend/src/components/SentimentPanel.jsx
+++ b/frontend/src/components/SentimentPanel.jsx
@@ -89,7 +89,7 @@ export default function SentimentPanel() {
   const maxVol = Math.max(...kwStats.map((k) => k.volume), 0.01)
 
   return (
-    <Panel id="sentiment" title={`${hasAI ? 'AI SENTIMENT' : 'NEWS VOLUME'} // GDELT`} info="News sentiment from GDELT tone analysis. Risk score 1-10 (1=very negative, 10=very positive)." collapsible headerRight={hasAI && <span className="font-mono text-[9px] text-purple-400 border border-purple-400/30 rounded px-1.5 py-0.5">AI</span>}>
+    <Panel id="sentiment" title={`${hasAI ? 'NEWS RISK' : 'NEWS VOLUME'} // GDELT`} info="News-risk score from GDELT tone analysis, 1-10 (HIGHER = more negative / risk-laden coverage). Descriptive context, not a forecast." collapsible headerRight={hasAI && riskData.score && <span className="font-mono text-[9px] text-neutral-500 border border-neutral-700/60 rounded px-1.5 py-0.5">GDELT</span>}>
       <div className="px-4 py-3">
 
       {hasAI && riskData.score && (
@@ -107,9 +107,22 @@ export default function SentimentPanel() {
               {riskData.score.risk_score}
             </div>
             <div>
-              <div className="font-mono text-[10px] text-neutral-500">RISK SCORE</div>
+              <div className="font-mono text-[10px] text-neutral-500">
+                NEWS RISK ·{' '}
+                <span
+                  className={
+                    riskData.score.risk_score >= 8
+                      ? 'text-red-400'
+                      : riskData.score.risk_score >= 6
+                      ? 'text-yellow-400'
+                      : 'text-green-glow'
+                  }
+                >
+                  {riskData.score.risk_score >= 8 ? 'ELEVATED' : riskData.score.risk_score >= 6 ? 'MODERATE' : 'LOW'}
+                </span>
+              </div>
               <div className="font-mono text-[9px] text-neutral-600">
-                {riskData.score.date} via {riskData.score.source}
+                {riskData.score.risk_score}/10 · {riskData.score.date}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Schließt die ursprüngliche „die Charts sagen nichts"-Klage: ein Radar-Alert führt jetzt per Klick auf das **exakte Evidenz-Chart**, nicht nur auf den Tab.

- **Panel**: exponiert eine DOM-id (`panel-<id>`) → Panels sind Scroll-/Anker-Ziele.
- **AlertsPanel**: Pro-Regel-`RULE_TARGET`-Map ({tab, panel}); Klick wechselt Tab, scrollt das Panel in den Blick und hebt es kurz hervor. Fallback vertical→tab für ungemappte Regeln.
- **SentimentPanel**: irreführenden Info-Text gefixt (behauptete 10=positiv, während Färbung+Detektor hoch=hohes-Risiko behandeln) + Klartext-Verdict LOW/MODERATE/ELEVATED; „AI"-Framing raus (Scorer ist regelbasiert GDELT, kein LLM). Vorbestehende leere `catch {}` in Panel.jsx aufgeräumt.

eslint sauber, build grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)