### PR TITLE
Gzip the raw cache and prune docker's build cache weekly

### DIFF
--- a/backend/gas/raw_cache.py
+++ b/backend/gas/raw_cache.py
@@ -1,15 +1,23 @@
 """Write-once raw-response disk cache.
 
 So recalibration never re-hits the API: every fetched payload is written to
-data/raw/<source>/<YYYY-MM>/<key>.json and read back on subsequent runs.
+data/raw/<source>/<YYYY-MM>/<key>.json.gz and read back on subsequent runs.
 Atomic writes (tmp + os.replace) avoid partial files. `overwrite=True` is
 used only to replace a provisional payload with its confirmed version.
+
+Blobs are gzipped. The ENTSO-E/ENTSOG payloads that dominate this cache are
+JSON and compress roughly 24x; uncompressed they had grown to 9.1 GB on the
+VPS and were a material part of what filled its disk on 2026-07-07. Entries
+written before that change are plain `.json` and stay readable, so an existing
+cache keeps working with or without the one-off migration
+(`backend/scripts/compress_raw_cache.py`).
 
 No DB, no network — pure filesystem, so it's unit-testable with tmp_path.
 """
 
 from __future__ import annotations
 
+import gzip
 import json
 import os
 from datetime import date
@@ -19,34 +27,69 @@ from pathlib import Path
 DATA_ROOT = Path("data/raw")
 
 
-def cache_path(source: str, key: str, dt: date) -> Path:
-    """data/raw/<source>/<YYYY-MM>/<key>.json — month-bucketed to keep dirs small."""
+def _bucket(source: str, key: str, dt: date) -> Path:
+    """data/raw/<source>/<YYYY-MM>/<key> — month-bucketed to keep dirs small."""
     safe_key = key.replace("/", "_").replace(" ", "_")
-    return DATA_ROOT / source / f"{dt:%Y-%m}" / f"{safe_key}.json"
+    return DATA_ROOT / source / f"{dt:%Y-%m}" / safe_key
+
+
+def cache_path(source: str, key: str, dt: date) -> Path:
+    """Canonical (compressed) location of a cached payload."""
+    base = _bucket(source, key, dt)
+    return base.with_name(f"{base.name}.json.gz")
+
+
+def legacy_path(source: str, key: str, dt: date) -> Path:
+    """Pre-compression location. Still read, never written."""
+    base = _bucket(source, key, dt)
+    return base.with_name(f"{base.name}.json")
 
 
 def read_cached(source: str, key: str, dt: date) -> dict | None:
-    """Return the cached payload, or None on miss / unreadable file."""
-    path = cache_path(source, key, dt)
-    if not path.exists():
-        return None
-    try:
-        with path.open("r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except (OSError, json.JSONDecodeError):
-        return None
+    """Return the cached payload, or None on miss / unreadable file.
+
+    The compressed blob wins: after a migration or an overwrite it is the
+    authoritative copy, and a stale `.json` sibling may still linger.
+    """
+    gz = cache_path(source, key, dt)
+    if gz.exists():
+        try:
+            with gzip.open(gz, "rt", encoding="utf-8") as fh:
+                return json.load(fh)
+        except (OSError, EOFError, json.JSONDecodeError):
+            return None
+
+    legacy = legacy_path(source, key, dt)
+    if legacy.exists():
+        try:
+            with legacy.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    return None
 
 
 def write_cached(source: str, key: str, dt: date, payload: dict, *, overwrite: bool = False) -> Path:
-    """Atomically write payload. Skips an existing file unless overwrite=True."""
+    """Atomically write payload, gzipped. Skips an existing entry unless overwrite=True."""
     path = cache_path(source, key, dt)
-    if path.exists() and not overwrite:
+    legacy = legacy_path(source, key, dt)
+
+    if not overwrite and (path.exists() or legacy.exists()):
         return path
+
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".json.tmp")
-    with tmp.open("w", encoding="utf-8") as fh:
-        json.dump(payload, fh)
+    tmp = path.with_name(f"{path.name}.tmp")
+    # mtime=0 keeps the blob byte-identical across rewrites of the same payload.
+    with tmp.open("wb") as raw, gzip.GzipFile(fileobj=raw, mode="wb", mtime=0) as gz:
+        gz.write(json.dumps(payload).encode("utf-8"))
     os.replace(tmp, path)  # atomic on the same filesystem
