### PR TITLE
feat(atlas): enrich energy + macro layers (climate/energy-mix/social)

### DIFF
--- a/backend/collectors/eia_international.py
+++ b/backend/collectors/eia_international.py
@@ -39,6 +39,9 @@ SERIES = [
     ("natural_gas", "consumption", "26", "2", "BCM"),
     ("electricity", "generation", "2", "12", "BKWH"),  # 2 = Electricity
     ("electricity", "consumption", "2", "2", "BKWH"),
+    ("nuclear", "production", "4417", "1", "QBTU"),     # primary energy from nuclear
+    ("renewables", "production", "4418", "1", "QBTU"),  # primary energy from renewables & other
+    ("co2_emissions", "emissions", "4008", "8", "MMTCD"),  # total energy CO2 (million t CO2)
 ]
 
 

--- a/backend/collectors/worldbank.py
+++ b/backend/collectors/worldbank.py
@@ -29,6 +29,12 @@ METRICS = [
     ("trade_pct_gdp", "NE.TRD.GNFS.ZS", "Trade (% of GDP)"),
     ("population", "SP.POP.TOTL", "Population, total"),
     ("inflation", "FP.CPI.TOTL.ZG", "Inflation, consumer prices (annual %)"),
+    ("co2_per_capita", "EN.GHG.CO2.PC.CE.AR5", "CO2 emissions excl. LULUCF per capita (t)"),
+    ("renewable_energy_pct", "EG.FEC.RNEW.ZS", "Renewable energy (% of final energy consumption)"),
+    ("energy_imports_pct", "EG.IMP.CONS.ZS", "Energy imports, net (% of energy use)"),
+    ("unemployment_pct", "SL.UEM.TOTL.ZS", "Unemployment (% of total labor force, ILO)"),
+    ("current_account_pct_gdp", "BN.CAB.XOKA.GD.ZS", "Current account balance (% of GDP)"),
+    ("electricity_access_pct", "EG.ELC.ACCS.ZS", "Access to electricity (% of population)"),
 ]
 
 


### PR DESCRIPTION
Billige Config-Erweiterungen bestehender Collectors (Codes/IDs vorab gegen die Live-APIs verifiziert), verbreitert den Metrik-Satz vor der Karte.

**World Bank +6:** CO₂/Kopf, Erneuerbare-Anteil, Netto-Energie-Importe, Arbeitslosigkeit, Leistungsbilanz %BIP, Strom-Zugang.
**EIA +3:** Nuklear (4417), Erneuerbare (4418), CO₂-total (4008/Activity 8, MMTCD).

Kein Modell-/Endpoint-/Logik-Change. ruff sauber, Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)