### PR TITLE
Ops & performance: batch the overview, dedupe outages in SQL, wire the incident crons

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Investigated and deliberately deferred (with their blockers), not silently dropp
 - **Germany imbalance** — four control areas with a combined reBAP not exposed under a single A85 control-area EIC; DE-LU is skipped for imbalance only.
 - **Curtailment / redispatch / reserves** (ENTSO-E A63/A80/…) — fragmented, border-specific congestion-management data, not a clean pan-EU series.
 - **Continuous intraday prices** — no clean, free, redistributable source.
+- **`power_hourly` retention** — the canonical store grows unbounded by design (all-time records need all-time history). If disk ever becomes the constraint, the 15-min `.qh` series are the thinning candidates (raw quarter-hours matter most recently; the hourly series keeps the long history) — documented option, deliberately not built.
 
 ## Tech Stack
 

--- a/backend/routes/api_v1.py
+++ b/backend/routes/api_v1.py
@@ -134,6 +134,7 @@ async def genmix(
     resolution: str = Query("monthly", pattern="^(daily|monthly)$"),
     format: str = Query("json", pattern="^(json|csv)$"),
     db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
 ):
     """Generation mix over time — every fuel (gen.<psr>) for one zone, aggregated to
     daily or monthly mean MW, in a wide shape ({t, <fuel>: mw, ...}) for a stacked area.
@@ -208,6 +209,7 @@ async def snapshot(
     start: str | None = Query(None, description="Override window start (ISO / YYYY-MM-DD)"),
     end: str | None = Query(None, description="Override window end (default: now)"),
     db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
 ):
     """Per-zone hourly values for one series over a window, aligned to a common
     timestamp grid ({timestamps: [...], zones: {zone: [v, ...]}}). Powers the map

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -32,6 +32,7 @@ from datetime import datetime, timedelta, timezone
 from datetime import datetime as _dt
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, tuple_
 from sqlalchemy.orm import Session
 
 from backend.config import settings
