### PR TITLE
Datentiefe-Roadmap Blöcke 1+2: Eindeutigkeit + 15-Minuten-Markt

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,9 +15,8 @@ from backend.database import init_db
 from backend.migrations import run_migrations
 from backend.observability import TraceIDMiddleware, setup_logging
 from backend.routes import alert_rules as alert_rules_routes
-from backend.routes import alerts, health, ports, prices, sentiment, vessels, voyages, weather
+from backend.routes import alerts, api_v1, health, ports, prices, sentiment, vessels, voyages, weather
 from backend.routes import analytics as analytics_routes
-from backend.routes import api_v1
 from backend.routes import atlas as atlas_routes
 from backend.routes import auth as auth_routes
 from backend.routes import briefing as briefing_routes

--- a/backend/power/entsoe_imbalance.py
+++ b/backend/power/entsoe_imbalance.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 from backend.config import settings
 from backend.gas import raw_cache
 from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
-from backend.power.hourly_store import upsert_day_hours
+from backend.power.hourly_store import upsert_day_hours, upsert_hourly
 from backend.power.zones import ZONE_REGISTRY
 
 logger = logging.getLogger(__name__)
@@ -84,6 +84,51 @@ def parse_imbalance_prices(xml_text: str) -> dict[str, dict[int, float]]:
     }
 
 
+def parse_imbalance_quarter_hourly(xml_text: str) -> list[tuple[int, float]]:
+    """Parse an A85 document into raw settlement-period points [(epoch_sec, EUR/MWh)].
+
+    Imbalance settles in 15-minute periods — that resolution IS the product; the
+    hourly mean above dilutes exactly the ±1000 €/MWh quarter-hours imbalance
+    watchers care about. Only PT15M TimeSeries contribute (hourly documents are
+    ignored rather than duplicated onto slots); overlapping series are averaged
+    per timestamp, matching the hourly parser.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A85 XML parse error: {exc}") from exc
+
+    by_ts: dict[int, list[float]] = {}
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            start_el = next((e for e in period.iter() if _localname(e.tag) == "start"), None)
+            res_el = next((e for e in period.iter() if _localname(e.tag) == "resolution"), None)
+            if start_el is None or res_el is None:
+                continue
+            if (res_el.text or "").strip() != "PT15M":
+                continue
+            start = _parse_utc(start_el.text)
+            if start is None:
+                continue
+            for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+                pos = next((e.text for e in point if _localname(e.tag) == "position"), None)
+                # DIRECT child only — not the nested Financial_Price amounts.
+                amt = next((e.text for e in point if _localname(e.tag) == "imbalance_Price.amount"), None)
+                if pos is None or amt is None:
+                    continue
+                try:
+                    slot = start + timedelta(minutes=15 * (int(pos) - 1))
+                    v = float(amt)
+                except (ValueError, TypeError):
+                    continue
+                epoch = int(slot.astimezone(timezone.utc).timestamp())
+                by_ts.setdefault(epoch, []).append(v)
+
+    return [(t, sum(vs) / len(vs)) for t, vs in sorted(by_ts.items())]
+
+
 async def _fetch_imbalance_month(ca_eic: str, month_start: date, *, overwrite: bool = False) -> str:
     """Fetch one control area's A85 for a calendar month; unzip the archive to inner XML (cached)."""
     nxt = (month_start.replace(day=28) + timedelta(days=4)).replace(day=1)
@@ -129,6 +174,7 @@ async def ingest_imbalance(
     wanted = set(days)
     months = sorted({datetime.strptime(d, "%Y-%m-%d").date().replace(day=1) for d in days})
     by_day: dict[str, dict[int, float]] = {}
+    qh_points: list[tuple[int, float]] = []
     for month_start in months:
         try:
             xml = await _fetch_imbalance_month(ca_eic, month_start, overwrite=overwrite)
@@ -140,6 +186,14 @@ async def ingest_imbalance(
         for day, hours in parse_imbalance_prices(xml).items():
             if day in wanted:
                 by_day[day] = hours
+        qh_points.extend(
+            (t, v)
+            for t, v in parse_imbalance_quarter_hourly(xml)
+            if datetime.fromtimestamp(t, tz=timezone.utc).strftime("%Y-%m-%d") in wanted
+        )
 
     written = upsert_day_hours(db, "imbalance.price", zone, by_day, unit="EUR/MWh") if by_day else 0
+    # Raw 15-min settlement points alongside the hourly mean (roadmap Block 2).
+    if qh_points:
+        upsert_hourly(db, "imbalance.price.qh", zone, qh_points, unit="EUR/MWh")
     return {"days": len(by_day), "written": written}

--- a/backend/power/entsoe_prices.py
+++ b/backend/power/entsoe_prices.py
@@ -26,7 +26,7 @@ from backend.config import settings
 from backend.gas import raw_cache
 from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
 from backend.models.energy import EnergyPrice, PowerPriceDaily
-from backend.power.hourly_store import upsert_day_hours
+from backend.power.hourly_store import upsert_day_hours, upsert_hourly
 
 logger = logging.getLogger(__name__)
 
@@ -165,6 +165,55 @@ def parse_day_ahead_stats(xml_text: str) -> dict[str, dict]:
     return result
 
 
+def parse_day_ahead_quarter_hourly(xml_text: str) -> list[tuple[int, float]]:
+    """Parse an A44 document into raw quarter-hour points [(epoch_sec, EUR/MWh)].
+
+    SDAC has traded 15-minute MTUs since delivery day 2025-10-01; the hourly
+    pipeline above averages those points away. This keeps them.
+
+    Only PT15M TimeSeries contribute. PT60M/PT30M series are ignored entirely —
+    duplicating an hourly price onto four QH slots would fake a granularity the
+    market did not trade. Before the switch this simply returns [] (the QH
+    series starts at the switch, no synthetic backfill). Overlapping PT15M
+    series for the same timestamp are averaged, matching the hourly parser's
+    handling of ENTSO-E duplicate TimeSeries.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A44 XML parse error: {exc}") from exc
+
+    by_ts: dict[int, list[float]] = {}
+
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            start_el = next((e for e in period.iter() if _localname(e.tag) == "start"), None)
+            res_el = next((e for e in period.iter() if _localname(e.tag) == "resolution"), None)
+            if start_el is None or res_el is None:
+                continue
+            if (res_el.text or "").strip() != "PT15M":
+                continue
+            start = _parse_utc(start_el.text)
+            if start is None:
+                continue
+            for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+                pos = next((e.text for e in point if _localname(e.tag) == "position"), None)
+                price_str = next((e.text for e in point if _localname(e.tag) == "price.amount"), None)
+                if pos is None or price_str is None:
+                    continue
+                try:
+                    slot = start + timedelta(minutes=15 * (int(pos) - 1))
+                    price = float(price_str)
+                except (ValueError, TypeError):
+                    continue
+                epoch = int(slot.astimezone(timezone.utc).timestamp())
+                by_ts.setdefault(epoch, []).append(price)
+
+    return [(t, sum(ps) / len(ps)) for t, ps in sorted(by_ts.items())]
+
+
 # ─── fetch ────────────────────────────────────────────────────────────────────
 
 
@@ -229,6 +278,7 @@ async def ingest_day_ahead(
     )
 
     stats_by_day: dict[str, dict] = {}
+    qh_points: list[tuple[int, float]] = []
     for month_start in months:
         try:
             xml = await _fetch_zone_month(eic, month_start, overwrite=overwrite)
@@ -240,6 +290,11 @@ async def ingest_day_ahead(
         for day, stats in parse_day_ahead_stats(xml).items():
             if day in wanted:
                 stats_by_day[day] = stats
+        qh_points.extend(
+            (t, p)
+            for t, p in parse_day_ahead_quarter_hourly(xml)
+            if datetime.fromtimestamp(t, tz=timezone.utc).strftime("%Y-%m-%d") in wanted
+        )
 
     written = 0
     for day, stats in stats_by_day.items():
@@ -259,6 +314,12 @@ async def ingest_day_ahead(
     }
     if price_by_day:
         upsert_day_hours(db, "price.dayahead", zone, price_by_day, unit="EUR/MWh")
+
+    # ── Raw 15-min auction points → price.dayahead.qh (roadmap Block 2) ──
+    # Present only for delivery days since the SDAC 15-min switch (2025-10-01);
+    # the hourly series above stays the averaged view for legacy consumers.
+    if qh_points:
+        upsert_hourly(db, "price.dayahead.qh", zone, qh_points, unit="EUR/MWh")
 
     logger.info(
         "entsoe_prices.ingest_day_ahead: %d/%d days written (symbol=%s)",

--- a/backend/routes/alert_rules.py
+++ b/backend/routes/alert_rules.py
@@ -111,6 +111,13 @@ class PatchRuleBody(BaseModel):
 # ---------- public-ish: templates ----------
 
 
+#: Verticals offered in the rule builder. The maritime/oil templates run on
+#: dormant data since the electricity refocus (2026-07-03) — offering rules on
+#: feeds that never fire misleads users. Their evaluators stay registered so
+#: existing rules keep evaluating; widen this set when the data returns.
+ACTIVE_TEMPLATE_VERTICALS = {"power", "gas"}
+
+
 @router.get("/templates")
 async def list_templates():
     """Schema discovery for the frontend rule-builder. Not behind require_pro
@@ -122,6 +129,7 @@ async def list_templates():
             "params_schema": t["params_schema"],
         }
         for rule_type, t in TEMPLATES.items()
+        if t.get("vertical") in ACTIVE_TEMPLATE_VERTICALS
     }
 
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -28,7 +28,8 @@ throughout the gas vertical (see backend/routes/gas.py).
 
 import json
 from datetime import date as _date
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from datetime import datetime as _dt
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
@@ -196,17 +197,70 @@ def _dedupe_hourly(points: list) -> list[dict]:
     return [{"hour": h, "price": round(sum(vs) / len(vs), 2)} for h, vs in sorted(acc.items())]
 
 
