### PR TITLE
feat(atlas): USGS minerals data layer (per-country mine production)

### DIFF
--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -44,6 +44,7 @@ from backend.collectors.portwatch_store import fetch_chokepoint_data, store_chok
 from backend.collectors.retention import run_retention
 from backend.collectors.spark_spreads import collect_spark_spreads
 from backend.collectors.sts_collector import collect_sts_events
+from backend.collectors.usgs_minerals import ingest_usgs_minerals
 from backend.collectors.worldbank import ingest_worldbank
 from backend.database import SessionLocal
 from backend.metals.usgs_copper import ingest_copper_supply
@@ -257,6 +258,18 @@ async def _run_worldbank():
         logger.info("worldbank macro: %s", result)
     except Exception as e:
         logger.error("worldbank macro ingest failed: %s", e)
+    finally:
+        db.close()
+
+
+async def _run_usgs_minerals():
+    """Monthly ingest of USGS per-country mineral production (ATLAS resources layer)."""
+    db = SessionLocal()
+    try:
+        result = await ingest_usgs_minerals(db)
+        logger.info("usgs minerals: %s", result)
+    except Exception as e:
+        logger.error("usgs minerals ingest failed: %s", e)
     finally:
         db.close()
 
@@ -602,6 +615,14 @@ def start_scheduler():
         _run_worldbank,
         CronTrigger(day=7, hour=6, minute=0),
         id="worldbank_macro",
+        **JOB_DEFAULTS,
+    )
+
+    # ATLAS — USGS per-country mineral production (annual MCS release): monthly on the 8th.
+    scheduler.add_job(
+        _run_usgs_minerals,
+        CronTrigger(day=8, hour=6, minute=0),
+        id="usgs_minerals",
         **JOB_DEFAULTS,
     )
 

--- a/backend/collectors/usgs_country_map.py
+++ b/backend/collectors/usgs_country_map.py
@@ -1,0 +1,32 @@
+"""USGS country-name → ISO-3166-1 alpha-3 map for the Mineral Commodity Summaries.
+
+USGS uses its own country spellings (e.g. "Burma", "Congo (Kinshasa)") and includes
+non-country aggregates ("Other Countries", "World total (rounded)") that must be dropped.
+This covers the producing countries that appear in the strategic-mineral set; any name not
+in the map is skipped + logged by the collector (so the map can be extended over time).
+"""
+
+# Aggregates / non-country rows to exclude outright.
+USGS_AGGREGATES = {"Other Countries", "World total (rounded)", "World total", "United States and Canada"}
+
+USGS_NAME_TO_ISO3 = {
+    "Argentina": "ARG", "Australia": "AUS", "Belarus": "BLR", "Bolivia": "BOL",
+    "Brazil": "BRA", "Burkina Faso": "BFA", "Burma": "MMR", "Canada": "CAN",
+    "Chile": "CHL", "China": "CHN", "Colombia": "COL", "Congo (Kinshasa)": "COD",
+    "Cuba": "CUB", "Germany": "DEU", "Ghana": "GHA", "Greece": "GRC", "Guinea": "GIN",
+    "India": "IND", "Indonesia": "IDN", "Iran": "IRN", "Israel": "ISR", "Jamaica": "JAM",
+    "Jordan": "JOR", "Kazakhstan": "KAZ", "Laos": "LAO", "Madagascar": "MDG",
+    "Malaysia": "MYS", "Mali": "MLI", "Mauritania": "MRT", "Mexico": "MEX",
+    "Namibia": "NAM", "New Caledonia": "NCL", "Nigeria": "NGA", "Papua New Guinea": "PNG",
+    "Peru": "PER", "Philippines": "PHL", "Poland": "POL", "Portugal": "PRT", "Russia": "RUS",
+    "Saudi Arabia": "SAU", "South Africa": "ZAF", "Spain": "ESP", "Sweden": "SWE",
+    "Tanzania": "TZA", "Thailand": "THA", "Turkey": "TUR", "Ukraine": "UKR",
+    "United States": "USA", "Uzbekistan": "UZB", "Vietnam": "VNM", "Zambia": "ZMB",
+    "Zimbabwe": "ZWE",
+    # extra common USGS spellings for future commodity additions:
+    "Congo (Brazzaville)": "COG", "Korea, Republic of": "KOR", "Korea, North": "PRK",
+    "Bahrain": "BHR", "United Arab Emirates": "ARE", "Egypt": "EGY", "Morocco": "MAR",
+    "Norway": "NOR", "Finland": "FIN", "Japan": "JPN", "Botswana": "BWA",
+    "Dominican Republic": "DOM", "Eritrea": "ERI", "Sierra Leone": "SLE", "Senegal": "SEN",
+    "Togo": "TGO", "Gabon": "GAB", "Mozambique": "MOZ", "Angola": "AGO", "Venezuela": "VEN",
+}

