### PR TITLE
Overview tuning round 2: grid column tuples + outage dedupe index

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -91,6 +91,15 @@ def run_migrations() -> None:
     if _add_column_if_missing("power_load_forecast", "hourly_forecast", "TEXT"):
         applied.append("power_load_forecast.hourly_forecast")
 
+    # 2026-07-12: composite index for the SQL revision-dedupe (highest revision
+    # per (zone, mRID)) — the window scan runs on every /overview request and
+    # radar pass; without the index it re-sorts the whole table each time.
+    with engine.begin() as conn:
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_power_outage_zone_mrid_revision "
+            "ON power_outage (zone, mrid, revision)"
+        ))
+
     if applied:
         logger.info("migrations applied: %s", ", ".join(applied))
     else:

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -16,7 +16,7 @@ is deferred until a reliable free source is confirmed.
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime, Float, Integer, String, Text, UniqueConstraint
+from sqlalchemy import DateTime, Float, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base
@@ -297,6 +297,10 @@ class PowerOutage(Base):
 
     __table_args__ = (
         UniqueConstraint("mrid", "revision", name="uq_power_outage_mrid_revision"),
+        # Revision-dedupe ("highest revision per (zone, mRID)") is a window/group
+        # scan on every /overview and radar run — this composite index turns it
+        # into an index-only walk. Existing DBs get it via migrations.py.
+        Index("ix_power_outage_zone_mrid_revision", "zone", "mrid", "revision"),
     )
 
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -368,29 +368,36 @@ async def get_spark_spread(
 DUNKELFLAUTE_THRESHOLD = 0.15
 
 
-def _compute_grid_row(r: PowerGrid) -> dict:
+def _grid_row_values(
+    date: str, load_mw: float | None, wind_mw: float | None, solar_mw: float | None
+) -> dict:
     """Derive residual_mw, renewable_share, and dunkelflaute flag for one row.
 
     None wind_mw / solar_mw are treated as 0 (they can be stored None when
-    genuinely near-zero during ingest failures).
+    genuinely near-zero during ingest failures). Value-based so the bulk
+    overview loader can feed column tuples without hydrating ORM entities.
     """
-    wind = r.wind_mw or 0.0
-    solar = r.solar_mw or 0.0
-    load = r.load_mw or 0.0
+    wind = wind_mw or 0.0
+    solar = solar_mw or 0.0
+    load = load_mw or 0.0
 
     residual_mw = load - wind - solar
     renewable_share = (wind + solar) / load if load > 0 else 0.0
     dunkelflaute = renewable_share < DUNKELFLAUTE_THRESHOLD
 
     return {
-        "date": r.date,
-        "load_mw": r.load_mw,
-        "wind_mw": r.wind_mw,
-        "solar_mw": r.solar_mw,
+        "date": date,
+        "load_mw": load_mw,
+        "wind_mw": wind_mw,
+        "solar_mw": solar_mw,
         "residual_mw": round(residual_mw, 2),
         "renewable_share": round(renewable_share, 4),
         "dunkelflaute": dunkelflaute,
     }
+
+
+def _compute_grid_row(r: PowerGrid) -> dict:
+    return _grid_row_values(r.date, r.load_mw, r.wind_mw, r.solar_mw)
 
 
 @router.get("/grid")
@@ -959,16 +966,20 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
         if z in price_by_zone:
             price_by_zone[z].append({"date": d, "close": mean, "negative_hours": neg})
 
-    # 2. Grid rows (load/wind/solar), all zones in one scan.
-    grid_by_zone: dict[str, list] = {z: [] for z in POWER_ZONES}
-    for r in (
-        db.query(PowerGrid)
+    # 2. Grid rows (load/wind/solar), all zones in one scan. Column tuples, not
+    #    ORM entities — hydrating ~4.5k PowerGrid objects cost 0.17s on prod.
+    grid_by_zone: dict[str, list[dict]] = {z: [] for z in POWER_ZONES}
+    latest_grid: dict[str, tuple[str, float | None]] = {}  # zone -> (date, load_mw)
+    for zone_key, d, load, wind, solar in (
+        db.query(PowerGrid.zone, PowerGrid.date, PowerGrid.load_mw,
+                 PowerGrid.wind_mw, PowerGrid.solar_mw)
         .filter(PowerGrid.date >= date_from, PowerGrid.date <= date_to)
         .order_by(PowerGrid.date.asc())
         .all()
     ):
-        if r.zone in grid_by_zone:
-            grid_by_zone[r.zone].append(r)
+        if zone_key in grid_by_zone:
+            grid_by_zone[zone_key].append(_grid_row_values(d, load, wind, solar))
+            latest_grid[zone_key] = (d, load)
 
     # 3. Coverage guard for each zone's LATEST grid day. Query by the small set
     #    of distinct dates (usually 1-2: yesterday/today) — the date index makes
@@ -976,8 +987,7 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
     #    SQLite scan all ~640k genmix rows (measured 0.15s on prod). Extra
     #    (zone, date) combos in the result are harmless — lookups use exact pairs.
     #    Same semantics as renewable_share_reliable: no genmix row → untrusted.
-    latest_grid = {z: rows[-1] for z, rows in grid_by_zone.items() if rows}
-    dates = sorted({r.date for r in latest_grid.values()})
+    dates = sorted({d for d, _ in latest_grid.values()})
     gen_totals: dict[tuple[str, str], float] = {}
     if dates:
         for z, d, total in (
@@ -989,15 +999,16 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
             gen_totals[(z, d)] = float(total) if total is not None else None
 
     def _coverage_ok(zone: str) -> bool:
-        r = latest_grid.get(zone)
-        if r is None:
+        lg = latest_grid.get(zone)
+        if lg is None:
             return True  # no grid rows at all — matches the per-zone path
-        if not r.load_mw or r.load_mw <= 0:
+        d, load_mw = lg
+        if not load_mw or load_mw <= 0:
             return False
-        total = gen_totals.get((r.zone, r.date))
+        total = gen_totals.get((zone, d))
         if total is None:
             return False
-        return total >= coverage_min_ratio(zone) * r.load_mw
+        return total >= coverage_min_ratio(zone) * load_mw
 
     # 4. Spark legs: every zone's power symbol + TTF. Query by DATE RANGE only —
     #    the (date, symbol) unique index turns 14 days × ~50 symbols into a few
@@ -1056,7 +1067,7 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
             situations[zone] = build_power_situation(
                 zone,
                 price_by_zone[zone],
-                [_compute_grid_row(r) for r in grid_by_zone[zone]],
+                grid_by_zone[zone],
                 _spark(zone),
                 spark_supported=True,
                 grid_coverage_ok=_coverage_ok(zone),


### PR DESCRIPTION
Zweite Runde nach Prod-Profiling (verbleibende 0,48 s warm):
- Grid-Slice als Spalten-Tupel statt ORM-Hydration (0,17 s → ~0,03 s erwartbar), gemeinsame Ableitung `_grid_row_values` für beide Pfade.
- Composite-Index `(zone, mrid, revision)` auf `power_outage` für die Revisions-Dedupe-Window-Query (0,22 s: der `ending_after`-Prune greift kaum, weil die meisten A77-Events weit in der Zukunft enden); Bestands-DBs bekommen ihn idempotent über die Startup-Migration.

ruff + 728 Tests grün; Parity-/Query-Count-Tests decken den Umbau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)