### PR TITLE
Overview query tuning + cron env-line fix

### DIFF
--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -32,7 +32,7 @@ from datetime import datetime, timedelta, timezone
 from datetime import datetime as _dt
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import func, tuple_
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from backend.config import settings
@@ -970,16 +970,19 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
         if r.zone in grid_by_zone:
             grid_by_zone[r.zone].append(r)
 
-    # 3. Coverage guard for each zone's LATEST grid day — one row-value IN query
-    #    replaces renewable_share_reliable's per-zone SUM (same semantics: no
-    #    genmix row at all → untrusted).
+    # 3. Coverage guard for each zone's LATEST grid day. Query by the small set
+    #    of distinct dates (usually 1-2: yesterday/today) — the date index makes
+    #    this a few hundred row visits, while a (zone, date) row-value IN made
+    #    SQLite scan all ~640k genmix rows (measured 0.15s on prod). Extra
+    #    (zone, date) combos in the result are harmless — lookups use exact pairs.
+    #    Same semantics as renewable_share_reliable: no genmix row → untrusted.
     latest_grid = {z: rows[-1] for z, rows in grid_by_zone.items() if rows}
-    pairs = [(r.zone, r.date) for r in latest_grid.values()]
+    dates = sorted({r.date for r in latest_grid.values()})
     gen_totals: dict[tuple[str, str], float] = {}
-    if pairs:
+    if dates:
         for z, d, total in (
             db.query(PowerGenMix.zone, PowerGenMix.date, func.sum(PowerGenMix.gen_mw))
-            .filter(tuple_(PowerGenMix.zone, PowerGenMix.date).in_(pairs))
+            .filter(PowerGenMix.date.in_(dates))
             .group_by(PowerGenMix.zone, PowerGenMix.date)
             .all()
         ):
@@ -996,17 +999,21 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
             return False
         return total >= coverage_min_ratio(zone) * r.load_mw
 
-    # 4. Spark legs: every zone's power symbol + TTF in one 14-day scan.
+    # 4. Spark legs: every zone's power symbol + TTF. Query by DATE RANGE only —
+    #    the (date, symbol) unique index turns 14 days × ~50 symbols into a few
+    #    hundred row visits, while `symbol IN (38)` made SQLite walk each
+    #    symbol's full multi-year history (measured 0.29s on prod). The symbol
+    #    filter happens in Python on the handful of returned rows.
     spark_from, spark_to = _window(14)
     symbols = {cfg["price_symbol"] for cfg in POWER_ZONES.values()} | {"TTF"}
     closes: dict[str, dict[str, float]] = {s: {} for s in symbols}
     for sym, d, close in (
         db.query(EnergyPrice.symbol, EnergyPrice.date, EnergyPrice.close)
-        .filter(EnergyPrice.symbol.in_(symbols),
-                EnergyPrice.date >= spark_from, EnergyPrice.date <= spark_to)
+        .filter(EnergyPrice.date >= spark_from, EnergyPrice.date <= spark_to)
         .all()
     ):
-        closes[sym][d] = close
+        if sym in symbols:
+            closes[sym][d] = close
     heat_rate = round(1.0 / settings.gas_ccgt_efficiency, 4)
 
     def _spark(zone: str) -> dict | None:

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -156,7 +156,9 @@ def forced_outage_severity(total_mw: float, installed_mw: float | None) -> str |
     return None
 
 
-def latest_outage_revisions(db, zone: str | None = None) -> list:
+def latest_outage_revisions(
+    db, zone: str | None = None, *, ending_after: str | None = None
+) -> list:
     """Highest revision per (zone, mRID), resolved in SQL via a window function.
 
     Withdrawn rows are still RETURNED — ranking must happen before any status
@@ -164,6 +166,12 @@ def latest_outage_revisions(db, zone: str | None = None) -> list:
     first would let an older active revision win and fabricate gigawatts; 26 of
     31 live-sampled documents were withdrawn revisions). Replaces loading every
     revision row into Python, which grew with the full revision history.
+
+    `ending_after` prunes the ranked set to mRIDs with ANY revision ending at or
+    after the cutoff — an event whose every revision ended in the past cannot be
+    running/upcoming no matter which revision wins. The filter is per-mRID, not
+    per-row: dropping single rows on end_utc would let an older longer revision
+    beat a newer shortened one.
     """
     from sqlalchemy import func
 