@@ -560,16 +561,14 @@ async def get_load_forecast_hourly(
 
 
 @router.get("/overview")
-async def get_power_overview(db: Session = Depends(get_db)):
+def get_power_overview(db: Session = Depends(get_db)):
     """All bidding zones at a glance — the single-glance overview (rows = zones,
-    each with its state + key metrics + vs-normal z-scores). Reuses the exact
-    per-zone synthesis (load_power_situation) so the overview and the detail agree."""
+    each with its state + key metrics + vs-normal z-scores). Uses the batched
+    loader (load_power_situations_bulk) — same synthesis as the per-zone detail,
+    ~7 queries instead of 37 × ~6. Sync def: FastAPI runs it in the threadpool,
+    so the (still synchronous) DB work no longer blocks the event loop."""
     zones = []
-    for zone in POWER_ZONES:
-        try:
-            sit = load_power_situation(db, zone)
-        except Exception:
-            continue
+    for sit in load_power_situations_bulk(db).values():
         if not sit.get("available"):
             continue
         price = sit.get("price", {})
@@ -934,6 +933,135 @@ def load_power_situation(db: Session, zone: str) -> dict:
     )
 
 
+def load_power_situations_bulk(db: Session) -> dict[str, dict]:
+    """Every zone's situation with a FIXED number of queries (~7) instead of the
+    per-zone path's 37 × ~6 — /overview is the default EUROPE tab, i.e. the most
+    trafficked endpoint, and the N+1 grew with zones × history. Feeds the SAME
+    pure build_power_situation as load_power_situation, so overview and detail
+    cannot disagree (pinned by a parity test)."""
+    from backend.models.energy import InstalledCapacity
+    from backend.power.coverage import coverage_min_ratio
+    from backend.signals.detectors.power import forced_outage_totals_now
+
+    date_from, date_to = _window(120)
+    today = datetime.utcnow().date()
+
+    # 1. Day-ahead price stats, all zones in one scan.
+    price_by_zone: dict[str, list[dict]] = {z: [] for z in POWER_ZONES}
+    price_rows = (
+        db.query(PowerPriceDaily.zone, PowerPriceDaily.date,
+                 PowerPriceDaily.mean_price, PowerPriceDaily.negative_hours)
+        .filter(PowerPriceDaily.date >= date_from, PowerPriceDaily.date <= date_to)
+        .order_by(PowerPriceDaily.date.asc())
+        .all()
+    )
+    for z, d, mean, neg in price_rows:
+        if z in price_by_zone:
+            price_by_zone[z].append({"date": d, "close": mean, "negative_hours": neg})
+
+    # 2. Grid rows (load/wind/solar), all zones in one scan.
+    grid_by_zone: dict[str, list] = {z: [] for z in POWER_ZONES}
+    for r in (
+        db.query(PowerGrid)
+        .filter(PowerGrid.date >= date_from, PowerGrid.date <= date_to)
+        .order_by(PowerGrid.date.asc())
+        .all()
+    ):
+        if r.zone in grid_by_zone:
+            grid_by_zone[r.zone].append(r)
+
+    # 3. Coverage guard for each zone's LATEST grid day — one row-value IN query
+    #    replaces renewable_share_reliable's per-zone SUM (same semantics: no
+    #    genmix row at all → untrusted).
+    latest_grid = {z: rows[-1] for z, rows in grid_by_zone.items() if rows}
+    pairs = [(r.zone, r.date) for r in latest_grid.values()]
+    gen_totals: dict[tuple[str, str], float] = {}
+    if pairs:
+        for z, d, total in (
+            db.query(PowerGenMix.zone, PowerGenMix.date, func.sum(PowerGenMix.gen_mw))
+            .filter(tuple_(PowerGenMix.zone, PowerGenMix.date).in_(pairs))
+            .group_by(PowerGenMix.zone, PowerGenMix.date)
+            .all()
+        ):
+            gen_totals[(z, d)] = float(total) if total is not None else None
+
+    def _coverage_ok(zone: str) -> bool:
+        r = latest_grid.get(zone)
+        if r is None:
+            return True  # no grid rows at all — matches the per-zone path
+        if not r.load_mw or r.load_mw <= 0:
+            return False
+        total = gen_totals.get((r.zone, r.date))
+        if total is None:
+            return False
+        return total >= coverage_min_ratio(zone) * r.load_mw
+
+    # 4. Spark legs: every zone's power symbol + TTF in one 14-day scan.
+    spark_from, spark_to = _window(14)
+    symbols = {cfg["price_symbol"] for cfg in POWER_ZONES.values()} | {"TTF"}
+    closes: dict[str, dict[str, float]] = {s: {} for s in symbols}
+    for sym, d, close in (
+        db.query(EnergyPrice.symbol, EnergyPrice.date, EnergyPrice.close)
+        .filter(EnergyPrice.symbol.in_(symbols),
+                EnergyPrice.date >= spark_from, EnergyPrice.date <= spark_to)
+        .all()
+    ):
+        closes[sym][d] = close
+    heat_rate = round(1.0 / settings.gas_ccgt_efficiency, 4)
+
+    def _spark(zone: str) -> dict | None:
+        power_by = closes.get(POWER_ZONES[zone]["price_symbol"], {})
+        ttf_by = closes.get("TTF", {})
+        common = sorted(set(power_by) & set(ttf_by))
+        if not common:
+            return None
+        d = common[-1]
+        return {
+            "date": d,
+            "power_price": power_by[d],
+            "gas_price": ttf_by[d],
+            "spark_spread": round(power_by[d] - ttf_by[d] * heat_rate, 4),
+        }
+
+    # 5. Forced outages per zone (SQL revision-dedupe, one query).
+    forced_by_zone = forced_outage_totals_now(db)
+
+    # 6. Installed capacity (latest A68 year) per zone, one query.
+    latest_year = (
+        db.query(InstalledCapacity.zone, func.max(InstalledCapacity.year).label("y"))
+        .group_by(InstalledCapacity.zone)
+        .subquery()
+    )
+    installed: dict[str, float] = {}
+    for z, total in (
+        db.query(InstalledCapacity.zone, func.sum(InstalledCapacity.capacity_mw))
+        .join(latest_year, (InstalledCapacity.zone == latest_year.c.zone)
+              & (InstalledCapacity.year == latest_year.c.y))
+        .group_by(InstalledCapacity.zone)
+        .all()
+    ):
+        if total:
+            installed[z] = float(total)
+
+    situations: dict[str, dict] = {}
+    for zone in POWER_ZONES:
+        try:
+            situations[zone] = build_power_situation(
+                zone,
+                price_by_zone[zone],
+                [_compute_grid_row(r) for r in grid_by_zone[zone]],
+                _spark(zone),
+                spark_supported=True,
+                grid_coverage_ok=_coverage_ok(zone),
+                forced_outage_mw=forced_by_zone.get(zone, 0.0),
+                forced_outage_installed_mw=installed.get(zone),
+                today=today,
+            )
+        except Exception:  # one broken zone must not blank the whole overview
+            continue
+    return situations
+
+
 @router.get("/situation")
 async def get_situation(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
@@ -1209,14 +1337,18 @@ async def get_outages(
     Descriptive: what capacity is off and why, not a price call.
     """
     from backend.models.energy import PowerOutage