+
+    # An overwrite supersedes the pre-compression copy; leaving it would let a
+    # stale payload resurface if the compressed blob is ever removed.
+    if legacy.exists():
+        legacy.unlink()
+
     return path
 
 

--- a/backend/scripts/compress_raw_cache.py
+++ b/backend/scripts/compress_raw_cache.py
@@ -1,0 +1,157 @@
+"""One-off migration: gzip the raw-response disk cache in place.
+
+`backend/gas/raw_cache.py` writes `.json.gz` and reads either form, so this can
+run at any time, twice, or not at all. On the VPS it turns ~9.1 GB of ENTSO-E /
+ENTSOG JSON into roughly 0.4 GB — the uncompressed cache was a material part of
+what filled the root filesystem on 2026-07-07.
+
+    python -m backend.scripts.compress_raw_cache --dry-run
+    python -m backend.scripts.compress_raw_cache
+
+Rules it will not break:
+  * a payload that cannot be parsed is left exactly where it is;
+  * a blob is only unlinked after its archive has been read back successfully;
+  * writes go to a temp file and are renamed into place, so an interrupted run
+    (a full disk, say) leaves no half-written archive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Stats:
+    compressed: int = 0
+    skipped: int = 0
+    already_archived: int = 0
+    not_worth_it: int = 0
+    bytes_before: int = 0
+    bytes_after: int = 0
+
+    @property
+    def saved(self) -> int:
+        return self.bytes_before - self.bytes_after
+
+
+def _is_readable_archive(gz: Path) -> bool:
+    try:
+        with gzip.open(gz, "rt", encoding="utf-8") as fh:
+            json.load(fh)
+    except (OSError, EOFError, json.JSONDecodeError):
+        return False
+    return True
+
+
+def _compress(blob: Path, gz: Path) -> None:
+    """Write `blob` to `gz` atomically, verifying the archive before returning."""
+    tmp = gz.with_name(f"{gz.name}.tmp")
+    try:
+        payload = blob.read_bytes()
+        with tmp.open("wb") as raw, gzip.GzipFile(fileobj=raw, mode="wb", mtime=0) as out:
+            out.write(payload)
+        if not _is_readable_archive(tmp):
+            raise OSError(f"archive of {blob} did not read back")
+        os.replace(tmp, gz)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def compress_tree(root: Path, *, dry_run: bool = False) -> Stats:
+    stats = Stats()
+
+    for blob in sorted(root.rglob("*.json")):
+        if not blob.is_file():
+            continue
+
+        gz = blob.with_name(f"{blob.name}.gz")
+        size = blob.stat().st_size
+
+        # A payload we cannot read is not ours to throw away.
+        try:
+            with blob.open("r", encoding="utf-8") as fh:
+                json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            logger.warning("skipping unreadable blob: %s", blob)
+            stats.skipped += 1
+            continue
+
+        # An intact archive already exists: drop the redundant plain copy.
+        if gz.exists() and _is_readable_archive(gz):
+            stats.already_archived += 1
+            if not dry_run:
+                blob.unlink()
+            continue
+
+        if dry_run:
+            # Compress into a temp file purely to learn whether it is worth it.
+            probe = len(gzip.compress(blob.read_bytes(), mtime=0))
+            if probe >= size:
+                stats.not_worth_it += 1
+            else:
+                stats.compressed += 1
+                stats.bytes_before += size
+                stats.bytes_after += probe
+            continue
+
+        _compress(blob, gz)
+        archived = gz.stat().st_size
+
+        # gzip's header costs ~20 bytes; a tiny payload would only grow. Leave it
+        # as plain JSON — raw_cache reads that form too.
+        if archived >= size:
+            gz.unlink()
+            stats.not_worth_it += 1
+            continue
+
+        stats.compressed += 1
+        stats.bytes_before += size
+        stats.bytes_after += archived
+        blob.unlink()
+
+    return stats
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("data/raw"))
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    if not args.root.is_dir():
+        logger.error("no such directory: %s", args.root)
+        return 1
+
+    stats = compress_tree(args.root, dry_run=args.dry_run)
+    verb = "would compress" if args.dry_run else "compressed"
+    logger.info(
+        "%s %d blobs (%.1f MB -> %.1f MB, saved %.1f MB); "
+        "%d already archived; %d too small to be worth it; %d skipped",
+        verb,
+        stats.compressed,
+        stats.bytes_before / 1e6,
+        stats.bytes_after / 1e6,
+        stats.saved / 1e6,
+        stats.already_archived,
+        stats.not_worth_it,
+        stats.skipped,
+    )
+    if stats.skipped:
+        logger.warning("%d unreadable blobs were left in place", stats.skipped)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_compress_raw_cache.py
+++ b/backend/tests/test_compress_raw_cache.py
@@ -1,0 +1,157 @@
+"""Tests for the one-off data/raw compression migration.
+
+It rewrites 22k production files, so its contract is narrow and paranoid: never
+destroy a payload it could not read back, never leave a half-written blob, and
+be safe to run twice.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.scripts.compress_raw_cache import compress_tree
+
+
+def _json_file(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+    return path
+
+
+#: Real ENTSO-E/ENTSOG payloads are hundreds of kilobytes of repetitive JSON.
+#: A handful of bytes would *grow* under gzip's header, which is its own case.
+BIG = {"series": [{"ts": f"2025-01-{d:02d}", "mw": 1234.5} for d in range(1, 29)]}
+
+
+@pytest.fixture
+def tree(tmp_path):
+    _json_file(tmp_path / "entsoe_genmix" / "2025-01" / "a.json", BIG)
+    _json_file(tmp_path / "entsog" / "2026-06" / "b.json", {"v": list(range(500))})
+    return tmp_path
+
+
+def test_compresses_every_json_blob(tree):
+    compress_tree(tree)
+    assert (tree / "entsoe_genmix" / "2025-01" / "a.json.gz").exists()
+    assert (tree / "entsog" / "2026-06" / "b.json.gz").exists()
+
+
+def test_payloads_survive_the_round_trip(tree):
+    compress_tree(tree)
+    gz = tree / "entsog" / "2026-06" / "b.json.gz"
+    assert json.loads(gzip.decompress(gz.read_bytes())) == {"v": list(range(500))}
+
+
+def test_a_blob_that_gzip_would_grow_is_left_uncompressed(tmp_path):
+    """gzip's header costs ~20 bytes. Tiny payloads must not be inflated —
+    raw_cache reads the plain form anyway."""
+    tiny = _json_file(tmp_path / "eurostat" / "2026-07" / "t.json", {"v": 1})
+
+    stats = compress_tree(tmp_path)
+
+    assert tiny.exists()
+    assert not tiny.with_name("t.json.gz").exists()
+    assert stats.compressed == 0
+    assert stats.not_worth_it == 1
+
+
+def test_originals_are_removed(tree):
+    compress_tree(tree)
+    assert list(tree.rglob("*.json")) == []
+
+
+def test_no_temporary_files_survive(tree):
+    compress_tree(tree)
+    assert list(tree.rglob("*.tmp")) == []
+
+
+def test_reports_the_bytes_it_saved(tree):
+    stats = compress_tree(tree)
+    assert stats.compressed == 2
+    assert stats.bytes_before > 0
+    assert stats.bytes_after < stats.bytes_before
+
+
+# ── paranoia ─────────────────────────────────────────────────────────────────
+
+
+def test_dry_run_changes_nothing(tree):
+    before = {p: p.read_bytes() for p in tree.rglob("*") if p.is_file()}
+    stats = compress_tree(tree, dry_run=True)
+    after = {p: p.read_bytes() for p in tree.rglob("*") if p.is_file()}
+    assert after == before
+    assert stats.compressed == 2  # still reports what it would do
+
+
+def test_an_unreadable_blob_is_left_alone(tree):
+    bad = tree / "entsog" / "2026-06" / "corrupt.json"
+    bad.write_text("{ this is not json")
+
+    stats = compress_tree(tree)
+
+    assert bad.exists(), "a payload we cannot parse must never be destroyed"
+    assert not (tree / "entsog" / "2026-06" / "corrupt.json.gz").exists()
+    assert stats.skipped == 1
+
+
+def test_a_pre_existing_archive_wins_and_the_plain_copy_goes(tree):
+    target = tree / "entsog" / "2026-06" / "b.json"
+    gz = target.with_name("b.json.gz")
+    gz.write_bytes(gzip.compress(json.dumps({"v": "already-archived"}).encode()))
+
+    compress_tree(tree)
+
+    assert not target.exists()
+    assert json.loads(gzip.decompress(gz.read_bytes())) == {"v": "already-archived"}
+
+
+def test_a_pre_existing_but_corrupt_archive_is_rebuilt(tree):
+    target = tree / "entsog" / "2026-06" / "b.json"
+    gz = target.with_name("b.json.gz")
+    gz.write_bytes(b"not gzip at all")
+
+    compress_tree(tree)
+
+    assert not target.exists()
+    assert json.loads(gzip.decompress(gz.read_bytes())) == {"v": list(range(500))}
+
+
+def test_running_twice_is_a_no_op(tree):
+    compress_tree(tree)
+    snapshot = {p: p.read_bytes() for p in tree.rglob("*") if p.is_file()}
+
+    stats = compress_tree(tree)
+
+    assert stats.compressed == 0
+    assert {p: p.read_bytes() for p in tree.rglob("*") if p.is_file()} == snapshot
+
+
+def test_a_blob_that_vanishes_mid_run_is_tolerated(tree, monkeypatch):
+    """obsyd's scheduler keeps writing to this cache while we migrate it. An
+    entry it overwrites (and whose plain copy it unlinks) must not abort the run.
+    """
+    ghost = tree / "entsog" / "2026-06" / "ghost.json"
+    real_rglob = Path.rglob
+    monkeypatch.setattr(
+        Path, "rglob", lambda self, pat: [*real_rglob(self, pat), ghost]
+    )
+
+    stats = compress_tree(tree)  # must not raise
+
+    assert stats.compressed == 2
+
+
+def test_non_json_files_are_untouched(tree):
+    """usgs_copper caches raw XLSX bytes as .bin — not our business."""
+    binary = tree / "usgs_copper" / "2025-06" / "mis-202506-coppe.bin"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"\x50\x4b\x03\x04binary")
+
+    compress_tree(tree)
+
+    assert binary.read_bytes() == b"\x50\x4b\x03\x04binary"
+    assert not binary.with_suffix(".bin.gz").exists()

