### PR TITLE
Never open a backup artifact writably

### DIFF
--- a/backend/tests/test_backup_script.py
+++ b/backend/tests/test_backup_script.py
@@ -197,6 +197,64 @@ def test_orphaned_zero_byte_backup_is_removed(dirs):
     assert not (backups / "obsyd-2026-07-08.db.gz").exists()
 
 
+# ── never destroy what you are inspecting ────────────────────────────────────
+#
+# `sqlite3 file 'PRAGMA ...'` is NOT a read-only operation. If a hot journal sits
+# next to the database, opening it runs rollback recovery. For a leftover from an
+# interrupted `.backup` the journal records "originally 0 pages", so the open
+# truncates the file to nothing. That is how the 2026-07-06 leftover was lost —
+# by a diagnostic command that looked like a read.
+
+
+def _recording_sqlite3(stubs: Path, calls: Path) -> None:
+    real = shutil.which("sqlite3")
+    assert real, "sqlite3 CLI required for this test"
+    _stub(stubs, "sqlite3", f'echo "$@" >> "{calls}"\nexec "{real}" "$@"')
+
+
+def test_leftover_with_a_hot_journal_is_discarded_never_opened(dirs, tmp_path):
+    app, backups, stubs = dirs
+    calls = tmp_path / "sqlite-calls"
+    _recording_sqlite3(stubs, calls)
+
+    orphan = backups / "obsyd-2026-07-06.db"
+    _make_db(orphan, rows=3)
+    (backups / "obsyd-2026-07-06.db-journal").write_bytes(b"\x00" * 1024)
+
+    _run(app, backups, stubs)
+
+    assert not orphan.exists(), "interrupted backup must be discarded"
+    assert not (backups / "obsyd-2026-07-06.db-journal").exists()
+    assert not (backups / "obsyd-2026-07-06.db.gz").exists(), (
+        "a torn backup must never be preserved as if it were good"
+    )
+    opened = calls.read_text() if calls.exists() else ""
+    assert orphan.name not in opened, "the script opened a database with a hot journal"
+
+
+def test_backup_artifacts_are_only_ever_opened_readonly(dirs, tmp_path):
+    app, backups, stubs = dirs
+    calls = tmp_path / "sqlite-calls"
+    _recording_sqlite3(stubs, calls)
+    orphan = backups / "obsyd-2026-07-06.db"
+    _make_db(orphan, rows=3)
+
+    r = _run(app, backups, stubs)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+    for line in calls.read_text().splitlines():
+        if str(backups) in line and ".backup" not in line:
+            assert "-readonly" in line, f"backup artifact opened writably: {line}"
+
+
+def test_orphaned_sidecar_without_a_database_is_removed(dirs):
+    app, backups, _ = dirs
+    debris = backups / "obsyd-2026-07-07.db-journal"
+    debris.write_bytes(b"\x00" * 512)
+    _run(app, backups)
+    assert not debris.exists()
+
+
 # ── retention ────────────────────────────────────────────────────────────────
 
 

--- a/deploy/backup-db.sh
+++ b/deploy/backup-db.sh
@@ -61,18 +61,41 @@ No usable snapshot was written for ${DATE}. Investigate before the next run." ||
 
 trap 'fail "unexpected error on line $LINENO"' ERR
 
+# `sqlite3 <file> 'PRAGMA ...'` is NOT a read-only operation: if a hot journal
+# sits next to the file, opening it runs rollback recovery. For an interrupted
+# `.backup` the journal records "originally 0 pages", so the open truncates the
+# artifact to nothing. `-readonly` makes SQLite refuse instead (SQLITE_READONLY_
+# ROLLBACK) and leaves the file alone. Never drop the flag.
 is_sqlite_db() {
-    [ -s "$1" ] && sqlite3 "$1" 'PRAGMA schema_version;' >/dev/null 2>&1
+    [ -s "$1" ] || return 1
+    sqlite3 -readonly "$1" 'PRAGMA quick_check(1);' 2>/dev/null | head -1 | grep -qx 'ok'
 }
 
