### PR TITLE
Datentiefe-Roadmap Blöcke 3+4: reBAP, A71, Hydro, Outages, Auto-Refresh, Records, Forecast-Fehler

### DIFF
--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -278,6 +278,22 @@ async def _run_capacity_monthly():
         db.close()
 
 
+async def _run_outages():
+    """Refresh the rolling generation-unavailability window (ENTSO-E A77) for all
+    enabled zones. Every 6 h: forced outages land intraday, and the desk's whole
+    point is showing them before the price does."""
+    from backend.power.entsoe_outages import ingest_outages
+
+    db = SessionLocal()
+    try:
+        result = await ingest_outages(db)
+        logger.info("outages: %s", result)
+    except Exception as exc:
+        logger.error("_run_outages failed: %s", exc)
+    finally:
+        db.close()
+
+
 async def _run_hydro_weekly():
     """Refresh weekly reservoir filling (ENTSO-E A72) for the hydro zones.
     Current year with overwrite=True — the raw cache is write-once and would
@@ -323,6 +339,9 @@ def start_scheduler():
     # varies by TSO) — Mon+Thu 06:30 UTC. Current year with overwrite, else the
     # write-once cache would freeze January's frontier.
     scheduler.add_job(_run_hydro_weekly, CronTrigger(day_of_week="mon,thu", hour=6, minute=30), id="hydro_weekly", **JOB_DEFAULTS)
+    # Generation unavailability (A77): rolling window, every 6 h — forced outages
+    # land intraday and are the desk's reason to exist.
+    scheduler.add_job(_run_outages, CronTrigger(hour="1,7,13,19", minute=15), id="outages_6h", **JOB_DEFAULTS)
 
     # Energy prices (TTF for the spark spread, + power ticker): daily 22:15 UTC.
     scheduler.add_job(collect_energy_prices, CronTrigger(hour=22, minute=15), id="energy_prices_daily", **JOB_DEFAULTS)

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -278,6 +278,24 @@ async def _run_capacity_monthly():
         db.close()
 
 
+async def _run_hydro_weekly():
+    """Refresh weekly reservoir filling (ENTSO-E A72) for the hydro zones.
+    Current year with overwrite=True — the raw cache is write-once and would
+    otherwise freeze the year at its first fetch."""
+    from datetime import datetime, timezone
+
+    from backend.power.entsoe_hydro import ingest_hydro
+
+    db = SessionLocal()
+    try:
+        result = await ingest_hydro(db, years=[datetime.now(timezone.utc).year], overwrite=True)
+        logger.info("hydro weekly: %s", result)
+    except Exception as exc:
+        logger.error("_run_hydro_weekly failed: %s", exc)
+    finally:
+        db.close()
+
+
 def scheduler_role_enabled(role: str) -> bool:
     """True if this process role should run the scheduler / be a DB writer.
 
@@ -301,6 +319,10 @@ def start_scheduler():
     scheduler.add_job(_run_power_prices_midday, CronTrigger(hour=12, minute=0), id="power_prices_midday", **JOB_DEFAULTS)
     # Installed capacity (A68): monthly, 2nd @ 03:00 UTC — annual data, cheap to refresh.
     scheduler.add_job(_run_capacity_monthly, CronTrigger(day=2, hour=3, minute=0), id="capacity_monthly", **JOB_DEFAULTS)
+    # Reservoir filling (A72): weekly data, refreshed twice a week (publication day
+    # varies by TSO) — Mon+Thu 06:30 UTC. Current year with overwrite, else the
+    # write-once cache would freeze January's frontier.
+    scheduler.add_job(_run_hydro_weekly, CronTrigger(day_of_week="mon,thu", hour=6, minute=30), id="hydro_weekly", **JOB_DEFAULTS)
 
     # Energy prices (TTF for the spark spread, + power ticker): daily 22:15 UTC.
     scheduler.add_job(collect_energy_prices, CronTrigger(hour=22, minute=15), id="energy_prices_daily", **JOB_DEFAULTS)

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -278,6 +278,22 @@ async def _run_capacity_monthly():
         db.close()
 
 
+async def _run_records_nightly():
+    """Recompute all-time records per series × zone (SQL min/max over
+    power_hourly). Runs after the nightly power ingest so a record day is
+    crowned the same night it happens."""
+    from backend.power.records import compute_records
+
+    db = SessionLocal()
+    try:
+        records = compute_records(db)
+        logger.info("records nightly: %d rows refreshed", len(records))
+    except Exception as exc:
+        logger.error("_run_records_nightly failed: %s", exc)
+    finally:
+        db.close()
+
+
 async def _run_outages():
     """Refresh the rolling generation-unavailability window (ENTSO-E A77) for all
     enabled zones. Every 6 h: forced outages land intraday, and the desk's whole
@@ -342,6 +358,8 @@ def start_scheduler():
     # Generation unavailability (A77): rolling window, every 6 h — forced outages
     # land intraday and are the desk's reason to exist.
     scheduler.add_job(_run_outages, CronTrigger(hour="1,7,13,19", minute=15), id="outages_6h", **JOB_DEFAULTS)
+    # All-time records: nightly at 23:45, after the 22:30 power ingest.
+    scheduler.add_job(_run_records_nightly, CronTrigger(hour=23, minute=45), id="records_nightly", **JOB_DEFAULTS)
 
     # Energy prices (TTF for the spark spread, + power ticker): daily 22:15 UTC.
     scheduler.add_job(collect_energy_prices, CronTrigger(hour=22, minute=15), id="energy_prices_daily", **JOB_DEFAULTS)

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -156,6 +156,14 @@ async def _run_power_daily():
                 logger.error("power daily ingest_load_forecast [%s] failed: %s", zone_key, exc)
 
             try:
+                from backend.power.entsoe_grid import ingest_generation_forecast
+
+                result = await ingest_generation_forecast(db, days, eic=zone_cfg["eic"], zone=zone_key, overwrite=True)
+                logger.info("power daily generation-forecast ingest [%s]: %s", zone_key, result)
+            except Exception as exc:
+                logger.error("power daily ingest_generation_forecast [%s] failed: %s", zone_key, exc)
+
+            try:
                 from backend.power.entsoe_imbalance import ingest_imbalance
 
                 result = await ingest_imbalance(db, days, zone=zone_key, overwrite=True)

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -259,3 +259,42 @@ class InstalledCapacity(Base):
     __table_args__ = (
         UniqueConstraint("zone", "year", "psr_type", name="uq_installed_capacity_zone_year_psr"),
     )
+
+
+class PowerOutage(Base):
+    """ENTSO-E unavailability of generation/production units (A77/A78/A80).
+
+    An EVENT, not a time series: one row per (mRID, revision) of an
+    Unavailability_MarketDocument. Revision semantics are the core — messages
+    are updated and withdrawn (docStatus A09); of 31 live DE_LU documents
+    sampled 2026-07-11, 26 were withdrawn. The read side must always take the
+    HIGHEST revision per mRID and hide withdrawn events; ingest keeps every
+    revision as history.
+
+    available_mw is the MINIMUM quantity over the Available_Period step
+    function (curveType A03) — the worst case, which is what the desk
+    headline should count. offline = nominal_mw − available_mw.
+    """
+
+    __tablename__ = "power_outage"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    mrid: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    revision: Mapped[int] = mapped_column(Integer, nullable=False)
+    doc_type: Mapped[str] = mapped_column(String, nullable=False, default="A77")  # A77/A78/A80
+    zone: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    business_type: Mapped[str] = mapped_column(String, nullable=False)  # A53 planned / A54 forced
+    psr_type: Mapped[Optional[str]] = mapped_column(String, nullable=True)   # raw B-code
+    unit_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    unit_eic: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    location: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    nominal_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    available_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    start_utc: Mapped[str] = mapped_column(String, nullable=False, index=True)  # ISO "YYYY-MM-DDTHH:MMZ"
+    end_utc: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="active")  # active | withdrawn
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("mrid", "revision", name="uq_power_outage_mrid_revision"),
+    )

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -298,3 +298,25 @@ class PowerOutage(Base):
     __table_args__ = (
         UniqueConstraint("mrid", "revision", name="uq_power_outage_mrid_revision"),
     )
+
+
+class PowerRecord(Base):
+    """All-time extreme per (series, zone, kind) — descriptive records like
+    "highest DE-LU day-ahead hour". Recomputed nightly by SQL min/max over
+    power_hourly (always correct, no incremental state); one row per key,
+    updated in place. ts_utc points at the evidence."""
+
+    __tablename__ = "power_record"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    series_key: Mapped[str] = mapped_column(String, nullable=False)
+    zone: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    kind: Mapped[str] = mapped_column(String, nullable=False)  # max | min
+    value: Mapped[float] = mapped_column(Float, nullable=False)
+    ts_utc: Mapped[int] = mapped_column(Integer, nullable=False)  # epoch sec of the record point
+    unit: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("series_key", "zone", "kind", name="uq_power_record_series_zone_kind"),
+    )

--- a/backend/power/entsoe_grid.py
+++ b/backend/power/entsoe_grid.py
@@ -497,6 +497,52 @@ async def ingest_load_forecast(
     return {"days": len(load_by_day), "written": written}
 
 
+async def ingest_generation_forecast(
+    db: Session,
+    days: list[str],
+    *,
+    eic: str = DE_LU_EIC,
+    zone: str = "DE_LU",
+    overwrite: bool = False,
+) -> dict:
+    """Fetch the ENTSO-E day-ahead TOTAL generation forecast (A71, processType A01)
+    and upsert it as the hourly series `generation.forecast`.
+
+    A71 shares the GL_MarketDocument shape with A65 (quantity points, no psrType),
+    so the load parsers do the work; only the document type, the domain param
+    (in_Domain, like A69) and the cache source differ. Complements load/wind/solar
+    forecast for the forecast-vs-actual view.
+    """
+    if not days:
+        return {"days": 0, "written": 0}
+    if not settings.entsoe_api_token:
+        logger.warning("entsoe_grid.ingest_generation_forecast: ENTSOE_API_TOKEN not set — skipping")
+        return {"skipped": "no token"}
+
+    wanted = set(days)
+    months = sorted({datetime.strptime(d, "%Y-%m-%d").date().replace(day=1) for d in days})
+
+    by_day: dict[str, dict[int, float]] = {}
+    for month_start in months:
+        try:
+            xml = await _fetch_zone_month(
+                eic, month_start, "A71",
+                {"processType": "A01", "in_Domain": eic},
+                overwrite=overwrite, cache_source="entsoe_gen_total_forecast",
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("entsoe_grid: A71/A01 %s fetch failed: %s", month_start, exc)
+            continue
+        if not xml:
+            continue
+        for day, hours in parse_load_hourly(xml).items():
+            if day in wanted:
+                by_day[day] = hours
+
+    written = upsert_day_hours(db, "generation.forecast", zone, by_day, unit="MW") if by_day else 0
+    return {"days": len(by_day), "written": written}
+
+
 async def ingest_grid(
     db: Session,
     days: list[str],

--- a/backend/power/entsoe_hydro.py
+++ b/backend/power/entsoe_hydro.py
@@ -1,0 +1,144 @@
+"""ENTSO-E A72: weekly reservoir filling → series `hydro.reservoir` (MWh).
+
+Spiked live 2026-07-11 (NO2): GL_MarketDocument, resolution P7D, unit MWh, one
+point per week — southern Norway alone holds ~21 TWh, which is why Nordic and
+Alpine reservoir levels move power prices continent-wide.
+
+"A72 light": this collector has its OWN zone list (HYDRO_ZONES) independent of
+ENABLED_ZONES — the trader question is "how full are the reservoirs vs normal",
+which needs no full price/load ingest for those zones. Data is tiny (52
+points/zone/year), so the deep backfill is trivial.
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from datetime import date, timedelta, timezone
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.gas import raw_cache
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
+from backend.power.hourly_store import upsert_hourly
+from backend.power.zones import ZONE_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+#: The reservoir geography — Nordics, Alps, Iberia, France. Deliberately NOT
+#: tied to ENABLED_ZONES; see module docstring.
+HYDRO_ZONES: list[str] = [
+    "NO1", "NO2", "NO3", "NO4", "NO5",
+    "SE1", "SE2", "SE3", "SE4",
+    "FI", "CH", "AT", "ES", "PT", "FR",
+]
+
+_WEEK = timedelta(days=7)
+
+
+def parse_reservoir_filling(xml_text: str) -> list[tuple[int, float]]:
+    """Parse an A72 GL_MarketDocument into [(epoch_sec_week_start, stored_mwh)].
+
+    Only P7D periods contribute — that is the reservoir product's native
+    cadence; anything else is a different document. Acknowledgements (no
+    TimeSeries) yield []. Overlapping series average per timestamp.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A72 XML parse error: {exc}") from exc
+
+    by_ts: dict[int, list[float]] = {}
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            start_el = next((e for e in period.iter() if _localname(e.tag) == "start"), None)
+            res_el = next((e for e in period.iter() if _localname(e.tag) == "resolution"), None)
+            if start_el is None or res_el is None:
+                continue
+            if (res_el.text or "").strip() != "P7D":
+                continue
+            start = _parse_utc(start_el.text)
+            if start is None:
+                continue
+            for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+                pos = next((e.text for e in point if _localname(e.tag) == "position"), None)
+                qty = next((e.text for e in point if _localname(e.tag) == "quantity"), None)
+                if pos is None or qty is None:
+                    continue
+                try:
+                    week_start = start + _WEEK * (int(pos) - 1)
+                    mwh = float(qty)
+                except (ValueError, TypeError):
+                    continue
+                epoch = int(week_start.astimezone(timezone.utc).timestamp())
+                by_ts.setdefault(epoch, []).append(mwh)
+
+    return [(t, sum(vs) / len(vs)) for t, vs in sorted(by_ts.items())]
+
+
+async def _fetch_zone_year(eic: str, year: int, *, overwrite: bool = False) -> str:
+    """One zone's A72 for a calendar year (52 points — a year per request keeps
+    the call count trivial). Cached year-keyed; the CURRENT year must be fetched
+    with overwrite=True or the write-once cache would freeze January's frontier."""
+    start = date(year, 1, 1)
+
+    async def _do() -> dict:
+        params = {
+            "securityToken": _token(),
+            "documentType": "A72",
+            "processType": "A16",
+            "in_Domain": eic,
+            "periodStart": f"{year}01010000",
+            "periodEnd": f"{year + 1}01010000",
+        }
+        async with httpx.AsyncClient(timeout=90) as client:
+            resp = await client.get(ENTSOE_BASE, params=params)
+            resp.raise_for_status()
+            return {"xml": resp.text}
+
+    payload = await raw_cache.fetch_or_cache(
+        "entsoe_hydro", f"{eic}_{year}", start, _do, overwrite=overwrite
+    )
+    return payload.get("xml", "")
+
+
+async def ingest_hydro(
+    db: Session,
+    *,
+    years: list[int],
+    zones: list[str] | None = None,
+    overwrite: bool = False,
+) -> dict:
+    """Fetch + upsert weekly reservoir filling for the hydro zones."""
+    if not settings.entsoe_api_token:
+        logger.warning("entsoe_hydro.ingest_hydro: ENTSOE_API_TOKEN not set — skipping")
+        return {"skipped": "no token"}
+
+    zones = zones if zones is not None else HYDRO_ZONES
+    written = 0
+    for zone in zones:
+        eic = ZONE_REGISTRY.get(zone, {}).get("eic")
+        if not eic:
+            logger.warning("entsoe_hydro: zone %s not in registry — skipping", zone)
+            continue
+        points: list[tuple[int, float]] = []
+        for year in years:
+            try:
+                xml = await _fetch_zone_year(eic, year, overwrite=overwrite)
+            except httpx.HTTPError as exc:
+                logger.warning("entsoe_hydro: %s %s fetch failed: %s", zone, year, exc)
+                continue
+            if not xml:
+                continue
+            try:
+                points.extend(parse_reservoir_filling(xml))
+            except ValueError as exc:
+                logger.warning("entsoe_hydro: %s %s parse failed: %s", zone, year, exc)
+        if points:
+            written += upsert_hourly(db, "hydro.reservoir", zone, points, unit="MWh")
+
+    return {"written": written, "zones": len(zones), "years": years}

