### PR TITLE
fix(radar): flow_anomaly — longer baseline + onset-detection

### DIFF
--- a/backend/scripts/backtest_radar.py
+++ b/backend/scripts/backtest_radar.py
@@ -25,7 +25,7 @@ from backend.models.energy import PowerGrid, PowerPriceDaily
 from backend.models.gas import GasBalance
 from backend.models.sentiment import SentimentScore
 from backend.models.thermal import ThermalHotspot
-from backend.models.vessels import FloatingStorageEvent
+from backend.models.vessels import FloatingStorageEvent, GeofenceEvent
 
 
 def _month(d: str) -> str:
@@ -189,6 +189,30 @@ def recall_ground_truth(db):
         print(f"    {d}  z={z:+.2f}  {f}")
 
 
+def flow_anomaly_old_vs_new(db):
+    hr("FLOW_ANOMALY — old 7d-zscore (every anomalous day) vs new 30d-baseline + onset")
+    zones = [z for (z,) in db.query(GeofenceEvent.zone).distinct().all()]
+    tot_old = tot_new = 0
+    for zone in zones:
+        rows = db.query(GeofenceEvent.tanker_count).filter(GeofenceEvent.zone == zone).order_by(GeofenceEvent.date).all()
+        counts = [r[0] for r in rows]  # oldest first
+        old = new = 0
+        anom = []
+        for i in range(len(counts)):
+            zo = _zscore(counts[i], counts[max(0, i - 7) : i], min_n=7)
+            if zo and abs(zo[0]) >= 2.0:
+                old += 1
+            zn = _zscore(counts[i], counts[max(0, i - 30) : i], min_n=16)
+            a = bool(zn and abs(zn[0]) >= 2.0)
+            anom.append(a)
+            if a and (i == 0 or not anom[i - 1]):  # onset only
+                new += 1
+        tot_old += old
+        tot_new += new
+        print(f"  {zone:9} old={old:4}  new(onset)={new:4}   (of {len(counts)} days)")
+    print(f"  TOTAL     old={tot_old:4}  new={tot_new:4}")
+
+
 def sharpening_onset_check(db):
     hr("SHARPENING — persistent fire-days vs onset events (the 3 chatty detectors)")
 
@@ -215,6 +239,7 @@ def main():
     db = SessionLocal()
     try:
         precision_old_vs_new(db)
+        flow_anomaly_old_vs_new(db)
         sharpening_onset_check(db)
         calibration(db)
         recall_ground_truth(db)

--- a/backend/signals/rules.py
+++ b/backend/signals/rules.py
@@ -17,9 +17,9 @@ from backend.models.vessels import GeofenceEvent
 logger = logging.getLogger(__name__)
 
 # Thresholds
-FLOW_ANOMALY_STD_DEVS = 2.0
-FLOW_ANOMALY_PCT_FALLBACK = 0.30  # 30% deviation when <7 days of data
-FLOW_ANOMALY_MIN_DAYS = 3  # minimum days for percentage-based fallback
+FLOW_ANOMALY_STD_DEVS = 2.0       # z-score threshold vs the zone's own trailing baseline
+FLOW_BASELINE_DAYS = 30           # trailing window (longer than the old 7d → stabler "normal")
+FLOW_MIN_HISTORY = 16             # enough history for a trustworthy baseline + onset check
 CUSHING_DRAWDOWN_THRESHOLD = -3000  # thousand barrels (= -3M barrels)
 
 # Regional anchor baselines — zone-specific thresholds for anchored vessel alerts.
