### PR TITLE
feat(atlas): per-country energy data layer — EIA International (node 1)

### DIFF
--- a/backend/collectors/eia_international.py
+++ b/backend/collectors/eia_international.py
@@ -1,0 +1,116 @@
+"""EIA International Energy Statistics — per-country energy (US Gov, public domain).
+
+ATLAS data node 1: petroleum production + consumption by country (ISO-3), annual.
+API: https://api.eia.gov/v2/international/data/ (reuses the existing EIA_API_KEY).
+
+Two API gotchas handled here:
+  - The dataset returns BOTH countries and regional aggregates; we keep only
+    countryRegionTypeId == 'c' (drops World/OPEC/OECD/continents).
+  - The same product is returned in MIXED units (e.g. TBPD and QBTU) — we pin one
+    unit per product via the `unit` facet so values are comparable across countries.
+"""
+
+import logging
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.models.atlas import CountryEnergy
+
+logger = logging.getLogger(__name__)
+
+BASE = "https://api.eia.gov/v2/international/data/"
+
+# (product label, EIA productId, pinned unit). Petroleum first; gas/coal/electricity
+# live in sibling EIA international datasets and are added as later nodes.
+PRODUCTS = [("petroleum", "53", "TBPD")]  # 53 = Total petroleum and other liquids
+ACTIVITIES = [("production", "1"), ("consumption", "2")]
+
+
+def _api_key() -> str:
+    k = settings.eia_api_key
+    if hasattr(k, "get_secret_value"):
+        k = k.get_secret_value()
+    return k or ""
+
+
+def _normalize_row(row: dict, product: str, activity: str, default_unit: str) -> dict | None:
+    """Validate + flatten one EIA data row. Returns None for aggregates / invalid rows."""
+    if row.get("countryRegionTypeId") != "c":
+        return None  # regional aggregate (World/OPEC/continent) — not a country
+    iso3 = row.get("countryRegionId")
+    raw = row.get("value")
+    if not iso3 or raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return {
+        "iso3": iso3,
+        "country_name": row.get("countryRegionName") or "",
+        "product": product,
+        "activity": activity,
+        "period": str(row.get("period")),
+        "value": value,
+        "unit": row.get("unit") or default_unit,
+    }
+
+
+async def _fetch(client: httpx.AsyncClient, product_id: str, activity_id: str, unit: str, start_year: int) -> list[dict]:
+    params = {
+        "api_key": _api_key(),
+        "frequency": "annual",
+        "data[0]": "value",
+        "facets[productId][]": product_id,
+        "facets[activityId][]": activity_id,
+        "facets[unit][]": unit,
+        "start": str(start_year),
+        "offset": "0",
+        "length": "5000",
+    }
+    resp = await client.get(BASE, params=params, timeout=60)
+    resp.raise_for_status()
+    return resp.json().get("response", {}).get("data", [])
+
+
+def _upsert(db: Session, rec: dict) -> None:
+    existing = (
+        db.query(CountryEnergy)
+        .filter_by(iso3=rec["iso3"], product=rec["product"], activity=rec["activity"], period=rec["period"])
+        .first()
+    )
+    if existing:
+        existing.value = rec["value"]
+        existing.unit = rec["unit"]
+        existing.country_name = rec["country_name"] or existing.country_name
+    else:
+        db.add(CountryEnergy(**rec))
+
+
+async def ingest_eia_international(db: Session, start_year: int = 2010) -> dict:
+    if not _api_key():
+        logger.warning("EIA International: no API key set; skipping")
+        return {"status": "skipped", "reason": "no_key"}
+
+    written = 0
+    async with httpx.AsyncClient() as client:
+        for product, product_id, unit in PRODUCTS:
+            for activity, activity_id in ACTIVITIES:
+                try:
+                    rows = await _fetch(client, product_id, activity_id, unit, start_year)
+                except Exception as e:
+                    logger.warning("EIA International fetch failed (%s/%s): %s", product, activity, e)
+                    continue
+                kept = 0
+                for row in rows:
+                    rec = _normalize_row(row, product, activity, unit)
+                    if rec is None:
+                        continue
+                    _upsert(db, rec)
+                    kept += 1
+                db.commit()
+                written += kept
+                logger.info("EIA International: %s/%s → %d country-rows (of %d)", product, activity, kept, len(rows))
+    return {"status": "ok", "written": written}

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -28,6 +28,7 @@ from backend.analytics.tonne_miles import compute_tonne_miles
 from backend.analytics.validation.scorecards import recompute_scorecards_job
 from backend.collectors.crack_spreads import collect_crack_spreads
 from backend.collectors.eia import collect_eia
+from backend.collectors.eia_international import ingest_eia_international
 from backend.collectors.energy_prices import collect_energy_prices
 from backend.collectors.equities import collect_equities
 from backend.collectors.finnhub_news import collect_finnhub_news