--- a/backend/power/entsoe_imbalance.py
+++ b/backend/power/entsoe_imbalance.py
@@ -2,9 +2,9 @@
 
 A85 is delivered as a ZIP archive (one inner XML per request) and is keyed by CONTROL
 AREA, not bidding zone. For single-TSO countries the bidding-zone EIC works as the
-control-area domain; Germany (DE_LU) has four control areas with a combined reBAP that
-ENTSO-E does not expose under a single A85 control-area EIC, so DE_LU is skipped
-(documented). Prices are per 15-min settlement period → averaged to hourly-canonical UTC.
+control-area domain; Germany (DE_LU) has four control areas with one uniform reBAP,
+published under the COUNTRY EIC (see _CONTROL_AREA_OVERRIDE). Prices are per 15-min
+settlement period → averaged to hourly-canonical UTC, plus raw as imbalance.price.qh.
 """
 from __future__ import annotations
 
@@ -27,15 +27,17 @@ logger = logging.getLogger(__name__)
 
 _RESOLUTION_HOURS = {"PT60M": 1.0, "PT30M": 0.5, "PT15M": 0.25}
 
-# Zones whose imbalance is not fetchable via a single control-area EIC.
-# DE_LU = four German control areas, combined reBAP not exposed under one A85 EIC.
-_CONTROL_AREA_SKIP = {"DE_LU"}
+# Zones whose A85 domain differs from their bidding-zone EIC. Germany has four
+# control areas with one uniform reBAP; spiked 2026-07-11 against the live API:
+# the CA EICs and the DE_LU bidding-zone EIC all return Acknowledgement 999,
+# but the COUNTRY EIC serves the full 96-slot reBAP.
+_CONTROL_AREA_OVERRIDE = {"DE_LU": "10Y1001A1001A83F"}
 
 
 def control_area_eic(zone: str) -> str | None:
     """Control-area domain EIC for A85 (single-TSO zones = the bidding EIC)."""
-    if zone in _CONTROL_AREA_SKIP:
-        return None
+    if zone in _CONTROL_AREA_OVERRIDE:
+        return _CONTROL_AREA_OVERRIDE[zone]
     return ZONE_REGISTRY.get(zone, {}).get("eic")
 
 
@@ -167,7 +169,7 @@ async def ingest_imbalance(
         return {"days": 0, "written": 0}
     ca_eic = control_area_eic(zone)
     if ca_eic is None:
-        return {"skipped": "no control area (DE has 4)"}
+        return {"skipped": f"no A85 domain for zone {zone}"}
     if not settings.entsoe_api_token:
         return {"skipped": "no token"}
 

--- a/backend/power/entsoe_outages.py
+++ b/backend/power/entsoe_outages.py
@@ -1,0 +1,193 @@
+"""ENTSO-E A77 generation unavailability → PowerOutage events.
+
+Spiked live 2026-07-11 (DE_LU): the API returns a ZIP with one
+Unavailability_MarketDocument per outage MESSAGE — and revision semantics are
+the whole game. Of 31 documents in a 2-day window, 26 carried docStatus A09
+(withdrawn); a naive reader would put 26 ghost outages on the desk. Ingest
+stores every (mRID, revision) as history; the read side takes the highest
+revision per mRID and hides withdrawn events.
+
+Deliberately NO raw-disk cache: outage messages mutate (revisions), the
+payloads are small (tens of KB per zone-window), and a write-once cache would
+either serve stale revisions or need its own retention machinery — the
+2026-07-07 disk incident says keep transient payloads off the disk. The DB
+row per (mrid, revision) IS the idempotency layer.
+
+Pagination: ENTSO-E caps unavailability responses at 200 documents; further
+pages via offset=200, 400, … We page until a page returns fewer than 200.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import xml.etree.ElementTree as ET
+import zipfile
+from datetime import datetime, timedelta, timezone
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _token
+from backend.models.energy import PowerOutage
+from backend.power.zones import POWER_ZONES
+
+logger = logging.getLogger(__name__)
+
+_PAGE_SIZE = 200
+
+#: docStatus values that mean "this message no longer stands".
+_WITHDRAWN_STATUSES = {"A09", "A13"}  # cancelled / withdrawn
+
+
+def _text(root: ET.Element, localname: str) -> str | None:
+    """First element text matching a local tag name, namespace-agnostic."""
+    for e in root.iter():
+        if _localname(e.tag) == localname:
+            return (e.text or "").strip() or None
+    return None
+
+
+def parse_unavailability(xml_text: str) -> dict | None:
+    """One Unavailability_MarketDocument → one event dict, or None for
+    acknowledgements/unparseable documents (fail-soft: a single bad inner
+    document must not sink the whole ZIP)."""
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return None
+    if _localname(root.tag) != "Unavailability_MarketDocument":
+        return None
+
+    mrid = _text(root, "mRID")
+    revision = _text(root, "revisionNumber")
+    if not mrid or revision is None:
+        return None
+
+    # Top-level unavailability window
+    interval = next((e for e in root.iter()
+                     if _localname(e.tag) == "unavailability_Time_Period.timeInterval"), None)
+    start = _text(interval, "start") if interval is not None else None
+    end = _text(interval, "end") if interval is not None else None
+    if not start or not end:
+        return None
+
+    # docStatus nests its code in <value>; absent docStatus means the message stands.
+    status_val = None
+    for e in root.iter():
+        if _localname(e.tag) == "docStatus":
+            status_val = _text(e, "value")
+            break
+
+    # Point quantities: the Available_Period is a step function; the desk
+    # headline counts the worst case, so take the minimum available MW.
+    quantities: list[float] = []
+    for e in root.iter():
+        if _localname(e.tag) == "quantity":
+            try:
+                quantities.append(float(e.text))
+            except (TypeError, ValueError):
+                continue
+    nominal = _text(root, "production_RegisteredResource.pSRType.powerSystemResources.nominalP")
+
+    return {
+        "mrid": mrid,
+        "revision": int(revision),
+        "business_type": _text(root, "businessType") or "A53",
+        "psr_type": _text(root, "production_RegisteredResource.pSRType.psrType"),
+        "unit_name": _text(root, "production_RegisteredResource.name"),
+        "unit_eic": _text(root, "production_RegisteredResource.mRID"),
+        "location": _text(root, "production_RegisteredResource.location.name"),
+        "nominal_mw": float(nominal) if nominal else None,
+        "available_mw": min(quantities) if quantities else None,
+        "start_utc": start,
+        "end_utc": end,
+        "status": "withdrawn" if status_val in _WITHDRAWN_STATUSES else "active",
+    }
+
+
+async def _fetch_outages_page(
+    eic: str, window_start: str, window_end: str, offset: int, *, doc_type: str = "A77"
+) -> bytes | None:
+    """One page of the unavailability ZIP (raw bytes), or None on empty/no data."""
+    params = {
+        "securityToken": _token(),
+        "documentType": doc_type,
+        "biddingZone_Domain": eic,
+        "periodStart": window_start,
+        "periodEnd": window_end,
+    }
+    if offset:
+        params["offset"] = str(offset)
+    async with httpx.AsyncClient(timeout=120) as client:
+        resp = await client.get(ENTSOE_BASE, params=params)
+        if resp.status_code == 400:  # past the last page / no data
+            return None
+        resp.raise_for_status()
+        return resp.content if resp.content[:2] == b"PK" else None
+
+
+async def ingest_outages(
+    db: Session,
+    *,
+    zones: list[str] | None = None,
+    doc_type: str = "A77",
+    lookahead_days: int = 365,
+    lookback_days: int = 7,
+) -> dict:
+    """Fetch the rolling outage window for `zones` and store new (mrid, revision)
+    rows. No deep backfill by design — active + upcoming messages are the
+    product; history accumulates from running daily."""
+    if not settings.entsoe_api_token:
+        logger.warning("entsoe_outages: ENTSOE_API_TOKEN not set — skipping")
+        return {"skipped": "no token"}
+
+    zones = zones if zones is not None else list(POWER_ZONES)
+    now = datetime.now(timezone.utc)
+    window_start = (now - timedelta(days=lookback_days)).strftime("%Y%m%d0000")
+    window_end = (now + timedelta(days=lookahead_days)).strftime("%Y%m%d0000")
+
+    written = 0
+    seen_docs = 0
+    for zone in zones:
+        eic = POWER_ZONES.get(zone, {}).get("eic")
+        if not eic:
+            continue
+        offset = 0
+        while True:
+            try:
+                blob = await _fetch_outages_page(eic, window_start, window_end, offset, doc_type=doc_type)
+            except httpx.HTTPError as exc:
+                logger.warning("entsoe_outages [%s offset=%d]: fetch failed: %s", zone, offset, exc)
+                break
+            if not blob:
+                break
+            try:
+                zf = zipfile.ZipFile(io.BytesIO(blob))
+                names = [n for n in zf.namelist() if n.endswith(".xml")]
+            except zipfile.BadZipFile:
+                logger.warning("entsoe_outages [%s]: bad zip at offset %d", zone, offset)
+                break
+
+            for name in names:
+                seen_docs += 1
+                event = parse_unavailability(zf.read(name).decode("utf-8", "replace"))
+                if event is None:
+                    continue
+                exists = (
+                    db.query(PowerOutage.id)
+                    .filter(PowerOutage.mrid == event["mrid"], PowerOutage.revision == event["revision"])
+                    .first()
+                )
+                if exists:
+                    continue
+                db.add(PowerOutage(zone=zone, doc_type=doc_type, **event))
+                written += 1
+            db.commit()
+
+            if len(names) < _PAGE_SIZE:
+                break
+            offset += _PAGE_SIZE
+
+    return {"written": written, "documents": seen_docs, "zones": len(zones)}