@@ -124,65 +124,48 @@ def check_anchored_vessels(db: Session, zone: str, slow_movers: int, total_tanke
 
 
 def check_flow_anomaly(db: Session, zone: str, current_count: int):
-    """
-    Chokepoint Flow Anomaly.
+    """Chokepoint Flow Anomaly — baseline-aware + onset-only.
 
-    With 7+ days: trigger when daily tanker count deviates > 2σ from rolling average.
-    With 3-6 days: trigger when count deviates > 30% from average (percentage fallback).
-    With <3 days: suppress (insufficient data).
+    Fires when the latest daily tanker count deviates > FLOW_ANOMALY_STD_DEVS from the zone's
+    OWN trailing baseline (FLOW_BASELINE_DAYS, longer/stabler than the old 7d), and ONLY on the
+    onset: if the prior day was already anomalous, it's persistence, not a new event → suppress.
     """
-    recent = (
+    # Lazy import avoids a circular import (detectors package imports _upsert_alert from here).
+    from backend.signals.detectors.base import trailing_zscore
+
+    rows = (
         db.query(GeofenceEvent.tanker_count)
         .filter(GeofenceEvent.zone == zone)
         .order_by(GeofenceEvent.date.desc())
-        .limit(7)
+        .limit(FLOW_BASELINE_DAYS + 2)
         .all()
     )
+    counts = [r.tanker_count for r in rows]  # newest first; counts[0] is the current day
+    if len(counts) < FLOW_MIN_HISTORY:
+        return  # not enough history for a trustworthy baseline yet
 
-    n_days = len(recent)
-    if n_days < FLOW_ANOMALY_MIN_DAYS:
+    today = trailing_zscore(counts[0], counts[1 : 1 + FLOW_BASELINE_DAYS])
+    if today is None or abs(today[0]) < FLOW_ANOMALY_STD_DEVS:
+        return
+    # Onset: suppress if the prior day was already anomalous (sustained deviation, not new).
+    yest = trailing_zscore(counts[1], counts[2 : 2 + FLOW_BASELINE_DAYS])
+    if yest is not None and abs(yest[0]) >= FLOW_ANOMALY_STD_DEVS:
         return
 
-    counts = [r.tanker_count for r in recent]
-    mean = sum(counts) / len(counts)
-
-    if mean == 0:
-        return
-
-    if n_days >= 7:
-        # Standard deviation method
-        variance = sum((c - mean) ** 2 for c in counts) / (len(counts) - 1)
-        std_dev = variance**0.5
-        if std_dev == 0:
-            return
-        z_score = abs(current_count - mean) / std_dev
-        if z_score <= FLOW_ANOMALY_STD_DEVS:
-            return
-        direction = "increase" if current_count > mean else "decrease"
-        detail = (
-            f"Current: {current_count} tankers, 7-day avg: {mean:.1f}, "
-            f"z-score: {z_score:.2f} (threshold: {FLOW_ANOMALY_STD_DEVS})"
-        )
-    else:
-        # Percentage fallback for bootstrap period (3-6 days)
-        pct_deviation = abs(current_count - mean) / mean
-        if pct_deviation <= FLOW_ANOMALY_PCT_FALLBACK:
-            return
-        direction = "increase" if current_count > mean else "decrease"
-        detail = (
-            f"Current: {current_count} tankers, {n_days}-day avg: {mean:.1f}, "
-            f"deviation: {pct_deviation * 100:.0f}% (threshold: {FLOW_ANOMALY_PCT_FALLBACK * 100:.0f}%)"
-        )
-
+    z, mean, _, n = today
+    direction = "increase" if counts[0] > mean else "decrease"
     _upsert_alert(
         db,
         rule="flow_anomaly",
         zone=zone,
         severity="warning",
-        title=f"Anomalous {direction} in {zone} transit",
-        detail=detail,
+        title=f"Anomalous {direction} in {zone} transit ({z:+.1f}σ)",
+        detail=(
+            f"Current {counts[0]} tankers vs ~{mean:.0f} normal over {n}d "
+            f"(z {z:+.2f}, threshold ±{FLOW_ANOMALY_STD_DEVS}σ)."
+        ),
     )
-    logger.info(f"Alert: flow_anomaly in {zone} ({direction})")
+    logger.info(f"Alert: flow_anomaly in {zone} ({direction}, z={z:+.2f})")
 
 
 def check_cushing_drawdown(db: Session):

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -21,7 +21,7 @@ from backend.models.analytics import (
 from backend.models.energy import PowerGrid, PowerPriceDaily
 from backend.models.gas import GasBalance
 from backend.models.sentiment import SentimentScore
-from backend.models.vessels import FloatingStorageEvent
+from backend.models.vessels import FloatingStorageEvent, GeofenceEvent
 from backend.signals.detectors import DETECTORS, run_all_detectors
 from backend.signals.detectors.gas import detect_gas_balance
 from backend.signals.detectors.oil import (
@@ -34,6 +34,7 @@ from backend.signals.detectors.oil import (
 )
 from backend.signals.detectors.power import detect_dunkelflaute, detect_negative_prices
 from backend.signals.detectors.sentiment import detect_sentiment_risk
+from backend.signals.rules import check_flow_anomaly
 
 
 @pytest.fixture
@@ -265,6 +266,50 @@ def test_run_all_detectors_isolates_failures(db_session, monkeypatch):
 
 def test_detector_registry_count(db_session):
     assert len(DETECTORS) == 10
+
+
+# ─── flow_anomaly (legacy maritime check) — baseline + onset cure ─────────────
+
+
+def _seed_geofence(db, zone, counts_newest_first):
+    """counts_newest_first[0] is the latest day; one GeofenceEvent per descending date."""
+    base = date(2026, 6, 24)
+    for i, c in enumerate(counts_newest_first):
+        db.add(GeofenceEvent(zone=zone, date=(base - timedelta(days=i)).isoformat(), tanker_count=c))
+    db.commit()
+
+
+def _flow_alert_count(db):
+    return db.query(Alert).filter(Alert.rule == "flow_anomaly").count()
+
+
+def test_flow_anomaly_onset_fires(db_session):
+    # ~30 days of stable ~10 tankers, today spikes to 40, yesterday was normal → onset → fire.
+    counts = [40] + [10 + (i % 3) for i in range(31)]
+    _seed_geofence(db_session, "hormuz", counts)
+    check_flow_anomaly(db_session, "hormuz", counts[0])
+    assert _flow_alert_count(db_session) == 1
+
+
+def test_flow_anomaly_persistence_suppressed(db_session):
+    # Spike sustained two days (today AND yesterday anomalous) → persistence → no fire.
+    counts = [41, 40] + [10 + (i % 3) for i in range(30)]
+    _seed_geofence(db_session, "hormuz", counts)
+    check_flow_anomaly(db_session, "hormuz", counts[0])
+    assert _flow_alert_count(db_session) == 0
+
+
+def test_flow_anomaly_normal_no_fire(db_session):
+    counts = [11] + [10 + (i % 3) for i in range(31)]
+    _seed_geofence(db_session, "hormuz", counts)
+    check_flow_anomaly(db_session, "hormuz", counts[0])
+    assert _flow_alert_count(db_session) == 0
+
+
+def test_flow_anomaly_insufficient_history_no_fire(db_session):
+    _seed_geofence(db_session, "hormuz", [40, 10, 10])  # < FLOW_MIN_HISTORY
+    check_flow_anomaly(db_session, "hormuz", 40)
+    assert _flow_alert_count(db_session) == 0
 
 
 # ─── Phase B: dunkelflaute / rerouting / chokepoint ───────────────────────────


### PR DESCRIPTION
flow_anomaly war z-Score-basiert, aber gegen ein kurzes **7-Tage-Fenster** und feuerte jeden Tag der Persistenz. Dieselbe Kur wie die anderen:
- Baseline 7d → **30d** (stabilere „Norm" der Zone, via `trailing_zscore`).
- **Onset-only**: unterdrücken, wenn der Vortag schon anomal war (Persistenz, kein neues Event).

**Backtest (echte Prod-Daten): 77 → 21 Fire-Tage (−73%)** — Malacca 20→7, Houston 17→3, Cape 15→6 …; Übergangs-Events bleiben. `backtest_radar.py` bekommt eine flow_anomaly alt-vs-neu-Sektion. Tests: Onset feuert, Persistenz/Normal/zu-wenig-Historie unterdrückt.

ruff sauber, 357 Backend-Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)