### PR TITLE
fix(radar): sharpen chatty analytics detectors (onset-detection) + backtest tool

### DIFF
--- a/backend/scripts/backtest_radar.py
+++ b/backend/scripts/backtest_radar.py
@@ -1,0 +1,227 @@
+"""Descriptive backtest of the anomaly radar over the full historical record.
+
+Posture B: we do NOT measure prediction skill (no IC/hit-rate). We measure whether the
+detectors are GOOD as a descriptive radar, on three axes:
+  - PRECISION  — when they fire, is it a real deviation? (old flat-threshold vs new baseline)
+  - RECALL     — do they catch the obvious real events? (ground-truth spot-checks)
+  - CALIBRATION— fire frequency + severity mix over time (not too noisy, not silent)
+
+Read-only. Replays each detector over the persisted per-day series. For detectors whose
+logic changed in Phase A/B, it runs BOTH the old and new decision rule on the same data to
+quantify the noise reduction (and confirm real spikes are still caught).
+
+Run on the VPS as the obsyd user:  python -m backend.scripts.backtest_radar
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import Counter, defaultdict
+from datetime import timedelta
+
+from backend.database import SessionLocal
+from backend.models.analytics import DaysOfSupplyHistory, FreightProxyHistory, SupplyDemandBalance
+from backend.models.energy import PowerGrid, PowerPriceDaily
+from backend.models.gas import GasBalance
+from backend.models.sentiment import SentimentScore
+from backend.models.thermal import ThermalHotspot
+from backend.models.vessels import FloatingStorageEvent
+
+
+def _month(d: str) -> str:
+    return d[:7]
+
+
+def _zscore(cur, hist, min_n=14):
+    if len(hist) < min_n:
+        return None
+    m = statistics.fmean(hist)
+    s = statistics.pstdev(hist)
+    if s == 0:
+        return None
+    return (cur - m) / s, m
+
+
+def hr(t):
+    print("\n" + "=" * 78 + f"\n{t}\n" + "=" * 78)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+def precision_old_vs_new(db):
+    hr("PRECISION — old flat-threshold vs new baseline (fire-events over full history)")
+
+    # FLOATING STORAGE: reconstruct daily active count per zone, apply both rules per day.
+    rows = db.query(FloatingStorageEvent.zone, FloatingStorageEvent.first_seen, FloatingStorageEvent.last_seen).all()
+    byz = defaultdict(list)
+    for z, fs, ls in rows:
+        byz[z or "global"].append((fs.date(), ls.date()))
+    if rows:
+        anchor = max(ls for _, _, ls in rows).date()
+        start = min(fs for _, fs, _ in rows).date()
+        span = (anchor - start).days
+        old_f = new_f = 0
+        per_zone = {}
+        for z, evs in byz.items():
+            o = n = 0
+            counts = []
+            for off in range(span + 1):
+                d = anchor - timedelta(days=off)
+                counts.append(sum(1 for fs, ls in evs if fs <= d <= ls))
+            for i, c in enumerate(counts):
+                if c >= 3:  # OLD flat rule
+                    o += 1
+                base = counts[i + 1 : i + 91]  # trailing 90d (older days)
+                zs = _zscore(c, base)
+                if zs and zs[1] >= 2.0 and zs[0] >= 2.0:  # NEW baseline rule
+                    n += 1
+            old_f += o
+            new_f += n
+            per_zone[z] = (o, n)
+        print(f"floating_storage: OLD fired {old_f} zone-days, NEW {new_f} zone-days  (over ~{span}d)")
+        for z, (o, n) in sorted(per_zone.items(), key=lambda x: -x[1][0]):
+            print(f"    {z:9} old={o:4}  new={n:4}   ({'STRUCTURAL HUB → old over-fired' if o > 5 * (n + 1) else 'ok'})")
+
+    # NEGATIVE PRICES per zone
+    for zone in [z for (z,) in db.query(PowerPriceDaily.zone).distinct().all()]:
+        prows = db.query(PowerPriceDaily.negative_hours).filter(PowerPriceDaily.zone == zone).order_by(PowerPriceDaily.date).all()
+        series = [r[0] for r in prows]
+        o = n = 0
+        for i, c in enumerate(series):
+            if c >= 1:  # OLD: any negative hour fired (info+)
+                o += 1
+            if c >= 3:
+                base = series[max(0, i - 45) : i]
+                zs = _zscore(c, base)
+                if zs and zs[0] >= 2.0:  # NEW
+                    n += 1
+        print(f"negative_prices[{zone}]: OLD fired {o} days, NEW {n} days  (of {len(series)})")
+
+    # SENTIMENT
+    srows = db.query(SentimentScore.risk_score).order_by(SentimentScore.date).all()
+    s = [r[0] for r in srows]
+    o = n = 0
+    for i, v in enumerate(s):
+        if v >= 6:  # OLD absolute
+            o += 1
+        if v >= 8 or (_zscore(v, s[max(0, i - 30) : i]) or (0, 0))[0] >= 2.0 and v >= 6:  # NEW
+            n += 1
+    print(f"sentiment_risk: OLD fired {o} days, NEW {n} days  (of {len(s)})")
+
+    # THERMAL per refinery (reconstruct daily nearby counts → old any≥1 vs new z-score)
+    from backend.collectors.firms import PROXIMITY_KM, REFINERIES, _haversine_km
+    for ref in REFINERIES:
+        trows = db.query(ThermalHotspot.latitude, ThermalHotspot.longitude, ThermalHotspot.acq_date).filter(
+            ThermalHotspot.area_name == ref["area"]
+        ).all()
+        byd = defaultdict(int)
+        for la, lo, d in trows:
+            if d and _haversine_km(ref["lat"], ref["lon"], la, lo) <= PROXIMITY_KM:
+                byd[d] += 1
+        if not byd:
+            continue
+        days = sorted(byd)
+        o = n = 0
+        for i, d in enumerate(days):
+            c = byd[d]
+            if c >= 1:  # OLD: any nearby hotspot → warning
+                o += 1
+            if c >= 2:
+                base = [byd[x] for x in days[:i]][-45:]
+                zs = _zscore(c, base)
+                if zs and zs[0] >= 2.0:  # NEW
+                    n += 1
+        print(f"refinery_thermal[{ref['name'][:22]:22}]: OLD fired {o} days, NEW {n} days  (of {len(days)})")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+def calibration(db):
+    hr("CALIBRATION — fire frequency + severity mix (NEW logic, per detector)")
+
+    # gas_balance from persisted flags
+    g = db.query(GasBalance.date, GasBalance.flag).filter(GasBalance.flag.isnot(None)).all()
+    fires = [(d, f.split(":")[0]) for d, f in g if f and f.split(":")[0] in ("WATCH", "SIGNAL")]
+    sev = Counter("critical" if lvl == "SIGNAL" else "warning" for _, lvl in fires)
+    months = sorted({_month(d) for d, _ in fires})
+    print(f"gas_balance: {len(fires)} fire-days  sev={dict(sev)}  across {len(months)} months")
+
+    # days_of_supply / supply_demand / freight (persisted categorical)
+    dos = db.query(DaysOfSupplyHistory.assessment).all()
+    print(f"days_of_supply assessments: {dict(Counter(a for (a,) in dos if a))}")
+    sd = db.query(SupplyDemandBalance.divergence_type).all()
+    print(f"supply_demand divergence_type: {dict(Counter(t for (t,) in sd if t))}")
+    fp = db.query(FreightProxyHistory.divergence_flag).all()
+    print(f"freight divergence_flag: {dict(Counter(f for (f,) in fp if f))}")
+
+    # dunkelflaute seasonality (renewable_share<15% per day)
+    pg = db.query(PowerGrid.date, PowerGrid.load_mw, PowerGrid.wind_mw, PowerGrid.solar_mw).filter(PowerGrid.zone == "DE_LU").all()
+    dunkel = [d for d, load, w, s in pg if load and load > 0 and ((w or 0) + (s or 0)) / load < 0.15]
+    print(f"dunkelflaute[DE_LU]: {len(dunkel)} days of {len(pg)}  by-month={dict(Counter(_month(d) for d in dunkel))}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+def recall_ground_truth(db):
+    hr("RECALL — ground-truth spot-checks")
+
+    # Rerouting during the (ongoing) Red Sea disruption: monthly Cape-share state.
+    try:
+        from backend.signals.tonnage_proxy import REROUTING_ELEVATED, REROUTING_HIGH, compute_rerouting_index
+        data = compute_rerouting_index(days=400)
+        if data.get("available"):
+            hist = data.get("history", [])
+            bym = defaultdict(list)
+            for h in hist:
+                bym[_month(h["date"])].append(h["ratio"])
+            print(f"rerouting Cape-share monthly avg (HIGH>={REROUTING_HIGH:.0%}, ELEV>={REROUTING_ELEVATED:.0%}):")
+            for m in sorted(bym):
+                avg = statistics.fmean(bym[m])
+                tag = "HIGH" if avg >= REROUTING_HIGH else "elev" if avg >= REROUTING_ELEVATED else "norm"
+                print(f"    {m}: {avg:5.0%}  {tag}")
+        else:
+            print("rerouting: no data")
+    except Exception as e:
+        print(f"rerouting check failed: {e}")
+
+    # Gas WATCH/SIGNAL dates — eyeball clustering.
+    g = db.query(GasBalance.date, GasBalance.flag, GasBalance.z_score).filter(GasBalance.flag.isnot(None)).order_by(GasBalance.date).all()
+    flagged = [(d, f, z) for d, f, z in g if f and f.split(":")[0] in ("WATCH", "SIGNAL")]
+    print(f"\ngas_balance flagged days ({len(flagged)} total), most extreme:")
+    for d, f, z in sorted(flagged, key=lambda x: -abs(x[2] or 0))[:8]:
+        print(f"    {d}  z={z:+.2f}  {f}")
+
+
+def sharpening_onset_check(db):
+    hr("SHARPENING — persistent fire-days vs onset events (the 3 chatty detectors)")
+
+    rows = db.query(DaysOfSupplyHistory.date, DaysOfSupplyHistory.assessment).order_by(DaysOfSupplyHistory.date).all()
+    tight = sum(1 for _, a in rows if a == "TIGHT")
+    onset = sum(1 for i, (_, a) in enumerate(rows) if a == "TIGHT" and (i == 0 or rows[i - 1][1] != "TIGHT"))
+    print(f"days_of_supply: TIGHT on {tight} readings → {onset} onset events (old fired all {tight})")
+
+    def dv(t):
+        return bool(t and "DIVERGENCE" in t)
+
+    rows = db.query(SupplyDemandBalance.date, SupplyDemandBalance.divergence_type).order_by(SupplyDemandBalance.date).all()
+    days = sum(1 for _, t in rows if dv(t))
+    onset = sum(1 for i, (_, t) in enumerate(rows) if dv(t) and (i == 0 or not dv(rows[i - 1][1])))
+    print(f"supply_demand: DIVERGENCE on {days} readings → {onset} onset events (old fired all {days})")
+
+    rows = db.query(FreightProxyHistory.date, FreightProxyHistory.divergence_flag).order_by(FreightProxyHistory.date).all()
+    days = sum(1 for _, f in rows if f)
+    onset = sum(1 for i, (_, f) in enumerate(rows) if f and (i == 0 or rows[i - 1][1] != f))
+    print(f"freight_divergence: flagged on {days} readings → {onset} onset events (old fired all {days}; of {len(rows)} rows)")
+
+
+def main():
+    db = SessionLocal()
+    try:
+        precision_old_vs_new(db)
+        sharpening_onset_check(db)
+        calibration(db)
+        recall_ground_truth(db)
+    finally:
+        db.close()
+    print("\n" + "=" * 78)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/signals/detectors/oil.py
+++ b/backend/signals/detectors/oil.py
@@ -19,7 +19,13 @@ from backend.models.vessels import FloatingStorageEvent
 from backend.signals.detectors.base import DetectorResult, trailing_zscore
 
 # Days-of-supply: both extremes are notable for a radar; tight is the urgent one.
-_DOS_SEVERITY = {"TIGHT": "warning", "COMFORTABLE": "info"}  # IN_LINE → suppress
+# These three read CATEGORICAL flags from the analytics layer, so they're sharpened by
+# ONSET-detection rather than a z-score: fire on the TRANSITION into the abnormal state, not
+# every day it persists. A radar pings on change; the steady state lives on the dashboard panel.
+
+
+def _latest_two(db, model):
+    return db.query(model).order_by(model.date.desc()).limit(2).all()
 
 # Floating storage: compare a zone's CURRENT count to its OWN trailing norm, not a flat
 # threshold — a permanent anchorage (Malacca/Singapore, Houston) is structurally high and a
@@ -31,57 +37,67 @@ FS_CRIT_Z = 3.0
 
 
 def detect_days_of_supply(db) -> list[DetectorResult]:
-    row = db.query(DaysOfSupplyHistory).order_by(DaysOfSupplyHistory.date.desc()).first()
-    if row is None:
+    """Fire when US crude inventories newly turn TIGHT (onset), not every day they stay tight."""
+    rows = _latest_two(db, DaysOfSupplyHistory)
+    if not rows or rows[0].assessment != "TIGHT":
         return []
-    severity = _DOS_SEVERITY.get(row.assessment or "")
-    if severity is None:
-        return []
-    dev = row.deviation if row.deviation is not None else 0.0
-    days = row.commercial_days if row.commercial_days is not None else 0.0
+    if len(rows) > 1 and rows[1].assessment == "TIGHT":
+        return []  # already tight last reading → persistence, not a new event
+    cur = rows[0]
+    dev = cur.deviation if cur.deviation is not None else 0.0
+    days = cur.commercial_days if cur.commercial_days is not None else 0.0
     return [
         DetectorResult(
             rule="days_of_supply",
             zone="us",
             vertical="oil",
-            severity=severity,
-            title=f"US crude days-of-supply {row.assessment.lower()}",
-            detail=f"{days:.1f} days cover, {dev:+.1f}d vs 5-year seasonal average (as of {row.date}).",
+            severity="warning",
+            title="US crude days-of-supply turned tight",
+            detail=f"{days:.1f} days cover, {dev:+.1f}d vs 5-year seasonal average (as of {cur.date}).",
         )
     ]
 
 
+def _has_divergence(row) -> bool:
+    return bool(row.divergence_type and "DIVERGENCE" in row.divergence_type)
+
+
 def detect_supply_demand_divergence(db) -> list[DetectorResult]:
-    row = db.query(SupplyDemandBalance).order_by(SupplyDemandBalance.date.desc()).first()
-    if row is None or not row.divergence_type:
+    """Fire when EIA-balance vs AIS newly diverges (onset); 'CONFIRMED' = sources agree → no alert."""
+    rows = _latest_two(db, SupplyDemandBalance)
+    if not rows or not _has_divergence(rows[0]):
         return []
-    # Only a genuine divergence is anomalous; "CONFIRMED" means the sources agree.
-    if "DIVERGENCE" not in row.divergence_type:
-        return []
+    if len(rows) > 1 and _has_divergence(rows[1]):
+        return []  # divergence already present last reading → persistence
+    cur = rows[0]
     return [
         DetectorResult(
             rule="supply_demand_divergence",
             zone="us",
             vertical="oil",
             severity="warning",
-            title="EIA balance vs AIS divergence",
-            detail=(row.divergence_detail or row.divergence_type) + f" (as of {row.date}).",
+            title="EIA balance vs AIS newly diverging",
+            detail=(cur.divergence_detail or cur.divergence_type) + f" (as of {cur.date}).",
         )
     ]
 
 
 def detect_freight_divergence(db) -> list[DetectorResult]:
-    row = db.query(FreightProxyHistory).order_by(FreightProxyHistory.date.desc()).first()
-    if row is None or not row.divergence_flag:
+    """Fire when the freight proxy newly diverges or changes regime (onset), not on persistence."""
+    rows = _latest_two(db, FreightProxyHistory)
+    if not rows or not rows[0].divergence_flag:
         return []
+    if len(rows) > 1 and rows[1].divergence_flag == rows[0].divergence_flag:
+        return []  # same divergence flag as last reading → persistence
+    cur = rows[0]
     return [
         DetectorResult(
             rule="freight_divergence",
             zone="tanker",
             vertical="oil",
             severity="info",
-            title=f"Freight proxy {row.divergence_flag.lower()}",
-            detail=f"Tanker-equity freight proxy diverging from rerouting / Brent (as of {row.date}).",
+            title=f"Freight proxy {cur.divergence_flag.lower()}",
+            detail=f"Tanker-equity freight proxy newly diverging from rerouting / Brent (as of {cur.date}).",
         )
     ]
 

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -113,6 +113,30 @@ def test_freight_divergence_info(db_session):
     assert r.severity == "info" and r.vertical == "oil"
 
 
+# Onset-detection: a persistent state (same as the prior reading) must NOT re-fire.
+
+
+def test_days_of_supply_persistence_suppressed(db_session):
+    db_session.add(DaysOfSupplyHistory(date="2026-06-23", assessment="TIGHT", deviation=-4.0, commercial_days=21.0))
+    db_session.add(DaysOfSupplyHistory(date="2026-06-24", assessment="TIGHT", deviation=-4.2, commercial_days=20.8))
+    db_session.commit()
+    assert detect_days_of_supply(db_session) == []
+
+
+def test_supply_demand_persistence_suppressed(db_session):
+    db_session.add(SupplyDemandBalance(date="2026-06-23", divergence_type="EIA_AIS_DIVERGENCE", divergence_detail="x"))
+    db_session.add(SupplyDemandBalance(date="2026-06-24", divergence_type="EIA_AIS_DIVERGENCE", divergence_detail="y"))
+    db_session.commit()
+    assert detect_supply_demand_divergence(db_session) == []
+
+
+def test_freight_persistence_suppressed(db_session):
+    db_session.add(FreightProxyHistory(date="2026-06-23", proxy_index=104.0, divergence_flag="FREIGHT_PROXY_DIVERGENCE"))
+    db_session.add(FreightProxyHistory(date="2026-06-24", proxy_index=103.0, divergence_flag="FREIGHT_PROXY_DIVERGENCE"))
+    db_session.commit()
+    assert detect_freight_divergence(db_session) == []
+
+
 _FS_ANCHOR = date(2026, 6, 24)
 
 


### PR DESCRIPTION
Ein deskriptiver Backtest über die volle Historie zeigte: drei Analytics-Flag-Detektoren feuerten **jeden Tag, solange ein Zustand anhielt**, statt beim Event — freight_divergence 45/106 Tage, days_of_supply TIGHT 8, supply_demand DIVERGENCE 6.

Sie lesen kategoriale Flags (zu wenig Punkte für z-Score) → **Onset-Detection**: feuern beim *Übergang* in den auffälligen Zustand, nicht während der Persistenz (Radar pingt bei Veränderung; Dauerzustand lebt im Dashboard-Panel + altert via 48h-Feed-Fenster aus).

**Backtest nach Schärfung (echte Prod-Daten):** freight 45→**10** Onset-Events, days_of_supply 8→**4**, supply_demand 6→**2** — Events bleiben, tägliche Wiederholungen weg.

- days_of_supply: nur bei *neu* TIGHT (nicht-alarmierendes COMFORTABLE entfernt).
- supply_demand / freight: feuern bei Onset/Regimewechsel.
- `backend/scripts/backtest_radar.py`: die deskriptive Validierungs-Harness (Präzision alt-vs-neu, Kalibrierung, Recall-Ground-Truth, Onset-Check) — wiederverwendbar, read-only.
- Tests: Persistenz unterdrückt für alle drei.

ruff sauber, 353 Backend-Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)