--- a/backend/power/records.py
+++ b/backend/power/records.py
@@ -1,0 +1,98 @@
+"""All-time records per series × zone, recomputed nightly.
+
+The cheapest "wow" from the gridstatus repertoire — "highest DE-LU day-ahead
+hour on record" — derived entirely from power_hourly. Recompute is a plain SQL
+min/max per (series, zone): always correct, no incremental state to corrupt.
+
+Plausibility guard: ENTSO-E ingest hiccups have produced absurd points; a
+record outside the plausible band is ignored rather than celebrated, and the
+guard is per series family (prices can be negative; loads cannot).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from backend.models.energy import PowerHourly, PowerRecord, SeriesDim, ZoneDim
+
+logger = logging.getLogger(__name__)
+
+#: Series worth a record headline. QH included: the record quarter-hour is
+#: sharper than the record hour since the 15-min switch.
+RECORD_SERIES = [
+    "price.dayahead",
+    "price.dayahead.qh",
+    "imbalance.price.qh",
+    "load.actual",
+    "residual.actual",
+]
+
+# Plausible bands per series family (guard, not physics).
+PRICE_MIN_PLAUSIBLE = -500.0
+PRICE_MAX_PLAUSIBLE = 4_000.0
+IMBALANCE_MIN_PLAUSIBLE = -20_000.0
+IMBALANCE_MAX_PLAUSIBLE = 20_000.0
+MW_MIN_PLAUSIBLE = 0.0
+MW_MAX_PLAUSIBLE = 200_000.0
+
+
+def _bounds(series_key: str) -> tuple[float, float]:
+    if series_key.startswith("imbalance."):
+        return IMBALANCE_MIN_PLAUSIBLE, IMBALANCE_MAX_PLAUSIBLE
+    if series_key.startswith("price."):
+        return PRICE_MIN_PLAUSIBLE, PRICE_MAX_PLAUSIBLE
+    return MW_MIN_PLAUSIBLE, MW_MAX_PLAUSIBLE
+
+
+def compute_records(db: Session) -> list[PowerRecord]:
+    """Recompute min/max records for every RECORD_SERIES × zone with data.
+    Upserts one PowerRecord per (series, zone, kind); returns the rows."""
+    out: list[PowerRecord] = []
+    for series_key in RECORD_SERIES:
+        sid_row = db.query(SeriesDim).filter(SeriesDim.key == series_key).first()
+        if sid_row is None:
+            continue
+        lo, hi = _bounds(series_key)
+        zone_ids = [
+            z for (z,) in db.query(PowerHourly.zone_id)
+            .filter(PowerHourly.series_id == sid_row.id).distinct()
+        ]
+        for zid in zone_ids:
+            zone_key = db.query(ZoneDim.key).filter(ZoneDim.id == zid).scalar()
+            if zone_key is None:
+                continue
+            base = db.query(PowerHourly).filter(
+                PowerHourly.series_id == sid_row.id,
+                PowerHourly.zone_id == zid,
+                PowerHourly.value >= lo,
+                PowerHourly.value <= hi,
+            )
+            for kind, agg in (("max", func.max), ("min", func.min)):
+                extreme = base.with_entities(agg(PowerHourly.value)).scalar()
+                if extreme is None:
+                    continue
+                # Evidence point: the (first) timestamp where the extreme occurred.
+                ts = (
+                    base.filter(PowerHourly.value == extreme)
+                    .with_entities(func.min(PowerHourly.ts_utc))
+                    .scalar()
+                )
+                row = (
+                    db.query(PowerRecord)
+                    .filter_by(series_key=series_key, zone=zone_key, kind=kind)
+                    .first()
+                )
+                if row is None:
+                    row = PowerRecord(series_key=series_key, zone=zone_key, kind=kind,
+                                      value=extreme, ts_utc=ts, unit=sid_row.unit)
+                    db.add(row)
+                else:
+                    row.value = extreme
+                    row.ts_utc = ts
+                    row.unit = sid_row.unit
+                out.append(row)
+    db.commit()
+    return out

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1050,6 +1050,95 @@ async def get_flows(
     }
 
 
+# ─── Hydro reservoirs (free) ──────────────────────────────────────────────────
+
+#: A72 publishes weekly; allow one late week before flagging.
+HYDRO_STALE_DAYS = 10
+
+
+def _same_week_band(points: list[tuple[int, float]]) -> dict:
+    """Compare the newest weekly filling against the SAME ISO week in prior years.
+
+    Reservoir levels are hard seasonal — a trailing window would flag every
+    spring melt as an anomaly. So the band is built from the nearest point
+    within ±4 days of (newest − i·52 weeks) for each prior year i.
+    """
+    import bisect
+
+    ts, value = points[-1]
+    keys = [t for t, _ in points]
+    band: list[float] = []
+    i = 1
+    while True:
+        target = ts - i * 364 * 86_400
+        if target < keys[0] - 4 * 86_400:
+            break
+        j = bisect.bisect_left(keys, target)
+        best = None
+        for k in (j - 1, j):
+            if 0 <= k < len(keys) and abs(keys[k] - target) <= 4 * 86_400:
+                if best is None or abs(keys[k] - target) < abs(keys[best] - target):
+                    best = k
+        if best is not None:
+            band.append(points[best][1])
+        i += 1
+
+    vs_band = None
+    if band:
+        vs_band = "below" if value < min(band) else "above" if value > max(band) else "within"
+    return {
+        "band_min_twh": round(min(band) / 1e6, 2) if band else None,
+        "band_max_twh": round(max(band) / 1e6, 2) if band else None,
+        "band_mean_twh": round(sum(band) / len(band) / 1e6, 2) if band else None,
+        "band_n": len(band),
+        "vs_band": vs_band,
+    }
+
+
+@router.get("/hydro")
+async def get_hydro(db: Session = Depends(get_db)):
+    """Weekly reservoir filling (ENTSO-E A72, MWh → TWh) for the hydro zones —
+    Nordics, Alps, Iberia, France — each compared against the same ISO week in
+    its own prior years. Descriptive: a filling level vs its seasonal norm,
+    not a price call. Free tier."""
+    from backend.power.entsoe_hydro import HYDRO_ZONES
+    from backend.power.hourly_store import read_hourly
+
+    zones_out: list[dict] = []
+    newest: str | None = None
+    for zone in HYDRO_ZONES:
+        points = read_hourly(db, "hydro.reservoir", zone)
+        if not points:
+            continue
+        ts, mwh = points[-1]
+        as_of = _dt.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+        newest = max(newest, as_of) if newest else as_of
+        prev = points[-2][1] if len(points) >= 2 else None
+        zones_out.append({
+            "zone": zone,
+            "zone_label": POWER_ZONES.get(zone, {}).get("label", zone),
+            "reservoir_twh": round(mwh / 1e6, 2),
+            "wow_twh": round((mwh - prev) / 1e6, 2) if prev is not None else None,
+            "as_of": as_of,
+            **_same_week_band(points),
+        })
+
+    if not zones_out:
+        return {
+            "available": False,
+            "reason": "No reservoir data yet — check back shortly.",
+        }
+
+    zones_out.sort(key=lambda z: z["reservoir_twh"], reverse=True)
+    return {
+        "available": True,
+        "unit": "TWh",
+        "note": "ENTSO-E A72 weekly filling; band = same ISO week across prior years",
+        "zones": zones_out,
+        **_freshness(newest, datetime.utcnow().date(), HYDRO_STALE_DAYS),
+    }
+
+
 # ─── Generation mix (free) ────────────────────────────────────────────────────
 
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1051,6 +1051,115 @@ async def get_flows(
     }
 
 
+# ─── Forecast error (free) ────────────────────────────────────────────────────
+
+#: forecast series → the series whose SUM is the realised counterpart.
+#: There is no wind.actual/solar.actual — realised wind/solar live in the
+#: generation mix (B18+B19 / B16), same derivation the residual ingest uses.
+_FORECAST_PAIRS: dict[str, tuple[str, list[str]]] = {
+    "load": ("load.forecast", ["load.actual"]),
+    "residual": ("residual.forecast", ["residual.actual"]),
+    "wind": ("wind.forecast", ["gen.B18", "gen.B19"]),
+    "solar": ("solar.forecast", ["gen.B16"]),
+}
+
+
+@router.get("/forecast-error")
+async def get_forecast_error(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    series: str = Query("load", pattern="^(load|residual|wind|solar)$"),
+    days: int = Query(7, ge=1, le=90),
+    db: Session = Depends(get_db),
+):
+    """How good was the published TSO day-ahead forecast, in numbers. Free tier.
+
+    bias_mw = mean(actual − forecast): positive means the forecast leaned LOW
+    (demand surprise / renewables over-delivered). mae_mw is the typical
+    per-hour miss. Only hours where both sides exist count. Posture B: this
+    describes ENTSO-E's OWN published forecast — no forecast claim of ours.
+    """
+    from backend.power.hourly_store import read_hourly
+
+    resolved_zone = _resolve_zone(zone)
+    fc_key, actual_keys = _FORECAST_PAIRS[series]
+    start_ts = int((datetime.utcnow() - timedelta(days=days)).timestamp())
+
+    forecast = dict(read_hourly(db, fc_key, resolved_zone, start_ts))
+    actual: dict[int, float] = {}
+    for key in actual_keys:
+        for t, v in read_hourly(db, key, resolved_zone, start_ts):
+            actual[t] = actual.get(t, 0.0) + v
+
+    common = sorted(set(forecast) & set(actual))
+    if not common:
+        return {
+            "available": False,
+            "zone": resolved_zone,
+            "zones": _ZONE_KEYS,
+            "series": series,
+            "reason": "No overlapping forecast/actual hours in the window yet.",
+        }
+
+    errors = [actual[t] - forecast[t] for t in common]
+    return {
+        "available": True,
+        "zone": resolved_zone,
+        "zones": _ZONE_KEYS,
+        "series": series,
+        "days": days,
+        "n_hours": len(common),
+        "bias_mw": round(sum(errors) / len(errors), 1),
+        "mae_mw": round(sum(abs(e) for e in errors) / len(errors), 1),
+        "note": "bias = mean(actual − forecast); describes the published TSO forecast",
+    }
+
+
+# ─── Records (free) ───────────────────────────────────────────────────────────
+
+#: A record set within this many days is "the story", not archive trivia.
+RECORD_FRESH_DAYS = 7
+
+
+@router.get("/records")
+async def get_records(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    db: Session = Depends(get_db),
+):
+    """All-time extremes per series for a zone — "highest day-ahead hour on
+    record", with the evidence date. Descriptive archive facts, recomputed
+    nightly; `fresh` flags records set in the last week. Free tier."""
+    from backend.models.energy import PowerRecord
+
+    resolved_zone = _resolve_zone(zone)
+    rows = db.query(PowerRecord).filter(PowerRecord.zone == resolved_zone).all()
+    if not rows:
+        return {
+            "available": False,
+            "zone": resolved_zone,
+            "zones": _ZONE_KEYS,
+            "reason": "No records computed yet — check back shortly.",
+        }
+
+    fresh_cutoff = int((datetime.utcnow() - timedelta(days=RECORD_FRESH_DAYS)).timestamp())
+    records = [
+        {
+            "series": r.series_key,
+            "kind": r.kind,
+            "value": round(r.value, 2),
+            "unit": r.unit,
+            "date": _dt.fromtimestamp(r.ts_utc, tz=timezone.utc).strftime("%Y-%m-%d"),
+            "fresh": r.ts_utc >= fresh_cutoff,
+        }
+        for r in sorted(rows, key=lambda r: (r.series_key, r.kind))
+    ]
+    return {
+        "available": True,
+        "zone": resolved_zone,
+        "zones": _ZONE_KEYS,
+        "records": records,
+    }
+
+
 # ─── Outages (free) ───────────────────────────────────────────────────────────
 
 _OUTAGE_KIND = {"A53": "planned", "A54": "forced"}

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -46,6 +46,7 @@ from backend.models.energy import (
 )
 from backend.power.coverage import renewable_share_reliable
 from backend.power.energy_charts_flows import ATTRIBUTION
+from backend.power.entsoe_grid import PSR_LABELS
 from backend.power.zones import DEFAULT_ZONE, POWER_ZONES
 from backend.signals.detectors.base import severity_from_zscore, trailing_zscore
 
@@ -1047,6 +1048,95 @@ async def get_flows(
         "to": date_to,
         "data": data,
         **_panel_freshness(data, "flows"),
+    }
+
+
+# ─── Outages (free) ───────────────────────────────────────────────────────────
+
+_OUTAGE_KIND = {"A53": "planned", "A54": "forced"}
+
+
+@router.get("/outages")
+async def get_outages(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    horizon_days: int = Query(30, ge=1, le=400,
+                              description="Include outages starting up to this many days out"),
+    db: Session = Depends(get_db),
+):
+    """Generation unavailability (ENTSO-E A77) for a bidding zone. Free tier.
+
+    Revision semantics: only the HIGHEST revision per message counts, and
+    withdrawn messages (docStatus A09) hide the event — of 31 live documents
+    sampled, 26 were withdrawn. `total_offline_mw` counts only outages running
+    RIGHT NOW; the list also includes ones starting within `horizon_days`.
+    Descriptive: what capacity is off and why, not a price call.
+    """
+    from backend.models.energy import PowerOutage
+
+    resolved_zone = _resolve_zone(zone)
+    now = datetime.utcnow()
+    now_iso = now.strftime("%Y-%m-%dT%H:%MZ")
+    horizon_iso = (now + timedelta(days=horizon_days)).strftime("%Y-%m-%dT%H:%MZ")
+
+    rows = db.query(PowerOutage).filter(PowerOutage.zone == resolved_zone).all()
+    if not rows:
+        return {
+            "available": False,
+            "zone": resolved_zone,
+            "zones": _ZONE_KEYS,
+            "reason": f"No outage messages for {POWER_ZONES[resolved_zone]['label']} yet — check back shortly.",
+        }
+
+    # Highest revision per mRID wins; withdrawn events disappear.
+    latest: dict[str, PowerOutage] = {}
+    for r in rows:
+        if r.mrid not in latest or r.revision > latest[r.mrid].revision:
+            latest[r.mrid] = r
+
+    outages: list[dict] = []
+    total_offline = 0.0
+    forced_offline = 0.0
+    for r in latest.values():
+        if r.status != "active":
+            continue
+        if r.end_utc < now_iso or r.start_utc > horizon_iso:
+            continue
+        offline = (
+            round(r.nominal_mw - (r.available_mw or 0.0), 1)
+            if r.nominal_mw is not None else None
+        )
+        running_now = r.start_utc <= now_iso <= r.end_utc
+        if running_now and offline:
+            total_offline += offline
+            if r.business_type == "A54":
+                forced_offline += offline
+        outages.append({
+            "mrid": r.mrid,
+            "unit_name": r.unit_name,
+            "location": r.location,
+            "fuel": PSR_LABELS.get(r.psr_type, r.psr_type),
+            "kind": _OUTAGE_KIND.get(r.business_type, r.business_type),
+            "nominal_mw": r.nominal_mw,
+            "available_mw": r.available_mw,
+            "offline_mw": offline,
+            "start_utc": r.start_utc,
+            "end_utc": r.end_utc,
+            "running_now": running_now,
+        })
+
+    outages.sort(key=lambda o: (not o["running_now"], -(o["offline_mw"] or 0.0)))
+    newest_msg = max((r.created_at for r in rows if r.created_at), default=None)
+    return {
+        "available": True,
+        "zone": resolved_zone,
+        "zones": _ZONE_KEYS,
+        "unit": "MW",
+        "total_offline_mw": round(total_offline, 1),
+        "forced_offline_mw": round(forced_offline, 1),
+        "horizon_days": horizon_days,
+        "outages": outages,
+        **_freshness(newest_msg.strftime("%Y-%m-%d") if newest_msg else None,
+                     now.date(), 2),
     }
 
 

--- a/backend/tests/test_forecast_error.py
+++ b/backend/tests/test_forecast_error.py
@@ -1,0 +1,93 @@
+"""Forecast-vs-actual error: how good was the published TSO forecast, in numbers.
+
+Posture B: this describes the accuracy of ENTSO-E's OWN published forecast —
+no model of ours, no forecast claim. Bias answers "does it lean high or low",
+MAE answers "how far off is a typical hour". Only hours where both forecast
+and actual exist count.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.power.hourly_store import upsert_hourly
+
+
+def _hour(days_ago: int, hour: int) -> int:
+    d = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return int(d.replace(hour=hour, minute=0, second=0, microsecond=0).timestamp())
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db) -> TestClient:
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _seed(db, zone="DE_LU"):
+    # Forecast always 1000 MW under actual for 2 days × 3 hours → bias +1000, mae 1000
+    fc, ac = [], []
+    for d in (1, 2):
+        for h in (6, 12, 18):
+            fc.append((_hour(d, h), 50_000.0))
+            ac.append((_hour(d, h), 51_000.0))
+    # one forecast hour without an actual — must not count
+    fc.append((_hour(0, 23), 48_000.0))
+    upsert_hourly(db, "load.forecast", zone, fc, unit="MW")
+    upsert_hourly(db, "load.actual", zone, ac, unit="MW")
+    db.commit()
+
+
+def test_forecast_error_bias_and_mae(db_session):
+    _seed(db_session)
+    body = _client(db_session).get("/api/power/forecast-error?zone=DE_LU&series=load").json()
+
+    assert body["available"] is True
+    assert body["series"] == "load"
+    assert body["n_hours"] == 6
+    # bias = mean(actual − forecast): the TSO forecast leaned LOW by 1 GW
+    assert body["bias_mw"] == pytest.approx(1000.0)
+    assert body["mae_mw"] == pytest.approx(1000.0)
+
+
+def test_forecast_error_wind_actual_is_the_genmix_sum(db_session):
+    """There is no wind.actual series — realised wind is gen.B18 + gen.B19."""
+    upsert_hourly(db_session, "wind.forecast", "DE_LU", [(_hour(1, 12), 10_000.0)], unit="MW")
+    upsert_hourly(db_session, "gen.B18", "DE_LU", [(_hour(1, 12), 3_000.0)], unit="MW")
+    upsert_hourly(db_session, "gen.B19", "DE_LU", [(_hour(1, 12), 5_000.0)], unit="MW")
+    db_session.commit()
+    body = _client(db_session).get("/api/power/forecast-error?zone=DE_LU&series=wind").json()
+    assert body["available"] is True
+    assert body["bias_mw"] == pytest.approx(-2000.0)  # wind UNDER-delivered vs forecast
+
+
+def test_forecast_error_solar_maps_to_gen_b16(db_session):
+    upsert_hourly(db_session, "solar.forecast", "DE_LU", [(_hour(1, 12), 6_000.0)], unit="MW")
+    upsert_hourly(db_session, "gen.B16", "DE_LU", [(_hour(1, 12), 7_500.0)], unit="MW")
+    db_session.commit()
+    body = _client(db_session).get("/api/power/forecast-error?zone=DE_LU&series=solar").json()
+    assert body["bias_mw"] == pytest.approx(1500.0)  # solar OVER-delivered
+
+
+def test_forecast_error_rejects_unknown_series(db_session):
+    r = _client(db_session).get("/api/power/forecast-error?zone=DE_LU&series=hack")
+    assert r.status_code == 422
+
+
+def test_forecast_error_empty_is_honest(db_session):
+    body = _client(db_session).get("/api/power/forecast-error?zone=DE_LU&series=load").json()
+    assert body["available"] is False
+    assert "reason" in body