-# ── 1. discard worthless leftovers (pure filesystem, no sqlite3, no space) ────
+has_sidecar() {
+    [ -e "$1-journal" ] || [ -e "$1-wal" ] || [ -e "$1-shm" ]
+}
+
+# ── 1. an interrupted `.backup` is not a backup — discard it, never open it ───
+discard_interrupted() {
+    local db side
+    for db in "$BACKUP_DIR"/*.db; do
+        [ -e "$db" ] || continue
+        if has_sidecar "$db"; then
+            echo "[backup] discarding interrupted backup (hot journal): $(basename "$db")"
+            rm -f "$db" "$db-journal" "$db-wal" "$db-shm"
+        fi
+    done
+    # sidecars whose database is already gone are debris
+    for side in "$BACKUP_DIR"/*.db-journal "$BACKUP_DIR"/*.db-wal "$BACKUP_DIR"/*.db-shm; do
+        [ -e "$side" ] || continue
+        echo "[backup] removing orphaned sqlite sidecar: $(basename "$side")"
+        rm -f "$side"
+    done
+}
+
+# ── 2. discard worthless leftovers (pure filesystem, no sqlite3, no space) ────
 discard_junk() {
     local f
-    for f in "$BACKUP_DIR"/*.db-journal "$BACKUP_DIR"/*.db-wal; do
-        [ -e "$f" ] || continue
-        echo "[backup] removing stale sqlite sidecar: $(basename "$f")"
-        rm -f "$f"
-    done
     for f in "$BACKUP_DIR"/*.db; do
         [ -e "$f" ] || continue
         if [ ! -s "$f" ]; then
@@ -82,7 +105,7 @@ discard_junk() {
     done
 }
 
-# ── 2. recover good-but-uncompressed leftovers, freeing space before preflight ─
+# ── 3. recover good-but-uncompressed leftovers, freeing space before preflight ─
 recover_leftovers() {
     local f
     for f in "$BACKUP_DIR"/*.db; do
@@ -100,7 +123,7 @@ recover_leftovers() {
     done
 }
 
-# ── 3. never start a backup that cannot fit ──────────────────────────────────
+# ── 4. never start a backup that cannot fit ──────────────────────────────────
 preflight() {
     local db bytes=0 need_kb free_kb
     for db in "${DBS[@]}"; do
@@ -114,7 +137,7 @@ preflight() {
     echo "[backup] preflight ok — ${free_kb} KB free, ${need_kb} KB required"
 }
 
-# ── 4. back up, verifying every step ─────────────────────────────────────────
+# ── 5. back up, verifying every step ─────────────────────────────────────────
 backup_one() {
     local db="$1" name out
     name=$(basename "$db" .db)
@@ -124,8 +147,8 @@ backup_one() {
     fi
 
     out="$BACKUP_DIR/${name}-${DATE}.db"
-    rm -f "$out" "$out.gz"
-    partial+=("$out" "$out.gz")
+    rm -f "$out" "$out.gz" "$out-journal" "$out-wal" "$out-shm"
+    partial+=("$out" "$out.gz" "$out-journal" "$out-wal" "$out-shm")
 
     sqlite3 "$db" ".backup '$out'" || fail "sqlite3 .backup failed for $db"
     [ -s "$out" ] || fail "backup of $db is empty"
@@ -143,7 +166,7 @@ backup_one() {
     echo "[backup] ok: $db -> $(basename "$out").gz ($(du -h "$out.gz" | cut -f1))"
 }
 
-# ── 5. retention: dailies, weeklies — and any stray .db a crash left behind ───
+# ── 6. retention: dailies, weeklies — and any stray .db a crash left behind ───
 prune() {
     find "$BACKUP_DIR" -maxdepth 1 -name '*.db.gz' ! -name 'weekly-*' \
         -mtime +"$RETENTION_DAYS" -delete
@@ -152,6 +175,7 @@ prune() {
 }
 
 mkdir -p "$BACKUP_DIR"
+discard_interrupted
 discard_junk
 recover_leftovers
 preflight


### PR DESCRIPTION
## Der Fund

Beim Untersuchen der Backup-Leichen aus dem 2026-07-07-Ausfall hat dieser Befehl —

```
sqlite3 /home/obsyd/backups/obsyd-2026-07-06.db 'PRAGMA schema_version;'
```

— die 959-MB-Datei **auf 0 Bytes verkürzt**. `sqlite3 <file> 'PRAGMA ...'` ist keine lesende Operation. Liegt ein hot journal daneben, führt das Öffnen Rollback-Recovery aus; bei einer Leiche aus einem abgebrochenen `.backup` vermerkt das Journal „ursprünglich 0 Seiten", also rollt der Open das Artefakt auf nichts zurück.

Exakt reproduziert:

```
db 37.953.536 B + hot journal 1.024 B
  sqlite3 …            -> db danach 0 B, Journal konsumiert
  sqlite3 -readonly …  -> "attempt to write a readonly database (8)", beide Dateien unangetastet
```

Die Produktionsdatei hatte ein 1,0-KB-Journal. Der Mechanismus passt bis auf die Größenordnung.

`recover_leftovers()` aus #52 hatte denselben Defekt: es validierte Leichen, indem es sie **öffnete**. Beim nächsten nächtlichen Lauf hätte es genau die Dateien zerstört, die es retten sollte.

## Was sich ändert

- `is_sqlite_db()` öffnet mit `-readonly` und prüft `quick_check` statt `schema_version` — eine header-intakte, aber zerrissene DB wird jetzt **abgelehnt** statt als gültig archiviert.
- Eine Leiche mit `-journal`/`-wal`/`-shm`-Sidecar ist ein **abgebrochenes** `.backup`, kein Backup. Sie wird samt Sidecars verworfen und **nie geöffnet**. Der bisherige Code löschte den Sidecar zuerst und behielt die DB — er hätte also eine zerrissene Datei aufbewahrt und dabei genau die Rollback-Information vernichtet, die ihre Zerrissenheit beweist.
- `backup_one()` räumt und trackt die Sidecars der eigenen Ausgabe mit.

## Was verloren ging

Nichts Wiederherstellbares. Ein Rollback **auf null Seiten** heißt, das Journal führte die Datei beim Transaktionsbeginn als leer — beide Leichen waren mitten im `.backup` abgebrochen und nie fertig. Jüngster brauchbarer Snapshot bleibt der 2026-07-05 (Daily + Weekly). Die Live-DB ist unversehrt (`quick_check: ok`).

## Tests

3 neue, zuerst rot:

```
AssertionError: backup artifact opened writably:
  .../backups/obsyd-2026-07-06.db PRAGMA schema_version;
```

- 28/28 der Backup-/Alarm-Tests grün, Gesamtsuite 577 passed / 1 skipped
- `test_backup_artifacts_are_only_ever_opened_readonly` verankert die Invariante dauerhaft

🤖 Generated with [Claude Code](https://claude.com/claude-code)