### PR TITLE
feat(atlas): World Bank macro data layer (GDP/trade/industry/population)

### DIFF
--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -44,6 +44,7 @@ from backend.collectors.portwatch_store import fetch_chokepoint_data, store_chok
 from backend.collectors.retention import run_retention
 from backend.collectors.spark_spreads import collect_spark_spreads
 from backend.collectors.sts_collector import collect_sts_events
+from backend.collectors.worldbank import ingest_worldbank
 from backend.database import SessionLocal
 from backend.metals.usgs_copper import ingest_copper_supply
 from backend.notifications.alert_runner import process_alert_rules
@@ -244,6 +245,18 @@ async def _run_eia_international():
         logger.info("eia international: %s", result)
     except Exception as e:
         logger.error("eia international ingest failed: %s", e)
+    finally:
+        db.close()
+
+
+async def _run_worldbank():
+    """Monthly ingest of World Bank per-country macro indicators (ATLAS data layer)."""
+    db = SessionLocal()
+    try:
+        result = await ingest_worldbank(db)
+        logger.info("worldbank macro: %s", result)
+    except Exception as e:
+        logger.error("worldbank macro ingest failed: %s", e)
     finally:
         db.close()
 
@@ -581,6 +594,14 @@ def start_scheduler():
         _run_eia_international,
         CronTrigger(day=6, hour=6, minute=0),
         id="eia_international",
+        **JOB_DEFAULTS,
+    )
+
+    # ATLAS — World Bank per-country macro (annual, lagging): monthly on the 7th.
+    scheduler.add_job(
+        _run_worldbank,
+        CronTrigger(day=7, hour=6, minute=0),
+        id="worldbank_macro",
         **JOB_DEFAULTS,
     )
 