--- a/backend/tests/test_generation_forecast.py
+++ b/backend/tests/test_generation_forecast.py
@@ -1,0 +1,69 @@
+"""A71 day-ahead TOTAL generation forecast → hourly series generation.forecast.
+
+Same GL_MarketDocument shape as A65 (quantity points, no psrType), so the load
+parsers do the work; only the document type, domain param and cache source
+differ. Feeds the forecast-vs-actual view (roadmap Block 4.3).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from backend.power import entsoe_grid as grid_mod
+from backend.power.hourly_store import read_hourly
+from backend.tests.test_power_grid import _a65, _load_ts
+
+
+def _epoch(iso: str) -> int:
+    from datetime import datetime, timezone
+
+    return int(datetime.fromisoformat(iso).replace(tzinfo=timezone.utc).timestamp())
+
+
+async def test_ingest_generation_forecast_writes_hourly_series(db_session, monkeypatch):
+    seen = {}
+
+    async def fake_fetch(eic, month_start, doctype, extra_params, *, overwrite=False, cache_source=None):
+        seen.update(doctype=doctype, params=extra_params, cache_source=cache_source)
+        return _a65(_load_ts("2026-06-01T00:00Z", 55_000.0, n=24))
+
+    monkeypatch.setattr(grid_mod, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", SecretStr("tok"))
+
+    r = await grid_mod.ingest_generation_forecast(db_session, ["2026-06-01"], zone="DE_LU")
+
+    assert r == {"days": 1, "written": 24}
+    assert seen["doctype"] == "A71"
+    assert seen["params"]["processType"] == "A01"
+    assert "in_Domain" in seen["params"]
+    assert seen["cache_source"] == "entsoe_gen_total_forecast", (
+        "A71 must not collide with the A65/A69 caches"
+    )
+
+    series = read_hourly(db_session, "generation.forecast", "DE_LU")
+    assert len(series) == 24
+    assert series[0] == (_epoch("2026-06-01T00:00"), 55_000.0)
+
+
+async def test_ingest_generation_forecast_respects_wanted_days(db_session, monkeypatch):
+    async def fake_fetch(eic, month_start, doctype, extra_params, *, overwrite=False, cache_source=None):
+        return _a65(
+            _load_ts("2026-06-01T00:00Z", 50_000.0, n=24)
+            + _load_ts("2026-06-02T00:00Z", 60_000.0, n=24)
+        )
+
+    monkeypatch.setattr(grid_mod, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", SecretStr("tok"))
+
+    await grid_mod.ingest_generation_forecast(db_session, ["2026-06-02"], zone="DE_LU")
+
+    series = read_hourly(db_session, "generation.forecast", "DE_LU")
+    assert len(series) == 24
+    assert all(v == 60_000.0 for _, v in series)
+
+
+async def test_ingest_generation_forecast_skips_without_token(db_session, monkeypatch):
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", None)
+    r = await grid_mod.ingest_generation_forecast(db_session, ["2026-06-01"])
+    assert r == {"skipped": "no token"}

--- a/backend/tests/test_generation_forecast.py
+++ b/backend/tests/test_generation_forecast.py
@@ -7,7 +7,6 @@ differ. Feeds the forecast-vs-actual view (roadmap Block 4.3).
 
 from __future__ import annotations
 
-import pytest
 from pydantic import SecretStr
 
 from backend.power import entsoe_grid as grid_mod

--- a/backend/tests/test_hydro.py
+++ b/backend/tests/test_hydro.py
@@ -1,0 +1,164 @@
+"""A72 weekly reservoir filling → series hydro.reservoir + same-week-vs-history route.
+
+Spiked live 2026-07-11 (NO2): GL_MarketDocument, resolution P7D, unit MWh,
+one point per week (~21 TWh for southern Norway). Reservoir levels are hard
+seasonal — a trailing z-score would flag every spring melt as an anomaly, so
+"vs. normal" compares against the SAME ISO week across prior years.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from backend.power import entsoe_hydro as hydro
+from backend.power.hourly_store import read_hourly
+
+NS = "urn:iec62325.351:tc57wg16:451-6:generationloaddocument:3:0"
+
+
+def _a72(start: str, quantities: list[float], res: str = "P7D") -> str:
+    pts = "".join(
+        f"<Point><position>{i + 1}</position><quantity>{q}</quantity></Point>"
+        for i, q in enumerate(quantities)
+    )
+    return (
+        f'<?xml version="1.0"?><GL_MarketDocument xmlns="{NS}"><type>A72</type>'
+        f"<TimeSeries><Period>"
+        f"<timeInterval><start>{start}</start></timeInterval>"
+        f"<resolution>{res}</resolution>{pts}</Period></TimeSeries></GL_MarketDocument>"
+    )
+
+
+def _epoch(iso: str) -> int:
+    return int(datetime.fromisoformat(iso).replace(tzinfo=timezone.utc).timestamp())
+
+
+# ─── parse ────────────────────────────────────────────────────────────────────
+
+
+def test_parse_weekly_points():
+    xml = _a72("2026-01-04T23:00Z", [21_000_000.0, 20_500_000.0, 20_100_000.0])
+    pts = hydro.parse_reservoir_filling(xml)
+    assert pts == [
+        (_epoch("2026-01-04T23:00"), 21_000_000.0),
+        (_epoch("2026-01-11T23:00"), 20_500_000.0),
+        (_epoch("2026-01-18T23:00"), 20_100_000.0),
+    ]
+
+
+def test_parse_ignores_non_weekly_resolution():
+    """Only P7D is the reservoir product; anything else is a different document."""
+    xml = _a72("2026-01-04T23:00Z", [1.0] * 24, res="PT60M")
+    assert hydro.parse_reservoir_filling(xml) == []
+
+
+def test_parse_acknowledgement_is_empty():
+    ack = '<?xml version="1.0"?><Acknowledgement_MarketDocument><Reason><code>999</code></Reason></Acknowledgement_MarketDocument>'
+    assert hydro.parse_reservoir_filling(ack) == []
+
+
+# ─── ingest ───────────────────────────────────────────────────────────────────
+
+
+async def test_ingest_writes_series_for_hydro_zones(db_session, monkeypatch):
+    seen = []
+
+    async def fake_fetch(eic, year, *, overwrite=False):
+        seen.append(eic)
+        return _a72("2026-01-04T23:00Z", [21_000_000.0, 20_500_000.0])
+
+    monkeypatch.setattr(hydro, "_fetch_zone_year", fake_fetch)
+    monkeypatch.setattr(hydro.settings, "entsoe_api_token", SecretStr("tok"))
+
+    r = await hydro.ingest_hydro(db_session, years=[2026], zones=["NO2", "CH"])
+
+    assert r["written"] == 4  # 2 zones × 2 weekly points
+    assert len(seen) == 2
+    no2 = read_hourly(db_session, "hydro.reservoir", "NO2")
+    assert no2[0] == (_epoch("2026-01-04T23:00"), 21_000_000.0)
+    assert len(read_hourly(db_session, "hydro.reservoir", "CH")) == 2
+
+
+async def test_ingest_skips_without_token(db_session, monkeypatch):
+    monkeypatch.setattr(hydro.settings, "entsoe_api_token", None)
+    assert await hydro.ingest_hydro(db_session, years=[2026]) == {"skipped": "no token"}
+
+
+def test_hydro_zone_list_is_the_reservoir_geography():
+    """The point of 'A72 light': reservoir zones, independent of ENABLED_ZONES."""
+    for z in ("NO2", "SE1", "CH", "AT", "ES", "PT", "FR"):
+        assert z in hydro.HYDRO_ZONES
+
+
+# ─── route: filling vs the same week across prior years ──────────────────────
+
+
+def _seed_history(db, zone: str, *, this_year_twh: float, prior_twh: list[float]) -> str:
+    """One point per year at the same ISO week; returns the current point's date."""
+    from backend.power.hourly_store import upsert_hourly
+
+    now = datetime.now(timezone.utc)
+    current = now - timedelta(days=7)
+    pts = [(int(current.timestamp()), this_year_twh * 1e6)]
+    for i, twh in enumerate(prior_twh, start=1):
+        prior = current - timedelta(days=364 * i)  # 52 weeks → same ISO week
+        pts.append((int(prior.timestamp()), twh * 1e6))
+    upsert_hourly(db, "hydro.reservoir", zone, pts, unit="MWh")
+    db.commit()
+    return current.strftime("%Y-%m-%d")
+
+
+def _client(db) -> TestClient:
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def test_route_reports_filling_vs_same_week_band(db_session):
+    _seed_history(db_session, "NO2", this_year_twh=15.0, prior_twh=[20.0, 21.0, 22.0])
+    body = _client(db_session).get("/api/power/hydro").json()
+
+    assert body["available"] is True
+    zones = {z["zone"]: z for z in body["zones"]}
+    no2 = zones["NO2"]
+    assert no2["reservoir_twh"] == pytest.approx(15.0, abs=0.01)
+    assert no2["band_min_twh"] == pytest.approx(20.0, abs=0.01)
+    assert no2["band_max_twh"] == pytest.approx(22.0, abs=0.01)
+    assert no2["band_n"] == 3
+    assert no2["vs_band"] == "below", "15 TWh against a 20-22 band is below normal"
+
+
+def test_route_within_band(db_session):
+    _seed_history(db_session, "CH", this_year_twh=21.0, prior_twh=[20.0, 22.0])
+    body = _client(db_session).get("/api/power/hydro").json()
+    ch = {z["zone"]: z for z in body["zones"]}["CH"]
+    assert ch["vs_band"] == "within"
+
+
+def test_route_no_band_with_short_history(db_session):
+    """First year of data: no prior same-week points → band absent, not fabricated."""
+    _seed_history(db_session, "AT", this_year_twh=3.0, prior_twh=[])
+    body = _client(db_session).get("/api/power/hydro").json()
+    at = {z["zone"]: z for z in body["zones"]}["AT"]
+    assert at["band_n"] == 0
+    assert at["vs_band"] is None
+
+
+def test_route_empty_is_honest(db_session):
+    body = _client(db_session).get("/api/power/hydro").json()
+    assert body["available"] is False
+    assert "reason" in body

