### PR TITLE
Flows backfill: honour Energy-Charts' rate limit (429 backoff + 2s spacing)

### DIFF
--- a/backend/power/energy_charts_flows.py
+++ b/backend/power/energy_charts_flows.py
@@ -48,9 +48,14 @@ logger = logging.getLogger(__name__)
 CBPF_BASE = "https://api.energy-charts.info/cbpf"
 ATTRIBUTION = "Energy-Charts (CC BY 4.0)"
 CACHE_SOURCE = "energy_charts_cbpf"
-# Pause between cache-miss month fetches in the backfill path — Energy-Charts is
-# free and unauthenticated; don't hammer it with ~24 countries × months at once.
-CACHE_THROTTLE_SECONDS = 0.5
+# Pause between cache-miss month fetches in the backfill path. Energy-Charts is
+# free and unauthenticated and rate-limits hard: the 2026-07-12 prod backfill got
+# HTTP 429 after ~6 back-to-back month requests at 0.5 s spacing, and the block
+# persisted for the rest of the run. 2 s spacing plus the 429 backoff below is
+# what actually completes a ~600-request historical sweep.
+CACHE_THROTTLE_SECONDS = 2.0
+RATE_LIMIT_ATTEMPTS = 6
+RATE_LIMIT_BASE_SECONDS = 30.0
 
 # Energy-Charts country names -> OBSYD zone codes.
 # "Germany" maps to DE_LU because the DE ENTSO-E bidding zone is the DE-LU
@@ -319,6 +324,34 @@ def _month_windows(start: date, end: date) -> list[tuple[date, date]]:
     return windows
 
 