--- a/backend/collectors/usgs_minerals.py
+++ b/backend/collectors/usgs_minerals.py
@@ -1,0 +1,129 @@
+"""USGS Mineral Commodity Summaries — per-country mine production (public domain).
+
+ATLAS "Rohstoffe" node: world mine production by country for strategic minerals.
+Source: USGS MCS 2025 Data Release (ScienceBase DOI 10.5066/P13XCP3R) — one CSV
+(MCS2025_World_Data.csv) with COMMODITY / COUNTRY / TYPE / UNIT_MEAS / PROD_2023 /
+PROD_EST_2024 columns. Each commodity has several TYPE rows (capacity/reserves/forms);
+we pick the "Mine production …" row per commodity. ISO-3 keyed via usgs_country_map.
+"""
+
+import csv
+import io
+import logging
+import zipfile
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.collectors.usgs_country_map import USGS_AGGREGATES, USGS_NAME_TO_ISO3
+from backend.models.atlas import CountryResource
+
+logger = logging.getLogger(__name__)
+
+# Pinned to the MCS 2025 release; bump the item id + names on a new annual release.
+SB_ITEM = "https://www.sciencebase.gov/catalog/item/677eaf95d34e760b392c4970?format=json"
+ZIP_NAME = "World_Data_Release_MCS_2025.zip"
+CSV_NAME = "MCS2025_World_Data.csv"
+
+# (friendly key, USGS commodity name, TYPE substring identifying the mine-production row).
+COMMODITIES = [
+    ("lithium", "Lithium", "lithium content"),
+    ("gold", "Gold", "gold content"),
+    ("iron_ore", "Iron Ore", "usable ore"),
+    ("rare_earths", "Rare earths", "rare-earth-oxide"),
+    ("cobalt", "Cobalt", "cobalt content"),
+    ("copper", "Copper", "recoverable copper"),
+    ("nickel", "Nickel", "nickel content"),
+    ("bauxite", "Bauxite", "bauxite"),
+    ("zinc", "Zinc", "zinc content"),
+    ("potash", "Potash", "potassium oxide"),
+]
+
+# CSV column for the latest-year production estimate (note the space in the header).
+_COL_2024 = "PROD_EST_ 2024"
+_COL_2023 = "PROD_2023"
+
+
+def _parse_value(raw) -> float | None:
+    if raw is None:
+        return None
+    s = str(raw).strip().replace(",", "")
+    if not s or s.upper() in ("W", "NA", "—", "--", "XX", "(1)"):
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def _records_from_rows(rows: list[dict], unmapped: set | None = None) -> list[dict]:
+    """Pure transform: USGS CSV rows → normalized CountryResource records."""
+    out: list[dict] = []
+    for key, name, sub in COMMODITIES:
+        for r in rows:
+            if (r.get("COMMODITY") or "").strip() != name:
+                continue
+            t = (r.get("TYPE") or "").strip().lower()
+            if "mine production" not in t or sub not in t:
+                continue
+            country = (r.get("COUNTRY") or "").strip()
+            if country in USGS_AGGREGATES:
+                continue
+            iso3 = USGS_NAME_TO_ISO3.get(country)
+            if not iso3:
+                if unmapped is not None:
+                    unmapped.add(country)
+                continue
+            unit = (r.get("UNIT_MEAS") or "").strip()
+            for col, period in ((_COL_2023, "2023"), (_COL_2024, "2024")):
+                val = _parse_value(r.get(col))
+                if val is None:
+                    continue
+                out.append({
+                    "iso3": iso3, "country_name": country, "commodity": key,
+                    "period": period, "value": val, "unit": unit,
+                })
+    return out
+
+
+async def _download_csv(client: httpx.AsyncClient) -> str:
+    item = (await client.get(SB_ITEM, timeout=60)).raise_for_status().json()
+    file_obj = next(f for f in item["files"] if f["name"] == ZIP_NAME)
+    resp = await client.get(file_obj["url"], timeout=90)
+    resp.raise_for_status()
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        return zf.read(CSV_NAME).decode("utf-8-sig")
+
+
+def _upsert(db: Session, rec: dict) -> None:
+    existing = (
+        db.query(CountryResource)
+        .filter_by(iso3=rec["iso3"], commodity=rec["commodity"], period=rec["period"])
+        .first()
+    )
+    if existing:
+        existing.value = rec["value"]
+        existing.unit = rec["unit"]
+        existing.country_name = rec["country_name"] or existing.country_name
+    else:
+        db.add(CountryResource(**rec))
+
+
+async def ingest_usgs_minerals(db: Session) -> dict:
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        try:
+            csv_text = await _download_csv(client)
+        except Exception as e:
+            logger.warning("USGS minerals: download/parse failed: %s", e)
+            return {"status": "error", "reason": str(e)[:80]}
+
+    rows = list(csv.DictReader(io.StringIO(csv_text)))
+    unmapped: set = set()
+    recs = _records_from_rows(rows, unmapped)
+    for rec in recs:
+        _upsert(db, rec)
+    db.commit()
+    if unmapped:
+        logger.info("USGS minerals: %d unmapped country names skipped: %s", len(unmapped), sorted(unmapped))
+    logger.info("USGS minerals: wrote %d records across %d commodities", len(recs), len(COMMODITIES))
+    return {"status": "ok", "written": len(recs), "unmapped": len(unmapped)}

