### PR TITLE
Radar depth: four new detectors from the depth-roadmap data + outage user alerts

### DIFF
--- a/backend/power/entsoe_hydro.py
+++ b/backend/power/entsoe_hydro.py
@@ -142,3 +142,43 @@ async def ingest_hydro(
             written += upsert_hourly(db, "hydro.reservoir", zone, points, unit="MWh")
 
     return {"written": written, "zones": len(zones), "years": years}
+
+
+def same_week_band(points: list[tuple[int, float]]) -> dict:
+    """Compare the newest weekly filling against the SAME ISO week in prior years.
+
+    Reservoir levels are hard seasonal — a trailing window would flag every
+    spring melt as an anomaly. So the band is built from the nearest point
+    within ±4 days of (newest − i·52 weeks) for each prior year i. Shared by
+    the /hydro route and the hydro_deviation radar detector (one derivation).
+    """
+    import bisect
+
+    ts, value = points[-1]
+    keys = [t for t, _ in points]
+    band: list[float] = []
+    i = 1
+    while True:
+        target = ts - i * 364 * 86_400
+        if target < keys[0] - 4 * 86_400:
+            break
+        j = bisect.bisect_left(keys, target)
+        best = None
+        for k in (j - 1, j):
+            if 0 <= k < len(keys) and abs(keys[k] - target) <= 4 * 86_400:
+                if best is None or abs(keys[k] - target) < abs(keys[best] - target):
+                    best = k
+        if best is not None:
+            band.append(points[best][1])
+        i += 1
+
+    vs_band = None
+    if band:
+        vs_band = "below" if value < min(band) else "above" if value > max(band) else "within"
+    return {
+        "band_min_twh": round(min(band) / 1e6, 2) if band else None,
+        "band_max_twh": round(max(band) / 1e6, 2) if band else None,
+        "band_mean_twh": round(sum(band) / len(band) / 1e6, 2) if band else None,
+        "band_n": len(band),
+        "vs_band": vs_band,
+    }

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1434,43 +1434,8 @@ async def get_outages(
 HYDRO_STALE_DAYS = 16
 
 
-def _same_week_band(points: list[tuple[int, float]]) -> dict:
-    """Compare the newest weekly filling against the SAME ISO week in prior years.
-
-    Reservoir levels are hard seasonal — a trailing window would flag every
-    spring melt as an anomaly. So the band is built from the nearest point
-    within ±4 days of (newest − i·52 weeks) for each prior year i.
-    """
-    import bisect
-
-    ts, value = points[-1]
-    keys = [t for t, _ in points]
-    band: list[float] = []
-    i = 1
-    while True:
-        target = ts - i * 364 * 86_400
-        if target < keys[0] - 4 * 86_400:
-            break
-        j = bisect.bisect_left(keys, target)
-        best = None
-        for k in (j - 1, j):
-            if 0 <= k < len(keys) and abs(keys[k] - target) <= 4 * 86_400:
-                if best is None or abs(keys[k] - target) < abs(keys[best] - target):
-                    best = k
-        if best is not None:
-            band.append(points[best][1])
-        i += 1
-
-    vs_band = None
-    if band:
-        vs_band = "below" if value < min(band) else "above" if value > max(band) else "within"
-    return {
-        "band_min_twh": round(min(band) / 1e6, 2) if band else None,
-        "band_max_twh": round(max(band) / 1e6, 2) if band else None,
-        "band_mean_twh": round(sum(band) / len(band) / 1e6, 2) if band else None,
-        "band_n": len(band),
-        "vs_band": vs_band,
-    }
+# same_week_band moved to backend/power/entsoe_hydro.py so the hydro_deviation
+# radar detector and this route share one derivation.
 
 
 @router.get("/hydro")
@@ -1479,7 +1444,7 @@ async def get_hydro(db: Session = Depends(get_db)):
     Nordics, Alps, Iberia, France — each compared against the same ISO week in
     its own prior years. Descriptive: a filling level vs its seasonal norm,
     not a price call. Free tier."""
-    from backend.power.entsoe_hydro import HYDRO_ZONES
+    from backend.power.entsoe_hydro import HYDRO_ZONES, same_week_band
     from backend.power.hourly_store import read_hourly
 
     zones_out: list[dict] = []
@@ -1498,7 +1463,7 @@ async def get_hydro(db: Session = Depends(get_db)):
             "reservoir_twh": round(mwh / 1e6, 2),
             "wow_twh": round((mwh - prev) / 1e6, 2) if prev is not None else None,
             "as_of": as_of,
-            **_same_week_band(points),
+            **same_week_band(points),
         })
 
     if not zones_out:

--- a/backend/signals/detectors/__init__.py
+++ b/backend/signals/detectors/__init__.py
@@ -28,7 +28,11 @@ from backend.signals.detectors.gas import detect_gas_balance
 from backend.signals.detectors.power import (
     detect_dunkelflaute,
     detect_forced_outages,
+    detect_hydro_deviations,
+    detect_imbalance_extremes,
     detect_negative_prices,
+    detect_price_spikes,
+    detect_record_breaks,
 )
 from backend.signals.rules import _upsert_alert
 
@@ -38,11 +42,17 @@ logger = logging.getLogger(__name__)
 # (electrons + their gas fuel). The oil/sentiment detectors (detectors/oil.py,
 # detectors/sentiment.py) stay in the tree but are unwired here; they move to the
 # sibling project in Phase 2. The radar now surfaces only power/gas anomalies.
+# Extended 2026-07-12 with the depth-roadmap data: imbalance peaks, day-ahead
+# spikes (both tails), hydro vs seasonal band, fresh all-time records.
 DETECTORS = [
     detect_gas_balance,
     detect_negative_prices,
     detect_dunkelflaute,
     detect_forced_outages,
+    detect_imbalance_extremes,
+    detect_price_spikes,
+    detect_hydro_deviations,
+    detect_record_breaks,
 ]
 
 
@@ -73,7 +83,11 @@ def run_all_detectors(db: Session, *, today: _date | None = None) -> int:
     for detector in DETECTORS:
         try:
             for result in detector(db):
-                max_age = _MAX_AGE_DAYS.get(result.vertical, _DEFAULT_MAX_AGE_DAYS)
+                max_age = (
+                    result.max_age_days
+                    if result.max_age_days is not None
+                    else _MAX_AGE_DAYS.get(result.vertical, _DEFAULT_MAX_AGE_DAYS)
+                )
                 if result.as_of is not None and is_stale(result.as_of, max_age, today=today):
                     logger.warning(
                         "suppressing stale %s/%s alert (data as of %s)",

--- a/backend/signals/detectors/base.py
+++ b/backend/signals/detectors/base.py
@@ -35,6 +35,10 @@ class DetectorResult:
     title: str
     detail: str = ""
     as_of: str | None = None  # ISO date of the underlying data; runner uses it for staleness
+    #: Per-result staleness override (days). The runner's per-vertical windows
+    #: assume daily cadence — a weekly source (hydro A72, ~2 weeks publication
+    #: lag) would be suppressed at "power": 3 without this.
+    max_age_days: int | None = None
 
 
 def is_stale(latest: str | _date | None, max_age_days: int, *, today: _date | None = None) -> bool:

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -313,3 +313,262 @@ def detect_forced_outages(db) -> list[DetectorResult]:
             )
         )
     return results
+
+
+# ── Imbalance extremes — the intraday stress signal ──────────────────────────
+# Imbalance (reBAP for DE_LU) is where grid stress prices first: ±1000 €/MWh
+# quarter-hours vanish in day-ahead means. Daily PEAK |price| per zone is
+# compared against the zone's own trailing norm; absolute floors keep quiet,
+# low-variance zones from flagging noise-level "extremes".
+IMB_WINDOW_DAYS = 45
+IMB_WARN_Z = 2.5
+IMB_CRIT_Z = 3.5
+IMB_WARN_FLOOR_EUR = 300.0
+IMB_CRIT_FLOOR_EUR = 500.0
+
+
+def _imbalance_zones(db) -> list[str]:
+    from backend.models.energy import PowerHourly, SeriesDim, ZoneDim
+
+    sid = db.query(SeriesDim.id).filter(SeriesDim.key == "imbalance.price").scalar()
+    if sid is None:
+        return []
+    rows = (
+        db.query(ZoneDim.key)
+        .join(PowerHourly, PowerHourly.zone_id == ZoneDim.id)
+        .filter(PowerHourly.series_id == sid)
+        .distinct()
+        .all()
+    )
+    return [z for (z,) in rows]
+
+
+def detect_imbalance_extremes(db) -> list[DetectorResult]:
+    """Zones whose latest daily peak imbalance price is extreme vs their own norm."""
+    from datetime import datetime, timedelta, timezone
+
+    from backend.power.hourly_store import read_hourly
+
+    start_ts = int(
+        (datetime.now(timezone.utc) - timedelta(days=IMB_WINDOW_DAYS + 1)).timestamp()
+    )
+    results: list[DetectorResult] = []
+    for zone in _imbalance_zones(db):
+        points = read_hourly(db, "imbalance.price", zone, start_ts=start_ts)
+        if not points:
+            continue
+        # Daily peak: the point with the largest magnitude, kept SIGNED for display.
+        daily: dict[str, float] = {}
+        for ts, v in points:
+            day = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+            if day not in daily or abs(v) > abs(daily[day]):
+                daily[day] = v
+        days = sorted(daily)
+        if len(days) < 2:
+            continue
+        current = daily[days[-1]]
+        baseline = [abs(daily[d]) for d in days[:-1]]
+        stat = trailing_zscore(abs(current), baseline)
+        if stat is None:
+            continue
+        z, mean, _, _n = stat
+        if z < IMB_WARN_Z or abs(current) < IMB_WARN_FLOOR_EUR:
+            continue
+        severity = (
+            "critical" if z >= IMB_CRIT_Z and abs(current) >= IMB_CRIT_FLOOR_EUR else "warning"
+        )
+        results.append(
+            DetectorResult(
+                rule="imbalance_extreme",
+                zone=zone,
+                vertical="power",
+                severity=severity,
+                title=f"{zone}: imbalance peaked at {current:.0f} €/MWh ({z:+.1f}σ)",
+                detail=(
+                    f"Peak imbalance price {current:.0f} €/MWh on {days[-1]} vs ~{mean:.0f} "
+                    f"normal daily peak (z {z:+.2f}). Imbalance is what being out of "
+                    f"balance actually costs — the intraday stress gauge."
+                ),
+                as_of=days[-1],
+                # Imbalance settles late (reBAP confirms ~2 weeks after delivery for
+                # DE_LU); mirrors the imbalance_qh freshness window, not "power": 3.
+                max_age_days=4,
+            )
+        )
+    return results
+
+
+# ── Day-ahead price spikes (both tails) ───────────────────────────────────────
+# Relative-only z would fire on micro-variance zones; the €/MWh delta floor
+# keeps "3σ above a flat 60±2 €" from paging anyone. Named price_spike — a
+# user-rule template `dayahead_spike` (absolute threshold breach) already
+# exists in the OTHER alert subsystem; distinct names keep the two apart.
+SPIKE_WINDOW_DAYS = 45
+SPIKE_WARN_Z = 2.5
+SPIKE_CRIT_Z = 3.5
+SPIKE_MIN_DELTA_EUR = 25.0
+
+
+def detect_price_spikes(db) -> list[DetectorResult]:
+    """Zones whose latest day-ahead daily mean sits far outside their own norm."""
+    zones = [z for (z,) in db.query(PowerPriceDaily.zone).distinct().all()]
+    results: list[DetectorResult] = []
+    for zone in zones:
+        rows = (
+            db.query(PowerPriceDaily)
+            .filter(PowerPriceDaily.zone == zone)
+            .order_by(PowerPriceDaily.date.desc())
+            .limit(SPIKE_WINDOW_DAYS + 1)
+            .all()
+        )
+        if not rows:
+            continue
+        current = rows[0].mean_price
+        if current is None:
+            continue
+        baseline = [r.mean_price for r in rows[1:] if r.mean_price is not None]
+        stat = trailing_zscore(current, baseline)
+        if stat is None:
+            continue
+        z, mean, _, _n = stat
+        if abs(z) < SPIKE_WARN_Z or abs(current - mean) < SPIKE_MIN_DELTA_EUR:
+            continue
+        direction = "high" if z > 0 else "low"
+        results.append(
+            DetectorResult(
+                rule="price_spike",
+                zone=zone,
+                vertical="power",
+                severity="critical" if abs(z) >= SPIKE_CRIT_Z else "warning",
+                title=f"{zone}: day-ahead unusually {direction} — {current:.0f} €/MWh ({z:+.1f}σ)",
+                detail=(
+                    f"Daily mean {current:.0f} €/MWh on {rows[0].date} vs ~{mean:.0f} €/MWh "
+                    f"45d norm (z {z:+.2f}). Descriptive deviation vs the zone's own "
+                    f"history, not a forecast."
+                ),
+                as_of=rows[0].date,
+            )
+        )
+    return results
+
+
+# ── Hydro reservoirs outside the seasonal band ────────────────────────────────
+
+
+def detect_hydro_deviations(db) -> list[DetectorResult]:
+    """Hydro zones whose reservoir filling left the same-ISO-week band of prior
+    years. Weekly A72 data with ~2 weeks publication lag → own staleness window."""
+    from datetime import datetime, timezone
+
+    from backend.power.entsoe_hydro import HYDRO_ZONES, same_week_band
+    from backend.power.hourly_store import read_hourly
+    from backend.routes.power import HYDRO_STALE_DAYS
+
+    results: list[DetectorResult] = []
+    for zone in HYDRO_ZONES:
+        points = read_hourly(db, "hydro.reservoir", zone)
+        if not points:
+            continue
+        band = same_week_band(points)
+        # band_n < 3 → the "band" is one or two old points, not a norm. Silence
+        # beats a confident-sounding comparison against nothing.
+        if band["band_n"] < 3 or band["vs_band"] not in ("below", "above"):
+            continue
+        ts, mwh = points[-1]
+        as_of = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+        twh = mwh / 1e6
+        results.append(
+            DetectorResult(
+                rule="hydro_deviation",
+                zone=zone,
+                vertical="power",
+                severity="warning",
+                title=f"{zone}: reservoirs {band['vs_band']} the seasonal band ({twh:.1f} TWh)",
+                detail=(
+                    f"Filling {twh:.2f} TWh vs {band['band_min_twh']}–{band['band_max_twh']} TWh "
+                    f"in the same ISO week across {band['band_n']} prior years. Hydro is "
+                    f"stored energy — a level outside its own seasonal range moves the "
+                    f"whole price stack."
+                ),
+                as_of=as_of,
+                max_age_days=HYDRO_STALE_DAYS,
+            )
+        )
+    return results
+
+
+# ── Fresh all-time records ────────────────────────────────────────────────────
+
+RECORD_SERIES_LABELS = {
+    "price.dayahead": "day-ahead hour",
+    "price.dayahead.qh": "day-ahead quarter-hour",
+    "imbalance.price.qh": "imbalance quarter-hour",
+    "load.actual": "load hour",
+    "residual.actual": "residual-load hour",
+}
+
+#: A "record" over three months of history is a statement about our coverage,
+#: not about the grid. Require at least a year of series history in the zone.
+RECORD_MIN_COVERAGE_DAYS = 365
+
+
+def detect_record_breaks(db) -> list[DetectorResult]:
+    """One info ping per zone with all-time records set in the last 7 days."""
+    from collections import defaultdict
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import func as _func
+
+    from backend.models.energy import PowerHourly, PowerRecord, SeriesDim, ZoneDim
+    from backend.routes.power import RECORD_FRESH_DAYS
+
+    fresh_cutoff = int(
+        (datetime.now(timezone.utc) - timedelta(days=RECORD_FRESH_DAYS)).timestamp()
+    )
+    rows = db.query(PowerRecord).filter(PowerRecord.ts_utc >= fresh_cutoff).all()
+    if not rows:
+        return []
+
+    def _coverage_days(series_key: str, zone: str) -> float:
+        sid = db.query(SeriesDim.id).filter(SeriesDim.key == series_key).scalar()
+        zid = db.query(ZoneDim.id).filter(ZoneDim.key == zone).scalar()
+        if sid is None or zid is None:
+            return 0.0
+        first = (
+            db.query(_func.min(PowerHourly.ts_utc))
+            .filter(PowerHourly.series_id == sid, PowerHourly.zone_id == zid)
+            .scalar()
+        )
+        if first is None:
+            return 0.0
+        return (datetime.now(timezone.utc).timestamp() - first) / 86_400
+
+    by_zone: dict[str, list[PowerRecord]] = defaultdict(list)
+    for r in rows:
+        if _coverage_days(r.series_key, r.zone) >= RECORD_MIN_COVERAGE_DAYS:
+            by_zone[r.zone].append(r)
+
+    results: list[DetectorResult] = []
+    for zone, recs in by_zone.items():
+        recs.sort(key=lambda r: r.ts_utc, reverse=True)
+        newest = datetime.fromtimestamp(recs[0].ts_utc, tz=timezone.utc).strftime("%Y-%m-%d")
+        parts = [
+            f"{'highest' if r.kind == 'max' else 'lowest'} "
+            f"{RECORD_SERIES_LABELS.get(r.series_key, r.series_key)} "
+            f"{r.value:.0f} {r.unit or ''} on "
+            f"{datetime.fromtimestamp(r.ts_utc, tz=timezone.utc):%Y-%m-%d}"
+            for r in recs
+        ]
+        results.append(
+            DetectorResult(
+                rule="record_break",
+                zone=zone,
+                vertical="power",
+                severity="info",
+                title=f"{zone}: new all-time record this week"
+                      + (f" (+{len(recs) - 1} more)" if len(recs) > 1 else ""),
+                detail="; ".join(parts) + ". All-time within our coverage (≥1 year).",
+                as_of=newest,
+            )
+        )
+    return results

--- a/backend/signals/user_alert_rules.py
+++ b/backend/signals/user_alert_rules.py
@@ -488,6 +488,53 @@ def evaluate_spark_spread_breach(
     )
 
 
+def evaluate_forced_outage(
+    db: Session,
+    params: dict,
+    *,
+    now: datetime,
+) -> EvaluatorResult | None:
+    """Forced (unplanned) generation loss running RIGHT NOW in a zone.
+
+    Same derivation as the radar detector and the situation-hero flag
+    (forced_outage_mw_now + forced_outage_severity — capacity-relative where
+    A68 covers the zone, absolute fallback elsewhere), so a user alert can
+    never disagree with the desk."""
+    from backend.signals.detectors.power import (
+        forced_outage_mw_now,
+        forced_outage_severity,
+        installed_capacity_mw,
+    )
+
+    zone = params.get("zone")
+    if zone not in POWER_ZONES:
+        return None
+
+    total, running = forced_outage_mw_now(db, zone)
+    installed = installed_capacity_mw(db, zone)
+    severity = forced_outage_severity(total, installed)
+    if severity is None:
+        return None
+
+    share_txt = f" — {total / installed * 100:.0f}% of fleet" if installed else ""
+    biggest = max(running, key=lambda r: r.nominal_mw - (r.available_mw or 0.0))
+    biggest_mw = biggest.nominal_mw - (biggest.available_mw or 0.0)
+    return EvaluatorResult(
+        title=f"{zone}: {total / 1000:.1f} GW forced outages{share_txt}",
+        detail=(
+            f"{len(running)} unplanned unavailabilities running now in {zone}; largest: "
+            f"{biggest.unit_name or biggest.mrid} ({biggest_mw:.0f} MW, until {biggest.end_utc[:10]})."
+        ),
+        payload={
+            "zone": zone,
+            "forced_mw": round(total, 1),
+            "installed_mw": round(installed, 1) if installed else None,
+            "severity": severity,
+            "units": len(running),
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # Template registry — exposed to the route layer for client-side schema
 # discovery and for params validation.
@@ -573,6 +620,15 @@ TEMPLATES: dict[str, dict] = {
         },
         "vertical": "power",
         "evaluator": evaluate_dayahead_spike,
+    },
+    "forced_outage": {
+        "label": "Forced power-plant outages",
+        "summary": "Notify me when unplanned generation loss in a zone is large vs its fleet (or 1 GW+ where fleet size is unknown).",
+        "params_schema": {
+            "zone": {"type": "enum", "options": list(POWER_ZONES), "required": True},
+        },
+        "vertical": "power",
+        "evaluator": evaluate_forced_outage,
     },
     "spark_spread_breach": {
         "label": "Spark spread breach (DE-LU)",

--- a/backend/tests/test_alert_rules.py
+++ b/backend/tests/test_alert_rules.py
@@ -401,6 +401,7 @@ def test_templates_endpoint_public(client):
         "dunkelflaute",
         "dayahead_spike",
         "spark_spread_breach",
+        "forced_outage",
     }
     # gas_balance is a no-param template (whole-EU signal).
     assert body["gas_balance"]["params_schema"] == {}

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -269,7 +269,7 @@ def test_run_all_detectors_isolates_failures(db_session, monkeypatch):
 
 
 def test_detector_registry_count(db_session):
-    assert len(DETECTORS) == 4  # gas_balance + negative_prices + dunkelflaute + forced_outages
+    assert len(DETECTORS) == 8  # gas/negative_prices/dunkelflaute/forced_outages + imbalance_extreme/price_spike/hydro_deviation/record_break
 
 
 # ─── flow_anomaly (legacy maritime check) — baseline + onset cure ─────────────
@@ -600,3 +600,193 @@ def test_forced_outages_latest_capacity_year_wins(db_session):
     _capacity(db_session, total_mw=20_000.0, year=2026)
     assert installed_capacity_mw(db_session, "DE_LU") == 20_000.0
     assert installed_capacity_mw(db_session, "FR") is None
+
+
+# ─── imbalance_extreme ────────────────────────────────────────────────────────
+
+
+def _seed_imbalance(db, zone="DE_LU", days=30, normal_peak=120.0, last_peak=None):
+    from datetime import date, timedelta
+
+    from backend.power.hourly_store import day_hour_ts, upsert_hourly
+
+    today = date.today()
+    points = []
+    for i in range(days):
+        d = (today - timedelta(days=days - 1 - i)).isoformat()
+        peak = last_peak if (i == days - 1 and last_peak is not None) else normal_peak + (i % 5)
+        # Two points per day: a quiet hour and the day's peak.
+        points.append((day_hour_ts(d, 3), 20.0))
+        points.append((day_hour_ts(d, 18), peak))
+    upsert_hourly(db, "imbalance.price", zone, points, unit="EUR/MWh")
+
+
+def test_imbalance_extreme_fires_on_spike_above_floor(db_session):
+    from backend.signals.detectors.power import detect_imbalance_extremes
+
+    _seed_imbalance(db_session, last_peak=650.0)
+    results = detect_imbalance_extremes(db_session)
+    assert len(results) == 1
+    r = results[0]
+    assert r.rule == "imbalance_extreme" and r.zone == "DE_LU"
+    assert r.severity == "critical"  # huge z AND >= 500 € floor
+    assert "650" in r.title
+    assert r.max_age_days == 4
+
+
+def test_imbalance_extreme_floor_suppresses_low_variance_zones(db_session):
+    """z alone must not page: a quiet zone spiking 40→250 €/MWh is a big z but
+    stays under the 300 € floor."""
+    from backend.signals.detectors.power import detect_imbalance_extremes
+
+    _seed_imbalance(db_session, normal_peak=40.0, last_peak=250.0)
+    assert detect_imbalance_extremes(db_session) == []
+
+
+def test_imbalance_extreme_needs_baseline(db_session):
+    from backend.signals.detectors.power import detect_imbalance_extremes
+
+    _seed_imbalance(db_session, days=5, last_peak=900.0)  # < MIN_BASELINE_N days
+    assert detect_imbalance_extremes(db_session) == []
+
+
+# ─── price_spike ──────────────────────────────────────────────────────────────
+
+
+def _seed_prices(db, zone="DE_LU", days=40, base=60.0, last=None):
+    from datetime import date, timedelta
+
+    from backend.models.energy import PowerPriceDaily
+
+    today = date.today()
+    for i in range(days):
+        d = (today - timedelta(days=days - 1 - i)).isoformat()
+        price = last if (i == days - 1 and last is not None) else base + (i % 5)
+        db.add(PowerPriceDaily(date=d, zone=zone, mean_price=price,
+                               min_price=price - 30, max_price=price + 40,
+                               negative_hours=0))
+    db.commit()
+
+
+def test_price_spike_fires_both_tails(db_session):
+    from backend.signals.detectors.power import detect_price_spikes
+
+    _seed_prices(db_session, zone="DE_LU", last=160.0)
+    _seed_prices(db_session, zone="FR", last=-40.0)
+    results = {r.zone: r for r in detect_price_spikes(db_session)}
+    assert results["DE_LU"].severity == "critical"
+    assert "unusually high" in results["DE_LU"].title
+    assert "unusually low" in results["FR"].title
+
+
+def test_price_spike_delta_floor_suppresses_micro_variance(db_session):
+    """60±2 € then 70 € is many σ but only 10 € — not a spike anyone trades."""
+    from backend.signals.detectors.power import detect_price_spikes
+
+    _seed_prices(db_session, base=60.0, last=70.0)
+    assert detect_price_spikes(db_session) == []
+
+
+# ─── hydro_deviation ──────────────────────────────────────────────────────────
+
+
+def _seed_hydro(db, zone="NO2", years=4, level=50e6, last=None):
+    """Weekly points; one point per year lands exactly at newest − i·364d so the
+    same-week band finds them."""
+    import time as _time
+
+    from backend.power.hourly_store import upsert_hourly
+
+    newest = (int(_time.time()) // 3600) * 3600
+    points = []
+    for i in range(years, 0, -1):
+        points.append((newest - i * 364 * 86_400, level + i * 1e6))
+    points.append((newest, last if last is not None else level))
+    upsert_hourly(db, "hydro.reservoir", zone, points, unit="MWh")
+
+
+def test_hydro_deviation_fires_below_band(db_session):
+    from backend.signals.detectors.power import detect_hydro_deviations
+
+    _seed_hydro(db_session, last=30e6)  # far below every prior year
+    results = detect_hydro_deviations(db_session)
+    assert len(results) == 1
+    r = results[0]
+    assert r.rule == "hydro_deviation" and r.zone == "NO2"
+    assert "below" in r.title
+    assert r.max_age_days == 16
+
+
+def test_hydro_deviation_within_band_is_silent(db_session):
+    from backend.signals.detectors.power import detect_hydro_deviations
+
+    _seed_hydro(db_session, last=52e6)  # inside the prior-year range
+    assert detect_hydro_deviations(db_session) == []
+
+
+def test_hydro_deviation_needs_three_band_years(db_session):
+    from backend.signals.detectors.power import detect_hydro_deviations
+
+    _seed_hydro(db_session, years=2, last=30e6)
+    assert detect_hydro_deviations(db_session) == []
+
+
+def test_hydro_max_age_override_survives_runner(db_session):
+    """A 10-day-old weekly hydro point must survive run_all_detectors — the
+    per-vertical 'power: 3' window would wrongly suppress it without the
+    per-result max_age_days override."""
+    from datetime import date, timedelta
+
+    from backend.models.alerts import Alert
+    from backend.signals.detectors import run_all_detectors
+
+    _seed_hydro(db_session, last=30e6)
+    run_all_detectors(db_session, today=date.today() + timedelta(days=10))
+    rules = {a.rule for a in db_session.query(Alert).all()}
+    assert "hydro_deviation" in rules
+
+
+# ─── record_break ─────────────────────────────────────────────────────────────
+
+
+def _seed_record(db, zone="DE_LU", series="price.dayahead", coverage_days=400, fresh=True):
+    import time as _time
+
+    from backend.models.energy import PowerRecord
+    from backend.power.hourly_store import upsert_hourly
+
+    now = int(_time.time())
+    upsert_hourly(db, series, zone, [
+        (now - coverage_days * 86_400, 50.0),
+        (now - 3 * 86_400, 60.0),
+    ], unit="EUR/MWh")
+    ts = now - (2 * 86_400 if fresh else 30 * 86_400)
+    db.add(PowerRecord(series_key=series, zone=zone, kind="max",
+                       value=871.0, ts_utc=ts, unit="EUR/MWh"))
+    db.commit()
+
+
+def test_record_break_pings_once_per_zone(db_session):
+    from backend.signals.detectors.power import detect_record_breaks
+
+    _seed_record(db_session)
+    results = detect_record_breaks(db_session)
+    assert len(results) == 1
+    r = results[0]
+    assert r.rule == "record_break" and r.severity == "info"
+    assert "871" in r.detail and "day-ahead hour" in r.detail
+
+
+def test_record_break_requires_a_year_of_coverage(db_session):
+    """A 'record' over 3 months of history describes our coverage, not the grid."""
+    from backend.signals.detectors.power import detect_record_breaks
+
+    _seed_record(db_session, coverage_days=100)
+    assert detect_record_breaks(db_session) == []
+
+
+def test_record_break_ignores_old_records(db_session):
+    from backend.signals.detectors.power import detect_record_breaks
+
+    _seed_record(db_session, fresh=False)
+    assert detect_record_breaks(db_session) == []

--- a/backend/tests/test_user_rule_templates.py
+++ b/backend/tests/test_user_rule_templates.py
@@ -72,3 +72,49 @@ def test_gas_balance_no_flag_no_trigger(db_session):
     db_session.add(GasBalance(date="2026-06-24", flag=None, z_score=0.4, residual_7d=5.0))
     db_session.commit()
     assert user_alert_rules.evaluate_gas_balance(db_session, {}, now=NOW) is None
+
+
+def test_forced_outage_template_registered_and_power_vertical():
+    entry = user_alert_rules.TEMPLATES.get("forced_outage")
+    assert entry is not None
+    assert entry["vertical"] == "power"  # passes the ACTIVE_TEMPLATE_VERTICALS filter
+    ok, _ = user_alert_rules.validate_params("forced_outage", {"zone": "FR"})
+    assert ok
+    ok, err = user_alert_rules.validate_params("forced_outage", {"zone": "XX"})
+    assert not ok and err
+
+
+def _outage_row(db, zone="FR", nominal=6_500.0, business_type="A54", status="active"):
+    from datetime import datetime, timedelta, timezone
+
+    from backend.models.energy import PowerOutage
+
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    db.add(PowerOutage(mrid=f"m{nominal}", revision=1, doc_type="A77", zone=zone,
+                       business_type=business_type, psr_type="B14", unit_name="Almaraz",
+                       unit_eic="11W", location=zone, nominal_mw=nominal, available_mw=0.0,
+                       start_utc=(now - timedelta(days=1)).strftime(fmt),
+                       end_utc=(now + timedelta(days=3)).strftime(fmt), status=status))
+    db.commit()
+
+
+def test_forced_outage_triggers_capacity_relative(db_session):
+    from backend.models.energy import InstalledCapacity
+
+    db_session.add(InstalledCapacity(zone="FR", year=2026, psr_type="Solar",
+                                     capacity_mw=135_000.0))
+    _outage_row(db_session, nominal=6_500.0)  # 4.8% of fleet → warning
+    res = user_alert_rules.evaluate_forced_outage(db_session, {"zone": "FR"}, now=NOW)
+    assert res is not None
+    assert "% of fleet" in res.title
+    assert res.payload["severity"] == "warning"
+
+
+def test_forced_outage_quiet_below_thresholds(db_session):
+    from backend.models.energy import InstalledCapacity
+
+    db_session.add(InstalledCapacity(zone="FR", year=2026, psr_type="Solar",
+                                     capacity_mw=135_000.0))
+    _outage_row(db_session, nominal=900.0)  # 0.7% → silent
+    assert user_alert_rules.evaluate_forced_outage(db_session, {"zone": "FR"}, now=NOW) is None

--- a/frontend/src/components/AlertsPanel.jsx
+++ b/frontend/src/components/AlertsPanel.jsx
@@ -38,6 +38,11 @@ const RULE_ICONS = {
   negative_prices: 'NEGP',
   sentiment_risk: 'SENT',
   dunkelflaute: 'DUNKL',
+  forced_outages: 'OUTG',
+  imbalance_extreme: 'IMBAL',
+  price_spike: 'SPIKE',
+  hydro_deviation: 'HYDRO',
+  record_break: 'REC',
 }
 
 // Which dashboard tab holds the evidence chart for each vertical (drill-down fallback).
@@ -49,6 +54,11 @@ const RULE_TARGET = {
   gas_balance: { tab: 'gas', panel: 'gas-balance' },
   dunkelflaute: { tab: 'energy', panel: 'power-grid' },
   negative_prices: { tab: 'energy', panel: 'power-day-ahead' },
+  forced_outages: { tab: 'energy', panel: 'power-outages' },
+  price_spike: { tab: 'energy', panel: 'power-day-ahead' },
+  hydro_deviation: { tab: 'europe', panel: 'hydro-reservoirs' },
+  record_break: { tab: 'energy' },
+  imbalance_extreme: { tab: 'energy' },
   sentiment_risk: { tab: 'sentiment', panel: 'sentiment' },
   floating_storage: { tab: 'signals', panel: 'sts-detection' },
   freight_divergence: { tab: 'signals', panel: 'freight-proxy' },
@@ -73,6 +83,11 @@ const RULE_GROUP_LABELS = {
   weather: 'weather alerts',
   refinery_thermal: 'thermal alerts',
   negative_prices: 'zones with negative prices',
+  forced_outages: 'zones with forced outages',
+  price_spike: 'zones with unusual day-ahead prices',
+  imbalance_extreme: 'zones with extreme imbalance prices',
+  hydro_deviation: 'reservoirs outside their seasonal band',
+  record_break: 'zones with fresh all-time records',
 }
 
 function timeAgo(isoStr) {


### PR DESCRIPTION
PR-B des Verbesserungsplans (Radar vertiefen). Die Datentiefe-Roadmap-Daten (Imbalance, Hydro, Records) hatten keinerlei Radar-Abdeckung.

**4 neue Detektoren (Registry 4 → 8), konservativ + deskriptiv:**
- `imbalance_extreme` — Tages-PEAK |Imbalance-Preis| je Zone vs. eigener 45d-Norm (z ≥ 2,5/3,5) mit 300/500-€-Floors; `max_age_days=4` (reBAP settelt spät).
- `price_spike` — Day-Ahead-Tagesmittel vs. 45d-Norm, BEIDE Tails, 25-€-Delta-Floor gegen Mikro-Varianz-Zonen. Bewusst nicht `dayahead_spike` genannt (User-Template-Namenskollision).
- `hydro_deviation` — Füllstand außerhalb des Gleiche-ISO-Woche-Bands (`same_week_band` nach `entsoe_hydro.py` verschoben: EINE Ableitung für Route + Detektor); `band_n ≥ 3`; `max_age_days=16`.
- `record_break` — ein Info-Ping je Zone für frische All-Time-Records, Guard ≥ 1 Jahr Serien-Coverage.

**Basis:** `DetectorResult.max_age_days` — wöchentliche Quellen überleben jetzt die per-Vertical-Staleness (per Test gepinnt: 10 Tage alter Hydro-Punkt darf nicht an `power: 3` ersticken).

**Rule-Builder:** `forced_outage`-User-Template (Landing impliziert es längst) — exakt dieselbe Ableitung wie Radar + Hero (`forced_outage_mw_now` + `forced_outage_severity`).

**AlertsPanel:** Icons/Drill-Downs/Gruppenlabels für alle 5 Power-Rules — inkl. `forced_outages`, das seit #63 in Prod feuert und bislang ohne Icon/Drill-Down renderte.

Verifikation: ruff + 743 Tests grün (17 neue); Detektoren-Smoke gegen lokale DB (price_spike fand 2 Kandidaten auf den stale Juni-Daten, Runner unterdrückte korrekt — Staleness-Design greift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)