@@ -231,6 +232,18 @@ async def _run_metals_monthly():
         logger.info("metals monthly: %s", result)
     except Exception as e:
         logger.error("metals monthly ingest failed: %s", e)
+    finally:
+        db.close()
+
+
+async def _run_eia_international():
+    """Monthly ingest of EIA International per-country energy (ATLAS data layer)."""
+    db = SessionLocal()
+    try:
+        result = await ingest_eia_international(db)
+        logger.info("eia international: %s", result)
+    except Exception as e:
+        logger.error("eia international ingest failed: %s", e)
     finally:
         db.close()
 
@@ -560,6 +573,14 @@ def start_scheduler():
         _run_metals_monthly,
         CronTrigger(day=5, hour=6, minute=0),
         id="metals_monthly",
+        **JOB_DEFAULTS,
+    )
+
+    # ATLAS — EIA International per-country energy (annual data, lagging): monthly on the 6th.
+    scheduler.add_job(
+        _run_eia_international,
+        CronTrigger(day=6, hour=6, minute=0),
+        id="eia_international",
         **JOB_DEFAULTS,
     )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from backend.observability import TraceIDMiddleware, setup_logging
 from backend.routes import alert_rules as alert_rules_routes
 from backend.routes import alerts, health, ports, prices, sentiment, vessels, voyages, weather
 from backend.routes import analytics as analytics_routes
+from backend.routes import atlas as atlas_routes
 from backend.routes import auth as auth_routes
 from backend.routes import briefing as briefing_routes
 from backend.routes import email as email_routes
@@ -214,4 +215,5 @@ app.include_router(analytics_routes.router)
 app.include_router(validation_routes.router)
 app.include_router(gas_routes.router)
 app.include_router(metals_routes.router)
+app.include_router(atlas_routes.router)
 app.include_router(power_routes.router)