+    from backend.signals.detectors.power import latest_outage_revisions
 
     resolved_zone = _resolve_zone(zone)
     now = datetime.utcnow()
     now_iso = now.strftime("%Y-%m-%dT%H:%MZ")
     horizon_iso = (now + timedelta(days=horizon_days)).strftime("%Y-%m-%dT%H:%MZ")
 
-    rows = db.query(PowerOutage).filter(PowerOutage.zone == resolved_zone).all()
-    if not rows:
+    # Highest revision per mRID wins; withdrawn events disappear. The dedupe
+    # runs in SQL (shared with the radar detector) instead of loading every
+    # revision row into Python.
+    latest_rows = latest_outage_revisions(db, resolved_zone)
+    if not latest_rows:
         return {
             "available": False,
             "zone": resolved_zone,
@@ -1224,16 +1356,10 @@ async def get_outages(
             "reason": f"No outage messages for {POWER_ZONES[resolved_zone]['label']} yet — check back shortly.",
         }
 
-    # Highest revision per mRID wins; withdrawn events disappear.
-    latest: dict[str, PowerOutage] = {}
-    for r in rows:
-        if r.mrid not in latest or r.revision > latest[r.mrid].revision:
-            latest[r.mrid] = r
-
     outages: list[dict] = []
     total_offline = 0.0
     forced_offline = 0.0
-    for r in latest.values():
+    for r in latest_rows:
         if r.status != "active":
             continue
         if r.end_utc < now_iso or r.start_utc > horizon_iso:
@@ -1262,7 +1388,13 @@ async def get_outages(
         })
 
     outages.sort(key=lambda o: (not o["running_now"], -(o["offline_mw"] or 0.0)))