+def _day_ahead_qh(db: Session, zone: str, date: str | None) -> dict:
+    """The raw 96-point 15-min auction curve for one delivery day, from the
+    canonical store (series price.dayahead.qh)."""
+    from backend.power.hourly_store import read_hourly
+
+    if date:
+        try:
+            day_start = int(_dt.fromisoformat(date + "T00:00").replace(tzinfo=timezone.utc).timestamp())
+        except ValueError:
+            return {"available": False, "zone": zone, "zones": _ZONE_KEYS,
+                    "reason": "Invalid date — expected YYYY-MM-DD."}
+        points = read_hourly(db, "price.dayahead.qh", zone, day_start, day_start + 86_400)
+    else:
+        # Latest delivery day that has any QH data: read the series tail and
+        # trim to the newest UTC day it covers.
+        points = read_hourly(db, "price.dayahead.qh", zone)
+        if points:
+            newest_day = _dt.fromtimestamp(points[-1][0], tz=timezone.utc).strftime("%Y-%m-%d")
+            day_start = int(_dt.fromisoformat(newest_day + "T00:00").replace(tzinfo=timezone.utc).timestamp())
+            points = [(t, v) for t, v in points if t >= day_start]
+
+    if not points:
+        return {
+            "available": False,
+            "zone": zone,
+            "zones": _ZONE_KEYS,
+            "reason": "No 15-min day-ahead data for this day — SDAC trades 15-minute products since 2025-10-01.",
+        }
+
+    day = _dt.fromtimestamp(points[0][0], tz=timezone.utc).strftime("%Y-%m-%d")
+    data = [
+        {"time": _dt.fromtimestamp(t, tz=timezone.utc).strftime("%H:%M"), "price": round(v, 2)}
+        for t, v in points
+    ]
+    return {
+        "available": True,
+        "zone": zone,
+        "zones": _ZONE_KEYS,
+        "date": day,
+        "unit": "EUR/MWh",
+        "resolution": "qh",
+        "data": data,
+    }
+
+
 @router.get("/day-ahead/hourly")
 async def get_day_ahead_hourly(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     date: str = Query(None, description="YYYY-MM-DD; default = latest day with hourly data"),
+    resolution: str = Query("hourly", pattern="^(hourly|qh)$",
+                            description="hourly = 24 averaged points; qh = the raw 96-point 15-min auction (since 2025-10-01)"),
     db: Session = Depends(get_db),
 ):