--- a/backend/models/atlas.py
+++ b/backend/models/atlas.py
@@ -52,3 +52,25 @@ class CountryMacro(Base):
     period: Mapped[str] = mapped_column(String)                    # year "YYYY" (WB is annual)
     value: Mapped[float] = mapped_column(Float)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class CountryResource(Base):
+    """Per-country mineral/metal mine production from USGS Mineral Commodity Summaries.
+
+    Public domain. ISO-3 keyed (USGS country names mapped via usgs_country_map; aggregates
+    excluded). `commodity` is a friendly key (e.g. "lithium", "rare_earths").
+    """
+
+    __tablename__ = "country_resource"
+    __table_args__ = (
+        UniqueConstraint("iso3", "commodity", "period", name="uq_country_resource"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    iso3: Mapped[str] = mapped_column(String, index=True)
+    country_name: Mapped[str] = mapped_column(String, default="")
+    commodity: Mapped[str] = mapped_column(String, index=True)     # e.g. "lithium", "cobalt"
+    period: Mapped[str] = mapped_column(String)                    # year "YYYY"
+    value: Mapped[float] = mapped_column(Float)
+    unit: Mapped[str] = mapped_column(String, default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/routes/atlas.py
+++ b/backend/routes/atlas.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from backend.database import get_db
-from backend.models.atlas import CountryEnergy, CountryMacro
+from backend.models.atlas import CountryEnergy, CountryMacro, CountryResource
 
 router = APIRouter(prefix="/api/atlas", tags=["atlas"])
 
@@ -72,6 +72,38 @@ def atlas_macro(
     return {
         "metric": metric,
         "source": "World Bank Open Data (CC BY 4.0)",
+        "as_of": max((r["period"] for r in items), default=None),
+        "coverage": len(items),
+        "countries": items,
+    }
+
+
+@router.get("/resources")
+def atlas_resources(
+    commodity: str = Query("lithium", description="lithium / gold / iron_ore / rare_earths / cobalt / copper / nickel / bauxite / zinc / potash"),
+    db: Session = Depends(get_db),
+):
+    """Latest-year mine production per country for a mineral commodity (USGS MCS).
+
+    Descriptive (official reported annual production, lagging — see `as_of`); only true
+    countries (USGS aggregates excluded at ingest). Coverage is the producing countries USGS
+    lists — non-producers/unlisted are simply absent, not zero.
+    """
+    rows = db.query(CountryResource).filter(CountryResource.commodity == commodity).all()
+    latest: dict[str, CountryResource] = {}
+    for r in rows:
+        cur = latest.get(r.iso3)
+        if cur is None or r.period > cur.period:
+            latest[r.iso3] = r
+
+    items = [
+        {"iso3": r.iso3, "country_name": r.country_name, "value": r.value, "unit": r.unit, "period": r.period}
+        for r in latest.values()
+    ]
+    items.sort(key=lambda x: x["value"], reverse=True)
+    return {
+        "commodity": commodity,
+        "source": "USGS Mineral Commodity Summaries (public domain)",
         "as_of": max((r["period"] for r in items), default=None),
         "coverage": len(items),
         "countries": items,

--- a/backend/tests/test_usgs_minerals.py
+++ b/backend/tests/test_usgs_minerals.py
@@ -1,0 +1,59 @@
+"""Tests for the USGS minerals collector + ATLAS /resources endpoint."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.collectors.usgs_minerals import _records_from_rows
+from backend.main import app
+from backend.models.atlas import CountryResource
+
+
+@pytest.fixture
+def client(db_session):
+    return TestClient(app)
+
+
+def _row(comm, country, type_, unit="metric tons", p2023=None, p2024=None):
+    return {"COMMODITY": comm, "COUNTRY": country, "TYPE": type_, "UNIT_MEAS": unit,
+            "PROD_2023": p2023, "PROD_EST_ 2024": p2024}
+
+
+def test_records_selects_production_and_maps_iso3():
+    rows = [_row("Lithium", "Australia", "Mine production, lithium content", p2023="91,700", p2024="88000")]
+    unmapped = set()
+    recs = _records_from_rows(rows, unmapped)
+    assert {r["period"] for r in recs} == {"2023", "2024"}
+    r23 = next(r for r in recs if r["period"] == "2023")
+    assert r23["iso3"] == "AUS" and r23["commodity"] == "lithium" and r23["value"] == 91700.0
+    assert r23["unit"] == "metric tons" and not unmapped
+
+
+def test_records_exclude_aggregate_wrongtype_nonnumeric():
+    rows = [
+        _row("Lithium", "Other Countries", "Mine production, lithium content", p2023="5000"),  # aggregate
+        _row("Lithium", "Chile", "Reserves, lithium content", p2023="9300000"),  # not mine production
+        _row("Lithium", "Argentina", "Mine production, lithium content", p2023="W"),  # withheld
+    ]
+    unmapped = set()
+    assert _records_from_rows(rows, unmapped) == []
+    assert not unmapped  # Chile/Argentina ARE mapped — excluded by type/value, not by mapping
+
+
+def test_records_tracks_unmapped_country():
+    rows = [_row("Gold", "Atlantis", "mine production, gold content", p2023="100")]
+    unmapped = set()
+    assert _records_from_rows(rows, unmapped) == [] and unmapped == {"Atlantis"}
+
+
+def test_atlas_resources_endpoint(client, db_session):
+    db_session.add_all([
+        CountryResource(iso3="AUS", country_name="Australia", commodity="lithium", period="2024", value=88000, unit="metric tons"),
+        CountryResource(iso3="AUS", country_name="Australia", commodity="lithium", period="2023", value=91700, unit="metric tons"),
+        CountryResource(iso3="CHL", country_name="Chile", commodity="lithium", period="2024", value=49000, unit="metric tons"),
+    ])
+    db_session.commit()
+    body = client.get("/api/atlas/resources?commodity=lithium").json()
+    assert body["as_of"] == "2024" and body["coverage"] == 2 and "public domain" in body["source"]
+    aus = next(c for c in body["countries"] if c["iso3"] == "AUS")
+    assert aus["value"] == 88000 and aus["period"] == "2024"
+    assert [c["iso3"] for c in body["countries"]] == ["AUS", "CHL"]


### PR DESCRIPTION
Rohstoff-Dimension: Weltproduktion nach Land fuer 10 strategische Minerale aus USGS MCS 2025 (public domain, ScienceBase). Lithium/Gold/Eisenerz/Seltene Erden/Kobalt/Kupfer/Nickel/Bauxit/Zink/Kali, ISO-3. Pro Commodity die Mine-production-TYPE; USGS-Laendernamen zu ISO-3 (Burma/Congo (Kinshasa)); Aggregate ausgeschlossen, unmapped geloggt. Endpoint GET /api/atlas/resources?commodity=. End-to-end verifiziert (kein Key): Seltene Erden CHN-dominant, Kobalt COD-dominant, Lithium AUS/CHL. ruff sauber, 369 Tests gruen.

Generated with Claude Code