--- a/backend/tests/test_imbalance.py
+++ b/backend/tests/test_imbalance.py
@@ -55,8 +55,12 @@ def test_parse_malformed_raises():
         parse_imbalance_prices("<not-xml")
 
 
-def test_control_area_eic_skips_de():
-    assert control_area_eic("DE_LU") is None  # 4 control areas, combined reBAP not exposed
+def test_control_area_eic_de_uses_country_code():
+    """Spike 2026-07-11 against the live API: the German reBAP is NOT published
+    under the four control-area EICs (Acknowledgement 999 for TenneT/Amprion)
+    nor under the DE_LU bidding-zone EIC — but the COUNTRY EIC returns the full
+    96-slot uniform reBAP. So DE_LU maps to the country code."""
+    assert control_area_eic("DE_LU") == "10Y1001A1001A83F"
     assert control_area_eic("FR") == "10YFR-RTE------C"
     assert control_area_eic("BE") == "10YBE----------2"
 
@@ -75,10 +79,20 @@ async def test_ingest_writes_series(db_session, monkeypatch):
     assert series[0][1] == 40.0
 
 
-async def test_ingest_de_skipped(db_session, monkeypatch):
+async def test_ingest_de_writes_rebap(db_session, monkeypatch):
+    """DE_LU was the only enabled zone without an imbalance series."""
     monkeypatch.setattr(imb.settings, "entsoe_api_token", "x")
-    r = await imb.ingest_imbalance(db_session, ["2026-06-01"], zone="DE_LU")
-    assert r == {"skipped": "no control area (DE has 4)"}
+    seen = {}
+
+    async def fake_fetch(ca_eic, month_start, **kw):
+        seen["eic"] = ca_eic
+        return _a85([40.0 + i for i in range(24)])
+
+    monkeypatch.setattr(imb, "_fetch_imbalance_month", fake_fetch)
+    r = await imb.ingest_imbalance(db_session, ["2026-06-01"], zone="DE_LU", overwrite=True)
+    assert r["written"] == 24
+    assert seen["eic"] == "10Y1001A1001A83F", "must query the country EIC, not a control area"
+    assert len(read_hourly(db_session, "imbalance.price", "DE_LU")) == 24
 
 
 # ─── quarter-hourly: imbalance settles in 15-min periods — that IS the native truth ─

--- a/backend/tests/test_negative_prices.py
+++ b/backend/tests/test_negative_prices.py
@@ -295,8 +295,8 @@ def test_stats_negative_hours_not_double_counted_across_overlapping_series():
 
 
 def test_stats_mean_unaffected_by_duplicate_series():
-    from backend.tests.test_power_prices import _a44, _ts
     from backend.power.entsoe_prices import parse_day_ahead_stats