-    """The 24 hourly day-ahead prices for one day — the peak/off-peak shape behind
-    the daily mean. Free tier. Defaults to the most recent day that has an hourly
-    series. Returns {available, zone, date, unit, data:[{"hour","price"}]}.
+    """The intraday day-ahead price shape for one day. Free tier.
+
+    resolution=hourly (default): the 24 per-hour means — unchanged legacy shape.
+    resolution=qh: the raw 96 quarter-hour auction points, exactly as traded —
+    SDAC has traded 15-minute MTUs since delivery day 2025-10-01, so the hourly
+    view is a smoothed picture of the real curve. Days before the switch have
+    no qh series.
     """
     resolved_zone = _resolve_zone(zone)
+    if resolution == "qh":
+        return _day_ahead_qh(db, resolved_zone, date)
     q = db.query(PowerPriceDaily).filter(
         PowerPriceDaily.zone == resolved_zone,
         PowerPriceDaily.hourly_prices.isnot(None),

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -42,7 +42,6 @@ from backend.models.energy import (
     PowerGrid,
     PowerLoadForecast,
     PowerPriceDaily,
-    SparkSpreadHistory,
 )
 from backend.power.coverage import renewable_share_reliable
 from backend.power.energy_charts_flows import ATTRIBUTION
@@ -145,6 +144,7 @@ async def get_day_ahead(
             "negative_days": negative_days,
             "latest": latest,
             "data": data,
+            **_panel_freshness(data, "day_ahead"),
         }
 
     # Fallback: legacy EnergyPrice rows (no min/negative_hours available)
@@ -177,6 +177,7 @@ async def get_day_ahead(
         "negative_days": 0,
         "latest": data[-1],
         "data": data,
+        **_panel_freshness(data, "day_ahead"),
     }
 
 
@@ -301,6 +302,7 @@ async def get_spark_spread(
         "from": date_from,
         "to": date_to,
         "data": data,
+        **_panel_freshness(data, "spark"),
     }
 
 
@@ -385,6 +387,7 @@ async def get_grid(
         "from": date_from,
         "to": date_to,
         "data": data,
+        **_panel_freshness(data, "grid"),
     }
 
 
@@ -456,6 +459,7 @@ async def get_load_forecast(
         "forward": forward,
         "from": date_from,
         "data": data,
+        **_panel_freshness(data, "load_forecast"),
     }
 
 
@@ -568,6 +572,46 @@ def _worst_state(severities: list[str]) -> str:
     return _STATE_LABEL[rank]
 
 
+# Panel-caption freshness thresholds. Values mirror the per-source windows in
+# backend/collectors/freshness.py::SPECS (enforced by test_power_panel_freshness),
+# so the UI captions and /api/health/collectors can never disagree. generation_mix
+# shares the grid window (same A75 ingest); load_forecast is frontier-based.
+PANEL_MAX_AGE_DAYS = {
+    "day_ahead": 2,
+    "grid": 3,
+    "generation_mix": 3,
+    "flows": 3,
+    "spark": 4,  # gas leg is yfinance TTF — ~3 trading days plus weekends
+    "load_forecast": 2,
+}
+
+
+def _freshness(as_of: str | None, today: _date | None,
+               max_age_days: int = SITUATION_STALE_DAYS) -> dict:
+    """as_of/age_days/stale triple for ONE component. Inert without `today`.
+
+    Every component carries its own freshness because a fresh series must never
+    mask a stale one: after the 2026-07-07 outage, prices resumed a day before
+    the grid series did, and the old top-level `as_of = max(...)` presented
+    days-old residual/renewables figures as current.
+    """
+    age_days: int | None = None
+    stale = False
+    if today is not None and as_of is not None:
+        try:
+            age_days = (today - _date.fromisoformat(as_of)).days
+            stale = age_days > max_age_days
+        except ValueError:
+            age_days = None
+    return {"as_of": as_of, "age_days": age_days, "stale": stale}
+
+
+def _panel_freshness(data: list[dict], panel: str) -> dict:
+    """Freshness triple for a detail endpoint from its ascending `data` rows."""
+    latest = data[-1]["date"] if data else None
+    return _freshness(latest, datetime.utcnow().date(), PANEL_MAX_AGE_DAYS[panel])
+
+
 def build_power_situation(
     zone: str,
     price_series: list[dict],
@@ -609,6 +653,7 @@ def build_power_situation(
         "z": price_z["z"] if price_z else None,
         "baseline_mean": price_z["baseline_mean"] if price_z else None,
         "baseline_n": price_z["baseline_n"] if price_z else None,
+        **_freshness(price_latest["date"] if price_latest else None, today),
     }
 
     # ── grid block (residual load + Dunkelflaute) ──
@@ -629,6 +674,7 @@ def build_power_situation(
         "z": resid_z["z"] if resid_z else None,
         "baseline_mean": resid_z["baseline_mean"] if resid_z else None,
         "baseline_n": resid_z["baseline_n"] if resid_z else None,
+        **_freshness(grid_latest["date"] if grid_latest else None, today),
     }
 
     # ── spark block (DE-LU only; signpost on FR/NL) ──
@@ -641,6 +687,7 @@ def build_power_situation(
         if has_spark and spark_latest.get("power_price") is not None else None,
         "gas_price": round(spark_latest["gas_price"], 2)
         if has_spark and spark_latest.get("gas_price") is not None else None,
+        **_freshness(spark_latest.get("date") if has_spark else None, today),
     }
 
     # ── flags + descriptive state ──
@@ -666,29 +713,30 @@ def build_power_situation(
     as_of = max(date_candidates) if date_candidates else None
 
     # ── staleness (vs wall-clock) — never assert a confident state on days-old data ──
-    age_days: int | None = None
-    stale = False
-    if today is not None and as_of is not None:
-        try:
-            age_days = (today - _date.fromisoformat(as_of)).days
-            stale = age_days > SITUATION_STALE_DAYS
-        except ValueError:
-            age_days = None
+    # Top-level as_of stays the NEWEST component date, but stale is worst-of: any
+    # available component lagging makes the whole situation stale. `max()` alone
+    # would let a fresh price mask a days-old grid series.
+    top = _freshness(as_of, today)
+    age_days = top["age_days"]
+    stale = any(c["stale"] for c in (price, grid, spark) if c["available"])
 
     # ── headline (descriptive one-liner) ──
+    def _age_suffix(comp: dict) -> str:
+        return f" ({comp['age_days']}d old)" if comp["stale"] else ""
+
     parts: list[str] = []
     if price["available"]:
         seg = f"day-ahead €{price['close']:.0f}/MWh"
         if price["z"] is not None:
             seg += f" ({price['z']:+.1f}σ)"
-        parts.append(seg)
+        parts.append(seg + _age_suffix(price))
     if grid["available"]:
         seg = f"residual {grid['residual_gw']:.0f} GW"
         if grid["z"] is not None:
             seg += f" ({grid['z']:+.1f}σ)"
-        parts.append(seg)
+        parts.append(seg + _age_suffix(grid))
     if spark["available"]:
-        parts.append(f"spark €{spark['spark_spread']:+.0f}/MWh")
+        parts.append(f"spark €{spark['spark_spread']:+.0f}/MWh" + _age_suffix(spark))
     headline = f"{zone_label} · " + " · ".join(parts) if parts else f"{zone_label} · no power data yet"
 
     return {
@@ -705,6 +753,39 @@ def build_power_situation(
         "spark": spark,
         "flags": flags,
         "headline": headline,
+    }
+
+
+def _latest_spark(db: Session, zone: str) -> dict | None:
+    """Latest live spark for `zone` — the same derivation as /spark-spread
+    (power − TTF × heat_rate on the newest day both series cover), so the
+    situation hero and the panel can never disagree. None when either leg
+    has no recent data."""
+    symbol = POWER_ZONES[zone]["price_symbol"]
+    heat_rate = round(1.0 / settings.gas_ccgt_efficiency, 4)
+    date_from, date_to = _window(14)
+
+    def _closes(sym: str) -> dict[str, float]:
+        return {
+            r.date: r.close
+            for r in db.query(EnergyPrice).filter(
+                EnergyPrice.symbol == sym,
+                EnergyPrice.date >= date_from,
+                EnergyPrice.date <= date_to,
+            )
+        }
+
+    power_by = _closes(symbol)
+    ttf_by = _closes("TTF")
+    common = sorted(set(power_by) & set(ttf_by))
+    if not common:
+        return None
+    d = common[-1]
+    return {
+        "date": d,
+        "power_price": power_by[d],
+        "gas_price": ttf_by[d],
+        "spark_spread": round(power_by[d] - ttf_by[d] * heat_rate, 4),
     }
 
 
@@ -753,27 +834,18 @@ def load_power_situation(db: Session, zone: str) -> dict:
             db, latest_grid.date, resolved_zone, latest_grid.load_mw
         )
 
-    spark_supported = resolved_zone == DEFAULT_ZONE
-    spark_latest = None
-    if spark_supported:
-        srow = (
-            db.query(SparkSpreadHistory)
-            .order_by(SparkSpreadHistory.date.desc())
-            .first()
-        )
-        if srow is not None:
-            spark_latest = {
-                "spark_spread": srow.spark_spread,
-                "power_price": srow.power_price,
-                "gas_price": srow.gas_price,
-            }
+    # Derive the spark live from the price series — the exact same computation as
+    # /spark-spread (gas leg = TTF for every zone), so the hero and the panel below
+    # it can never disagree. The old SparkSpreadHistory read was DE-only and made
+    # the hero claim "DE-LU only" while the panel showed a real FR/NL spark.
+    spark_latest = _latest_spark(db, resolved_zone)
 
     return build_power_situation(
         resolved_zone,
         price_series,
         grid_series,
         spark_latest,
-        spark_supported=spark_supported,
+        spark_supported=True,
         grid_coverage_ok=grid_coverage_ok,
         today=datetime.utcnow().date(),
     )
@@ -920,6 +992,7 @@ async def get_flows(
         "from": date_from,
         "to": date_to,
         "data": data,
+        **_panel_freshness(data, "flows"),
     }
 
 
@@ -992,4 +1065,5 @@ async def get_generation_mix(
         "from": date_from,
         "to": date_to,
         "data": data,
+        **_panel_freshness(data, "generation_mix"),
     }

--- a/backend/signals/user_alert_rules.py
+++ b/backend/signals/user_alert_rules.py
@@ -505,6 +505,7 @@ TEMPLATES: dict[str, dict] = {
                 "default": "either",
             },
         },
+        "vertical": "maritime",
         "evaluator": evaluate_chokepoint_anomaly,
     },
     "floating_storage_surge": {
@@ -519,6 +520,7 @@ TEMPLATES: dict[str, dict] = {
             "min_vessels": {"type": "number", "min": 1, "max": 100, "default": 3},
             "window_days": {"type": "number", "min": 1, "max": 30, "default": 7},
         },
+        "vertical": "maritime",
         "evaluator": evaluate_floating_storage_surge,
     },
     "crack_spread_breach": {
@@ -532,6 +534,7 @@ TEMPLATES: dict[str, dict] = {
             },
             "threshold_usd": {"type": "number", "min": 0, "max": 100, "required": True},
         },
+        "vertical": "oil",
         "evaluator": evaluate_crack_spread_breach,
     },
     "negative_prices": {
@@ -540,12 +543,14 @@ TEMPLATES: dict[str, dict] = {
         "params_schema": {
             "zone": {"type": "enum", "options": list(POWER_ZONES), "required": True},
         },
+        "vertical": "power",
         "evaluator": evaluate_negative_prices,
     },
     "gas_balance": {
         "label": "EU gas balance signal",
         "summary": "Notify me when the EU gas-balance residual flags a WATCH or SIGNAL deviation vs its 90d norm.",
         "params_schema": {},
+        "vertical": "gas",
         "evaluator": evaluate_gas_balance,
     },
     "dunkelflaute": {
@@ -555,6 +560,7 @@ TEMPLATES: dict[str, dict] = {
             "zone": {"type": "enum", "options": list(POWER_ZONES), "required": True},
             "threshold_pct": {"type": "number", "min": 5, "max": 40, "default": 15},
         },
+        "vertical": "power",
         "evaluator": evaluate_dunkelflaute,
     },
     "dayahead_spike": {
@@ -565,6 +571,7 @@ TEMPLATES: dict[str, dict] = {
             "direction": {"type": "enum", "options": ["above", "below"], "required": True},
             "threshold_eur": {"type": "number", "min": -50, "max": 1000, "required": True},
         },
+        "vertical": "power",
         "evaluator": evaluate_dayahead_spike,
     },
     "spark_spread_breach": {
@@ -574,6 +581,7 @@ TEMPLATES: dict[str, dict] = {
             "direction": {"type": "enum", "options": ["above", "below"], "required": True},
             "threshold_eur": {"type": "number", "min": -100, "max": 200, "required": True},
         },
+        "vertical": "power",
         "evaluator": evaluate_spark_spread_breach,
     },
 }

--- a/backend/tests/test_alert_rules.py
+++ b/backend/tests/test_alert_rules.py
@@ -388,22 +388,32 @@ def test_user_cannot_delete_someone_elses_rule(client, db_session):
 
 
 def test_templates_endpoint_public(client):
+    """Only power/gas templates are offered. The maritime/oil ones (chokepoint,
+    floating storage, crack spread) live on dormant data since the electricity
+    refocus — offering rules on feeds that never fire misleads users. Evaluators
+    and existing rules stay untouched (reversible; extraction pending)."""
     resp = client.get("/api/alerts/templates")
     assert resp.status_code == 200
     body = resp.json()
     assert set(body) == {
-        "chokepoint_anomaly",
-        "floating_storage_surge",
-        "crack_spread_breach",
         "negative_prices",
         "gas_balance",
         "dunkelflaute",
         "dayahead_spike",
         "spark_spread_breach",
     }
-    assert body["chokepoint_anomaly"]["params_schema"]["zone"]["type"] == "enum"
     # gas_balance is a no-param template (whole-EU signal).
     assert body["gas_balance"]["params_schema"] == {}
+
+
+def test_dormant_maritime_templates_still_evaluate_existing_rules():
+    """Hiding a template from the builder must not orphan rules users already have."""
+    from backend.signals.user_alert_rules import TEMPLATES
+
+    for dormant in ("chokepoint_anomaly", "floating_storage_surge", "crack_spread_breach"):
+        assert dormant in TEMPLATES, "evaluator registry must keep dormant types"
+        assert callable(TEMPLATES[dormant]["evaluator"])
+        assert TEMPLATES[dormant]["vertical"] not in ("power", "gas")
 
 
 # ---------- runner / cooldown ----------

--- a/backend/tests/test_imbalance.py
+++ b/backend/tests/test_imbalance.py
@@ -79,3 +79,64 @@ async def test_ingest_de_skipped(db_session, monkeypatch):
     monkeypatch.setattr(imb.settings, "entsoe_api_token", "x")
     r = await imb.ingest_imbalance(db_session, ["2026-06-01"], zone="DE_LU")
     assert r == {"skipped": "no control area (DE has 4)"}
+
+
+# ─── quarter-hourly: imbalance settles in 15-min periods — that IS the native truth ─
+#
+# The hourly mean erases exactly what imbalance watchers care about: single
+# ±1000 €/MWh quarter-hours vanish into a bland average.
+
+
+def _epoch(iso: str) -> int:
+    from datetime import datetime, timezone
+
+    return int(datetime.fromisoformat(iso).replace(tzinfo=timezone.utc).timestamp())
+
+
+def test_parse_qh_keeps_raw_quarter_hours():
+    from backend.power.entsoe_imbalance import parse_imbalance_quarter_hourly
+
+    amounts = [50.0] * 95 + [-990.0]  # one extreme settlement period
+    xml = _a85(amounts, res="PT15M")
+    pts = parse_imbalance_quarter_hourly(xml)
+
+    assert len(pts) == 96
+    assert pts[0] == (_epoch("2026-06-01T00:00"), 50.0)
+    assert pts[-1] == (_epoch("2026-06-01T23:45"), -990.0)
+
+
+def test_parse_qh_ignores_hourly_documents():
+    from backend.power.entsoe_imbalance import parse_imbalance_quarter_hourly
+
+    assert parse_imbalance_quarter_hourly(_a85([50.0] * 24, res="PT60M")) == []
+
+
+def test_parse_qh_takes_point_amount_not_financial(db_session):
+    from backend.power.entsoe_imbalance import parse_imbalance_quarter_hourly
+
+    pts = parse_imbalance_quarter_hourly(_a85([70.0] * 96, res="PT15M", financial=True))
+    assert len(pts) == 96
+    assert all(v == 70.0 for _, v in pts)
+
+
+async def test_ingest_writes_qh_series_alongside_hourly(db_session, monkeypatch):
+    from pydantic import SecretStr
+
+    amounts = [50.0] * 95 + [-990.0]
+    xml = _a85(amounts, res="PT15M")
+
+    async def fake_fetch(ca_eic, month_start, *, overwrite=False):
+        return xml
+
+    monkeypatch.setattr(imb, "_fetch_imbalance_month", fake_fetch)
+    monkeypatch.setattr(imb.settings, "entsoe_api_token", SecretStr("tok"))
+
+    await imb.ingest_imbalance(db_session, ["2026-06-01"], zone="FR")
+
+    qh = read_hourly(db_session, "imbalance.price.qh", "FR")
+    assert len(qh) == 96
+    assert qh[-1][1] == -990.0
+    # hourly stays the averaged view: the extreme quarter-hour is diluted there
+    hourly = read_hourly(db_session, "imbalance.price", "FR")
+    assert len(hourly) == 24
+    assert hourly[-1][1] == pytest.approx((50.0 * 3 - 990.0) / 4)

--- a/backend/tests/test_power_hourly.py
+++ b/backend/tests/test_power_hourly.py
@@ -112,3 +112,71 @@ def test_hourly_endpoint_unavailable_when_missing(db_session):
     with _Client(db_session) as c:
         body = c.get("/api/power/day-ahead/hourly?zone=DE_LU").json()
     assert body["available"] is False
+
+
+# ─── resolution=qh: the raw 15-min auction curve (SDAC 15-min since 2025-10-01) ─
+
+
+def _seed_qh(db, day: str, prices: list[float]) -> None:
+    from datetime import datetime, timezone
+
+    from backend.power.hourly_store import upsert_hourly
+
+    base = int(datetime.fromisoformat(day + "T00:00").replace(tzinfo=timezone.utc).timestamp())
+    upsert_hourly(db, "price.dayahead.qh", "DE_LU",
+                  [(base + i * 900, p) for i, p in enumerate(prices)], unit="EUR/MWh")
+    db.commit()
+
+
+def test_qh_endpoint_returns_96_point_curve(db_session):
+    _seed_qh(db_session, "2026-05-01", [float(10 + i) for i in range(96)])
+    with _Client(db_session) as c:
+        body = c.get("/api/power/day-ahead/hourly?zone=DE_LU&resolution=qh").json()
+    assert body["available"] is True
+    assert body["resolution"] == "qh"
+    assert body["date"] == "2026-05-01"
+    assert len(body["data"]) == 96
+    assert body["data"][0] == {"time": "00:00", "price": 10.0}
+    assert body["data"][1] == {"time": "00:15", "price": 11.0}
+    assert body["data"][-1] == {"time": "23:45", "price": 105.0}
+
+
+def test_qh_endpoint_picks_latest_day_with_qh_data(db_session):
+    _seed_qh(db_session, "2026-05-01", [10.0] * 96)
+    _seed_qh(db_session, "2026-05-02", [20.0] * 96)
+    with _Client(db_session) as c:
+        body = c.get("/api/power/day-ahead/hourly?zone=DE_LU&resolution=qh").json()
+    assert body["date"] == "2026-05-02"
+    assert all(p["price"] == 20.0 for p in body["data"])
+
+
+def test_qh_endpoint_explicit_date(db_session):
+    _seed_qh(db_session, "2026-05-01", [10.0] * 96)
+    _seed_qh(db_session, "2026-05-02", [20.0] * 96)
+    with _Client(db_session) as c:
+        body = c.get("/api/power/day-ahead/hourly?zone=DE_LU&resolution=qh&date=2026-05-01").json()
+    assert body["date"] == "2026-05-01"
+    assert all(p["price"] == 10.0 for p in body["data"])
+
+
+def test_qh_endpoint_signposts_pre_switch_days(db_session):
+    """No QH data (e.g. any day before 2025-10-01) → honest reason, not an error."""
+    with _Client(db_session) as c:
+        body = c.get("/api/power/day-ahead/hourly?zone=DE_LU&resolution=qh").json()
+    assert body["available"] is False
+    assert "15-min" in body["reason"]
+
+
+def test_hourly_endpoint_default_resolution_unchanged(db_session):
+    """resolution defaults to hourly — existing consumers see the same shape."""
+    hourly = [{"hour": h, "price": 40.0 + h} for h in range(24)]
+    db_session.add(PowerPriceDaily(
+        date="2026-05-01", zone="DE_LU", mean_price=51.5, min_price=40, max_price=63,
+        negative_hours=0, hourly_prices=json.dumps(hourly),
+    ))
+    db_session.commit()
+    with _Client(db_session) as c:
+        body = c.get("/api/power/day-ahead/hourly?zone=DE_LU").json()
+    assert body["available"] is True
+    assert len(body["data"]) == 24
+    assert body["data"][0] == {"hour": 0, "price": 40.0}

--- a/backend/tests/test_power_panel_freshness.py
+++ b/backend/tests/test_power_panel_freshness.py
@@ -1,0 +1,112 @@
+"""Every power detail endpoint must state how old its data is.
+
+The panels used to show a neutral "latest {date}" caption — a hung feed looked
+identical to a healthy one. Each endpoint now returns `as_of`/`age_days`/`stale`,
+with thresholds mirroring backend/collectors/freshness.py::SPECS so the panel
+captions and /api/health/collectors can never disagree.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from backend.models.energy import (
+    EnergyPrice,
+    PowerFlow,
+    PowerGenMix,
+    PowerGrid,
+    PowerLoadForecast,
+    PowerPriceDaily,
+)
+
+_TODAY = date.today()
+
+
+@pytest.fixture(autouse=True)
+def _clear_dependency_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db: Session) -> TestClient:
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _seed_all(db: Session, end: date, n: int = 3) -> None:
+    for i in range(n):
+        d = (end - timedelta(days=n - 1 - i)).isoformat()
+        db.add(PowerPriceDaily(date=d, zone="DE_LU", mean_price=60.0, min_price=20.0,
+                               max_price=90.0, negative_hours=0))
+        db.add(PowerGrid(date=d, zone="DE_LU", load_mw=50_000.0, wind_mw=10_000.0,
+                         solar_mw=5_000.0, residual_mw=35_000.0))
+        db.add(PowerGenMix(date=d, zone="DE_LU", psr_type="Solar", gen_mw=5_000.0))
+        db.add(PowerFlow(date=d, from_zone="DE_LU", to_zone="FR", net_mw=1_000.0))
+        # /spark-spread computes live from the POWER_DE + TTF price series
+        db.add(EnergyPrice(date=d, symbol="POWER_DE", close=60.0))
+        db.add(EnergyPrice(date=d, symbol="TTF", close=30.0))
+        db.add(PowerLoadForecast(date=d, zone="DE_LU", forecast_mw=50_000.0,
+                                 wind_forecast_mw=10_000.0, solar_forecast_mw=5_000.0))
+    db.commit()
+
+
+ENDPOINTS = [
+    "/api/power/day-ahead?zone=DE_LU",
+    "/api/power/grid?zone=DE_LU",
+    "/api/power/generation-mix?zone=DE_LU",
+    "/api/power/flows",
+    "/api/power/spark-spread",
+    "/api/power/load-forecast?zone=DE_LU",
+]
+
+
+@pytest.mark.parametrize("endpoint", ENDPOINTS)
+def test_stale_data_is_declared(db_session, endpoint):
+    old_end = _TODAY - timedelta(days=10)
+    _seed_all(db_session, old_end)
+    body = _client(db_session).get(endpoint).json()
+
+    assert body["available"] is True
+    assert body["as_of"] == old_end.isoformat(), endpoint
+    assert body["age_days"] == 10, endpoint
+    assert body["stale"] is True, endpoint
+
+
+@pytest.mark.parametrize("endpoint", ENDPOINTS)
+def test_fresh_data_is_not_stale(db_session, endpoint):
+    _seed_all(db_session, _TODAY)
+    body = _client(db_session).get(endpoint).json()
+
+    assert body["available"] is True
+    assert body["as_of"] == _TODAY.isoformat(), endpoint
+    assert body["age_days"] == 0, endpoint
+    assert body["stale"] is False, endpoint
+
+
+def test_forecast_frontier_in_the_future_is_not_stale(db_session):
+    """The load forecast legitimately extends into tomorrow (D+1)."""
+    _seed_all(db_session, _TODAY + timedelta(days=1))
+    body = _client(db_session).get("/api/power/load-forecast?zone=DE_LU").json()
+    assert body["stale"] is False
+    assert body["age_days"] == -1
+
+
+def test_panel_thresholds_match_health_specs():
+    """UI captions and /api/health/collectors must share one truth."""
+    from backend.collectors.freshness import SPECS
+    from backend.routes.power import PANEL_MAX_AGE_DAYS
+
+    by_key = {s.key.split(":")[0]: s.max_age.days for s in SPECS}
+    assert PANEL_MAX_AGE_DAYS["day_ahead"] == by_key["power_dayahead"]
+    assert PANEL_MAX_AGE_DAYS["grid"] == by_key["power_grid"]
+    assert PANEL_MAX_AGE_DAYS["flows"] == by_key["power_flows"]
+    assert PANEL_MAX_AGE_DAYS["spark"] == by_key["ttf"]