--- a/backend/models/atlas.py
+++ b/backend/models/atlas.py
@@ -1,0 +1,31 @@
+"""ATLAS — per-country economic data for the map/globe layer.
+
+Node 1: per-country energy from EIA International Energy Statistics (public domain).
+`countryRegionId` is the EIA native key and is ISO-3166-1 alpha-3, so we store it as
+`iso3` directly (no code→ISO map needed); only true countries (countryRegionTypeId='c')
+are persisted — regional aggregates (World, OPEC, OECD, …) are excluded at ingest.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class CountryEnergy(Base):
+    __tablename__ = "country_energy"
+    __table_args__ = (
+        UniqueConstraint("iso3", "product", "activity", "period", name="uq_country_energy"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    iso3: Mapped[str] = mapped_column(String, index=True)          # ISO-3166-1 alpha-3
+    country_name: Mapped[str] = mapped_column(String, default="")
+    product: Mapped[str] = mapped_column(String, index=True)       # e.g. "petroleum"
+    activity: Mapped[str] = mapped_column(String)                  # "production" | "consumption"
+    period: Mapped[str] = mapped_column(String)                    # year "YYYY" (EIA international is annual)
+    value: Mapped[float] = mapped_column(Float)
+    unit: Mapped[str] = mapped_column(String, default="")          # pinned per product (e.g. "TBPD")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/routes/atlas.py
+++ b/backend/routes/atlas.py
@@ -1,0 +1,47 @@
+"""ATLAS API — per-country data for the map/globe layer (read-only, ungated)."""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models.atlas import CountryEnergy
+
+router = APIRouter(prefix="/api/atlas", tags=["atlas"])
+
+
+@router.get("/energy")
+def atlas_energy(
+    product: str = Query("petroleum"),
+    activity: str = Query("production"),
+    db: Session = Depends(get_db),
+):
+    """Latest-year value per country for an energy product/activity (EIA International).
+
+    Descriptive, honest: values are official reported annual figures (lagging — see `as_of`);
+    only true countries are present (regional aggregates excluded at ingest). Feeds the
+    upcoming country choropleth (join on ISO-3).
+    """
+    rows = (
+        db.query(CountryEnergy)
+        .filter(CountryEnergy.product == product, CountryEnergy.activity == activity)
+        .all()
+    )
+    latest: dict[str, CountryEnergy] = {}
+    for r in rows:
+        cur = latest.get(r.iso3)
+        if cur is None or r.period > cur.period:
+            latest[r.iso3] = r
+
+    items = [
+        {"iso3": r.iso3, "country_name": r.country_name, "value": r.value, "unit": r.unit, "period": r.period}
+        for r in latest.values()
+    ]
+    items.sort(key=lambda x: x["value"], reverse=True)
+    return {
+        "product": product,
+        "activity": activity,
+        "source": "EIA International Energy Statistics (public domain)",
+        "as_of": max((r["period"] for r in items), default=None),
+        "coverage": len(items),
+        "countries": items,
+    }

--- a/backend/tests/test_eia_international.py
+++ b/backend/tests/test_eia_international.py
@@ -1,0 +1,57 @@
+"""Tests for the EIA International per-country energy collector + ATLAS endpoint."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.collectors.eia_international import _normalize_row
+from backend.main import app
+from backend.models.atlas import CountryEnergy
+
+
+@pytest.fixture
+def client(db_session):
+    return TestClient(app)
+
+
+# ─── _normalize_row: keep countries, drop aggregates / invalid ───────────────
+
+
+def test_normalize_keeps_country():
+    row = {"countryRegionId": "SAU", "countryRegionTypeId": "c", "countryRegionName": "Saudi Arabia",
+           "value": "9748.4", "unit": "TBPD", "period": "2023"}
+    rec = _normalize_row(row, "petroleum", "production", "TBPD")
+    assert rec["iso3"] == "SAU" and rec["value"] == pytest.approx(9748.4)
+    assert rec["product"] == "petroleum" and rec["activity"] == "production" and rec["unit"] == "TBPD"
+
+
+def test_normalize_drops_region_aggregate():
+    row = {"countryRegionId": "WORL", "countryRegionTypeId": "r", "value": "82060.0", "unit": "TBPD", "period": "2023"}
+    assert _normalize_row(row, "petroleum", "production", "TBPD") is None
+
+
+def test_normalize_drops_missing_or_nonnumeric_value():
+    base = {"countryRegionId": "DEU", "countryRegionTypeId": "c", "period": "2023"}
+    assert _normalize_row({**base, "value": None}, "petroleum", "production", "TBPD") is None
+    assert _normalize_row({**base, "value": "n/a"}, "petroleum", "production", "TBPD") is None
+
+
+# ─── /api/atlas/energy ───────────────────────────────────────────────────────
+
+
+def test_atlas_energy_returns_latest_year_per_country(client, db_session):
+    db_session.add_all([
+        CountryEnergy(iso3="USA", country_name="United States", product="petroleum", activity="production", period="2022", value=18000.0, unit="TBPD"),
+        CountryEnergy(iso3="USA", country_name="United States", product="petroleum", activity="production", period="2023", value=19000.0, unit="TBPD"),
+        CountryEnergy(iso3="SAU", country_name="Saudi Arabia", product="petroleum", activity="production", period="2023", value=9700.0, unit="TBPD"),
+        # different activity must not leak in
+        CountryEnergy(iso3="USA", country_name="United States", product="petroleum", activity="consumption", period="2023", value=20000.0, unit="TBPD"),
+    ])
+    db_session.commit()
+
+    body = client.get("/api/atlas/energy?product=petroleum&activity=production").json()
+    assert body["as_of"] == "2023" and body["coverage"] == 2
+    assert "public domain" in body["source"]
+    usa = next(c for c in body["countries"] if c["iso3"] == "USA")
+    assert usa["value"] == 19000.0 and usa["period"] == "2023"  # latest year only
+    # sorted by value desc → USA before SAU
+    assert [c["iso3"] for c in body["countries"]] == ["USA", "SAU"]


### PR DESCRIPTION
Erster **ATLAS-Daten-Knoten** Richtung Volkswirtschafts-Globus. Ingestiert Energie *pro Land* aus **EIA International Energy Statistics** (public domain, **bestehender EIA-Key**) — Öl Production + Consumption, jährlich, ISO-3.

**Quellen-Landkarte** (Ehrlichkeits-Latte): Energie/Rohstoffe/Makro sind frei+redistributierbar (EIA-intl / GIE / ENTSO-E / World Bank / USGS); **Börsenindizes = Lizenz-Mauer (aufgeschoben)**. Erster Knoten = EIA International (on-domain, kein neuer Key).

**API-Gotchas gelöst:**
- nur `countryRegionTypeId='c'` (Aggregate World/OPEC/OECD/Kontinente raus).
- `countryRegionId` **ist ISO-3** → direkt gespeichert, kein Code→ISO-Map nötig.
- Einheit pinnen (`TBPD`) — die API mischt TBPD/QBTU fürs selbe Produkt.

- `models/atlas.py` `CountryEnergy`; `collectors/eia_international.py` (fetch + `_normalize_row` + idempotenter Upsert); `routes/atlas.py` `GET /api/atlas/energy` (latest-Jahr/Land, ungated) — Verifikation jetzt + spätere Choropleth (Join auf ISO-3); monatlicher Scheduler-Job; Router eingehängt.
- Tests: Länder behalten / Aggregate+invalide droppen; Endpoint latest-year-per-country.

Nur der **Daten-Layer**; Choropleth/Globus-UI ist ein späterer Knoten. ruff sauber, 361 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)