-    newest_msg = max((r.created_at for r in rows if r.created_at), default=None)
+    # Freshness = newest message we EVER ingested for the zone (any revision) —
+    # a superseded revision still proves the collector is alive.
+    newest_msg = (
+        db.query(func.max(PowerOutage.created_at))
+        .filter(PowerOutage.zone == resolved_zone)
+        .scalar()
+    )
     return {
         "available": True,
         "zone": resolved_zone,

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -156,33 +156,74 @@ def forced_outage_severity(total_mw: float, installed_mw: float | None) -> str |
     return None
 
 
-def forced_outage_mw_now(db, zone: str) -> tuple[float, list]:
-    """(total forced MW offline RIGHT NOW, contributing rows) for `zone`.
+def latest_outage_revisions(db, zone: str | None = None) -> list:
+    """Highest revision per (zone, mRID), resolved in SQL via a window function.
 
-    Highest revision per mRID wins, withdrawn events vanish — the same
-    semantics as /api/power/outages (26 of 31 live-sampled documents were
-    withdrawn revisions; counting them would fabricate gigawatts).
+    Withdrawn rows are still RETURNED — ranking must happen before any status
+    filter, because a withdrawn latest revision has to hide the event (filtering
+    first would let an older active revision win and fabricate gigawatts; 26 of
+    31 live-sampled documents were withdrawn revisions). Replaces loading every
+    revision row into Python, which grew with the full revision history.
     """
-    from datetime import datetime, timezone
+    from sqlalchemy import func
 
     from backend.models.energy import PowerOutage
 
-    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
-    rows = db.query(PowerOutage).filter(PowerOutage.zone == zone).all()
-    latest: dict[str, PowerOutage] = {}
-    for r in rows:
-        if r.mrid not in latest or r.revision > latest[r.mrid].revision:
-            latest[r.mrid] = r
+    rn = (
+        func.row_number()
+        .over(
+            partition_by=[PowerOutage.zone, PowerOutage.mrid],
+            order_by=PowerOutage.revision.desc(),
+        )
+        .label("rn")
+    )
+    ranked = db.query(PowerOutage.id.label("oid"), rn)
+    if zone is not None:
+        ranked = ranked.filter(PowerOutage.zone == zone)
+    ranked = ranked.subquery()
+    return (
+        db.query(PowerOutage)
+        .join(ranked, PowerOutage.id == ranked.c.oid)
+        .filter(ranked.c.rn == 1)
+        .all()
+    )
 
-    running = [
-        r for r in latest.values()
+
+def _running_forced(rows, now_iso: str) -> list:
+    return [
+        r for r in rows
         if r.status == "active"
         and r.business_type == "A54"
         and r.nominal_mw is not None
         and r.start_utc <= now_iso <= r.end_utc
     ]
+
+
+def forced_outage_mw_now(db, zone: str) -> tuple[float, list]:
+    """(total forced MW offline RIGHT NOW, contributing rows) for `zone`.
+
+    Highest revision per mRID wins, withdrawn events vanish — the same
+    semantics as /api/power/outages (shared latest_outage_revisions helper).
+    """
+    from datetime import datetime, timezone
+
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    running = _running_forced(latest_outage_revisions(db, zone), now_iso)
     total = sum(r.nominal_mw - (r.available_mw or 0.0) for r in running)
     return total, running
+
+
+def forced_outage_totals_now(db) -> dict[str, float]:
+    """Forced MW offline RIGHT NOW for EVERY zone in one query — the bulk
+    counterpart of forced_outage_mw_now for /api/power/overview."""
+    from collections import defaultdict
+    from datetime import datetime, timezone
+
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    totals: dict[str, float] = defaultdict(float)
+    for r in _running_forced(latest_outage_revisions(db), now_iso):
+        totals[r.zone] += r.nominal_mw - (r.available_mw or 0.0)
+    return dict(totals)
 
 
 def detect_forced_outages(db) -> list[DetectorResult]:

--- a/backend/tests/test_api_v1.py
+++ b/backend/tests/test_api_v1.py
@@ -231,3 +231,19 @@ def test_rate_limit_returns_429(db_session, monkeypatch):
     assert c.get(url).status_code == 200
     assert c.get(url).status_code == 200
     assert c.get(url).status_code == 429  # third within the window
+
+
+def test_rate_limit_covers_genmix_and_snapshot(db_session, monkeypatch):
+    """The expensive aggregation endpoints share /series' per-IP budget — they
+    were the unthrottled ones."""
+    import backend.routes.api_v1 as v1
+    from backend.auth.ratelimit import reset_limits
+
+    reset_limits()
+    monkeypatch.setattr(v1, "RATE_PER_MIN", 2)
+    _seed(db_session)
+    c = _client(db_session)
+    assert c.get("/api/v1/genmix?zone=DE_LU").status_code == 200
+    assert c.get("/api/v1/snapshot?series=load.actual").status_code == 200
+    assert c.get("/api/v1/genmix?zone=DE_LU").status_code == 429
+    reset_limits()

--- a/backend/tests/test_backup_script.py
+++ b/backend/tests/test_backup_script.py
@@ -345,3 +345,15 @@ def test_weekly_backups_survive_daily_retention(dirs):
     weekly.write_bytes(b"x")
     _run(app, backups, OBSYD_BACKUP_RETENTION_DAYS=7)
     assert weekly.exists()
+
+
+def test_setup_vps_wires_disk_alarm_and_docker_prune_crons():
+    """The two post-mortem scripts of the 2026-07-07 disk-full incident must be
+    INSTALLED by setup-vps.sh, not just exist next to it — an unwired alarm is
+    how the incident went unnoticed for two days."""
+    text = (SCRIPT.parent / "setup-vps.sh").read_text()
+    assert "deploy/disk-alarm.sh >> /home/obsyd/obsyd/logs/disk-alarm.log" in text
+    assert "*/15 * * * *" in text
+    assert "deploy/docker-prune.sh >> /home/obsyd/obsyd/logs/docker-prune.log" in text
+    # health-line dedupe must not sweep the docker-prune line (path contains "obsyd")
+    assert "| grep -v obsyd |" not in text

--- a/backend/tests/test_power_overview.py
+++ b/backend/tests/test_power_overview.py
@@ -1,10 +1,22 @@
 """Single-glance power overview: /api/power/overview (all zones at once)."""
 from __future__ import annotations
 
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import event
 
 from backend.main import app
-from backend.models.energy import PowerGrid, PowerPriceDaily
+from backend.models.energy import (
+    EnergyPrice,
+    InstalledCapacity,
+    PowerGenMix,
+    PowerGrid,
+    PowerOutage,
+    PowerPriceDaily,
+)
+from backend.routes.power import load_power_situation, load_power_situations_bulk
 
 
 def test_overview_empty_is_unavailable(db_session):
@@ -28,3 +40,100 @@ def test_overview_returns_seeded_zone_with_state(db_session):
     assert de["state"] in ("CALM", "ELEVATED", "STRESSED")
     assert de["price_close"] == 71.0
     assert de["residual_gw"] is not None
+
+
+# ─── batching (bulk loader) ───────────────────────────────────────────────────
+# The bulk loader must agree with the per-zone path bit for bit (it feeds the
+# same pure build_power_situation), and do so in a FIXED number of queries —
+# the endpoint is the default EUROPE tab and the old loop was a 37×N+1.
+
+
+def _seed_zone(db, zone, *, base_price, load, wind, solar, days=40, gen_coverage=0.8):
+    today = date.today()
+    for i in range(days):
+        d = (today - timedelta(days=days - 1 - i)).isoformat()
+        db.add(PowerPriceDaily(date=d, zone=zone, mean_price=base_price + (i % 7),
+                               min_price=base_price - 30, max_price=base_price + 40,
+                               negative_hours=0))
+        db.add(PowerGrid(date=d, zone=zone, load_mw=load, wind_mw=wind, solar_mw=solar))
+        db.add(PowerGenMix(date=d, zone=zone, psr_type="Fossil Gas",
+                           gen_mw=load * gen_coverage))
+
+
+def _seed_multi(db):
+    today = date.today()
+    _seed_zone(db, "DE_LU", base_price=80.0, load=55_000.0, wind=9_000.0, solar=5_000.0)
+    _seed_zone(db, "FR", base_price=60.0, load=48_000.0, wind=3_000.0, solar=4_000.0)
+    # NL: incomplete A75 coverage (~33% of load) → renewable share untrusted
+    _seed_zone(db, "NL", base_price=70.0, load=12_000.0, wind=100.0, solar=80.0,
+               gen_coverage=0.33)
+
+    for i in range(10):  # spark legs
+        d = (today - timedelta(days=9 - i)).isoformat()
+        db.add(EnergyPrice(date=d, symbol="TTF", close=35.0))
+        db.add(EnergyPrice(date=d, symbol="POWER_DE", close=82.0))
+
+    # Outages: superseding revision counts, withdrawn vanishes; plus A68 capacity.
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    common = dict(doc_type="A77", zone="DE_LU", business_type="A54", psr_type="B14",
+                  unit_name="Block A", unit_eic="11W", location="DE",
+                  start_utc=(now - timedelta(days=1)).strftime(fmt),
+                  end_utc=(now + timedelta(days=3)).strftime(fmt))
+    db.add(PowerOutage(mrid="m1", revision=1, nominal_mw=900.0, available_mw=0.0,
+                       status="active", **common))
+    db.add(PowerOutage(mrid="m1", revision=2, nominal_mw=700.0, available_mw=0.0,
+                       status="active", **common))
+    db.add(PowerOutage(mrid="wd", revision=1, nominal_mw=5_000.0, available_mw=0.0,
+                       status="active", **common))
+    db.add(PowerOutage(mrid="wd", revision=2, nominal_mw=5_000.0, available_mw=0.0,
+                       status="withdrawn", **common))
+    db.add(InstalledCapacity(zone="DE_LU", year=2026, psr_type="Solar", capacity_mw=200_000.0))
+    db.commit()
+
+
+def test_bulk_matches_per_zone_path(db_session):
+    _seed_multi(db_session)
+    bulk = load_power_situations_bulk(db_session)
+    for zone in ("DE_LU", "FR", "NL"):
+        assert bulk[zone] == load_power_situation(db_session, zone), zone
+
+
+def test_bulk_matches_per_zone_on_empty_zones(db_session):
+    _seed_multi(db_session)
+    bulk = load_power_situations_bulk(db_session)
+    for zone in ("AT", "SE3"):
+        if zone in bulk:  # only enabled zones are built
+            assert bulk[zone] == load_power_situation(db_session, zone), zone
+
+
+def test_bulk_uses_fixed_query_count(db_session):
+    """Budget leaves headroom but catches any reintroduced N+1."""
+    _seed_multi(db_session)
+    statements = []
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            statements.append(statement)
+
+    engine = db_session.get_bind()
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        load_power_situations_bulk(db_session)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+    assert len(statements) <= 12, f"{len(statements)} SELECTs — bulk loader regressed to N+1"
+
+
+def test_forced_outage_totals_now_matches_per_zone(db_session):
+    from backend.signals.detectors.power import (
+        forced_outage_mw_now,
+        forced_outage_totals_now,
+    )
+
+    _seed_multi(db_session)
+    totals = forced_outage_totals_now(db_session)
+    per_zone, _ = forced_outage_mw_now(db_session, "DE_LU")
+    # Highest revision of m1 (700 MW) counts; withdrawn wd vanishes entirely.
+    assert per_zone == pytest.approx(700.0)
+    assert totals == {"DE_LU": pytest.approx(700.0)}

--- a/deploy/setup-vps.sh
+++ b/deploy/setup-vps.sh
@@ -63,8 +63,11 @@ echo "nginx configured and reloaded"
 # below can't). Set the URL by editing the crontab env line after creating a
 # check at healthchecks.io / UptimeRobot; empty = no-op.
 echo "[6/7] Installing health-check cron..."
-(crontab -l 2>/dev/null | grep -v obsyd | grep -v '^HEALTHCHECKS_URL='; \
- echo 'HEALTHCHECKS_URL='; \
+# Dedupe filter matches ONLY this health line ('grep -v obsyd' would also wipe
+# the docker-prune line installed in step 9 — its path contains "obsyd"), and a
+# HEALTHCHECKS_URL the operator already configured survives a re-run.
+(crontab -l 2>/dev/null | grep -v 'systemctl restart obsyd' | grep -v '^HEALTHCHECKS_URL='; \
+ crontab -l 2>/dev/null | grep '^HEALTHCHECKS_URL=' || echo 'HEALTHCHECKS_URL='; \
  echo '*/5 * * * * if curl -sf http://127.0.0.1:8000/health >/dev/null; then [ -n "$HEALTHCHECKS_URL" ] && curl -fsS -m 10 --retry 2 "$HEALTHCHECKS_URL" >/dev/null 2>&1; else systemctl restart obsyd; fi') | crontab -
 echo "Cron health-check installed (set HEALTHCHECKS_URL in root crontab to enable off-box ping)"
 
@@ -78,6 +81,24 @@ sudo -u obsyd bash -c '(crontab -l 2>/dev/null | grep -v backup-db.sh | grep -v 
   echo "OBSYD_BACKUP_REMOTE="; \
   echo "30 3 * * * /home/obsyd/obsyd/deploy/backup-db.sh >> /home/obsyd/backups/backup.log 2>&1") | crontab -'
 echo "Daily backup cron installed (03:30, retention 14 days; set OBSYD_BACKUP_REMOTE for offsite)"
+
+# 8. Disk alarm cron (as obsyd user, every 15 min — the 2026-07-07 disk-full
+# incident took dockerd, Caddy and both sites down for two days before anyone
+# noticed; this is the script written as its post-mortem, so it MUST be wired).
+echo "[8/9] Installing disk-alarm cron..."
+chmod +x /home/obsyd/obsyd/deploy/disk-alarm.sh
+sudo -u obsyd bash -c 'mkdir -p /home/obsyd/obsyd/logs; (crontab -l 2>/dev/null | grep -v disk-alarm.sh; \
+  echo "*/15 * * * * /home/obsyd/obsyd/deploy/disk-alarm.sh >> /home/obsyd/obsyd/logs/disk-alarm.log 2>&1") | crontab -'
+echo "Disk-alarm cron installed (*/15 min, obsyd crontab)"
+
+# 9. Weekly docker prune (root — needs docker rights). Dangling images + build
+# cache only; never volumes (valuekick postgres) and never `image prune -a`
+# (would reap node:20 that valuekick's 30-min cron re-pulls). See script header.
+echo "[9/9] Installing docker-prune cron..."
+chmod +x /home/obsyd/obsyd/deploy/docker-prune.sh
+(crontab -l 2>/dev/null | grep -v docker-prune.sh; \
+ echo '15 4 * * 0 /home/obsyd/obsyd/deploy/docker-prune.sh >> /home/obsyd/obsyd/logs/docker-prune.log 2>&1') | crontab -
+echo "Docker-prune cron installed (Sun 04:15, root crontab)"
 
 echo ""
 echo "=== VPS base setup complete ==="


### PR DESCRIPTION
PR-C des Verbesserungsplans (Ops & Performance).

- **`/overview`-N+1 weg:** 37 Zonen × ~6 Queries + je ein voller `power_outage`-Scan → ~7 Batch-Queries, gleiche pure Synthese (`build_power_situation`), per Paritätstest gepinnt (bulk == per-zone, dict-identisch) + Query-Count-Assertion ≤12. `async def` → `def` (Threadpool), der Event-Loop wird nicht mehr blockiert. Prod-Baseline vor Deploy: ~0,59 s warm — Nachher-Messung folgt im Deploy-Kommentar.
- **Outage-Dedupe in SQL** (Window-Function, höchste Revision je (zone, mRID), Ranking VOR Status-Filter — sonst gewinnt eine ältere aktive Revision gegen eine withdrawn-Neuere). Ein Helper für Radar-Detektor, Hero-Flag und `/api/power/outages`; Freshness probt weiter alle Revisionen.
- **Rate-Limit auf `/api/v1/genmix` + `/snapshot`** (teuerste Endpoints waren ungedrosselt). E2E verifiziert: 120×200, dann 429.
- **Disk-Incident-Nachsorge endlich verdrahtet:** setup-vps.sh installiert disk-alarm (15 min) + docker-prune (wöchentl.) Crons. Dabei zwei Footguns im Health-Cron-Block entschärft: `grep -v obsyd` hätte die neue docker-prune-Zeile mitgelöscht, und eine konfigurierte `HEALTHCHECKS_URL` überlebt jetzt Re-Runs.
- `.qh`-Retention als bewusste Option dokumentiert (nicht gebaut).

Verifikation: ruff + 727 Tests grün (6 neue), E2E lokal (Overview-Shape, Outage-Envelope, 429-Loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)