--- a/backend/tests/test_docker_prune.py
+++ b/backend/tests/test_docker_prune.py
@@ -1,0 +1,139 @@
+"""Tests for deploy/docker-prune.sh.
+
+Docker's build cache had grown to 5.1 GB on the VPS and was a large part of what
+filled the disk on 2026-07-07. Nothing ever pruned it.
+
+Pruning docker on this host is dangerous in two specific ways, and both are
+pinned here rather than left to a reviewer's memory:
+
+  * `docker volume prune` would destroy valuekick's postgres data;
+  * `docker image prune -a` would remove node:20-bookworm-slim, which
+    valuekick's prod-task.sh pulls for every cron run, every 30 minutes.
+
+`docker` is stubbed via PATH: the script is never allowed near a real daemon in
+a test, and every subcommand it issues is recorded and asserted on.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "deploy" / "docker-prune.sh"
+#: Absolute, so a test may strip PATH down to the stub dir without also hiding
+#: the interpreter from subprocess itself.
+BASH = shutil.which("bash") or "/bin/bash"
+
+
+@pytest.fixture
+def env(tmp_path):
+    stubs = tmp_path / "stubs"
+    stubs.mkdir()
+    calls = tmp_path / "docker-calls"
+    return stubs, calls
+
+
+def _stub_docker(stubs: Path, calls: Path, *, info_rc: int = 0, prune_rc: int = 0) -> None:
+    script = f"""#!/bin/sh
+echo "$@" >> "{calls}"
+case "$1" in
+  info) exit {info_rc} ;;
+  builder|image) exit {prune_rc} ;;
+esac
+exit 0
+"""
+    p = stubs / "docker"
+    p.write_text(script)
+    p.chmod(0o755)
+
+
+def _run(stubs, **env_extra):
+    e = dict(os.environ)
+    e["PATH"] = f"{stubs}:{e['PATH']}"
+    e["RESEND_API_KEY"] = ""  # never mail from the test suite
+    e.update({k: str(v) for k, v in env_extra.items()})
+    return subprocess.run(
+        [BASH, str(SCRIPT)], env=e, capture_output=True, text=True, timeout=30
+    )
+
+
+def _calls(calls: Path) -> list[str]:
+    return calls.read_text().splitlines() if calls.exists() else []
+
+
+# ── what it must do ──────────────────────────────────────────────────────────
+
+
+def test_prunes_the_build_cache(env):
+    stubs, calls = env
+    _stub_docker(stubs, calls)
+    r = _run(stubs)
+    assert r.returncode == 0, r.stderr
+    assert any(c.startswith("builder prune") for c in _calls(calls)), _calls(calls)
+
+
+def test_prunes_dangling_images(env):
+    stubs, calls = env
+    _stub_docker(stubs, calls)
+    _run(stubs)
+    assert any(c.startswith("image prune") for c in _calls(calls)), _calls(calls)
+
+
+# ── what it must never do ────────────────────────────────────────────────────
+
+
+def test_never_prunes_volumes(env):
+    """valuekick's postgres lives in a docker volume."""
+    stubs, calls = env
+    _stub_docker(stubs, calls)
+    _run(stubs)
+    assert not any("volume" in c for c in _calls(calls)), _calls(calls)
+
+
+def test_never_runs_system_prune(env):
+    stubs, calls = env
+    _stub_docker(stubs, calls)
+    _run(stubs)
+    assert not any(c.startswith("system prune") for c in _calls(calls)), _calls(calls)
+
+
+def test_never_removes_images_that_have_no_container(env):
+    """`image prune -a` would drop node:20-bookworm-slim, which prod-task.sh
+    needs every 30 minutes — it only ever runs it with --rm."""
+    stubs, calls = env
+    _stub_docker(stubs, calls)
+    _run(stubs)
+    for call in _calls(calls):
+        if call.startswith("image prune"):
+            assert " -a" not in f" {call}", f"dangling-only, got: {call}"
+            assert "--all" not in call, f"dangling-only, got: {call}"
+
+
+# ── it must not fight the daemon it cannot reach ─────────────────────────────
+
+
+def test_does_nothing_when_the_daemon_is_down(env):
+    """A dead dockerd is how the outage started. Do not add noise to it."""
+    stubs, calls = env
+    _stub_docker(stubs, calls, info_rc=1)
+    r = _run(stubs)
+    assert r.returncode == 0, r.stderr
+    assert not any("prune" in c for c in _calls(calls)), _calls(calls)
+
+
+def test_a_failing_prune_is_loud(env):
+    stubs, calls = env
+    _stub_docker(stubs, calls, prune_rc=1)
+    r = _run(stubs)
+    assert r.returncode != 0
+    assert "FAIL" in (r.stdout + r.stderr)
+
+
+def test_missing_docker_binary_is_not_a_crash(env):
+    stubs, _ = env  # no docker stub written at all
+    r = _run(stubs, PATH=str(stubs))
+    assert r.returncode == 0, r.stderr