+async def _fetch_with_rate_limit(country_code: str, start_iso: str, end_iso: str) -> dict:
+    """fetch_cbpf with HTTP-429 backoff for the backfill path.
+
+    A month-sweep is hundreds of requests; without honouring the rate limit the
+    2026-07-12 run "completed" in 20 s having skipped almost every country-month
+    (ingest_cbpf logs per-country failures as warnings, so nothing retried).
+    Non-429 errors propagate immediately.
+    """
+    for attempt in range(RATE_LIMIT_ATTEMPTS):
+        try:
+            return await fetch_cbpf(country_code, start_iso, end_iso)
+        except httpx.HTTPStatusError as exc:
+            resp = exc.response
+            if resp is None or resp.status_code != 429 or attempt == RATE_LIMIT_ATTEMPTS - 1:
+                raise
+            retry_after = resp.headers.get("Retry-After", "")
+            try:
+                wait = float(retry_after)
+            except ValueError:
+                wait = RATE_LIMIT_BASE_SECONDS * (2**attempt)
+            logger.warning(
+                "energy_charts_flows: 429 for %s %s..%s — backing off %.0fs (attempt %d/%d)",
+                country_code, start_iso, end_iso, wait, attempt + 1, RATE_LIMIT_ATTEMPTS,
+            )
+            await asyncio.sleep(wait)
+    raise AssertionError("unreachable")  # loop always returns or raises
+
+
 async def _fetch_range(
     country_code: str,
     start_date: date,
@@ -354,7 +387,7 @@ async def _fetch_range(
             # Running (incomplete) month: fetch the requested window live, never
             # persist — a mid-month blob would freeze and shadow the remainder.
             payloads.append(
-                await fetch_cbpf(country_code, m_start.isoformat(), m_end.isoformat())
+                await _fetch_with_rate_limit(country_code, m_start.isoformat(), m_end.isoformat())
             )
             await asyncio.sleep(CACHE_THROTTLE_SECONDS)
             continue
@@ -367,7 +400,7 @@ async def _fetch_range(
                 continue
         # Cached blobs always span the FULL month, whatever day subset was
         # requested — the key claims the month, so the content must deliver it.
-        payload = await fetch_cbpf(country_code, month_first.isoformat(), month_last.isoformat())
+        payload = await _fetch_with_rate_limit(country_code, month_first.isoformat(), month_last.isoformat())
         raw_cache.write_cached(CACHE_SOURCE, key, month_first, payload, overwrite=overwrite)
         payloads.append(payload)
         await asyncio.sleep(CACHE_THROTTLE_SECONDS)

--- a/backend/tests/test_energy_charts_flows.py
+++ b/backend/tests/test_energy_charts_flows.py
@@ -574,3 +574,67 @@ async def test_use_cache_never_caches_the_current_month(db_session, tmp_path, mo
 
     assert calls.count("de") == 2, "current month must be re-fetched, never cached"
     assert list(tmp_path.rglob("*.json.gz")) == []
+
+
+# ─── 429 backoff (backfill path) ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_use_cache_backs_off_on_429_and_recovers(db_session, tmp_path, monkeypatch):
+    """Energy-Charts 429s after short bursts (observed in prod 2026-07-12); the
+    backfill path must back off and retry instead of silently skipping the month."""
+    import httpx
+
+    import backend.gas.raw_cache as rc
+    from backend.power.energy_charts_flows import ingest_cbpf
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(flows, "CACHE_THROTTLE_SECONDS", 0.0)
+    base = 1717200000  # 2024-06-01 00:00 UTC
+    payload = _make_payload({"France": [1.0] * 96}, base_ts=base)
+    attempts = {"de": 0}
+
+    async def mock_fetch(country, start, end):
+        if country == "de":
+            attempts["de"] += 1
+            if attempts["de"] <= 2:
+                resp = httpx.Response(429, headers={"Retry-After": "0"},
+                                      request=httpx.Request("GET", "http://x"))
+                raise httpx.HTTPStatusError("429", request=resp.request, response=resp)
+            return payload
+        resp = httpx.Response(404, request=httpx.Request("GET", "http://x"))
+        raise httpx.HTTPStatusError("404", request=resp.request, response=resp)
+
+    with patch("backend.power.energy_charts_flows.fetch_cbpf", side_effect=mock_fetch):
+        result = await ingest_cbpf(db_session, ["2024-06-01"], use_cache=True)
+
+    assert attempts["de"] == 3, "two 429s then success"
+    assert result["written"] >= 1
+    assert len(list(tmp_path.rglob("de_2024-06.json.gz"))) == 1, "recovered month is cached"
+
+
+@pytest.mark.asyncio
+async def test_use_cache_gives_up_after_max_429s(db_session, tmp_path, monkeypatch):
+    """Persistent 429 must not loop forever: after RATE_LIMIT_ATTEMPTS the country
+    is skipped (uncached), so a later re-run heals it."""
+    import httpx
+
+    import backend.gas.raw_cache as rc
+    from backend.power.energy_charts_flows import ingest_cbpf
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(flows, "CACHE_THROTTLE_SECONDS", 0.0)
+    calls = {"n": 0}
+
+    async def mock_fetch(country, start, end):
+        calls["n"] += 1
+        resp = httpx.Response(429, headers={"Retry-After": "0"},
+                              request=httpx.Request("GET", "http://x"))
+        raise httpx.HTTPStatusError("429", request=resp.request, response=resp)
+
+    with patch("backend.power.energy_charts_flows.fetch_cbpf", side_effect=mock_fetch):
+        result = await ingest_cbpf(db_session, ["2024-06-01"], use_cache=True)
+
+    assert result["written"] == 0
+    assert calls["n"] == len(flows.BASE_COUNTRIES) * flows.RATE_LIMIT_ATTEMPTS
+    assert list(tmp_path.rglob("*.json.gz")) == [], "a failed month must never cache"


### PR DESCRIPTION
Der erste Prod-Lauf des flows-Backfills (#63-Follow-up) bekam nach ~6 Monats-Requests à 0,5 s Abstand HTTP 429, und der Block hielt für den Rest des Laufs an — weil `ingest_cbpf` Fetch-Fehler pro Land als Warning schluckt, lief der Job in 20 s „erfolgreich" durch und hatte genau einen Teilmonat ingested (Log: `logs/flows_backfill_20260712.log`, 571 Warnings).

- `_fetch_with_rate_limit`: Retry-After-bewusster exponentieller Backoff (30 s·2^n, max 6 Versuche) NUR im Backfill-Pfad; Nicht-429-Fehler propagieren sofort; der Live-Scheduler-Pfad bleibt unangetastet.
- `CACHE_THROTTLE_SECONDS` 0,5 → 2,0 s.
- Ein endgültig gescheiterter Monat wird nie gecacht → Re-Run heilt (per Test gepinnt, ebenso der Recover-Fall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)