--- a/backend/tests/test_power_prices.py
+++ b/backend/tests/test_power_prices.py
@@ -208,3 +208,117 @@ async def test_ingest_filters_to_requested_days(db_session, monkeypatch):
     result = await entsoe_prices.ingest_day_ahead(db_session, ["2026-05-01"])
     assert result == {"days": 1, "written": 1}
     assert db_session.query(EnergyPrice).filter_by(date="2026-05-02").first() is None
+
+
+# ─── quarter-hourly parse + ingest (SDAC trades 15-min MTUs since 2025-10-01) ──
+#
+# The hourly pipeline averages PT15M points into hours — fine for the legacy
+# series, but it renders a smoothed picture of a market that has traded in
+# 15-minute products since 1 October 2025. The QH series keeps the raw points.
+
+
+def _epoch(iso: str) -> int:
+    from datetime import datetime, timezone
+
+    return int(datetime.fromisoformat(iso).replace(tzinfo=timezone.utc).timestamp())
+
+
+def test_parse_qh_returns_raw_quarter_hour_points():
+    from backend.power.entsoe_prices import parse_day_ahead_quarter_hourly
+
+    prices = [float(10 + i) for i in range(96)]
+    xml = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", prices, res="PT15M"))
+    pts = parse_day_ahead_quarter_hourly(xml)
+
+    assert len(pts) == 96
+    assert pts[0] == (_epoch("2026-05-01T00:00"), 10.0)
+    assert pts[1] == (_epoch("2026-05-01T00:15"), 11.0)
+    assert pts[-1] == (_epoch("2026-05-01T23:45"), 105.0)
+
+
+def test_parse_qh_ignores_hourly_timeseries_entirely():
+    """PT60M points must never be duplicated onto four QH slots — a chart built
+    from that would fake a granularity the market did not trade."""
+    from backend.power.entsoe_prices import parse_day_ahead_quarter_hourly
+
+    xml = _a44(
+        _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [50.0] * 24, res="PT60M")
+        + _ts("2026-05-02T00:00Z", "2026-05-03T00:00Z", [60.0] * 96, res="PT15M")
+    )
+    pts = parse_day_ahead_quarter_hourly(xml)
+
+    assert len(pts) == 96
+    assert all(_epoch("2026-05-02T00:00") <= ts for ts, _ in pts)
+
+
+def test_parse_qh_hourly_only_document_yields_nothing():
+    """Before 2025-10-01 the auction was hourly — the QH series simply starts
+    at the switch, no synthetic backfill."""
+    from backend.power.entsoe_prices import parse_day_ahead_quarter_hourly
+
+    xml = _a44(_ts("2025-05-01T00:00Z", "2025-05-02T00:00Z", [50.0] * 24, res="PT60M"))
+    assert parse_day_ahead_quarter_hourly(xml) == []
+
+
+def test_parse_qh_overlapping_series_are_averaged_per_timestamp():
+    from backend.power.entsoe_prices import parse_day_ahead_quarter_hourly
+
+    xml = _a44(
+        _ts("2026-05-01T00:00Z", "2026-05-01T01:00Z", [40.0] * 4, res="PT15M")
+        + _ts("2026-05-01T00:00Z", "2026-05-01T01:00Z", [60.0] * 4, res="PT15M")
+    )
+    pts = parse_day_ahead_quarter_hourly(xml)
+
+    assert len(pts) == 4
+    assert all(p == 50.0 for _, p in pts)
+
+
+async def test_ingest_writes_qh_series_alongside_legacy(db_session, monkeypatch):
+    from pydantic import SecretStr
+
+    from backend.power import entsoe_prices
+    from backend.power.hourly_store import read_hourly
+
+    xml = _a44(_ts("2026-05-01T00:00Z", "2026-05-02T00:00Z",
+                   [-5.0 if i < 4 else 80.0 for i in range(96)], res="PT15M"))
+
+    async def fake_fetch(eic, month_start, *, overwrite=False):
+        return xml
+
+    monkeypatch.setattr(entsoe_prices, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(entsoe_prices.settings, "entsoe_api_token", SecretStr("tok"))
+
+    await entsoe_prices.ingest_day_ahead(db_session, ["2026-05-01"])
+
+    qh = read_hourly(db_session, "price.dayahead.qh", "DE_LU")
+    assert len(qh) == 96
+    assert qh[0] == (_epoch("2026-05-01T00:00"), -5.0)
+    assert qh[4][1] == 80.0
+    # legacy hourly series keeps its averaged shape, untouched
+    hourly = read_hourly(db_session, "price.dayahead", "DE_LU")
+    assert len(hourly) == 24
+    assert hourly[0][1] == pytest.approx(-5.0)  # 4 × −5.0 averaged
+
+
+async def test_ingest_qh_respects_the_requested_days(db_session, monkeypatch):
+    from pydantic import SecretStr
+
+    from backend.power import entsoe_prices
+    from backend.power.hourly_store import read_hourly
+
+    xml = _a44(
+        _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [10.0] * 96, res="PT15M")
+        + _ts("2026-05-02T00:00Z", "2026-05-03T00:00Z", [20.0] * 96, res="PT15M")
+    )
+
+    async def fake_fetch(eic, month_start, *, overwrite=False):
+        return xml
+
+    monkeypatch.setattr(entsoe_prices, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(entsoe_prices.settings, "entsoe_api_token", SecretStr("tok"))
+
+    await entsoe_prices.ingest_day_ahead(db_session, ["2026-05-01"])
+
+    qh = read_hourly(db_session, "price.dayahead.qh", "DE_LU")
+    assert len(qh) == 96
+    assert all(v == 10.0 for _, v in qh)

--- a/backend/tests/test_power_situation.py
+++ b/backend/tests/test_power_situation.py
@@ -14,7 +14,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from backend.models.energy import PowerGenMix, PowerGrid, PowerPriceDaily, SparkSpreadHistory
+from backend.models.energy import EnergyPrice, PowerGenMix, PowerGrid, PowerPriceDaily
 from backend.routes.power import build_power_situation
 
 
@@ -185,6 +185,84 @@ def test_situation_staleness_defaults_off_without_today():
     assert s["age_days"] is None
 
 
+# ─── per-component staleness: one fresh series must not mask a stale one ──────
+#
+# The old top-level `as_of = max(price, grid)` let a fresh day-ahead price make
+# 5-day-old residual/renewables/Dunkelflaute figures look current — exactly the
+# failure mode of the 2026-07-07 outage aftermath, when prices resumed before
+# the grid series did.
+
+
+def test_stale_grid_behind_fresh_price_is_flagged():
+    today = date(2026, 7, 11)
+    price = _series_ending(today, 5, lambda i: {"close": 50.0 + (i % 2), "negative_hours": 0})
+    grid = _series_ending(
+        date(2026, 7, 6), 5,
+        lambda i: {"residual_mw": 40_000.0, "renewable_share": 0.25, "dunkelflaute": False},
+    )
+    s = build_power_situation("DE_LU", price, grid, None, today=today)
+
+    assert s["price"]["stale"] is False
+    assert s["price"]["age_days"] == 0
+    assert s["grid"]["stale"] is True
+    assert s["grid"]["age_days"] == 5
+    # top level: newest date stays as_of, but staleness is worst-of, not max-of
+    assert s["as_of"] == "2026-07-11"
+    assert s["stale"] is True
+
+
+def test_component_freshness_fields_on_fresh_data():
+    price = _price_series([50.0, 51.0, 52.0])
+    grid = _flat_grid([45_000.0, 46_000.0, 47_000.0])
+    spark = {"spark_spread": 5.0, "power_price": 52.0, "gas_price": 30.0,
+             "date": date.today().isoformat()}
+    s = build_power_situation("DE_LU", price, grid, spark, today=date.today())
+
+    for comp in ("price", "grid", "spark"):
+        assert s[comp]["as_of"] is not None
+        assert s[comp]["age_days"] == 0
+        assert s[comp]["stale"] is False
+    assert s["stale"] is False
+
+
+def test_stale_spark_is_flagged_from_its_own_date():
+    today = date(2026, 7, 11)
+    price = _series_ending(today, 5, lambda i: {"close": 50.0, "negative_hours": 0})
+    grid = _series_ending(
+        today, 5,
+        lambda i: {"residual_mw": 40_000.0, "renewable_share": 0.25, "dunkelflaute": False},
+    )
+    spark = {"spark_spread": 5.0, "power_price": 52.0, "gas_price": 30.0, "date": "2026-07-04"}
+    s = build_power_situation("DE_LU", price, grid, spark, today=today)
+
+    assert s["spark"]["stale"] is True
+    assert s["spark"]["age_days"] == 7
+    assert s["stale"] is True, "a stale component must surface at the top level"
+
+
+def test_headline_marks_stale_components():
+    today = date(2026, 7, 11)
+    price = _series_ending(today, 5, lambda i: {"close": 50.0, "negative_hours": 0})
+    grid = _series_ending(
+        date(2026, 7, 6), 5,
+        lambda i: {"residual_mw": 40_000.0, "renewable_share": 0.25, "dunkelflaute": False},
+    )
+    s = build_power_situation("DE_LU", price, grid, None, today=today)
+    assert "5d old" in s["headline"], s["headline"]
+    # the fresh price segment must NOT carry an age marker
+    price_seg = [p for p in s["headline"].split("·") if "day-ahead" in p][0]
+    assert "old" not in price_seg
+
+
+def test_component_staleness_inert_without_today():
+    price = _price_series([50.0, 51.0, 52.0])
+    grid = _flat_grid([45_000.0, 46_000.0, 47_000.0])
+    s = build_power_situation("DE_LU", price, grid, None)
+    for comp in ("price", "grid"):
+        assert s[comp]["stale"] is False
+        assert s[comp]["age_days"] is None
+
+
 # ─── coverage: an unreliable renewable share must not flag Dunkelflaute ────────
 
 
@@ -239,9 +317,11 @@ def _seed_de_lu(db: Session) -> None:
         d = (_TODAY - timedelta(days=2 - i)).isoformat()
         db.add(PowerPriceDaily(date=d, zone="DE_LU", mean_price=50.0 + i, min_price=10.0, max_price=90.0, negative_hours=0))
         db.add(PowerGrid(date=d, zone="DE_LU", load_mw=50_000.0, wind_mw=8_000.0, solar_mw=4_000.0))
-    db.add(SparkSpreadHistory(
-        date=_TODAY.isoformat(), power_price=52.0, gas_price=30.0, heat_rate=2.0, spark_spread=-8.0,
-    ))
+    # The hero derives the spark live from the price series (same as /spark-spread)
+    for i in range(3):
+        d = (_TODAY - timedelta(days=2 - i)).isoformat()
+        db.add(EnergyPrice(date=d, symbol="POWER_DE", close=52.0))
+        db.add(EnergyPrice(date=d, symbol="TTF", close=30.0))
     db.commit()
 
 
@@ -259,18 +339,42 @@ def test_route_de_lu_available(db_session):
     assert "DE_LU" in body["zones"]
 
 
-def test_route_non_de_zone_spark_unsupported(db_session):
+def test_route_fr_spark_matches_the_panel(db_session):
+    """The hero and the /spark-spread panel must never disagree: the route computes
+    a live TTF-leg spark for EVERY zone, so the hero saying "DE-LU only" while the
+    panel below shows an FR spark was a contradiction. The hero now derives the
+    spark the same way the panel does."""
+    for i in range(3):
+        d = (_TODAY - timedelta(days=2 - i)).isoformat()
+        db_session.add(PowerPriceDaily(date=d, zone="FR", mean_price=40.0 + i, min_price=10.0, max_price=80.0, negative_hours=0))
+        db_session.add(PowerGrid(date=d, zone="FR", load_mw=45_000.0, wind_mw=5_000.0, solar_mw=3_000.0))
+        db_session.add(EnergyPrice(date=d, symbol="POWER_FR", close=100.0))
+        db_session.add(EnergyPrice(date=d, symbol="TTF", close=30.0))
+    db_session.commit()
+    client = _make_client(db_session)
+    body = client.get("/api/power/situation?zone=FR").json()
+    assert body["available"] is True
+    assert body["spark"]["supported"] is True
+    assert body["spark"]["available"] is True
+    # heat_rate = 1/0.50 → spark = 100 − 30·2 = 40
+    assert body["spark"]["spark_spread"] == pytest.approx(40.0)
+    assert body["spark"]["as_of"] == _TODAY.isoformat()
+
+    panel = client.get("/api/power/spark-spread?zone=FR&days=7").json()
+    assert panel["latest"]["spark_spread"] == pytest.approx(body["spark"]["spark_spread"])
+
+
+def test_route_fr_spark_without_prices_is_signposted_not_pretended(db_session):
     for i in range(3):
         d = (_TODAY - timedelta(days=2 - i)).isoformat()
         db_session.add(PowerPriceDaily(date=d, zone="FR", mean_price=40.0 + i, min_price=10.0, max_price=80.0, negative_hours=0))
         db_session.add(PowerGrid(date=d, zone="FR", load_mw=45_000.0, wind_mw=5_000.0, solar_mw=3_000.0))
     db_session.commit()
     client = _make_client(db_session)
-    resp = client.get("/api/power/situation?zone=FR")
-    body = resp.json()
-    assert body["available"] is True
-    assert body["zone"] == "FR"
-    assert body["spark"]["supported"] is False
+    body = client.get("/api/power/situation?zone=FR").json()
+    assert body["spark"]["supported"] is True
+    assert body["spark"]["available"] is False
+    assert body["spark"]["spark_spread"] is None
 
 
 def test_route_empty_unavailable(db_session):

--- a/frontend/src/components/AlertRulesPanel.jsx
+++ b/frontend/src/components/AlertRulesPanel.jsx
@@ -414,7 +414,9 @@ function RuleRow({ rule, templates, onToggle, onDelete, disabled }) {
           <div className="font-mono text-[9px] text-neutral-700 mt-1">
             last triggered {fmtAgo(rule.last_triggered_at)}
             {rule.cooldown_until && new Date(rule.cooldown_until) > new Date() && (
-              <> · cooldown until {new Date(rule.cooldown_until).toLocaleTimeString()}</>
+              <> · cooldown until {new Date(rule.cooldown_until).toLocaleTimeString('en-GB', {
+                hour: '2-digit', minute: '2-digit', timeZone: 'UTC',
+              })} UTC</>
             )}
           </div>
         )}