--- a/backend/tests/test_gas_raw_cache.py
+++ b/backend/tests/test_gas_raw_cache.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import gzip
+import json
 from datetime import date
 
 import pytest
@@ -17,6 +19,11 @@ def cache_root(tmp_path, monkeypatch):
 
 def test_cache_path_is_month_bucketed(cache_root):
     p = raw_cache.cache_path("entsog", "flows_2026-06-01", date(2026, 6, 1))
+    assert p == cache_root / "entsog" / "2026-06" / "flows_2026-06-01.json.gz"
+
+
+def test_legacy_path_is_the_uncompressed_sibling(cache_root):
+    p = raw_cache.legacy_path("entsog", "flows_2026-06-01", date(2026, 6, 1))
     assert p == cache_root / "entsog" / "2026-06" / "flows_2026-06-01.json"
 
 
@@ -50,6 +57,74 @@ def test_no_tmp_file_left_behind(cache_root):
     raw_cache.write_cached("entsog", "k", dt, {"v": 1})
     leftovers = list(cache_root.rglob("*.tmp"))
     assert leftovers == []
+
+
+# ── compression ──────────────────────────────────────────────────────────────
+#
+# The raw cache reached 9.1 GB on the VPS and helped fill the disk. These blobs
+# are ENTSO-E/ENTSOG JSON and compress ~24x, so they are stored gzipped. The
+# uncompressed form stays readable so an existing cache keeps working before and
+# during the one-off migration.
+
+
+def test_write_stores_a_gzipped_blob(cache_root):
+    dt = date(2026, 6, 1)
+    raw_cache.write_cached("entsog", "k", dt, {"v": 1})
+
+    gz = raw_cache.cache_path("entsog", "k", dt)
+    assert gz.exists()
+    assert not raw_cache.legacy_path("entsog", "k", dt).exists()
+    assert gz.read_bytes()[:2] == b"\x1f\x8b", "not a gzip stream"
+    assert json.loads(gzip.decompress(gz.read_bytes())) == {"v": 1}
+
+
+def test_reads_a_legacy_uncompressed_entry(cache_root):
+    dt = date(2026, 6, 1)
+    legacy = raw_cache.legacy_path("agsi", "k", dt)
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(json.dumps({"v": "old"}))
+
+    assert raw_cache.read_cached("agsi", "k", dt) == {"v": "old"}
+
+
+def test_write_once_also_respects_a_legacy_entry(cache_root):
+    dt = date(2026, 6, 1)
+    legacy = raw_cache.legacy_path("agsi", "k", dt)
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(json.dumps({"v": "old"}))
+
+    raw_cache.write_cached("agsi", "k", dt, {"v": "new"})  # must be ignored
+    assert raw_cache.read_cached("agsi", "k", dt) == {"v": "old"}
+
+
+def test_overwrite_replaces_a_legacy_entry_and_removes_it(cache_root):
+    dt = date(2026, 6, 1)
+    legacy = raw_cache.legacy_path("agsi", "k", dt)
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(json.dumps({"v": "old"}))
+
+    raw_cache.write_cached("agsi", "k", dt, {"v": "new"}, overwrite=True)
+
+    assert raw_cache.read_cached("agsi", "k", dt) == {"v": "new"}
+    assert not legacy.exists(), "stale uncompressed copy left behind"
+
+
+def test_the_compressed_blob_wins_over_a_stale_legacy_one(cache_root):
+    dt = date(2026, 6, 1)
+    raw_cache.write_cached("agsi", "k", dt, {"v": "fresh"})
+    legacy = raw_cache.legacy_path("agsi", "k", dt)
+    legacy.write_text(json.dumps({"v": "stale"}))
+
+    assert raw_cache.read_cached("agsi", "k", dt) == {"v": "fresh"}
+
+
+def test_a_corrupt_compressed_blob_is_a_miss_not_a_crash(cache_root):
+    dt = date(2026, 6, 1)
+    gz = raw_cache.cache_path("entsog", "k", dt)
+    gz.parent.mkdir(parents=True)
+    gz.write_bytes(b"this is not gzip")
+
+    assert raw_cache.read_cached("entsog", "k", dt) is None
 
 
 async def test_fetch_or_cache_only_fetches_on_miss(cache_root):