@@ -180,6 +188,11 @@ def latest_outage_revisions(db, zone: str | None = None) -> list:
     ranked = db.query(PowerOutage.id.label("oid"), rn)
     if zone is not None:
         ranked = ranked.filter(PowerOutage.zone == zone)
+    if ending_after is not None:
+        relevant = db.query(PowerOutage.mrid).filter(PowerOutage.end_utc >= ending_after)
+        if zone is not None:
+            relevant = relevant.filter(PowerOutage.zone == zone)
+        ranked = ranked.filter(PowerOutage.mrid.in_(relevant.subquery().select()))
     ranked = ranked.subquery()
     return (
         db.query(PowerOutage)
@@ -208,7 +221,8 @@ def forced_outage_mw_now(db, zone: str) -> tuple[float, list]:
     from datetime import datetime, timezone
 
     now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
-    running = _running_forced(latest_outage_revisions(db, zone), now_iso)
+    rows = latest_outage_revisions(db, zone, ending_after=now_iso)
+    running = _running_forced(rows, now_iso)
     total = sum(r.nominal_mw - (r.available_mw or 0.0) for r in running)
     return total, running
 
@@ -221,7 +235,7 @@ def forced_outage_totals_now(db) -> dict[str, float]:
 
     now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
     totals: dict[str, float] = defaultdict(float)
-    for r in _running_forced(latest_outage_revisions(db), now_iso):
+    for r in _running_forced(latest_outage_revisions(db, ending_after=now_iso), now_iso):
         totals[r.zone] += r.nominal_mw - (r.available_mw or 0.0)
     return dict(totals)
 

--- a/backend/tests/test_backup_script.py
+++ b/backend/tests/test_backup_script.py
@@ -357,3 +357,7 @@ def test_setup_vps_wires_disk_alarm_and_docker_prune_crons():
     assert "deploy/docker-prune.sh >> /home/obsyd/obsyd/logs/docker-prune.log" in text
     # health-line dedupe must not sweep the docker-prune line (path contains "obsyd")
     assert "| grep -v obsyd |" not in text
+    # empty env values must be quoted — vixie cron rejects a bare NAME= line and
+    # then refuses to install the ENTIRE crontab (hit live 2026-07-12)
+    assert "echo 'HEALTHCHECKS_URL=\"\"'" in text
+    assert 'OBSYD_BACKUP_REMOTE=\\"\\"' in text

--- a/backend/tests/test_outages.py
+++ b/backend/tests/test_outages.py
@@ -285,3 +285,37 @@ def test_route_empty_is_honest(db_session):
     body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
     assert body["available"] is False
     assert "reason" in body
+
+
+def test_latest_revisions_ending_after_prunes_by_mrid_not_row(db_session):
+    """The shortened-revision case: r1 ends in the future, but the LATEST
+    revision r2 ends in the past. With ending_after=now the mRID must still be
+    ranked (some revision ends later) and r2 must win — a per-ROW end filter
+    would wrongly resurrect r1 and show an event that was cut short."""
+    from datetime import datetime, timedelta, timezone
+
+    from backend.models.energy import PowerOutage
+    from backend.signals.detectors.power import (
+        forced_outage_mw_now,
+        latest_outage_revisions,
+    )
+
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    common = dict(doc_type="A77", zone="DE_LU", business_type="A54", psr_type="B14",
+                  unit_name="U", unit_eic="11W", location="DE", status="active",
+                  start_utc=(now - timedelta(days=2)).strftime(fmt))
+    db_session.add(PowerOutage(mrid="cut", revision=1, nominal_mw=800.0, available_mw=0.0,
+                               end_utc=(now + timedelta(days=3)).strftime(fmt), **common))
+    db_session.add(PowerOutage(mrid="cut", revision=2, nominal_mw=800.0, available_mw=0.0,
+                               end_utc=(now - timedelta(hours=2)).strftime(fmt), **common))
+    # An event whose EVERY revision ended long ago is pruned entirely.
+    db_session.add(PowerOutage(mrid="old", revision=1, nominal_mw=900.0, available_mw=0.0,
+                               end_utc=(now - timedelta(days=30)).strftime(fmt), **common))
+    db_session.commit()
+
+    now_iso = now.strftime(fmt)
+    rows = latest_outage_revisions(db_session, "DE_LU", ending_after=now_iso)
+    assert {(r.mrid, r.revision) for r in rows} == {("cut", 2)}
+    total, running = forced_outage_mw_now(db_session, "DE_LU")
+    assert total == 0.0 and running == [], "the shortened event is over — no MW"

--- a/deploy/setup-vps.sh
+++ b/deploy/setup-vps.sh
@@ -66,8 +66,10 @@ echo "[6/7] Installing health-check cron..."
 # Dedupe filter matches ONLY this health line ('grep -v obsyd' would also wipe
 # the docker-prune line installed in step 9 — its path contains "obsyd"), and a
 # HEALTHCHECKS_URL the operator already configured survives a re-run.
+# NB: an EMPTY env value must be written as NAME="" — vixie cron rejects a bare
+# NAME= line ("bad minute") and then refuses the ENTIRE crontab (hit live 2026-07-12).
 (crontab -l 2>/dev/null | grep -v 'systemctl restart obsyd' | grep -v '^HEALTHCHECKS_URL='; \
- crontab -l 2>/dev/null | grep '^HEALTHCHECKS_URL=' || echo 'HEALTHCHECKS_URL='; \
+ crontab -l 2>/dev/null | grep '^HEALTHCHECKS_URL=' || echo 'HEALTHCHECKS_URL=""'; \
  echo '*/5 * * * * if curl -sf http://127.0.0.1:8000/health >/dev/null; then [ -n "$HEALTHCHECKS_URL" ] && curl -fsS -m 10 --retry 2 "$HEALTHCHECKS_URL" >/dev/null 2>&1; else systemctl restart obsyd; fi') | crontab -
 echo "Cron health-check installed (set HEALTHCHECKS_URL in root crontab to enable off-box ping)"
 
@@ -78,7 +80,7 @@ echo "Cron health-check installed (set HEALTHCHECKS_URL in root crontab to enabl
 echo "[7/7] Installing daily backup cron..."
 chmod +x /home/obsyd/obsyd/deploy/backup-db.sh
 sudo -u obsyd bash -c '(crontab -l 2>/dev/null | grep -v backup-db.sh | grep -v "^OBSYD_BACKUP_REMOTE="; \
-  echo "OBSYD_BACKUP_REMOTE="; \
+  crontab -l 2>/dev/null | grep "^OBSYD_BACKUP_REMOTE=" || echo "OBSYD_BACKUP_REMOTE=\"\""; \
   echo "30 3 * * * /home/obsyd/obsyd/deploy/backup-db.sh >> /home/obsyd/backups/backup.log 2>&1") | crontab -'
 echo "Daily backup cron installed (03:30, retention 14 days; set OBSYD_BACKUP_REMOTE for offsite)"
 


### PR DESCRIPTION
Follow-up zu #65 nach Prod-Profiling (bulk 0,70 s → Ziel <0,15 s):

- Spark-Query: `symbol IN (38)` ließ SQLite je Symbol die volle Mehrjahres-Historie laufen (gemessen 0,29 s) → Date-Range-Query über den (date, symbol)-Unique-Index, Symbolfilter in Python.
- Coverage-Query: (zone, date)-Row-Value-IN scannte alle ~640k genmix-Zeilen (0,15 s) → `date IN (1-2 Werte)` über den Date-Index.
- `latest_outage_revisions(ending_after=…)`: Ranking auf mRIDs mit irgendeiner noch relevanten Revision begrenzt — pro mRID, nicht pro Zeile (der Shortened-Revision-Fall ist per Test gepinnt); `/api/power/outages` behält volles Ranking.
- setup-vps.sh: leere Cron-Env-Werte als `NAME=""` — die heutige VPS-Installation scheiterte live an vixie-crons „bad minute" für nacktes `NAME=`; konfigurierte Werte überleben Re-Runs.

ruff + 728 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)