--- a/backend/collectors/worldbank.py
+++ b/backend/collectors/worldbank.py
@@ -1,0 +1,125 @@
+"""World Bank Open Data — per-country macro indicators (CC BY 4.0, no API key).
+
+ATLAS macro node: GDP, GDP/capita, growth, industry + manufacturing (% GDP), trade
+(% GDP), population, inflation. ISO-3 keyed (matches CountryEnergy → clean join).
+
+API: https://api.worldbank.org/v2/country/all/indicator/{code}?format=json&date=Y1:Y2
+The dataset mixes real countries and regional/income AGGREGATES (World, EU, Arab World,
+"High income", …); we exclude them via the country list (region.value == 'Aggregates').
+"""
+
+import logging
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.models.atlas import CountryMacro
+
+logger = logging.getLogger(__name__)
+
+BASE = "https://api.worldbank.org/v2"
+
+# (friendly metric key, World Bank indicator code, human label).
+METRICS = [
+    ("gdp_usd", "NY.GDP.MKTP.CD", "GDP (current US$)"),
+    ("gdp_per_capita", "NY.GDP.PCAP.CD", "GDP per capita (current US$)"),
+    ("gdp_growth", "NY.GDP.MKTP.KD.ZG", "GDP growth (annual %)"),
+    ("industry_pct_gdp", "NV.IND.TOTL.ZS", "Industry (incl. construction) value added (% of GDP)"),
+    ("manufacturing_pct_gdp", "NV.IND.MANF.ZS", "Manufacturing value added (% of GDP)"),
+    ("trade_pct_gdp", "NE.TRD.GNFS.ZS", "Trade (% of GDP)"),
+    ("population", "SP.POP.TOTL", "Population, total"),
+    ("inflation", "FP.CPI.TOTL.ZG", "Inflation, consumer prices (annual %)"),
+]
+
+
+def _normalize_row(row: dict, metric: str, code: str, countries: dict) -> dict | None:
+    """Validate + flatten one WB data row. None for aggregates / null / non-numeric values."""
+    iso3 = row.get("countryiso3code")
+    if iso3 not in countries:  # aggregate (World/EU/income group) or unknown → drop
+        return None
+    raw = row.get("value")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return {
+        "iso3": iso3,
+        "country_name": countries[iso3],
+        "metric": metric,
+        "indicator_code": code,
+        "period": str(row.get("date")),
+        "value": value,
+    }
+
+
+async def _fetch_countries(client: httpx.AsyncClient) -> dict:
+    """ISO-3 → name for REAL countries only (region != 'Aggregates')."""
+    resp = await client.get(f"{BASE}/country", params={"format": "json", "per_page": "400"}, timeout=60)
+    resp.raise_for_status()
+    rows = resp.json()[1]
+    return {r["id"]: r["name"] for r in rows if (r.get("region") or {}).get("value") != "Aggregates"}
+
+
+async def _fetch_indicator(client: httpx.AsyncClient, code: str, start: int, end: int) -> list[dict]:
+    out: list[dict] = []
+    page = 1
+    while True:
+        resp = await client.get(
+            f"{BASE}/country/all/indicator/{code}",
+            params={"format": "json", "per_page": "20000", "date": f"{start}:{end}", "page": str(page)},
+            timeout=90,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        if not isinstance(body, list) or len(body) < 2 or not body[1]:
+            break
+        meta, rows = body[0], body[1]
+        out.extend(rows)
+        if page >= (meta.get("pages") or 1):
+            break
+        page += 1
+    return out
+
+
+def _upsert(db: Session, rec: dict) -> None:
+    existing = (
+        db.query(CountryMacro)
+        .filter_by(iso3=rec["iso3"], metric=rec["metric"], period=rec["period"])
+        .first()
+    )
+    if existing:
+        existing.value = rec["value"]
+        existing.indicator_code = rec["indicator_code"]
+        existing.country_name = rec["country_name"] or existing.country_name
+    else:
+        db.add(CountryMacro(**rec))
+
+
+async def ingest_worldbank(db: Session, start_year: int = 2010, end_year: int = 2024) -> dict:
+    written = 0
+    async with httpx.AsyncClient() as client:
+        try:
+            countries = await _fetch_countries(client)
+        except Exception as e:
+            logger.warning("World Bank: country list fetch failed: %s", e)
+            return {"status": "error", "reason": "country_list"}
+
+        for metric, code, _label in METRICS:
+            try:
+                rows = await _fetch_indicator(client, code, start_year, end_year)
+            except Exception as e:
+                logger.warning("World Bank fetch failed (%s): %s", metric, e)
+                continue
+            kept = 0
+            for row in rows:
+                rec = _normalize_row(row, metric, code, countries)
+                if rec is None:
+                    continue
+                _upsert(db, rec)
+                kept += 1
+            db.commit()
+            written += kept
+            logger.info("World Bank: %s → %d country-rows (of %d)", metric, kept, len(rows))
+    return {"status": "ok", "written": written}

--- a/backend/models/atlas.py
+++ b/backend/models/atlas.py
@@ -29,3 +29,26 @@ class CountryEnergy(Base):
     value: Mapped[float] = mapped_column(Float)
     unit: Mapped[str] = mapped_column(String, default="")          # pinned per product (e.g. "TBPD")
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class CountryMacro(Base):
+    """Per-country macro indicators from World Bank Open Data (CC BY 4.0, no key).
+
+    ISO-3 keyed (matches CountryEnergy → clean cross-source join). Only real countries are
+    stored; World Bank regional/income aggregates (region == 'Aggregates') are excluded at
+    ingest. `metric` is a friendly key (e.g. "gdp_usd"); `indicator_code` is the WB code.
+    """
+
+    __tablename__ = "country_macro"
+    __table_args__ = (
+        UniqueConstraint("iso3", "metric", "period", name="uq_country_macro"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    iso3: Mapped[str] = mapped_column(String, index=True)
+    country_name: Mapped[str] = mapped_column(String, default="")
+    metric: Mapped[str] = mapped_column(String, index=True)        # e.g. "gdp_usd", "trade_pct_gdp"
+    indicator_code: Mapped[str] = mapped_column(String, default="")  # World Bank indicator code
+    period: Mapped[str] = mapped_column(String)                    # year "YYYY" (WB is annual)
+    value: Mapped[float] = mapped_column(Float)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/routes/atlas.py
+++ b/backend/routes/atlas.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from backend.database import get_db
-from backend.models.atlas import CountryEnergy
+from backend.models.atlas import CountryEnergy, CountryMacro
 
 router = APIRouter(prefix="/api/atlas", tags=["atlas"])
 
@@ -41,6 +41,37 @@ def atlas_energy(
         "product": product,
         "activity": activity,
         "source": "EIA International Energy Statistics (public domain)",
+        "as_of": max((r["period"] for r in items), default=None),
+        "coverage": len(items),
+        "countries": items,
+    }
+
+
+@router.get("/macro")
+def atlas_macro(
+    metric: str = Query("gdp_usd", description="gdp_usd / gdp_per_capita / gdp_growth / industry_pct_gdp / manufacturing_pct_gdp / trade_pct_gdp / population / inflation"),
+    db: Session = Depends(get_db),
+):
+    """Latest-year value per country for a World Bank macro indicator.
+
+    Descriptive context (official reported annual figures, lagging — see `as_of`); only true
+    countries (aggregates excluded at ingest). Joins the energy layer on ISO-3.
+    """
+    rows = db.query(CountryMacro).filter(CountryMacro.metric == metric).all()
+    latest: dict[str, CountryMacro] = {}
+    for r in rows:
+        cur = latest.get(r.iso3)
+        if cur is None or r.period > cur.period:
+            latest[r.iso3] = r
+
+    items = [
+        {"iso3": r.iso3, "country_name": r.country_name, "value": r.value, "period": r.period}
+        for r in latest.values()
+    ]
+    items.sort(key=lambda x: x["value"], reverse=True)
+    return {
+        "metric": metric,
+        "source": "World Bank Open Data (CC BY 4.0)",
         "as_of": max((r["period"] for r in items), default=None),
         "coverage": len(items),
         "countries": items,

--- a/backend/tests/test_worldbank.py
+++ b/backend/tests/test_worldbank.py
@@ -1,0 +1,49 @@
+"""Tests for the World Bank macro collector + ATLAS /macro endpoint."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.collectors.worldbank import _normalize_row
+from backend.main import app
+from backend.models.atlas import CountryMacro
+
+_COUNTRIES = {"USA": "United States", "DEU": "Germany"}  # real-country ISO-3 set
+
+
+@pytest.fixture
+def client(db_session):
+    return TestClient(app)
+
+
+def test_normalize_keeps_real_country():
+    row = {"countryiso3code": "USA", "country": {"value": "United States"}, "date": "2023", "value": 27360000000000.0}
+    rec = _normalize_row(row, "gdp_usd", "NY.GDP.MKTP.CD", _COUNTRIES)
+    assert rec["iso3"] == "USA" and rec["metric"] == "gdp_usd" and rec["period"] == "2023"
+    assert rec["value"] == pytest.approx(27360000000000.0) and rec["country_name"] == "United States"
+
+
+def test_normalize_drops_aggregate():
+    # WLD (World) is not in the real-country set → dropped.
+    row = {"countryiso3code": "WLD", "date": "2023", "value": 100000000000000.0}
+    assert _normalize_row(row, "gdp_usd", "NY.GDP.MKTP.CD", _COUNTRIES) is None
+
+
+def test_normalize_drops_null_value():
+    row = {"countryiso3code": "DEU", "date": "2023", "value": None}
+    assert _normalize_row(row, "gdp_usd", "NY.GDP.MKTP.CD", _COUNTRIES) is None
+
+
+def test_atlas_macro_latest_year_per_country(client, db_session):
+    db_session.add_all([
+        CountryMacro(iso3="USA", country_name="United States", metric="gdp_usd", indicator_code="NY.GDP.MKTP.CD", period="2022", value=25.0e12),
+        CountryMacro(iso3="USA", country_name="United States", metric="gdp_usd", indicator_code="NY.GDP.MKTP.CD", period="2023", value=27.0e12),
+        CountryMacro(iso3="CHN", country_name="China", metric="gdp_usd", indicator_code="NY.GDP.MKTP.CD", period="2023", value=17.0e12),
+        CountryMacro(iso3="USA", country_name="United States", metric="population", indicator_code="SP.POP.TOTL", period="2023", value=3.3e8),
+    ])
+    db_session.commit()
+
+    body = client.get("/api/atlas/macro?metric=gdp_usd").json()
+    assert body["as_of"] == "2023" and body["coverage"] == 2 and "CC BY 4.0" in body["source"]
+    usa = next(c for c in body["countries"] if c["iso3"] == "USA")
+    assert usa["value"] == 27.0e12 and usa["period"] == "2023"  # latest year only
+    assert [c["iso3"] for c in body["countries"]] == ["USA", "CHN"]  # sorted by value desc


### PR DESCRIPTION
Macro-Dimension → ATLAS wird vom Energie- zum **Volkswirtschafts**-Datensatz. World Bank Open Data (CC BY 4.0, kein Key), ISO-3 (joint CountryEnergy). 8 Kern-Indikatoren/Land: BIP, BIP/Kopf, Wachstum, Industrie %BIP, Fertigung %BIP, Handel %BIP, Bevölkerung, Inflation. Aggregate (World/EU/Income-Groups) via Länder-Liste ausgeschlossen. `GET /api/atlas/macro?metric=…`. End-to-end verifiziert (kein Key nötig): BIP USA/CHN/DEU, Bevölkerung IND/CHN, Handel%BIP HKG/LUX — korrekte Rangfolgen, ~213 Länder. ruff sauber, 365 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)