### PR TITLE
Deduplicate day-ahead stats before counting negative hours

### DIFF
--- a/backend/power/entsoe_prices.py
+++ b/backend/power/entsoe_prices.py
@@ -140,14 +140,23 @@ def parse_day_ahead_stats(xml_text: str) -> dict[str, dict]:
     for day, pairs in by_day.items():
         if not pairs:
             continue
-        pairs.sort(key=lambda x: x[0])  # order by time so the hourly series is ascending
-        prices = [p for _, p, _ in pairs]
-        # Collapse to ONE mean price per hour: ENTSO-E can return several
-        # overlapping TimeSeries and/or sub-hourly (PT15M) slots for the same day,
-        # so a raw per-point list would show multiple values per hour. Averaging
-        # per hour normalises both into a clean 0-23 curve.
+        # ENTSO-E returns overlapping TimeSeries for the same delivery day
+        # (contract revisions) and can mix resolutions. Stats computed over the
+        # raw point list double-count: prod 2026-07-07 reported 7.0 negative
+        # hours where the deduplicated auction had 4.5. So first the finest
+        # resolution wins the day, then duplicates are averaged per slot, and
+        # every stat is computed over those deduplicated slots.
+        finest = min(res for _, _, res in pairs)
+        slot_acc: dict[datetime, list[float]] = {}
+        for t, p, res in pairs:
+            if res == finest:
+                slot_acc.setdefault(t, []).append(p)
+        slots = sorted((t, sum(ps) / len(ps)) for t, ps in slot_acc.items())
+        prices = [p for _, p in slots]
+
+        # Collapse to ONE mean price per hour for the legacy 0-23 curve.
         hour_acc: dict[int, list[float]] = {}
-        for t, p, _ in pairs:
+        for t, p in slots:
             hour_acc.setdefault(t.astimezone(timezone.utc).hour, []).append(p)
         hourly = [
             {"hour": h, "price": round(sum(ps) / len(ps), 2)}
@@ -159,7 +168,7 @@ def parse_day_ahead_stats(xml_text: str) -> dict[str, dict]:
             "max": max(prices),
             # True hours: weight each negative slot by its resolution so PT15M
             # (96 slots/day) yields real hours (0.25 each), not raw interval counts.
-            "negative_hours": round(sum(res for _, p, res in pairs if p < 0), 2),
+            "negative_hours": round(sum(finest for _, p in slots if p < 0), 2),
             "hourly": hourly,
         }
     return result

--- a/backend/tests/test_negative_prices.py
+++ b/backend/tests/test_negative_prices.py
@@ -274,3 +274,35 @@ def test_route_latest_has_negative_hours(db_session):
     body = client.get("/api/power/day-ahead?days=120").json()
     assert body["latest"]["negative_hours"] == 5
     assert body["latest"]["negative"] is True
+
+
+def test_stats_negative_hours_not_double_counted_across_overlapping_series():
+    """ENTSO-E returns overlapping TimeSeries for the same delivery day (contract
+    revisions). Counting negative slots across ALL points double-counts them:
+    prod 2026-07-07 reported 7.0 negative hours where the deduplicated auction
+    had 4.5. Slots must be deduplicated per timestamp before counting."""
+    from backend.tests.test_power_prices import _a44, _ts
+
+    prices = [-5.0] * 4 + [50.0] * 92  # one negative hour in QH slots
+    xml = _a44(
+        _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", prices, res="PT15M")
+        + _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", prices, res="PT15M")
+    )
+    from backend.power.entsoe_prices import parse_day_ahead_stats
+
+    day = parse_day_ahead_stats(xml)["2026-05-01"]
+    assert day["negative_hours"] == 1.0, f"double-counted: {day['negative_hours']}"
+
+
+def test_stats_mean_unaffected_by_duplicate_series():
+    from backend.tests.test_power_prices import _a44, _ts
+    from backend.power.entsoe_prices import parse_day_ahead_stats
+
+    xml = _a44(
+        _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [100.0] * 24)
+        + _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [110.0] * 24)
+    )
+    day = parse_day_ahead_stats(xml)["2026-05-01"]
+    assert day["mean"] == 105.0
+    assert day["min"] == 105.0  # min of per-slot means, not of raw duplicate points
+    assert day["max"] == 105.0


### PR DESCRIPTION
Found while verifying the new QH series against prod: for delivery day
2026-07-07 the deduplicated 15-min auction has 18 negative slots (4.5 h), but
PowerPriceDaily said negative_hours = 7.0. The raw XML holds only PT15M — the
overcount comes from ENTSO-E's overlapping TimeSeries (contract revisions) for
the same day. parse_day_ahead_stats computed negative_hours (and min/max) over
the raw point list, so every duplicated negative slot counted twice; the
negative-price headline number has been overstated whenever ENTSO-E delivered
duplicates. The new parse_day_ahead_quarter_hourly deduplicates per timestamp,
which is how the discrepancy surfaced.

parse_day_ahead_stats now (1) lets the finest resolution win the day — an
hourly duplicate series must not dilute the real 15-min auction — and
(2) averages duplicates per slot before computing mean/min/max/negative_hours
and the hourly curve. Two tests pin it: duplicated series must not double the
negative-hours count, and min/max are over per-slot means, not raw duplicate
points.

Historical PowerPriceDaily rows keep the overstated values until re-ingested;
the raw cache makes that a local re-parse (--sources price).

646 passed, 1 skipped.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