--- a/frontend/src/components/CrossBorderFlowPanel.jsx
+++ b/frontend/src/components/CrossBorderFlowPanel.jsx
@@ -148,6 +148,7 @@ export default function CrossBorderFlowPanel({ zone = 'DE_LU' }) {
   return (
     <Panel
       id="cross-border-flows"
+      freshness={data}
       title={`CROSS-BORDER FLOWS · ${zl}`}
       info={`Net physical electricity flows across ${zl}'s real interconnectors with its neighbours — sorted by magnitude. Daily mean MW — positive = net export in the shown direction. Green = net exporter, orange = net importer. Sparkline shows the selected window, signed. Source: Fraunhofer ISE Energy-Charts (CC BY 4.0).`}
       collapsible

--- a/frontend/src/components/FreshnessCaption.jsx
+++ b/frontend/src/components/FreshnessCaption.jsx
@@ -1,0 +1,32 @@
+/**
+ * Compact data-age chip for panel headers. Reads the `as_of`/`age_days`/`stale`
+ * triple every power detail endpoint now returns (thresholds mirror
+ * backend/collectors/freshness.py::SPECS via the route layer).
+ *
+ * A hung feed used to look identical to a healthy one — the panels only said
+ * "latest {date}". Fresh data renders as a quiet date stamp; a lagging series
+ * gets an amber STALE tag with its age. Dates are delivery dates in UTC.
+ */
+export default function FreshnessCaption({ meta }) {
+  if (!meta?.as_of) return null
+
+  if (meta.stale) {
+    return (
+      <span
+        className="font-mono text-[9px] tracking-wide text-orange-400 border border-orange-500/30 rounded px-1.5 py-0.5"
+        title={`Latest data ${meta.as_of} (UTC) — ${meta.age_days}d old, this feed may be stalled`}
+      >
+        STALE · {meta.age_days}d
+      </span>
+    )
+  }
+
+  return (
+    <span
+      className="font-mono text-[9px] text-neutral-600 hidden sm:inline"
+      title="Delivery date of the newest data point (UTC)"
+    >
+      {meta.as_of}
+    </span>
+  )
+}

--- a/frontend/src/components/GenerationMixPanel.jsx
+++ b/frontend/src/components/GenerationMixPanel.jsx
@@ -65,6 +65,7 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
   return (
     <Panel
       id="generation-mix"
+      freshness={data}
       title={`GENERATION MIX · ${zoneLabel}`}
       info="Full ENTSO-E A75 generation breakdown by production type (daily mean MW). Covers nuclear, coal, gas, hydro, biomass, wind, solar and more. Source: ENTSO-E Transparency Platform, processType A16."
       collapsible

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -39,6 +39,7 @@ export default function Header({ aisActive, gdeltActive, compactMode, onToggleCo
           </div>
           <div className="text-neutral-500 font-mono text-xs hidden md:block">
             // THE EUROPEAN ELECTRICITY DESK
+            <span className="text-neutral-700 ml-2" title="Every date and time on this desk is UTC — delivery dates, chart axes, data-age stamps.">· ALL TIMES UTC</span>
           </div>
         </div>
 

--- a/frontend/src/components/Panel.jsx
+++ b/frontend/src/components/Panel.jsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 
+import FreshnessCaption from './FreshnessCaption'
+
 export function InfoPopover({ text }) {
   const [open, setOpen] = useState(false)
   const ref = useRef(null)
@@ -31,7 +33,7 @@ export function InfoPopover({ text }) {
   )
 }
 
-export default function Panel({ id, title, info, collapsible = false, defaultCollapsed = false, headerRight, downloadUrl, children }) {
+export default function Panel({ id, title, info, collapsible = false, defaultCollapsed = false, headerRight, downloadUrl, freshness, children }) {
   const [collapsed, setCollapsed] = useState(() => {
     if (!collapsible) return false
     try {
@@ -64,6 +66,7 @@ export default function Panel({ id, title, info, collapsible = false, defaultCol
           {info && <InfoPopover text={info} />}
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          {freshness && <FreshnessCaption meta={freshness} />}
           {downloadUrl && (
             <a
               href={downloadUrl}

--- a/frontend/src/components/PowerDayAheadPanel.jsx
+++ b/frontend/src/components/PowerDayAheadPanel.jsx
@@ -25,6 +25,9 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
   // The 24h shape behind the daily mean (peak/off-peak). Latest day only, so it is
   // independent of the global range. The toggle just swaps which series is charted.
   const { data: hourlyData } = useFetchWithError(`${API}/power/day-ahead/hourly?zone=${zone}`, { deps: [zone] })
+  // The raw 96-point auction curve — SDAC trades 15-minute MTUs since 2025-10-01,
+  // so the hourly view is a smoothed picture of what the market actually cleared.
+  const { data: qhData } = useFetchWithError(`${API}/power/day-ahead/hourly?zone=${zone}&resolution=qh`, { deps: [zone] })
   const [view, setView] = useState('daily')
 
   if (error)
@@ -49,13 +52,15 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
   const zoneLabel = data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)
   const hourlyAvail = !!hourlyData?.available && Array.isArray(hourlyData?.data) && hourlyData.data.length > 0
   const hourly = hourlyAvail ? hourlyData.data : []
+  const qhAvail = !!qhData?.available && Array.isArray(qhData?.data) && qhData.data.length > 0
+  const qh = qhAvail ? qhData.data : []
 
   return (
     <Panel
       id="power-day-ahead"
       freshness={data}
       title={`POWER DAY-AHEAD · ${zoneLabel}`}
-      info="ENTSO-E day-ahead electricity prices for the selected bidding zone (EUR/MWh). Daily view = the mean of 24 hourly auction results (A44); red markers flag days with a negative-price hour (renewable oversupply). Toggle to HOURLY for the 24h peak/off-peak shape of the latest day. Free, official redistributable data."
+      info="ENTSO-E day-ahead electricity prices for the selected bidding zone (EUR/MWh). Daily view = the mean of the day's auction results (A44); red markers flag days with a negative-price hour (renewable oversupply). HOURLY shows the 24h peak/off-peak shape; 15-MIN shows the raw 96-point auction exactly as traded — SDAC has traded 15-minute products since 1 Oct 2025. Free, official redistributable data."
       collapsible
       downloadUrl={`${API}/v1/series?series=price.dayahead&zone=${zone}&start=${rangeStart(range)}&resolution=daily&format=csv`}
       headerRight={
@@ -98,10 +103,11 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
                 : ''}
             </PanelTakeaway>
           </div>
-          {/* Daily-mean ⇄ hourly-shape toggle (hourly = the 24h peak/off-peak curve). */}
+          {/* Daily mean ⇄ hourly shape ⇄ raw 15-min auction. The 15-MIN button only
+              appears once QH data exists (SDAC switch: 2025-10-01). */}
           {hourlyAvail && (
             <div className="flex items-center gap-1 px-4 pt-2">
-              {['daily', 'hourly'].map((v) => (
+              {['daily', 'hourly', ...(qhAvail ? ['qh'] : [])].map((v) => (
                 <button
                   key={v}
                   onClick={() => setView(v)}
@@ -111,16 +117,52 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
                       : 'text-neutral-500 border-border hover:text-neutral-300'
                   }`}
                 >
-                  {v === 'daily' ? 'DAILY MEAN' : 'HOURLY'}
+                  {v === 'daily' ? 'DAILY MEAN' : v === 'hourly' ? 'HOURLY' : '15-MIN'}
                 </button>
               ))}
               {view === 'hourly' && hourlyData?.date && (
                 <span className="font-mono text-[9px] text-neutral-600 ml-1">{hourlyData.date} · UTC</span>
               )}
+              {view === 'qh' && qhData?.date && (
+                <span className="font-mono text-[9px] text-neutral-600 ml-1">
+                  {qhData.date} · UTC · as traded (15-min MTU)
+                </span>
+              )}
             </div>
           )}
 
-          {view === 'hourly' && hourlyAvail ? (
+          {view === 'qh' && qhAvail ? (
+            <div className="px-2 py-2">
+              <ResponsiveContainer width="100%" height={120}>
+                <AreaChart data={qh} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <XAxis
+                    dataKey="time"
+                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    interval={7}
+                  />
+                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={30} />
+                  <Tooltip
+                    contentStyle={CHART_TOOLTIP_STYLE}
+                    formatter={(v) => [`${Number(v).toFixed(1)} €/MWh`, '15-min']}
+                    labelFormatter={(t) => `${t} UTC`}
+                  />
+                  {/* stepAfter: each auction price holds for its full 15-min slot —
+                      a smoothed spline would misrepresent discrete clearing prices */}
+                  <Area
+                    type="stepAfter"
+                    dataKey="price"
+                    stroke="#22d3ee"
+                    fill="#22d3ee"
+                    fillOpacity={0.06}
+                    strokeWidth={1}
+                    dot={false}
+                    activeDot={{ r: 3, fill: '#22d3ee' }}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          ) : view === 'hourly' && hourlyAvail ? (
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={120}>
                 <AreaChart data={hourly} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>

--- a/frontend/src/components/PowerDayAheadPanel.jsx
+++ b/frontend/src/components/PowerDayAheadPanel.jsx
@@ -53,6 +53,7 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
   return (
     <Panel
       id="power-day-ahead"
+      freshness={data}
       title={`POWER DAY-AHEAD · ${zoneLabel}`}
       info="ENTSO-E day-ahead electricity prices for the selected bidding zone (EUR/MWh). Daily view = the mean of 24 hourly auction results (A44); red markers flag days with a negative-price hour (renewable oversupply). Toggle to HOURLY for the 24h peak/off-peak shape of the latest day. Free, official redistributable data."
       collapsible

--- a/frontend/src/components/PowerGridPanel.jsx
+++ b/frontend/src/components/PowerGridPanel.jsx
@@ -56,6 +56,7 @@ export default function PowerGridPanel({ zone = 'DE_LU' }) {
   return (
     <Panel
       id="power-grid"
+      freshness={data}
       title={`RESIDUAL LOAD · ${zoneLabel}`}
       info="Residual load = total electricity demand − wind − solar (MW daily mean). This is the demand that dispatchable plants (gas, coal, nuclear, hydro) must cover. Dunkelflaute = day when renewable share < 15% of total load — a physical stress signal, not a price forecast."
       collapsible

--- a/frontend/src/components/PowerLoadForecastPanel.jsx
+++ b/frontend/src/components/PowerLoadForecastPanel.jsx
@@ -60,6 +60,7 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
   return (
     <Panel
       id="power-load-forecast"
+      freshness={data}
       title="LOAD FORECAST vs ACTUAL // ENTSO-E"
       info="ENTSO-E day-ahead forecasts (processType A01): total load (A65) and wind+solar (A69). The headline is tomorrow's RESIDUAL load = load − wind − solar — the demand dispatchable plants must cover, and the quantity that most drives the day-ahead price. DAILY view tracks the load forecast (violet) vs realised (cyan) — the gap is the forecast error. HOURLY view shows tomorrow's residual shape (evening ramp, midday solar trough, Dunkelflaute windows). Descriptive — higher residual tends to firm prices, but this is not a price call."
       collapsible

--- a/frontend/src/components/PowerSituationHeader.jsx
+++ b/frontend/src/components/PowerSituationHeader.jsx
@@ -22,10 +22,28 @@ const STATE_STYLE = {
   STRESSED: { text: 'text-red-400', dot: 'bg-red-400', border: 'border-red-500/30' },
 }
 
-function Metric({ label, value, sub, color, band }) {
+// Per-component age tag: each metric carries its own freshness so a fresh
+// day-ahead price can never make a days-old residual/renewables figure look
+// current (the backend flags each block separately).
+function StaleTag({ comp }) {
+  if (!comp?.stale) return null
+  return (
+    <span
+      className="font-mono text-[8px] tracking-wide text-orange-400 border border-orange-500/30 rounded px-1 py-px ml-1.5 align-middle"
+      title={`Latest data ${comp.as_of} — this series may be stalled`}
+    >
+      {comp.age_days}d old
+    </span>
+  )
+}
+
+function Metric({ label, value, sub, color, band, comp }) {
   return (
     <div className="min-w-0">
-      <div className="font-mono text-[9px] text-neutral-600 tracking-wider uppercase">{label}</div>
+      <div className="font-mono text-[9px] text-neutral-600 tracking-wider uppercase">
+        {label}
+        <StaleTag comp={comp} />
+      </div>
       <div className={`font-mono text-xl font-bold leading-tight truncate ${color || 'text-neutral-200'}`}>
         {value}
       </div>
@@ -89,12 +107,20 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
           <span className={`font-mono text-[11px] font-bold tracking-wider ${st.text}`}>{data.state}</span>
           <InfoPopover text={STATE_LEGEND} />
           {data.stale ? (
-            <span
-              className="font-mono text-[9px] tracking-wide text-orange-400 border border-orange-500/30 rounded px-1 py-0.5"
-              title={`Latest data ${data.as_of} — source may be stalled`}
-            >
-              STALE · {data.age_days}d
-            </span>
+            // Show the age of the OLDEST lagging component — top-level age_days
+            // tracks the newest date, which reads "0d" when only one series hangs.
+            (() => {
+              const worst = Math.max(
+                ...[price, grid, spark].filter((c) => c?.stale).map((c) => c.age_days ?? 0), 0)
+              return (
+                <span
+                  className="font-mono text-[9px] tracking-wide text-orange-400 border border-orange-500/30 rounded px-1 py-0.5"
+                  title="At least one series is lagging — see the metric tags below"
+                >
+                  STALE · {worst}d
+                </span>
+              )
+            })()
           ) : (
             data.as_of && <span className="font-mono text-[9px] text-neutral-600 hidden sm:inline">{data.as_of}</span>
           )}
@@ -127,6 +153,7 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
             value={price.close != null ? `€${price.close.toFixed(0)}` : '—'}
             sub="EUR/MWh"
             color={priceColor}
+            comp={price}
             band={price.z != null && <ReferenceBand z={price.z} baselineN={price.baseline_n} className="mt-1.5" />}
           />
           <Metric
@@ -134,16 +161,19 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
             value={grid.residual_gw != null ? `${grid.residual_gw.toFixed(0)} GW` : '—'}
             sub="load − wind − solar"
             color={residColor}
+            comp={grid}
             band={grid.z != null && <ReferenceBand z={grid.z} baselineN={grid.baseline_n} className="mt-1.5" />}
           />
           <Metric
             label="Spark spread"
             value={spark.spark_spread != null ? `${spark.spark_spread >= 0 ? '+' : ''}€${spark.spark_spread.toFixed(0)}` : '—'}
-            sub={spark.supported ? 'CCGT margin' : 'DE-LU only'}
+            sub={spark.available ? 'CCGT margin' : 'no data yet'}
             color={sparkColor}
+            comp={spark}
           />
           <Metric
             label="Renewables"
+            comp={grid}
             value={
               grid.renewable_share_reliable === false ? '—'
                 : grid.renewable_share != null ? `${(grid.renewable_share * 100).toFixed(0)}%` : '—'

--- a/frontend/src/components/PriceTicker.jsx
+++ b/frontend/src/components/PriceTicker.jsx
@@ -2,9 +2,11 @@ import { useState, useEffect } from 'react'
 
 // Refocus 2026-07-03 (electricity desk): the fuels that set the marginal power
 // price — TTF gas and NG. Oil/metals moved to the sibling project.
+// `unit` is mandatory context, not decoration: TTF quotes in EUR/MWh while
+// Henry-Hub NG quotes in USD/MMBtu — bare numbers side by side are unreadable.
 const TICKERS = [
-  { key: 'TTF', label: 'TTF', color: 'text-pink-400' },
-  { key: 'NG', label: 'NG', color: 'text-purple-400' },
+  { key: 'TTF', label: 'TTF', unit: '€/MWh', color: 'text-pink-400' },
+  { key: 'NG', label: 'NG', unit: '$/MMBtu', color: 'text-purple-400' },
 ]
 
 export default function PriceTicker() {
@@ -54,6 +56,7 @@ export default function PriceTicker() {
             <span className={`font-mono text-xs font-bold ${t.color}`}>
               {price != null ? price.toFixed(2) : '--'}
             </span>
+            <span className="font-mono text-[9px] text-neutral-600">{t.unit}</span>
             {pct != null && (
               <span className={`font-mono text-[10px] ${pct >= 0 ? 'text-green-glow' : 'text-red-400'}`}>
                 {pct >= 0 ? '+' : ''}{pct.toFixed(1)}%

--- a/frontend/src/components/SparkSpreadPanel.jsx
+++ b/frontend/src/components/SparkSpreadPanel.jsx
@@ -26,7 +26,15 @@ export default function SparkSpreadPanel({ zone = 'DE_LU' }) {
         <div className="font-mono text-[10px] text-red-400">SPARK SPREAD // FETCH ERROR</div>
       </div>
     )
-  if (authError || (!data?.available && !loading)) return null
+  // Never vanish silently: say why there is no chart instead of rendering nothing.
+  if (authError || (!data?.available && !loading))
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          SPARK SPREAD · {zoneLabel} — no overlapping power/TTF price days yet.
+        </div>
+      </div>
+    )
 
   const rows = data?.data ?? []
   const latest = data?.latest
@@ -36,6 +44,7 @@ export default function SparkSpreadPanel({ zone = 'DE_LU' }) {
   return (
     <Panel
       id="spark-spread"
+      freshness={data}
       title={`SPARK SPREAD · ${zoneLabel} · CCGT MARGIN`}
       info="Spark spread = power − gas × heat-rate (CCGT generation margin). Measures the theoretical profitability of gas-fired power generation. Positive = burning gas to generate electricity is profitable. Gas leg = TTF (the European benchmark hub) for every zone. Clean spark (− CO₂ cost) coming once EUA data is wired."
       collapsible

--- a/frontend/src/utils/chart.js
+++ b/frontend/src/utils/chart.js
@@ -1,7 +1,12 @@
 // Shared chart helpers for the EU gas panels.
 
+// Delivery-date labels are UTC dates. Without an explicit timeZone the browser
+// renders UTC midnight in local time, which shifts every label a day backwards
+// for viewers west of UTC.
 export function fmtDate(d) {
-  return new Date(d + 'T00:00:00Z').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return new Date(d + 'T00:00:00Z').toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', timeZone: 'UTC',
+  })
 }
 
 export const CHART_TOOLTIP_STYLE = { background: '#0f1115', border: '1px solid #262a33', fontFamily: 'inherit', fontSize: 12, borderRadius: 8 }


### PR DESCRIPTION
Erste zwei Blöcke der genehmigten „gridstatus-Lücke"-Roadmap (Plan: wir-brauchen-f-r-obsyd-enumerated-otter).

## Block 1 — Eindeutigkeit (f9c04e5)

Jede sichtbare Zahl trägt jetzt Alter, Einheit und eine ehrliche Verfügbarkeits-Story:

- **Per-Komponenten-Staleness**: `as_of = max(price, grid)` ließ eine frische Preis-Serie tagealte Residuallast/Renewables als aktuell erscheinen (exakt der Zustand nach dem 07-07-Ausfall). Jede Komponente (price/grid/spark) trägt eigene `as_of`/`age_days`/`stale`; Top-Level ist worst-of; die Headline markiert nachhängende Segmente; das Badge zeigt das Alter der ältesten hängenden Komponente statt „0d".
- **Spark-Widerspruch behoben**: Der Hero behauptete „DE-LU only", während das Panel darunter einen echten FR/NL-Spark zeigte (Prod: FR 22,36). Der Hero rechnet jetzt live wie das Panel (`_latest_spark`), per Test aneinander gepinnt.
- **FreshnessCaption** auf allen 6 Detail-Panels; Schwellen per Test an `freshness.py::SPECS` gekoppelt — UI und /api/health können nicht divergieren.
- **UTC-Fix**: `fmtDate` verschob für Betrachter westlich von UTC jedes Achsen-Label um einen Tag. Header sagt einmal „ALL TIMES UTC".
- **Ticker-Einheiten** (TTF €/MWh vs. NG $/MMBtu) und **dormant Maritim-Alert-Templates** aus dem Builder gefiltert (Evaluatoren bleiben — Bestandsregeln laufen weiter).

## Block 2 — 15-Minuten-Markt (1091e11)

SDAC handelt seit 1.10.2025 in 15-min-MTUs; die Parser mittelten PT15M weg. Neu:

- `price.dayahead.qh` (rohe 96-Punkte-Auktion) + `imbalance.price.qh` (rohe Settlement-Perioden — dort verschwanden ±1000-€-Viertelstunden im Stundenmittel).
- PT60M wird **nie** auf QH-Slots dupliziert; vor dem Switch existieren die Serien schlicht nicht.
- `/api/power/day-ahead/hourly?resolution=qh` + 15-MIN-Toggle (stepAfter — Auktionspreise gelten für ihren ganzen Slot).
- Alt-Serien byte-identisch; Backfill = lokales Re-Parsen aus dem Raw-Cache, **null ENTSO-E-Calls**:
  `python -m backend.scripts.power_backfill --sources price,imbalance --start 2025-10-01`

## Tests

644 passed, 1 skipped (37 neue, alle TDD: erst rot gesehen). Frontend-Build grün, Ruff sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)