### PR TITLE
feat(product): Critical Materials & Energy Security hero (wedge node 1)

### DIFF
--- a/backend/routes/atlas.py
+++ b/backend/routes/atlas.py
@@ -9,6 +9,85 @@ from backend.models.atlas import CountryEnergy, CountryMacro, CountryResource
 router = APIRouter(prefix="/api/atlas", tags=["atlas"])
 
 
+# ─── Criticality (the product wedge: supply concentration of strategic materials) ────────────
+
+# (key, label, kind, spec). kind="resources" → CountryResource.commodity; kind="energy" →
+# (product, activity) on CountryEnergy. Concentration is computed over production only.
+CRITICAL_MATERIALS = [
+    ("rare_earths", "Rare earths", "resources", "rare_earths"),
+    ("cobalt", "Cobalt", "resources", "cobalt"),
+    ("lithium", "Lithium", "resources", "lithium"),
+    ("nickel", "Nickel", "resources", "nickel"),
+    ("copper", "Copper", "resources", "copper"),
+    ("oil", "Oil", "energy", ("petroleum", "production")),
+    ("natural_gas", "Natural gas", "energy", ("natural_gas", "production")),
+]
+
+
+def _latest_by_country(rows):
+    """rows: ORM objects with .iso3/.country_name/.value/.period/.unit → latest period per iso3."""
+    latest = {}
+    for r in rows:
+        cur = latest.get(r.iso3)
+        if cur is None or r.period > cur.period:
+            latest[r.iso3] = r
+    return list(latest.values())
+
+
+def _material_rows(db, kind, spec):
+    if kind == "resources":
+        q = db.query(CountryResource).filter(CountryResource.commodity == spec).all()
+    else:
+        product, activity = spec
+        q = db.query(CountryEnergy).filter(
+            CountryEnergy.product == product, CountryEnergy.activity == activity
+        ).all()
+    return _latest_by_country(q)
+
+
+def _concentration(rows):
+    """Supply concentration: top producer share, top-3, HHI (0–1, higher = more concentrated)."""
+    items = [r for r in rows if r.value and r.value > 0]
+    total = sum(r.value for r in items)
+    if not items or total <= 0:
+        return None
+    items.sort(key=lambda r: -r.value)
+    top3 = [
+        {"iso3": r.iso3, "country_name": r.country_name, "value": r.value, "share": round(r.value / total, 4)}
+        for r in items[:3]
+    ]
+    return {
+        "producers": len(items),
+        "top_country": items[0].iso3,
+        "top_country_name": items[0].country_name,
+        "top_share": round(items[0].value / total, 4),
+        "top3": top3,
+        "hhi": round(sum((r.value / total) ** 2 for r in items), 4),
+        "unit": items[0].unit,
+        "as_of": max(r.period for r in items),
+    }
+
+
+@router.get("/criticality")
+def atlas_criticality(db: Session = Depends(get_db)):
+    """Supply concentration of strategic materials — the product's dependency view.
+
+    For each material: who produces it, how concentrated supply is (top producer's world
+    share + HHI), most-concentrated first. Descriptive, from official public-domain data.
+    """
+    materials = []
+    for key, label, kind, spec in CRITICAL_MATERIALS:
+        conc = _concentration(_material_rows(db, kind, spec))
+        if conc is None:
+            continue
+        materials.append({"key": key, "label": label, "kind": kind, **conc})
+    materials.sort(key=lambda m: -m["hhi"])  # most concentrated (most strategically fragile) first
+    return {
+        "materials": materials,
+        "source": "USGS Mineral Commodity Summaries + EIA International (public domain)",
+    }
+
+
 @router.get("/energy")
 def atlas_energy(
     product: str = Query("petroleum"),

--- a/backend/tests/test_atlas_criticality.py
+++ b/backend/tests/test_atlas_criticality.py
@@ -1,0 +1,45 @@
+"""Tests for the /api/atlas/criticality endpoint (supply concentration — the product wedge)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.models.atlas import CountryEnergy, CountryResource
+
+
+@pytest.fixture
+def client(db_session):
+    return TestClient(app)
+
+
+def test_criticality_concentration(client, db_session):
+    db_session.add_all([
+        CountryResource(iso3="CHN", country_name="China", commodity="rare_earths", period="2024", value=270000, unit="metric tons"),
+        CountryResource(iso3="USA", country_name="United States", commodity="rare_earths", period="2024", value=45000, unit="metric tons"),
+        CountryResource(iso3="AUS", country_name="Australia", commodity="rare_earths", period="2024", value=13000, unit="metric tons"),
+        # oil: more spread out → lower HHI than rare earths
+        CountryEnergy(iso3="USA", country_name="United States", product="petroleum", activity="production", period="2024", value=20000, unit="TBPD"),
+        CountryEnergy(iso3="SAU", country_name="Saudi Arabia", product="petroleum", activity="production", period="2024", value=11000, unit="TBPD"),
+        CountryEnergy(iso3="RUS", country_name="Russia", product="petroleum", activity="production", period="2024", value=10000, unit="TBPD"),
+    ])
+    db_session.commit()
+
+    body = client.get("/api/atlas/criticality").json()
+    mats = {m["key"]: m for m in body["materials"]}
+
+    re = mats["rare_earths"]
+    assert re["top_country"] == "CHN" and re["top_share"] > 0.8 and re["hhi"] > 0.6
+    assert re["top3"][0]["iso3"] == "CHN" and re["producers"] == 3 and re["as_of"] == "2024"
+
+    oil = mats["oil"]
+    assert oil["top_country"] == "USA" and oil["hhi"] < re["hhi"]
+
+    # most-concentrated first → rare earths ahead of oil
+    assert body["materials"][0]["key"] == "rare_earths"
+    assert "public domain" in body["source"]
+
+
+def test_criticality_skips_material_with_no_data(client, db_session):
+    # No rows at all → no materials, but the endpoint still responds cleanly.
+    body = client.get("/api/atlas/criticality").json()
+    assert body["materials"] == []

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import MacroPanel from './components/MacroPanel'
 import SentimentPanel from './components/SentimentPanel'
 import VesselMap from './components/VesselMap'
 import AtlasMap from './components/AtlasMap'
+import CriticalMaterialsView from './components/CriticalMaterialsView'
 import AlertsPanel from './components/AlertsPanel'
 import FundamentalsPanel from './components/FundamentalsPanel'
 import JODIPanel from './components/JODIPanel'
@@ -49,6 +50,7 @@ import { useAuth } from './context/AuthContext'
 const API = '/api'
 
 const TABS = [
+  { key: 'critical', label: 'CRITICAL' },
   { key: 'overview', label: 'OVERVIEW' },
   { key: 'market', label: 'MARKET' },
   { key: 'signals', label: 'SIGNALS' },
@@ -171,7 +173,7 @@ function Dashboard() {
 
   const [activeTab, setActiveTab] = useState(() => {
     const hash = window.location.hash.replace('#', '')
-    return TABS.find((t) => t.key === hash) ? hash : 'overview'
+    return TABS.find((t) => t.key === hash) ? hash : 'critical'
   })
 
   // Selected bidding zone for the ENERGY tab (DE_LU / FR / NL).
@@ -342,6 +344,13 @@ function Dashboard() {
 
       {/* ===== TAB CONTENT ===== */}
       <div className="mt-3">
+
+        {/* CRITICAL MATERIALS TAB — the product hero */}
+        {activeTab === 'critical' && (
+          <ErrorBoundary name="critical-materials">
+            <CriticalMaterialsView />
+          </ErrorBoundary>
+        )}
 
         {/* OVERVIEW TAB */}
         {activeTab === 'overview' && (

--- a/frontend/src/components/CriticalMaterialsView.jsx
+++ b/frontend/src/components/CriticalMaterialsView.jsx
@@ -1,0 +1,122 @@
+import { useState, useEffect, useMemo } from 'react'
+
+const API = '/api'
+
+// Alert rules that are about physical SUPPLY (the wedge), filtered out of the full radar.
+const SUPPLY_RULES = new Set([
+  'chokepoint_anomaly', 'rerouting_high', 'floating_storage', 'flow_anomaly', 'convergence',
+  'days_of_supply', 'supply_demand_divergence', 'freight_divergence', 'gas_balance',
+  'dunkelflaute', 'negative_prices',
+])
+
+const SEV = {
+  critical: 'text-red-400 border-red-500/40',
+  warning: 'text-yellow-400 border-yellow-500/40',
+  info: 'text-cyan-glow border-cyan-glow/30',
+}
+
+function concLevel(hhi) {
+  if (hhi >= 0.5) return { label: 'EXTREME', cls: 'text-red-400', bar: '#f87171' }
+  if (hhi >= 0.25) return { label: 'HIGH', cls: 'text-orange-400', bar: '#fb923c' }
+  if (hhi >= 0.15) return { label: 'MODERATE', cls: 'text-yellow-400', bar: '#facc15' }
+  return { label: 'DIVERSIFIED', cls: 'text-green-glow', bar: '#34d399' }
+}
+
+function MaterialCard({ m }) {
+  const lvl = concLevel(m.hhi)
+  return (
+    <button
+      type="button"
+      onClick={() => { window.location.hash = 'atlas' }}
+      className="text-left border border-border bg-surface rounded p-3 hover:border-cyan-glow/40 transition-colors"
+      title="Open on the world map"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="font-mono text-xs text-neutral-300 tracking-wider">{m.label}</span>
+        <span className={`font-mono text-[9px] px-1.5 py-0.5 border rounded ${lvl.cls} border-current/30`}>{lvl.label}</span>
+      </div>
+      <div className="flex items-baseline gap-1.5 mt-1.5">
+        <span className="font-mono text-2xl font-bold text-cyan-glow">{Math.round(m.top_share * 100)}%</span>
+        <span className="font-mono text-[10px] text-neutral-500">{m.top_country_name?.slice(0, 18) || m.top_country}</span>
+      </div>
+      <div className="font-mono text-[9px] text-neutral-600 mb-1.5">top producer · {m.producers} sources · as of {m.as_of}</div>
+      <div className="space-y-1">
+        {m.top3.map((c) => (
+          <div key={c.iso3} className="flex items-center gap-1.5">
+            <span className="font-mono text-[9px] text-neutral-500 w-7 shrink-0">{c.iso3}</span>
+            <div className="flex-1 h-1.5 bg-neutral-800 rounded-full overflow-hidden">
+              <div className="h-1.5 rounded-full" style={{ width: `${c.share * 100}%`, background: lvl.bar }} />
+            </div>
+            <span className="font-mono text-[9px] text-neutral-500 w-8 text-right shrink-0">{Math.round(c.share * 100)}%</span>
+          </div>
+        ))}
+      </div>
+    </button>
+  )
+}
+
+export default function CriticalMaterialsView() {
+  const [crit, setCrit] = useState(null)
+  const [alerts, setAlerts] = useState([])
+
+  useEffect(() => {
+    fetch(`${API}/atlas/criticality`).then((r) => (r.ok ? r.json() : null)).then(setCrit).catch((e) => console.error('criticality:', e))
+    fetch(`${API}/alerts?limit=80`).then((r) => (r.ok ? r.json() : [])).then(setAlerts).catch((e) => console.error('alerts:', e))
+  }, [])
+
+  const disruptions = useMemo(() => {
+    const rank = { critical: 0, warning: 1, info: 2 }
+    return (alerts || [])
+      .filter((a) => SUPPLY_RULES.has(a.rule))
+      .sort((a, b) => (rank[a.severity] ?? 9) - (rank[b.severity] ?? 9))
+  }, [alerts])
+
+  return (
+    <div className="space-y-4">
+      {/* Product header / value proposition */}
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-sm text-neutral-200 tracking-wide">CRITICAL MATERIALS &amp; ENERGY SECURITY</div>
+        <div className="font-mono text-[11px] text-neutral-500 mt-1 leading-relaxed">
+          Who controls the world&apos;s strategic resources — and where that supply is disrupted right now.
+          Official, public-domain data (USGS · EIA · ENTSO-E). Descriptive, no black box.
+        </div>
+      </div>
+
+      {/* Pillar 1 — supply concentration */}
+      <div>
+        <div className="font-mono text-[10px] text-neutral-500 tracking-wider mb-2 px-1">SUPPLY CONCENTRATION · who controls production</div>
+        {!crit ? (
+          <div className="font-mono text-[10px] text-neutral-600 px-1 animate-pulse">loading…</div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {crit.materials.map((m) => <MaterialCard key={m.key} m={m} />)}
+          </div>
+        )}
+        {crit && <div className="font-mono text-[9px] text-neutral-700 mt-2 px-1">Source: {crit.source}. Sorted by concentration (most strategically fragile first).</div>}
+      </div>
+
+      {/* Pillar 2 — live supply disruptions */}
+      <div>
+        <div className="font-mono text-[10px] text-neutral-500 tracking-wider mb-2 px-1">SUPPLY DISRUPTIONS · what&apos;s abnormal now</div>
+        <div className="border border-border bg-surface rounded divide-y divide-border">
+          {disruptions.length === 0 ? (
+            <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 text-center">No supply disruptions flagged right now.</div>
+          ) : (
+            disruptions.map((a) => (
+              <div key={a.id} className="px-4 py-2.5 flex items-start gap-2.5">
+                <span className={`font-mono text-[9px] mt-0.5 px-1.5 py-0.5 border rounded shrink-0 ${SEV[a.severity] || SEV.info}`}>{a.severity.toUpperCase().slice(0, 4)}</span>
+                <div className="min-w-0">
+                  <div className="font-mono text-[11px] text-neutral-300 truncate">{a.title}</div>
+                  <div className="font-mono text-[9px] text-neutral-600 leading-relaxed">{a.detail}</div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+        <div className="font-mono text-[9px] text-neutral-700 mt-2 px-1">
+          Physical supply anomalies from the radar (chokepoints, rerouting, floating storage, gas/power balance). Descriptive — deviation vs history, not a forecast.
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Macht aus dem Funktions-Haufen EIN fokussiertes Produkt. Neuer Default-Tab CRITICAL fuehrt mit dem Wedge: wer kontrolliert die strategischen Materialien der Welt, und wo wird die Versorgung gerade gestoert.

- /api/atlas/criticality: Versorgungs-Konzentration je Material (Top-Produzent + Welt-Anteil + Top-3 + HHI), am-konzentriertesten zuerst. Reine Aggregation ueber vorhandene Daten.
- CriticalMaterialsView: Produkt-Held — Value-Prop + Konzentrations-Karten (Seltene Erden CHN 69%, Kobalt COD 78%, Nickel IDN 66%) -> Karte, + fokussierte Stoerungs-Liste (Radar gefiltert auf Versorgungssignale).
- App.jsx: neuer CRITICAL-Tab als Default.

Posture B ist hier ein Feature (Lagebild statt Alpha). ruff sauber, 371 Tests, build gruen.

Generated with Claude Code