### PR TITLE
Outages: send offset explicitly and keep the window under one year

### DIFF
--- a/backend/power/entsoe_outages.py
+++ b/backend/power/entsoe_outages.py
@@ -13,8 +13,14 @@ either serve stale revisions or need its own retention machinery — the
 2026-07-07 disk incident says keep transient payloads off the disk. The DB
 row per (mrid, revision) IS the idempotency layer.
 
-Pagination: ENTSO-E caps unavailability responses at 200 documents; further
-pages via offset=200, 400, … We page until a page returns fewer than 200.
+Pagination — learned from the live API, both the hard way:
+  * >200 documents WITHOUT an offset param is HTTP 400 ("number of instances
+    exceeds the allowed maximum"); the API only paginates when offset is sent
+    EXPLICITLY, including offset=0. DE_LU alone had 362 documents in a
+    362-day window.
+  * The request window must span less than one year, or HTTP 400
+    ("must not span more than one year").
+We page in 200s until a page comes back non-full.
 """
 
 from __future__ import annotations
@@ -36,6 +42,10 @@ from backend.power.zones import POWER_ZONES
 logger = logging.getLogger(__name__)
 
 _PAGE_SIZE = 200
+
+# Window must stay under the API's one-year span limit.
+DEFAULT_LOOKBACK_DAYS = 7
+DEFAULT_LOOKAHEAD_DAYS = 355
 
 #: docStatus values that mean "this message no longer stands".
 _WITHDRAWN_STATUSES = {"A09", "A13"}  # cancelled / withdrawn
@@ -117,12 +127,19 @@ async def _fetch_outages_page(
         "biddingZone_Domain": eic,
         "periodStart": window_start,
         "periodEnd": window_end,
+        # ALWAYS explicit, including 0 — without it the API refuses to paginate
+        # and answers >200-document windows with HTTP 400.
+        "offset": str(offset),
     }
-    if offset:
-        params["offset"] = str(offset)
     async with httpx.AsyncClient(timeout=120) as client:
         resp = await client.get(ENTSOE_BASE, params=params)
-        if resp.status_code == 400:  # past the last page / no data
+        if resp.status_code == 400:
+            # Past the last page is a 400/ACK; on the FIRST page it is a real
+            # error (bad window, bad domain) that must not be silent — the
+            # initial prod run wrote 0 documents without a single log line.
+            if offset == 0:
+                logger.warning("entsoe_outages [%s]: HTTP 400 on first page: %.200s",
+                               eic, resp.text)
             return None
         resp.raise_for_status()
         return resp.content if resp.content[:2] == b"PK" else None
@@ -133,8 +150,8 @@ async def ingest_outages(
     *,
     zones: list[str] | None = None,
     doc_type: str = "A77",
-    lookahead_days: int = 365,
-    lookback_days: int = 7,
+    lookahead_days: int = DEFAULT_LOOKAHEAD_DAYS,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
 ) -> dict:
     """Fetch the rolling outage window for `zones` and store new (mrid, revision)
     rows. No deep backfill by design — active + upcoming messages are the

--- a/backend/tests/test_outages.py
+++ b/backend/tests/test_outages.py
@@ -148,6 +148,68 @@ async def test_ingest_keeps_every_revision(db_session, monkeypatch):
     assert db_session.query(out.PowerOutage).count() == 2
 
 
+# ─── pagination + window limits (learned from the live API) ──────────────────
+
+
+def test_window_stays_under_the_one_year_api_limit():
+    """A 372-day window returns HTTP 400 'must not span more than one year' —
+    and DE_LU alone had 362 documents in a 362-day window, so the window must
+    fit AND pagination must work."""
+    assert out.DEFAULT_LOOKBACK_DAYS + out.DEFAULT_LOOKAHEAD_DAYS < 365
+
+
+async def test_ingest_pages_past_200_documents(db_session, monkeypatch):
+    """ENTSO-E does NOT paginate implicitly: >200 docs without an offset param
+    is HTTP 400. offset must be sent explicitly (even 0), and a full page
+    means there may be another."""
+    full_page = _zip(*[_doc(mrid=f"m{i}") for i in range(200)])
+    second_page = _zip(_doc(mrid="last"))
+    offsets = []
+
+    async def fake_fetch(eic, window_start, window_end, offset, *, doc_type="A77"):
+        offsets.append(offset)
+        return {0: full_page, 200: second_page}.get(offset)
+
+    monkeypatch.setattr(out, "_fetch_outages_page", fake_fetch)
+    monkeypatch.setattr(out.settings, "entsoe_api_token", SecretStr("tok"))
+    r = await out.ingest_outages(db_session, zones=["DE_LU"])
+
+    assert offsets == [0, 200], "a non-full page ends the paging"
+    assert r["written"] == 201
+
+
+async def test_fetch_always_sends_the_offset_param(monkeypatch):
+    """Live finding: >200 documents WITHOUT an offset param is HTTP 400 — the
+    API only paginates when offset is explicit, including offset=0."""
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        content = b"PK\x03\x04fake"
+
+        def raise_for_status(self):
+            pass
+
+    class _FakeClient:
+        def __init__(self, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, params=None):
+            captured.update(params or {})
+            return _FakeResponse()
+
+    monkeypatch.setattr(out.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(out.settings, "entsoe_api_token", SecretStr("tok"))
+    await out._fetch_outages_page("10Y1001A1001A82H", "202607040000", "202608040000", 0)
+    assert captured.get("offset") == "0"
+
+
 # ─── route: active outages, highest revision wins ─────────────────────────────
 
 


### PR DESCRIPTION
The initial prod run wrote 0 documents across 37 zones — silently. Two live
API behaviors the spike's small window never hit:

* A >200-document window WITHOUT an offset param is HTTP 400 ('number of
  instances exceeds the allowed maximum') — the API only paginates when
  offset is EXPLICIT, including offset=0. DE_LU alone holds 362 documents
  in its rolling window.
* The request window must span less than one year ('must not span more than
  one year'); the default lookahead of 365d + 7d lookback was 372.

offset is now always sent; the default window is 7d back + 355d forward; and
a 400 on the FIRST page logs a warning instead of masquerading as 'no data' —
that silence is exactly how the empty run went unnoticed.

685 passed, 1 skipped.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