--- a/deploy/docker-prune.sh
+++ b/deploy/docker-prune.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Docker housekeeping — weekly via root's crontab.
+#
+#   0 5 * * 0 /home/obsyd/obsyd/deploy/docker-prune.sh >> /home/obsyd/obsyd/logs/docker-prune.log 2>&1
+#
+# Nothing ever pruned docker on this host. By 2026-07-07 the build cache alone
+# held 5.1 GB — one `--build` deploy's worth of layers per deploy, kept forever —
+# and helped fill the root filesystem, which killed dockerd, which took Caddy and
+# therefore obsyd.dev and valuekick.de offline for two days.
+#
+# What this deliberately does NOT do, and must never do:
+#
+#   docker volume prune   -> valuekick's postgres lives in a volume.
+#   docker system prune   -> same, plus it takes everything else with it.
+#   docker image prune -a -> would remove node:20-bookworm-slim. valuekick's
+#                            prod-task.sh runs it with --rm every 30 minutes, so
+#                            docker sees no container using it, so -a reaps it —
+#                            and every cron run would then re-pull 200 MB.
+#
+# Dangling images and the build cache are regenerable by definition. The first
+# deploy after a prune rebuilds without cache; that is the whole price.
+
+set -Eeuo pipefail
+
+# No `dirname`: this script must survive a PATH that has nothing on it, so it can
+# report "docker is not installed" rather than dying on a missing coreutil.
+SCRIPT_DIR=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+# shellcheck source=deploy/notify.sh
+. "$SCRIPT_DIR/notify.sh"
+
+fail() {
+    local msg="$1"
+    echo "[docker-prune] FAIL: $msg" >&2
+    obsyd_alert "OBSYD ALERT: docker prune FAILED" \
+        "Weekly docker housekeeping on $(hostname 2>/dev/null || echo unknown-host) failed.
+
+Reason: ${msg}
+
+Disk:
+$(df -Ph / 2>/dev/null || echo '  (df unavailable)')" || true
+    exit 1
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[docker-prune] docker not installed — nothing to do"
+    exit 0
+fi
+
+# A dead daemon is how the outage started. Say so and stay out of the way.
+if ! docker info >/dev/null 2>&1; then
+    echo "[docker-prune] docker daemon not reachable — skipping"
+    exit 0
+fi
+
+free_before=$(df -Pk / | awk 'NR==2 { print $4 }')
+
+docker builder prune -af >/dev/null || fail "builder prune failed"
+docker image prune -f    >/dev/null || fail "image prune failed"   # dangling only
+
+free_after=$(df -Pk / | awk 'NR==2 { print $4 }')
+reclaimed_mb=$(( (free_after - free_before) / 1024 ))
+[ "$reclaimed_mb" -lt 0 ] && reclaimed_mb=0
+
+echo "[docker-prune] OK — reclaimed ${reclaimed_mb} MB, $(df -Ph / | awk 'NR==2 { print $4 }') free"


### PR DESCRIPTION
Die zwei letzten Beitragenden zum Volllauf vom 2026-07-07 — beide wurden von nichts jemals zurückgewonnen.

## `data/raw` (9,1 GB)

Fast alles davon ist ENTSO-E-/ENTSOG-JSON für die **live** Strom- und Gas-Vertikalen, zurück bis 2021 — genau der Korpus, für den der Cache existiert („so recalibration never re-hits the API"). Alte Monate zu löschen würde echte Historie wegwerfen und rate-limitierte Re-Fetches erzwingen.

Eine Stichprobe komprimiert **um Faktor 24** (2.519.448 → 103.952 Bytes). Komprimieren schlägt jedes Retention-Fenster um eine Größenordnung: **~9,1 GB → ~0,4 GB, ohne einen Byte Verlust.**

- `raw_cache` schreibt jetzt `.json.gz` und liest **beide** Formen — ein bestehender Cache funktioniert vor, während und nach der Migration.
- Blobs, die durch gzips Header *wachsen* würden, bleiben Klartext.
- `backend/scripts/compress_raw_cache.py` migriert in-place. Es weigert sich, eine Payload zu zerstören, die es nicht parsen kann; es entfernt einen Blob erst, **nachdem** sein Archiv erfolgreich zurückgelesen wurde; und es schreibt über eine Temp-Datei, sodass ein abgebrochener Lauf (volle Platte etwa) kein halbes Archiv hinterlässt. Idempotent, und sicher gegen den laufenden Scheduler: die Klartext-Kopie verschwindet erst, wenn das Archiv existiert — ein nebenläufiger Leser sieht immer eines von beiden.

## Docker Build-Cache (5,1 GB)

`deploy/docker-prune.sh`, wöchentlich aus roots crontab: `builder prune -af` plus **dangling-only** `image prune -f`. Beides ist per Definition regenerierbar; das erste Deploy danach baut ohne Cache — das ist der gesamte Preis.

Was es **niemals** tun darf, ist durch Tests verankert statt dem Gedächtnis eines Reviewers überlassen:

| Verboten | Warum |
|---|---|
| `docker volume prune` | dort liegt valuekicks Postgres |
| `docker system prune` | dasselbe, plus alles andere |
| `docker image prune -a` | würde `node:20-bookworm-slim` reapen — valuekicks `prod-task.sh` startet es alle 30 min mit `--rm`, also hält es kein Container, also holt `-a` es. Jeder Cron-Lauf würde danach 200 MB neu ziehen. |

Außerdem hält es sich raus, wenn der Daemon tot ist — so fing der Ausfall an.

## Tests

- `raw_cache`: gzip-Roundtrip, Legacy-Fallback, write-once respektiert Legacy-Einträge, overwrite entfernt sie, korruptes Archiv = Miss statt Crash
- Migration: Payload überlebt, Original erst nach Verifikation weg, unlesbarer Blob bleibt liegen, Dry-Run ändert nichts, zweimal laufen ist ein No-Op, `.bin` unangetastet
- Docker: die drei „darf niemals"-Invarianten, plus Daemon-down und lautes Scheitern

608 passed, 1 skipped. Ruff sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)