+    from backend.tests.test_power_prices import _a44, _ts
 
     xml = _a44(
         _ts("2026-05-01T00:00Z", "2026-05-02T00:00Z", [100.0] * 24)

--- a/backend/tests/test_outages.py
+++ b/backend/tests/test_outages.py
@@ -1,0 +1,225 @@
+"""A77 generation unavailability → PowerOutage events + /api/power/outages.
+
+Fixture structure mirrors the live API (spiked 2026-07-11, DE_LU): one
+Unavailability_MarketDocument per outage message, delivered inside a ZIP.
+Revision semantics are the core — of 31 live documents, 26 carried docStatus
+A09 (withdrawn); showing those as active would put 26 ghost outages on the
+desk. Only the highest revision per mRID counts, withdrawals hide the event.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from backend.power import entsoe_outages as out
+
+NS = "urn:iec62325.351:tc57wg16:451-6:outagedocument:3:0"
+
+
+def _doc(
+    mrid: str = "abc123",
+    revision: int = 1,
+    *,
+    business_type: str = "A53",
+    doc_status: str | None = None,
+    start: str = "2026-07-10T22:00Z",
+    end: str = "2026-08-21T14:00Z",
+    unit_name: str = "Kraftwerk X Block 1",
+    unit_eic: str = "11WD43VIWXHOILLM",
+    psr: str = "B14",
+    nominal_mw: float = 1400.0,
+    available: list[tuple[int, float]] = ((1, 400.0),),
+    location: str = "Somewhere",
+) -> str:
+    status = f"<docStatus><value>{doc_status}</value></docStatus>" if doc_status else ""
+    points = "".join(
+        f"<Point><position>{p}</position><quantity>{q}</quantity></Point>"
+        for p, q in available
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<Unavailability_MarketDocument xmlns="{NS}">
+  <mRID>{mrid}</mRID>
+  <revisionNumber>{revision}</revisionNumber>
+  <type>A77</type>
+  <createdDateTime>2026-07-01T08:00:00Z</createdDateTime>
+  <unavailability_Time_Period.timeInterval>
+    <start>{start}</start><end>{end}</end>
+  </unavailability_Time_Period.timeInterval>
+  {status}
+  <TimeSeries>
+    <mRID>1</mRID>
+    <businessType>{business_type}</businessType>
+    <biddingZone_Domain.mRID codingScheme="A01">10Y1001A1001A82H</biddingZone_Domain.mRID>
+    <production_RegisteredResource.mRID codingScheme="A01">{unit_eic}</production_RegisteredResource.mRID>
+    <production_RegisteredResource.name>{unit_name}</production_RegisteredResource.name>
+    <production_RegisteredResource.location.name>{location}</production_RegisteredResource.location.name>
+    <production_RegisteredResource.pSRType.psrType>{psr}</production_RegisteredResource.pSRType.psrType>
+    <production_RegisteredResource.pSRType.powerSystemResources.nominalP unit="MAW">{nominal_mw}</production_RegisteredResource.pSRType.powerSystemResources.nominalP>
+    <Available_Period>
+      <timeInterval><start>{start}</start><end>{end}</end></timeInterval>
+      <resolution>PT1M</resolution>
+      {points}
+    </Available_Period>
+  </TimeSeries>
+</Unavailability_MarketDocument>"""
+
+
+def _zip(*docs: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for i, d in enumerate(docs):
+            zf.writestr(f"doc_{i}.xml", d)
+    return buf.getvalue()
+
+
+# ─── parse ────────────────────────────────────────────────────────────────────
+
+
+def test_parse_extracts_the_event():
+    ev = out.parse_unavailability(_doc())
+    assert ev["mrid"] == "abc123"
+    assert ev["revision"] == 1
+    assert ev["business_type"] == "A53"
+    assert ev["status"] == "active"
+    assert ev["unit_name"] == "Kraftwerk X Block 1"
+    assert ev["unit_eic"] == "11WD43VIWXHOILLM"
+    assert ev["psr_type"] == "B14"
+    assert ev["nominal_mw"] == 1400.0
+    assert ev["available_mw"] == 400.0
+    assert ev["start_utc"] == "2026-07-10T22:00Z"
+    assert ev["end_utc"] == "2026-08-21T14:00Z"
+
+
+def test_parse_docstatus_a09_is_withdrawn():
+    """26 of 31 live documents carried A09 — miss this and the desk shows ghosts."""
+    ev = out.parse_unavailability(_doc(doc_status="A09"))
+    assert ev["status"] == "withdrawn"
+
+
+def test_parse_available_mw_is_the_minimum_over_the_window():
+    """The Available_Period is a step function (curveType A03, sparse PT1M points);
+    the panel's headline is the worst case, so take the minimum quantity."""
+    ev = out.parse_unavailability(_doc(available=((1, 1968.0), (10561, 1912.0), (20000, 1950.0))))
+    assert ev["available_mw"] == 1912.0
+
+
+def test_parse_acknowledgement_returns_none():
+    ack = '<?xml version="1.0"?><Acknowledgement_MarketDocument><Reason><code>999</code></Reason></Acknowledgement_MarketDocument>'
+    assert out.parse_unavailability(ack) is None
+
+
+# ─── ingest: revision upsert ──────────────────────────────────────────────────
+
+
+async def _run_ingest(db, monkeypatch, zip_bytes: bytes, zone: str = "DE_LU"):
+    async def fake_fetch(eic, window_start, window_end, offset, *, doc_type="A77"):
+        return zip_bytes if offset == 0 else None
+
+    monkeypatch.setattr(out, "_fetch_outages_page", fake_fetch)
+    monkeypatch.setattr(out.settings, "entsoe_api_token", SecretStr("tok"))
+    return await out.ingest_outages(db, zones=[zone])
+
+
+async def test_ingest_stores_events(db_session, monkeypatch):
+    r = await _run_ingest(db_session, monkeypatch, _zip(_doc(), _doc(mrid="other", revision=3)))
+    assert r["written"] == 2
+    rows = db_session.query(out.PowerOutage).all()
+    assert {(x.mrid, x.revision) for x in rows} == {("abc123", 1), ("other", 3)}
+    assert all(x.zone == "DE_LU" for x in rows)
+
+
+async def test_ingest_is_idempotent_per_revision(db_session, monkeypatch):
+    await _run_ingest(db_session, monkeypatch, _zip(_doc(revision=2)))
+    r = await _run_ingest(db_session, monkeypatch, _zip(_doc(revision=2)))
+    assert r["written"] == 0
+    assert db_session.query(out.PowerOutage).count() == 1
+
+
+async def test_ingest_keeps_every_revision(db_session, monkeypatch):
+    """Revisions are history — the read side picks the highest, ingest keeps all."""
+    await _run_ingest(db_session, monkeypatch, _zip(_doc(revision=1)))
+    await _run_ingest(db_session, monkeypatch, _zip(_doc(revision=2, doc_status="A09")))
+    assert db_session.query(out.PowerOutage).count() == 2
+
+
+# ─── route: active outages, highest revision wins ─────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db) -> TestClient:
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _seed(db, **kw):
+    now = datetime.now(timezone.utc)
+    defaults = dict(
+        mrid="m1", revision=1, doc_type="A77", zone="DE_LU", business_type="A53",
+        psr_type="B14", unit_name="Unit", unit_eic="11WXX", location="X",
+        nominal_mw=1400.0, available_mw=400.0,
+        start_utc=(now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%MZ"),
+        end_utc=(now + timedelta(days=5)).strftime("%Y-%m-%dT%H:%MZ"),
+        status="active",
+    )
+    defaults.update(kw)
+    db.add(out.PowerOutage(**defaults))
+    db.commit()
+
+
+def test_route_reports_active_outages_with_mw_offline(db_session):
+    _seed(db_session)
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["available"] is True
+    assert body["total_offline_mw"] == pytest.approx(1000.0)  # 1400 nominal − 400 available
+    assert len(body["outages"]) == 1
+    o = body["outages"][0]
+    assert o["unit_name"] == "Unit"
+    assert o["offline_mw"] == pytest.approx(1000.0)
+    assert o["kind"] == "planned"
+
+
+def test_route_highest_revision_wins_and_withdrawal_hides(db_session):
+    _seed(db_session, revision=1)
+    _seed(db_session, revision=5, status="withdrawn")
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["outages"] == []
+
+
+def test_route_excludes_ended_and_far_future(db_session):
+    now = datetime.now(timezone.utc)
+    _seed(db_session, mrid="past", end_utc=(now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%MZ"))
+    _seed(db_session, mrid="future", start_utc=(now + timedelta(days=40)).strftime("%Y-%m-%dT%H:%MZ"),
+          end_utc=(now + timedelta(days=50)).strftime("%Y-%m-%dT%H:%MZ"))
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["outages"] == [], "ended and >30d-out outages are not 'offline now'"
+    upcoming = _client(db_session).get("/api/power/outages?zone=DE_LU&horizon_days=60").json()
+    assert {o["mrid"] for o in upcoming["outages"]} == {"future"}
+
+
+def test_route_forced_outages_are_flagged(db_session):
+    _seed(db_session, business_type="A54")
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["outages"][0]["kind"] == "forced"
+    assert body["forced_offline_mw"] == pytest.approx(1000.0)
+
+
+def test_route_empty_is_honest(db_session):
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["available"] is False
+    assert "reason" in body

--- a/backend/tests/test_records.py
+++ b/backend/tests/test_records.py
@@ -1,0 +1,119 @@
+"""All-time records per series × zone — descriptive, evidence-linked.
+
+The cheapest "wow" from the gridstatus repertoire: "highest DE-LU day-ahead
+hour since 2015". Recomputed nightly by SQL min/max over the canonical store —
+always correct, no incremental state. A plausibility guard keeps ENTSO-E
+ingest glitches from being celebrated as records.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.power.hourly_store import upsert_hourly
+from backend.power.records import PRICE_MAX_PLAUSIBLE, PRICE_MIN_PLAUSIBLE, compute_records
+
+
+def _ts(days_ago: int, hour: int = 12) -> int:
+    d = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return int(d.replace(hour=hour, minute=0, second=0, microsecond=0).timestamp())
+
+
+def _seed_prices(db, zone="DE_LU", values=None):
+    values = values or [(_ts(300), 50.0), (_ts(200), 120.0), (_ts(100), -10.0), (_ts(2), 80.0)]
+    upsert_hourly(db, "price.dayahead", zone, values, unit="EUR/MWh")
+    db.commit()
+
+
+def test_compute_finds_max_and_min(db_session):
+    _seed_prices(db_session)
+    records = compute_records(db_session)
+
+    recs = {(r.series_key, r.kind): r for r in records}
+    hi = recs[("price.dayahead", "max")]
+    assert hi.zone == "DE_LU"
+    assert hi.value == 120.0
+    assert hi.ts_utc == _ts(200)
+    lo = recs[("price.dayahead", "min")]
+    assert lo.value == -10.0
+
+
+def test_compute_is_idempotent_and_updates_in_place(db_session):
+    _seed_prices(db_session)
+    compute_records(db_session)
+    # a new all-time high arrives
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(_ts(1), 300.0)], unit="EUR/MWh")
+    db_session.commit()
+    compute_records(db_session)
+
+    from backend.models.energy import PowerRecord
+
+    rows = db_session.query(PowerRecord).filter_by(series_key="price.dayahead", zone="DE_LU", kind="max").all()
+    assert len(rows) == 1, "one row per (series, zone, kind), updated in place"
+    assert rows[0].value == 300.0
+
+
+def test_price_glitches_are_not_records(db_session):
+    """ENTSO-E hiccups have produced absurd points; a record must be plausible."""
+    _seed_prices(db_session, values=[(_ts(300), 50.0), (_ts(10), 99_999.0), (_ts(5), -20_000.0)])
+    compute_records(db_session)
+
+    from backend.models.energy import PowerRecord
+
+    hi = db_session.query(PowerRecord).filter_by(series_key="price.dayahead", kind="max").first()
+    lo = db_session.query(PowerRecord).filter_by(series_key="price.dayahead", kind="min").first()
+    assert hi.value == 50.0, f"glitch above {PRICE_MAX_PLAUSIBLE} must be ignored"
+    assert lo.value == 50.0 or lo.value >= PRICE_MIN_PLAUSIBLE
+
+
+# ─── route ────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db) -> TestClient:
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_route_returns_records_with_evidence_date(db_session):
+    _seed_prices(db_session)
+    compute_records(db_session)
+    body = _client(db_session).get("/api/power/records?zone=DE_LU").json()
+
+    assert body["available"] is True
+    recs = {(r["series"], r["kind"]): r for r in body["records"]}
+    hi = recs[("price.dayahead", "max")]
+    assert hi["value"] == 120.0
+    assert hi["date"] == datetime.fromtimestamp(_ts(200), tz=timezone.utc).strftime("%Y-%m-%d")
+    assert hi["unit"] == "EUR/MWh"
+
+
+def test_route_flags_fresh_records(db_session):
+    """A record set in the last 7 days is the story — flag it."""
+    _seed_prices(db_session)  # max 200d ago, but the -10 min is 100d ago; freshest point 2d ago is no record
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(_ts(1), 500.0)], unit="EUR/MWh")
+    db_session.commit()
+    compute_records(db_session)
+    body = _client(db_session).get("/api/power/records?zone=DE_LU").json()
+
+    recs = {(r["series"], r["kind"]): r for r in body["records"]}
+    assert recs[("price.dayahead", "max")]["fresh"] is True
+    assert recs[("price.dayahead", "min")]["fresh"] is False
+
+
+def test_route_empty_is_honest(db_session):
+    body = _client(db_session).get("/api/power/records?zone=DE_LU").json()
+    assert body["available"] is False

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,6 +52,7 @@ import InsightsStrip from './components/InsightsStrip'
 import NarrativeHero from './components/NarrativeHero'
 import RangeSelector from './components/RangeSelector'
 import PowerSituationHeader from './components/PowerSituationHeader'
+import HydroReservoirPanel from './components/HydroReservoirPanel'
 import PowerOverviewMatrix from './components/PowerOverviewMatrix'
 import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
@@ -680,6 +681,9 @@ function Dashboard() {
             </div>
             <ErrorBoundary name="insights">
               <InsightsStrip onMore={() => goToTab('alerts')} />
+            </ErrorBoundary>
+            <ErrorBoundary name="hydro">
+              <HydroReservoirPanel />
             </ErrorBoundary>
             <ErrorBoundary name="live-charts">
               <LiveCharts />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -54,6 +54,7 @@ import RangeSelector from './components/RangeSelector'
 import PowerSituationHeader from './components/PowerSituationHeader'
 import HydroReservoirPanel from './components/HydroReservoirPanel'
 import OutagePanel from './components/OutagePanel'
+import RecordChip from './components/RecordChip'
 import PowerOverviewMatrix from './components/PowerOverviewMatrix'
 import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
@@ -569,6 +570,9 @@ function Dashboard() {
 
             <ErrorBoundary name="power-situation">
               <PowerSituationHeader zone={energyZone} />
+            </ErrorBoundary>
+            <ErrorBoundary name="record-chip">
+              <RecordChip zone={energyZone} />
             </ErrorBoundary>
 
             {/* PRICES — day-ahead + spark spread */}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -53,6 +53,7 @@ import NarrativeHero from './components/NarrativeHero'
 import RangeSelector from './components/RangeSelector'
 import PowerSituationHeader from './components/PowerSituationHeader'
 import HydroReservoirPanel from './components/HydroReservoirPanel'
+import OutagePanel from './components/OutagePanel'
 import PowerOverviewMatrix from './components/PowerOverviewMatrix'
 import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
@@ -581,9 +582,12 @@ function Dashboard() {
               </ErrorBoundary>
             </div>
 
-            {/* GRID & GENERATION — residual/Dunkelflaute, load forecast, generation mix */}
+            {/* GRID & GENERATION — outages, residual/Dunkelflaute, load forecast, generation mix */}
             <div id="section-power-grid" className="scroll-mt-16 space-y-3">
               <SectionLabel>GRID &amp; GENERATION</SectionLabel>
+              <ErrorBoundary name="power-outages">
+                <OutagePanel zone={energyZone} />
+              </ErrorBoundary>
               <ErrorBoundary name="power-grid">
                 <PowerGridPanel zone={energyZone} />
               </ErrorBoundary>

--- a/frontend/src/components/CrossBorderFlowPanel.jsx
+++ b/frontend/src/components/CrossBorderFlowPanel.jsx
@@ -1,5 +1,6 @@
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeDays } from '../utils/ranges'
 import {
@@ -123,7 +124,7 @@ function BorderRow({ border, data }) {
 export default function CrossBorderFlowPanel({ zone = 'DE_LU' }) {
   const { range } = useViewState()
   const url = `${API}/power/flows?days=${rangeDays(range)}`
-  const { data, loading, error } = useFetchWithError(url, { deps: [range] })
+  const { data, loading, error } = useFetchWithError(url, { deps: [range], pollMs: POLL_SLOW_MS })
 
   if (error) {
     return (

--- a/frontend/src/components/ForecastErrorStrip.jsx
+++ b/frontend/src/components/ForecastErrorStrip.jsx
@@ -1,0 +1,44 @@
+import useFetchWithError from '../hooks/useFetchWithError'
+
+const API = '/api'
+
+function gw(mw) {
+  return `${mw >= 0 ? '+' : ''}${(mw / 1000).toFixed(1)} GW`
+}
+
+function Line({ label, err }) {
+  if (!err?.available) return null
+  const lean = err.bias_mw > 200 ? 'leaned low' : err.bias_mw < -200 ? 'leaned high' : 'was on target'
+  return (
+    <div className="font-mono text-[10px] text-neutral-500">
+      <span className="text-neutral-400">{label}</span>: forecast {lean} — actual ran{' '}
+      <span className={err.bias_mw >= 0 ? 'text-cyan-glow' : 'text-orange-400'}>{gw(err.bias_mw)}</span>{' '}
+      vs forecast on average (typical miss {(err.mae_mw / 1000).toFixed(1)} GW, {err.n_hours}h)
+    </div>
+  )
+}
+
+/**
+ * Quantifies the published TSO day-ahead forecast against what happened —
+ * gridstatus' "forecast vs actual" in Posture-B language: we describe ENTSO-E's
+ * own forecast, we do not make one. bias = mean(actual − forecast); positive =
+ * demand surprise / renewables over-delivered.
+ */
+export default function ForecastErrorStrip({ zone = 'DE_LU' }) {
+  const { data: load } = useFetchWithError(`${API}/power/forecast-error?zone=${zone}&series=load`, { deps: [zone] })
+  const { data: wind } = useFetchWithError(`${API}/power/forecast-error?zone=${zone}&series=wind`, { deps: [zone] })
+  const { data: solar } = useFetchWithError(`${API}/power/forecast-error?zone=${zone}&series=solar`, { deps: [zone] })
+
+  if (!load?.available && !wind?.available && !solar?.available) return null
+
+  return (
+    <div className="px-4 py-2 border-t border-border/30 space-y-0.5">
+      <div className="font-mono text-[9px] text-neutral-600 tracking-wider uppercase">
+        Forecast vs actual · last 7 days · published TSO forecast, not ours
+      </div>
+      <Line label="Load" err={load} />
+      <Line label="Wind" err={wind} />
+      <Line label="Solar" err={solar} />
+    </div>
+  )
+}

--- a/frontend/src/components/GenerationMixPanel.jsx
+++ b/frontend/src/components/GenerationMixPanel.jsx
@@ -1,5 +1,6 @@
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeDays, rangeStart } from '../utils/ranges'
 import {
@@ -34,7 +35,7 @@ const DEFAULT_COLOR = '#64748b'
 export default function GenerationMixPanel({ zone = 'DE_LU' }) {
   const { range } = useViewState()
   const url = `${API}/power/generation-mix?days=${rangeDays(range)}&zone=${zone}`
-  const { data, loading, error } = useFetchWithError(url, { deps: [zone, range] })
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone, range], pollMs: POLL_SLOW_MS })
 
   if (error)
     return (

--- a/frontend/src/components/HydroReservoirPanel.jsx
+++ b/frontend/src/components/HydroReservoirPanel.jsx
@@ -1,0 +1,84 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+
+const API = '/api'
+
+// Reservoir filling is hard seasonal, so "vs normal" is the SAME ISO week across
+// prior years (the backend builds that band) — never a trailing window, which
+// would flag every spring melt as an anomaly.
+const BAND_STYLE = {
+  below: { label: 'BELOW NORMAL', cls: 'text-orange-400 border-orange-500/30' },
+  above: { label: 'ABOVE NORMAL', cls: 'text-cyan-glow border-cyan-glow/30' },
+  within: { label: 'WITHIN BAND', cls: 'text-neutral-500 border-border' },
+}
+
+function BandTag({ zone }) {
+  if (!zone.vs_band) {
+    return <span className="font-mono text-[9px] text-neutral-700">building history (n={zone.band_n})</span>
+  }
+  const s = BAND_STYLE[zone.vs_band]
+  return (
+    <span
+      className={`font-mono text-[9px] tracking-wide border rounded px-1.5 py-0.5 ${s.cls}`}
+      title={`Same-week band across ${zone.band_n} prior year${zone.band_n === 1 ? '' : 's'}: ${zone.band_min_twh}–${zone.band_max_twh} TWh`}
+    >
+      {s.label}
+    </span>
+  )
+}
+
+/**
+ * Weekly reservoir filling (ENTSO-E A72) for the hydro zones — Nordics, Alps,
+ * Iberia, France. Southern Norway alone stores ~20 TWh; these levels move
+ * power prices continent-wide. Descriptive: filling vs its own seasonal norm.
+ */
+export default function HydroReservoirPanel() {
+  const { data, loading } = useFetchWithError(`${API}/power/hydro`, { deps: [] })
+
+  if (!data?.available && !loading) return null
+  const zones = data?.zones ?? []
+
+  return (
+    <Panel
+      id="hydro-reservoirs"
+      title="HYDRO RESERVOIRS · WEEKLY FILLING"
+      freshness={data}
+      info="ENTSO-E A72 stored hydro energy per zone (TWh), published weekly. 'vs normal' compares the newest week against the SAME calendar week in the zone's own prior years — reservoir levels are seasonal, so only a same-week band is meaningful. Descriptive: a filling level vs its norm, not a price forecast."
+      collapsible
+    >
+      {loading && !data ? (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">Loading reservoirs…</div>
+      ) : (
+        <div className="px-2 py-2 overflow-x-auto">
+          <table className="w-full font-mono text-[11px]">
+            <thead>
+              <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                <th className="text-left px-2 py-1">Zone</th>
+                <th className="text-right px-2 py-1">Stored</th>
+                <th className="text-right px-2 py-1">Δ week</th>
+                <th className="text-left px-2 py-1">vs normal (same week)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {zones.map((z) => (
+                <tr key={z.zone} className="border-t border-border/30">
+                  <td className="px-2 py-1.5 text-neutral-300">{z.zone_label}</td>
+                  <td className="px-2 py-1.5 text-right text-neutral-200 font-bold">
+                    {z.reservoir_twh.toFixed(1)} <span className="text-[9px] text-neutral-600 font-normal">TWh</span>
+                  </td>
+                  <td className={`px-2 py-1.5 text-right ${
+                    z.wow_twh == null ? 'text-neutral-700'
+                      : z.wow_twh >= 0 ? 'text-cyan-glow' : 'text-orange-400'
+                  }`}>
+                    {z.wow_twh == null ? '—' : `${z.wow_twh >= 0 ? '+' : ''}${z.wow_twh.toFixed(2)}`}
+                  </td>
+                  <td className="px-2 py-1.5"><BandTag zone={z} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/NarrativeHero.jsx
+++ b/frontend/src/components/NarrativeHero.jsx
@@ -1,4 +1,5 @@
 import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_FAST_MS } from '../utils/poll'
 import Provenance from './Provenance'
 
 const API = '/api'
@@ -11,7 +12,7 @@ const sig = (z) => `${z >= 0 ? '+' : ''}${z.toFixed(1)}σ`
 const list = (zs, n = 3) => zs.slice(0, n).map((z) => z.zone_label || z.zone).join(', ')
 
 export default function NarrativeHero() {
-  const { data } = useFetchWithError(`${API}/power/overview`)
+  const { data } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
   const zones = data?.zones || []
   if (!data?.available || zones.length === 0) return null
 

--- a/frontend/src/components/OutagePanel.jsx
+++ b/frontend/src/components/OutagePanel.jsx
@@ -1,0 +1,112 @@
+import Panel from './Panel'
+import PanelTakeaway from './PanelTakeaway'
+import useFetchWithError from '../hooks/useFetchWithError'
+
+const API = '/api'
+
+function fmtGw(mw) {
+  if (mw == null) return '—'
+  return mw >= 1000 ? `${(mw / 1000).toFixed(1)} GW` : `${Math.round(mw)} MW`
+}
+
+// "2026-08-21T14:00Z" → "Aug 21" (dates are UTC by construction)
+function fmtEnd(iso) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
+}
+
+/**
+ * Generation unavailability (ENTSO-E A77) — which plants are off, how much
+ * capacity that is, and whether it was planned. No free EU product shows this
+ * legibly; it is the desk's clearest edge. Only the highest revision per
+ * message is shown and withdrawn messages are hidden (the backend enforces
+ * that — most raw messages are withdrawn revisions).
+ */
+export default function OutagePanel({ zone = 'DE_LU' }) {
+  const { data, loading } = useFetchWithError(`${API}/power/outages?zone=${zone}`, { deps: [zone] })
+
+  if (!data?.available && !loading) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          OUTAGES — no unavailability messages for this zone yet.
+        </div>
+      </div>
+    )
+  }
+
+  const outages = data?.outages ?? []
+  const running = outages.filter((o) => o.running_now)
+  const upcoming = outages.filter((o) => !o.running_now)
+  const forced = data?.forced_offline_mw ?? 0
+
+  return (
+    <Panel
+      id="power-outages"
+      title={`GENERATION OUTAGES · ${data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)}`}
+      freshness={data}
+      info="ENTSO-E A77 unavailability of generation units. Counts the worst case of each message's availability curve; only the highest revision per message is shown, withdrawn messages are hidden. PLANNED = scheduled maintenance, FORCED = unplanned trip — forced capacity loss is what moves prices intraday. Descriptive, not a price call."
+      collapsible
+      headerRight={
+        data?.total_offline_mw != null && (
+          <span className="font-mono text-[10px] font-bold text-orange-400">
+            {fmtGw(data.total_offline_mw)} offline
+          </span>
+        )
+      }
+    >
+      {loading && !data ? (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">Loading outages…</div>
+      ) : (
+        <>
+          <div className="px-4 py-3 border-b border-border/30">
+            <PanelTakeaway tone={forced > 1000 ? 'warn' : 'info'}>
+              {`${fmtGw(data.total_offline_mw)} of generation is offline right now` +
+                (forced > 0 ? ` — ${fmtGw(forced)} of it forced (unplanned).` : ', all of it planned maintenance.')}
+              {upcoming.length > 0 ? ` ${upcoming.length} more outage${upcoming.length === 1 ? '' : 's'} start within 30 days.` : ''}
+            </PanelTakeaway>
+          </div>
+          <div className="px-2 py-2 overflow-x-auto">
+            <table className="w-full font-mono text-[11px]">
+              <thead>
+                <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                  <th className="text-left px-2 py-1">Unit</th>
+                  <th className="text-left px-2 py-1">Fuel</th>
+                  <th className="text-right px-2 py-1">Offline</th>
+                  <th className="text-left px-2 py-1">Kind</th>
+                  <th className="text-left px-2 py-1">Until</th>
+                </tr>
+              </thead>
+              <tbody>
+                {running.slice(0, 12).map((o) => (
+                  <tr key={o.mrid} className="border-t border-border/30">
+                    <td className="px-2 py-1.5 text-neutral-300 max-w-[180px] truncate" title={o.unit_name}>
+                      {o.unit_name || o.mrid}
+                    </td>
+                    <td className="px-2 py-1.5 text-neutral-500">{o.fuel || '—'}</td>
+                    <td className="px-2 py-1.5 text-right font-bold text-neutral-200">{fmtGw(o.offline_mw)}</td>
+                    <td className="px-2 py-1.5">
+                      <span className={`text-[9px] tracking-wide border rounded px-1.5 py-0.5 ${
+                        o.kind === 'forced'
+                          ? 'text-orange-400 border-orange-500/30'
+                          : 'text-neutral-500 border-border'
+                      }`}>
+                        {o.kind === 'forced' ? 'FORCED' : 'PLANNED'}
+                      </span>
+                    </td>
+                    <td className="px-2 py-1.5 text-neutral-500">{fmtEnd(o.end_utc)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {running.length > 12 && (
+              <div className="font-mono text-[9px] text-neutral-600 px-2 pt-1">
+                + {running.length - 12} smaller outages running
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/OutagePanel.jsx
+++ b/frontend/src/components/OutagePanel.jsx
@@ -1,6 +1,7 @@
 import Panel from './Panel'
 import PanelTakeaway from './PanelTakeaway'
 import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
 
 const API = '/api'
 
@@ -23,7 +24,7 @@ function fmtEnd(iso) {
  * that — most raw messages are withdrawn revisions).
  */
 export default function OutagePanel({ zone = 'DE_LU' }) {
-  const { data, loading } = useFetchWithError(`${API}/power/outages?zone=${zone}`, { deps: [zone] })
+  const { data, loading } = useFetchWithError(`${API}/power/outages?zone=${zone}`, { deps: [zone], pollMs: POLL_SLOW_MS })
 
   if (!data?.available && !loading) {
     return (

--- a/frontend/src/components/PowerGridPanel.jsx
+++ b/frontend/src/components/PowerGridPanel.jsx
@@ -1,5 +1,6 @@
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeDays, rangeStart } from '../utils/ranges'
 import {
@@ -25,7 +26,7 @@ function DunkelDot({ cx, cy, payload }) {
 export default function PowerGridPanel({ zone = 'DE_LU' }) {
   const { range } = useViewState()
   const url = `${API}/power/grid?days=${rangeDays(range)}&zone=${zone}`
-  const { data, loading, error } = useFetchWithError(url, { deps: [zone, range] })
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone, range], pollMs: POLL_SLOW_MS })
 
   if (error)
     return (

--- a/frontend/src/components/PowerLoadForecastPanel.jsx
+++ b/frontend/src/components/PowerLoadForecastPanel.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import ForecastErrorStrip from './ForecastErrorStrip'
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import {
@@ -154,6 +155,7 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
           </div>
         )
       )}
+      <ForecastErrorStrip zone={zone} />
       <div className="px-4 py-2 font-mono text-[9px] text-neutral-700">
         Source: ENTSO-E day-ahead load forecast (A65/A01) + wind/solar (A69/A01) · descriptive, not a forecast of price
       </div>

--- a/frontend/src/components/PowerOverviewMatrix.jsx
+++ b/frontend/src/components/PowerOverviewMatrix.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_FAST_MS } from '../utils/poll'
 
 // Single-glance overview — read all bidding zones at once, colour-first, like
 // Electricity Maps / Grid Status. Colour encodes how far each metric sits from its
@@ -26,7 +27,7 @@ const COLUMNS = [
 ]
 
 export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
-  const { data } = useFetchWithError(`${API}/power/overview`)
+  const { data } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
   const [sort, setSort] = useState({ key: 'zone', dir: 'asc' })
 
   const sorted = useMemo(() => {

--- a/frontend/src/components/PowerSituationHeader.jsx
+++ b/frontend/src/components/PowerSituationHeader.jsx
@@ -1,4 +1,5 @@
 import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_FAST_MS } from '../utils/poll'
 import { InfoPopover } from './Panel'
 import PanelTakeaway from './PanelTakeaway'
 import ReferenceBand from './ReferenceBand'
@@ -60,7 +61,7 @@ function Metric({ label, value, sub, color, band, comp }) {
  * drill-down evidence). Always-on hero across every tab.
  */
 export default function PowerSituationHeader({ zone = 'DE_LU' }) {
-  const { data, loading } = useFetchWithError(`${API}/power/situation?zone=${zone}`, { deps: [zone] })
+  const { data, loading } = useFetchWithError(`${API}/power/situation?zone=${zone}`, { deps: [zone], pollMs: POLL_FAST_MS })
 
   if (loading && !data) {
     return (

--- a/frontend/src/components/RecordChip.jsx
+++ b/frontend/src/components/RecordChip.jsx
@@ -1,0 +1,41 @@
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+
+const API = '/api'
+
+const SERIES_LABEL = {
+  'price.dayahead': 'day-ahead hour',
+  'price.dayahead.qh': 'day-ahead 15-min slot',
+  'imbalance.price.qh': 'imbalance settlement',
+  'load.actual': 'load',
+  'residual.actual': 'residual load',
+}
+
+function fmt(r) {
+  const what = SERIES_LABEL[r.series] || r.series
+  const dir = r.kind === 'max' ? 'highest' : 'lowest'
+  const val = r.unit === 'EUR/MWh' ? `€${r.value.toFixed(0)}/MWh` : `${(r.value / 1000).toFixed(1)} GW`
+  return `${dir} ${what} on record: ${val} (${r.date})`
+}
+
+/**
+ * Renders ONLY when a record fell within the last 7 days — a fresh all-time
+ * extreme is the story of the week; archive records live in the API. Not
+ * rendering is the normal state, not a data gap.
+ */
+export default function RecordChip({ zone = 'DE_LU' }) {
+  const { data } = useFetchWithError(`${API}/power/records?zone=${zone}`, { deps: [zone], pollMs: POLL_SLOW_MS })
+  const fresh = (data?.records ?? []).filter((r) => r.fresh)
+  if (fresh.length === 0) return null
+
+  return (
+    <div className="border border-yellow-500/30 bg-yellow-500/5 rounded px-3 py-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+      <span className="font-mono text-[9px] font-bold tracking-widest text-yellow-400">⚡ NEW RECORD</span>
+      {fresh.slice(0, 2).map((r) => (
+        <span key={`${r.series}-${r.kind}`} className="font-mono text-[10px] text-neutral-300">
+          {fmt(r)}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useFetchWithError.js
+++ b/frontend/src/hooks/useFetchWithError.js
@@ -20,9 +20,14 @@ const swrCache = new Map() // url -> last successful (transformed) payload
  *
  * `opts.deps` extends the dependency list so callers can refetch
  * when their own state changes.
+ *
+ * `opts.pollMs` re-fetches on an interval so today-views keep filling in
+ * without a reload (the ingest runs every 30 min; panels poll slower).
+ * Polling pauses while the tab is hidden and resumes — with an immediate
+ * refresh — when it becomes visible again.
  */
 export default function useFetchWithError(url, opts = {}) {
-  const { transform, deps = [], headers, signalRef } = opts
+  const { transform, deps = [], headers, signalRef, pollMs } = opts
   const [data, setData] = useState(() => (swrCache.has(url) ? swrCache.get(url) : null))
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(() => !swrCache.has(url))
@@ -82,6 +87,25 @@ export default function useFetchWithError(url, opts = {}) {
     run(controller)
     return () => controller.abort()
   }, [run, signalRef])
+
+  useEffect(() => {
+    if (!pollMs) return
+    let controller = null
+    const tick = () => {
+      if (document.hidden) return // don't burn requests for a backgrounded tab
+      controller = new AbortController()
+      run(controller)
+    }
+    const interval = setInterval(tick, pollMs)
+    // Coming back to the tab: refresh immediately instead of waiting a full cycle.
+    const onVisible = () => { if (!document.hidden) tick() }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisible)
+      controller?.abort()
+    }
+  }, [run, pollMs])
 
   return { data, loading, error, refetch }
 }

--- a/frontend/src/utils/poll.js
+++ b/frontend/src/utils/poll.js
@@ -1,0 +1,4 @@
+// Central poll cadences for the auto-refreshing views. The ENTSO-E ingest runs
+// every 30 minutes, so anything faster than these just re-reads the same data.
+export const POLL_FAST_MS = 5 * 60 * 1000 // situation views: hero, overview, narrative
+export const POLL_SLOW_MS = 10 * 60 * 1000 // detail panels: grid, mix, flows, outages


### PR DESCRIPTION
Abschluss der genehmigten Roadmap (Blöcke 3+4). Die Zonen-Wellen (3.1/3.2) entfielen — Prod hat bereits alle 37 Zonen enabled.

## Block 3 — Neue Datenarten

**reBAP für DE_LU (7f436b5)** — Live-Spike ergab: Die 4 Regelzonen-EICs und der Bidding-Zone-EIC liefern alle Acknowledgement 999; der **Länder-EIC** `10Y1001A1001A83F` liefert den vollen 96-Slot-reBAP. `_CONTROL_AREA_SKIP` → `_CONTROL_AREA_OVERRIDE`; die Kernzone bekommt endlich eine Imbalance-Serie.

**A71 Generation-Forecast (00778fb)** — Serie `generation.forecast`, eigener Cache-Source, läuft nightly pro Zone mit.

**Hydro-Reservoirs A72 (eab9e52)** — Live-Spike: P7D-Wochenpunkte in MWh (NO2 ~21 TWh). Eigener Collector mit **eigener Zonenliste** (Nordics/Alpen/Iberia/FR, unabhängig von ENABLED_ZONES). Füllstände sind hart saisonal → „vs. normal" vergleicht gegen die **gleiche ISO-Woche der Vorjahre** (ein rollierendes Fenster würde jede Schneeschmelze als Anomalie flaggen). EUROPE-Tab bekommt die Reservoir-Tabelle.

**Ausfälle A77 — das Flaggschiff (696f153)** — Live-Spike: **26 von 31 Dokumenten waren zurückgezogen** (docStatus A09); ein naiver Reader hätte 26 Geister-Ausfälle gezeigt. Deshalb: `PowerOutage` speichert jede (mRID, revision) als Historie, die Leseseite nimmt die höchste Revision und versteckt Withdrawals. `available_mw` = Minimum der Stückfunktion (worst case). `/api/power/outages` zählt nur JETZT laufende Ausfälle in die Summen (planned/forced getrennt); OutagePanel führt die GRID-Sektion an. Bewusste Plan-Abweichung: **kein** Disk-Cache (Meldungen mutieren; die (mrid,revision)-Zeile ist die Idempotenz — Disk-Incident-Lehre).

## Block 4 — Darstellungs-Parität

**Auto-Refresh (92a9ec0)** — `useFetchWithError` bekommt `pollMs` (pausiert bei verstecktem Tab, sofortiger Refresh bei Rückkehr); 5 min für Situation-Views, 10 min für Detail-Panels, zentral in `utils/poll.js`.

**Records (264bdbe)** — `PowerRecord` nightly per SQL-min/max; Plausibilitäts-Band gegen Ingest-Glitches; `RecordChip` erscheint **nur** bei einem frischen Rekord (≤7d).

**Forecast-vs-Actual (264bdbe)** — `/api/power/forecast-error`: Bias + MAE des publizierten TSO-Forecasts (load/residual/wind/solar; realisierter Wind = gen.B18+B19). Posture B: misst deren Forecast, macht keinen eigenen.

## Tests

682 passed, 1 skipped (+36 neue, alle TDD mit Live-API-verifizierten Fixtures). Build + Ruff grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)