### PR TITLE
Surface the depth-roadmap data: hourly flows UI, imbalance panel, records browse, honest empty states

### DIFF
--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -642,6 +642,8 @@ PANEL_MAX_AGE_DAYS = {
     "grid": 3,
     "generation_mix": 3,
     "flows": 3,
+    "flows_hourly": 3,  # mirrors SPECS "flows_hourly"
+    "imbalance": 4,     # mirrors SPECS "imbalance_qh" — reBAP settles late
     "spark": 4,  # gas leg is yfinance TTF — ~3 trading days plus weekends
     "load_forecast": 2,
 }
@@ -1285,6 +1287,153 @@ async def get_forecast_error(
         "bias_mw": round(sum(errors) / len(errors), 1),
         "mae_mw": round(sum(abs(e) for e in errors) / len(errors), 1),
         "note": "bias = mean(actual − forecast); describes the published TSO forecast",
+    }
+
+
+# ─── Hourly cross-border flows (free) ─────────────────────────────────────────
+
+
+@router.get("/flows/hourly")
+async def get_flows_hourly(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    hours: int = Query(72, ge=6, le=720, description="Lookback window in hours"),
+    db: Session = Depends(get_db),
+):
+    """Hourly cross-border flows for one zone's borders (Energy-Charts CBPF,
+    CC BY 4.0). Free tier.
+
+    Reads the canonical store (series ``flow.<TO>`` under zone ``<FROM>``,
+    canonical sorted border) and normalises every border to the SELECTED zone's
+    perspective: net_mw > 0 = the selected zone EXPORTS to that neighbour.
+    Country-level source — sub-zones without an Energy-Charts country (Italian
+    sub-zones, DK1/DK2 …) return available:false with the reason, not a blank.
+    """
+    from backend.models.energy import PowerHourly, SeriesDim, ZoneDim
+    from backend.power.hourly_store import read_hourly
+
+    resolved_zone = _resolve_zone(zone)
+    start_ts = int((datetime.now(timezone.utc) - timedelta(hours=hours)).timestamp())
+
+    borders: dict[str, list[tuple[int, float]]] = {}
+
+    # Case A — resolved zone is the canonical sorted-FIRST zone: its exports
+    # live as series flow.<neighbor> under itself.
+    for (key,) in db.query(SeriesDim.key).filter(SeriesDim.key.like("flow.%")).all():
+        neighbor = key[len("flow."):]
+        if neighbor == resolved_zone:
+            continue
+        pts = read_hourly(db, key, resolved_zone, start_ts=start_ts)
+        if pts:
+            borders[neighbor] = pts  # net > 0 = resolved zone exports (native sign)
+
+    # Case B — resolved zone is sorted-SECOND: series flow.<resolved> under the
+    # neighbours. One query across all zones; flip the sign to "selected exports".
+    sid = db.query(SeriesDim.id).filter(SeriesDim.key == f"flow.{resolved_zone}").scalar()
+    if sid is not None:
+        rows = (
+            db.query(ZoneDim.key, PowerHourly.ts_utc, PowerHourly.value)
+            .join(PowerHourly, PowerHourly.zone_id == ZoneDim.id)
+            .filter(PowerHourly.series_id == sid, PowerHourly.ts_utc >= start_ts)
+            .order_by(PowerHourly.ts_utc.asc())
+            .all()
+        )
+        for neighbor, ts, v in rows:
+            borders.setdefault(neighbor, []).append((int(ts), -float(v)))
+
+    if not borders:
+        return {
+            "available": False,
+            "zone": resolved_zone,
+            "zones": _ZONE_KEYS,
+            "reason": (
+                f"No hourly flow series for {POWER_ZONES[resolved_zone]['label']} — "
+                "Energy-Charts flows are country-level, so sub-zones (Italian zones, "
+                "DK1/DK2, Nordic sub-zones) have no border series of their own."
+            ),
+        }
+
+    newest_ts = max(pts[-1][0] for pts in borders.values())
+    as_of = _dt.fromtimestamp(newest_ts, tz=timezone.utc).strftime("%Y-%m-%d")
+    out = []
+    for neighbor, pts in borders.items():
+        latest_mw = pts[-1][1]
+        out.append({
+            "neighbor": neighbor,
+            "neighbor_label": _zone_label(neighbor),
+            "latest_mw": round(latest_mw, 1),
+            "direction": "export" if latest_mw >= 0 else "import",
+            "data": [
+                {"ts_utc": _dt.fromtimestamp(t, tz=timezone.utc).isoformat(), "net_mw": round(v, 1)}
+                for t, v in pts
+            ],
+        })
+    out.sort(key=lambda b: -abs(b["latest_mw"]))
+    return {
+        "available": True,
+        "zone": resolved_zone,
+        "zones": _ZONE_KEYS,
+        "unit": "MW",
+        "hours": hours,
+        "note": f"net_mw > 0 = {POWER_ZONES[resolved_zone]['label']} exports to the neighbour; hourly means",
+        "source": ATTRIBUTION,
+        "borders": out,
+        **_freshness(as_of, datetime.utcnow().date(), PANEL_MAX_AGE_DAYS["flows_hourly"]),
+    }
+
+
+# ─── Imbalance prices (free) ──────────────────────────────────────────────────
+
+
+@router.get("/imbalance")
+async def get_imbalance(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    days: int = Query(7, ge=1, le=90),
+    resolution: str = Query("hourly", pattern="^(hourly|qh)$"),
+    db: Session = Depends(get_db),
+):
+    """Imbalance prices (ENTSO-E A85; reBAP for DE-LU via the country EIC) for a
+    zone — what being out of balance actually costs, the intraday stress gauge
+    that day-ahead means smooth away. `resolution=qh` returns the raw 15-min
+    settlement points where they exist. Free tier, descriptive.
+    """
+    from backend.power.hourly_store import read_hourly
+
+    resolved_zone = _resolve_zone(zone)
+    series_key = "imbalance.price" if resolution == "hourly" else "imbalance.price.qh"
+    start_ts = int((datetime.now(timezone.utc) - timedelta(days=days)).timestamp())
+    points = read_hourly(db, series_key, resolved_zone, start_ts=start_ts)
+    if not points:
+        return {
+            "available": False,
+            "zone": resolved_zone,
+            "zones": _ZONE_KEYS,
+            "reason": (
+                f"No imbalance-price series for {POWER_ZONES[resolved_zone]['label']} — "
+                "A85 coverage varies by zone (and 15-min settlement only exists where "
+                "the market settles in quarter-hours)."
+            ),
+        }
+
+    values = [v for _, v in points]
+    peak = max(points, key=lambda p: abs(p[1]))
+    as_of = _dt.fromtimestamp(points[-1][0], tz=timezone.utc).strftime("%Y-%m-%d")
+    return {
+        "available": True,
+        "zone": resolved_zone,
+        "zones": _ZONE_KEYS,
+        "unit": "EUR/MWh",
+        "resolution": resolution,
+        "days": days,
+        "latest": round(values[-1], 2),
+        "peak": {
+            "price": round(peak[1], 2),
+            "ts_utc": _dt.fromtimestamp(peak[0], tz=timezone.utc).isoformat(),
+        },
+        "data": [
+            {"ts_utc": _dt.fromtimestamp(t, tz=timezone.utc).isoformat(), "price": round(v, 2)}
+            for t, v in points
+        ],
+        **_freshness(as_of, datetime.utcnow().date(), PANEL_MAX_AGE_DAYS["imbalance"]),
     }
 
 

--- a/backend/tests/test_energy_charts_flows.py
+++ b/backend/tests/test_energy_charts_flows.py
@@ -638,3 +638,43 @@ async def test_use_cache_gives_up_after_max_429s(db_session, tmp_path, monkeypat
     assert result["written"] == 0
     assert calls["n"] == len(flows.BASE_COUNTRIES) * flows.RATE_LIMIT_ATTEMPTS
     assert list(tmp_path.rglob("*.json.gz")) == [], "a failed month must never cache"
+
+
+# ─── GET /api/power/flows/hourly ──────────────────────────────────────────────
+
+
+def _seed_hourly_flows(db):
+    """DE_LU-FR border (DE_LU sorted-first: series flow.FR under DE_LU) and
+    CH-DE_LU border (CH sorted-first: series flow.DE_LU under CH)."""
+    import time as _time
+
+    from backend.power.hourly_store import upsert_hourly
+
+    now = (int(_time.time()) // 3600) * 3600
+    # DE_LU exports 1.5 GW to FR (native sign already "DE_LU exports")
+    upsert_hourly(db, "flow.FR", "DE_LU",
+                  [(now - i * 3600, 1500.0) for i in range(24, 0, -1)], unit="MW")
+    # CH exports 2 GW to DE_LU → from DE_LU's perspective an IMPORT (−2000)
+    upsert_hourly(db, "flow.DE_LU", "CH",
+                  [(now - i * 3600, 2000.0) for i in range(24, 0, -1)], unit="MW")
+
+
+def test_flows_hourly_normalises_both_border_directions(db_session):
+    _seed_hourly_flows(db_session)
+    body = _make_client(db_session).get("/api/power/flows/hourly?zone=DE_LU&hours=48").json()
+    assert body["available"] is True
+    by_neighbor = {b["neighbor"]: b for b in body["borders"]}
+    assert by_neighbor["FR"]["latest_mw"] == 1500.0
+    assert by_neighbor["FR"]["direction"] == "export"
+    assert by_neighbor["CH"]["latest_mw"] == -2000.0, \
+        "sorted-second border must flip sign to the selected zone's perspective"
+    assert by_neighbor["CH"]["direction"] == "import"
+    assert body["stale"] is False and body["unit"] == "MW"
+    assert body["borders"][0]["neighbor"] == "CH", "sorted by |latest| desc"
+
+
+def test_flows_hourly_subzone_without_series_is_honest(db_session):
+    _seed_hourly_flows(db_session)
+    body = _make_client(db_session).get("/api/power/flows/hourly?zone=NL").json()
+    assert body["available"] is False
+    assert "country-level" in body["reason"]

--- a/backend/tests/test_imbalance.py
+++ b/backend/tests/test_imbalance.py
@@ -154,3 +154,55 @@ async def test_ingest_writes_qh_series_alongside_hourly(db_session, monkeypatch)
     hourly = read_hourly(db_session, "imbalance.price", "FR")
     assert len(hourly) == 24
     assert hourly[-1][1] == pytest.approx((50.0 * 3 - 990.0) / 4)
+
+
+# ─── GET /api/power/imbalance ─────────────────────────────────────────────────
+
+
+def _client(db):
+    from fastapi.testclient import TestClient
+
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _seed_imbalance_series(db, zone="DE_LU", resolution="hourly"):
+    import time as _time
+
+    from backend.power.hourly_store import upsert_hourly
+
+    key = "imbalance.price" if resolution == "hourly" else "imbalance.price.qh"
+    now = (int(_time.time()) // 3600) * 3600
+    step = 3600 if resolution == "hourly" else 900
+    points = [(now - i * step, 80.0 + i) for i in range(48, 0, -1)]
+    points.append((now, -740.0))  # the spike that makes the panel worth reading
+    upsert_hourly(db, key, zone, points, unit="EUR/MWh")
+
+
+def test_imbalance_route_hourly(db_session):
+    _seed_imbalance_series(db_session)
+    body = _client(db_session).get("/api/power/imbalance?zone=DE_LU&days=7").json()
+    assert body["available"] is True
+    assert body["unit"] == "EUR/MWh" and body["resolution"] == "hourly"
+    assert body["latest"] == -740.0
+    assert body["peak"]["price"] == -740.0
+    assert body["stale"] is False and body["as_of"] is not None
+    assert len(body["data"]) >= 48
+
+
+def test_imbalance_route_qh(db_session):
+    _seed_imbalance_series(db_session, resolution="qh")
+    body = _client(db_session).get("/api/power/imbalance?zone=DE_LU&resolution=qh").json()
+    assert body["available"] is True and body["resolution"] == "qh"
+
+
+def test_imbalance_route_zone_without_series_is_honest(db_session):
+    _seed_imbalance_series(db_session, zone="DE_LU")
+    body = _client(db_session).get("/api/power/imbalance?zone=NL").json()
+    assert body["available"] is False
+    assert "A85 coverage" in body["reason"]
+    from backend.main import app
+    app.dependency_overrides.clear()

--- a/backend/tests/test_power_panel_freshness.py
+++ b/backend/tests/test_power_panel_freshness.py
@@ -109,4 +109,6 @@ def test_panel_thresholds_match_health_specs():
     assert PANEL_MAX_AGE_DAYS["day_ahead"] == by_key["power_dayahead"]
     assert PANEL_MAX_AGE_DAYS["grid"] == by_key["power_grid"]
     assert PANEL_MAX_AGE_DAYS["flows"] == by_key["power_flows"]
+    assert PANEL_MAX_AGE_DAYS["flows_hourly"] == by_key["flows_hourly"]
+    assert PANEL_MAX_AGE_DAYS["imbalance"] == by_key["imbalance_qh"]
     assert PANEL_MAX_AGE_DAYS["spark"] == by_key["ttf"]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -55,6 +55,8 @@ import PowerSituationHeader from './components/PowerSituationHeader'
 import HydroReservoirPanel from './components/HydroReservoirPanel'
 import OutagePanel from './components/OutagePanel'
 import RecordChip from './components/RecordChip'
+import ImbalancePanel from './components/ImbalancePanel'
+import RecordsPanel from './components/RecordsPanel'
 import PowerOverviewMatrix from './components/PowerOverviewMatrix'
 import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
@@ -565,6 +567,9 @@ function Dashboard() {
               <ErrorBoundary name="power-dayahead">
                 <PowerDayAheadPanel zone={energyZone} />
               </ErrorBoundary>
+              <ErrorBoundary name="power-imbalance">
+                <ImbalancePanel zone={energyZone} />
+              </ErrorBoundary>
               <ErrorBoundary name="power-spark">
                 <SparkSpreadPanel zone={energyZone} />
               </ErrorBoundary>
@@ -584,6 +589,11 @@ function Dashboard() {
               </ErrorBoundary>
               <ErrorBoundary name="generation-mix">
                 <GenerationMixPanel zone={energyZone} />
+              </ErrorBoundary>
+              {/* Zone-desk hydro: renders only for zones that HAVE A72 reservoirs
+                  (structural absence elsewhere, not a data gap). */}
+              <ErrorBoundary name="power-hydro">
+                <HydroReservoirPanel zone={energyZone} />
               </ErrorBoundary>
             </div>
 
@@ -645,6 +655,11 @@ function Dashboard() {
             <div className="mt-3">
               <ErrorBoundary name="merit-order">
                 <MeritOrderScatter zone={energyZone} />
+              </ErrorBoundary>
+            </div>
+            <div className="mt-3">
+              <ErrorBoundary name="power-records">
+                <RecordsPanel zone={energyZone} />
               </ErrorBoundary>
             </div>
           </>

--- a/frontend/src/components/CrossBorderFlowPanel.jsx
+++ b/frontend/src/components/CrossBorderFlowPanel.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { POLL_SLOW_MS } from '../utils/poll'
@@ -12,7 +13,7 @@ import {
   Tooltip,
   ReferenceLine,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, fmtTs, CHART_TOOLTIP_STYLE } from '../utils/chart'
 
 const API = '/api'
 
@@ -35,16 +36,9 @@ function zoneLabel(zone) {
   return zone === 'DE_LU' ? 'DE-LU' : zone
 }
 
-// Each border = one sparkline + headline bar
-function BorderRow({ border, data }) {
-  const { label, net_mw: netMw, direction, from_zone, to_zone } = border
-
-  const arrowKey = `${zoneLabel(from_zone)}→${zoneLabel(to_zone)}`
-
-  const sparkData = data
-    .filter((d) => d[arrowKey] != null)
-    .map((d) => ({ date: d.date, net_mw: d[arrowKey] }))
-
+// Each border = one sparkline + headline bar. Grain-agnostic: `spark` is
+// [{x, net_mw}] with x either a date string (daily) or an ISO timestamp (hourly).
+function BorderRow({ label, netMw, direction, spark, xFormatter }) {
   const absGW = netMw != null ? Math.abs(netMw / 1000).toFixed(2) : '—'
   const color = borderColor(netMw)
 
@@ -95,16 +89,16 @@ function BorderRow({ border, data }) {
       </div>
 
       {/* Sparkline */}
-      {sparkData.length > 1 && (
+      {spark.length > 1 && (
         <ResponsiveContainer width="100%" height={36}>
-          <LineChart data={sparkData} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
-            <XAxis dataKey="date" hide />
+          <LineChart data={spark} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+            <XAxis dataKey="x" hide />
             <YAxis hide />
             <ReferenceLine y={0} stroke="#2a2a3a" strokeDasharray="2 2" />
             <Tooltip
               contentStyle={CHART_TOOLTIP_STYLE}
               formatter={(v) => [`${(v / 1000).toFixed(2)} GW`, 'net']}
-              labelFormatter={fmtDate}
+              labelFormatter={xFormatter}
             />
             <Line
               type="monotone"
@@ -121,10 +115,39 @@ function BorderRow({ border, data }) {
   )
 }
 
+function ModeToggle({ mode, onChange }) {
+  return (
+    <div className="flex gap-1">
+      {['daily', 'hourly'].map((m) => (
+        <button
+          key={m}
+          onClick={() => onChange(m)}
+          className={`font-mono text-[9px] tracking-wider px-1.5 py-0.5 rounded border transition-colors ${
+            mode === m
+              ? 'border-cyan-glow/40 text-cyan-glow'
+              : 'border-border text-neutral-600 hover:text-neutral-400'
+          }`}
+        >
+          {m.toUpperCase()}
+        </button>
+      ))}
+    </div>
+  )
+}
+
 export default function CrossBorderFlowPanel({ zone = 'DE_LU' }) {
   const { range } = useViewState()
-  const url = `${API}/power/flows?days=${rangeDays(range)}`
-  const { data, loading, error } = useFetchWithError(url, { deps: [range], pollMs: POLL_SLOW_MS })
+  const [mode, setMode] = useState('daily')
+  const hourly = mode === 'hourly'
+  const url = hourly
+    ? `${API}/power/flows/hourly?zone=${zone}&hours=72`
+    : `${API}/power/flows?days=${rangeDays(range)}`
+  const { data, loading, error } = useFetchWithError(url, {
+    deps: [range, zone, mode],
+    pollMs: POLL_SLOW_MS,
+  })
+
+  const zl = zoneLabel(zone)
 
   if (error) {
     return (
@@ -136,30 +159,43 @@ export default function CrossBorderFlowPanel({ zone = 'DE_LU' }) {
     )
   }
 
-  if (!data?.available && !loading) return null
+  // Never vanish silently: a zone without flow series (Italian sub-zones,
+  // DK1/DK2 …) gets the reason, not a blank spot in the grid section.
+  if (!data?.available && !loading) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          CROSS-BORDER FLOWS · {zl} — {data?.reason || 'no flow data yet.'}
+        </div>
+      </div>
+    )
+  }
 
-  // Coherence with the zone selector: show the interconnectors that touch the
-  // selected zone, not all 20 borders (the API returns the full network).
-  const zl = zoneLabel(zone)
-  const borders = (data?.borders ?? []).filter(
+  // Daily mode: coherence with the zone selector — show the interconnectors
+  // that touch the selected zone, not all 20 borders.
+  const dailyBorders = hourly ? [] : (data?.borders ?? []).filter(
     (b) => b.from_zone === zone || b.to_zone === zone,
   )
-  const rows = data?.data ?? []
+  const dailyRows = data?.data ?? []
+  const hourlyBorders = hourly ? (data?.borders ?? []) : []
+  const borderCount = hourly ? hourlyBorders.length : dailyBorders.length
 
   return (
     <Panel
       id="cross-border-flows"
       freshness={data}
       title={`CROSS-BORDER FLOWS · ${zl}`}
-      info={`Net physical electricity flows across ${zl}'s real interconnectors with its neighbours — sorted by magnitude. Daily mean MW — positive = net export in the shown direction. Green = net exporter, orange = net importer. Sparkline shows the selected window, signed. Source: Fraunhofer ISE Energy-Charts (CC BY 4.0).`}
+      info={`Net physical electricity flows across ${zl}'s real interconnectors with its neighbours — sorted by magnitude. Positive = net export in the shown direction. Green = net exporter, orange = net importer. DAILY shows daily means over the selected window; HOURLY shows the last 72 hours from the canonical hourly store. Source: Fraunhofer ISE Energy-Charts (CC BY 4.0).`}
       collapsible
-      defaultCollapsed
       headerRight={
-        borders.length > 0 && (
-          <span className="font-mono text-[9px] text-neutral-600">
-            {borders.length} borders · CBPF
-          </span>
-        )
+        <div className="flex items-center gap-2">
+          <ModeToggle mode={mode} onChange={setMode} />
+          {borderCount > 0 && (
+            <span className="font-mono text-[9px] text-neutral-600">
+              {borderCount} borders · CBPF
+            </span>
+          )}
+        </div>
       }
     >
       {loading && (
@@ -168,31 +204,61 @@ export default function CrossBorderFlowPanel({ zone = 'DE_LU' }) {
         </div>
       )}
 
-      {!loading && data?.available && (
+      {!loading && data?.available && !hourly && (
         <>
-          {borders.map((border) => (
-            <BorderRow
-              key={`${border.from_zone}-${border.to_zone}`}
-              border={border}
-              data={rows}
-            />
-          ))}
+          {dailyBorders.map((border) => {
+            const arrowKey = `${zoneLabel(border.from_zone)}→${zoneLabel(border.to_zone)}`
+            const spark = dailyRows
+              .filter((d) => d[arrowKey] != null)
+              .map((d) => ({ x: d.date, net_mw: d[arrowKey] }))
+            return (
+              <BorderRow
+                key={`${border.from_zone}-${border.to_zone}`}
+                label={border.label}
+                netMw={border.net_mw}
+                direction={border.direction}
+                spark={spark}
+                xFormatter={fmtDate}
+              />
+            )
+          })}
           <div className="px-4 py-2 font-mono text-[9px] text-neutral-700">
             daily mean MW · latest {data?.latest?.date}
           </div>
-          <div className="px-4 pb-2 font-mono text-[9px] text-neutral-700">
-            Source:{' '}
-            <a
-              href="https://www.energy-charts.info"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-neutral-500"
-            >
-              Energy-Charts
-            </a>
-            {' '}(CC BY 4.0)
+        </>
+      )}
+
+      {!loading && data?.available && hourly && (
+        <>
+          {hourlyBorders.map((b) => (
+            <BorderRow
+              key={b.neighbor}
+              label={`${zl}↔${b.neighbor_label}`}
+              netMw={b.latest_mw}
+              direction={b.direction}
+              spark={(b.data ?? []).map((p) => ({ x: p.ts_utc, net_mw: p.net_mw }))}
+              xFormatter={fmtTs}
+            />
+          ))}
+          <div className="px-4 py-2 font-mono text-[9px] text-neutral-700">
+            hourly mean MW · last {data?.hours}h · {data?.note}
           </div>
         </>
+      )}
+
+      {!loading && data?.available && (
+        <div className="px-4 pb-2 font-mono text-[9px] text-neutral-700">
+          Source:{' '}
+          <a
+            href="https://www.energy-charts.info"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-neutral-500"
+          >
+            Energy-Charts
+          </a>
+          {' '}(CC BY 4.0)
+        </div>
       )}
     </Panel>
   )

--- a/frontend/src/components/ForecastErrorStrip.jsx
+++ b/frontend/src/components/ForecastErrorStrip.jsx
@@ -25,10 +25,18 @@ function Line({ label, err }) {
  * demand surprise / renewables over-delivered.
  */
 export default function ForecastErrorStrip({ zone = 'DE_LU' }) {
-  const { data: load } = useFetchWithError(`${API}/power/forecast-error?zone=${zone}&series=load`, { deps: [zone] })
-  const { data: wind } = useFetchWithError(`${API}/power/forecast-error?zone=${zone}&series=wind`, { deps: [zone] })
-  const { data: solar } = useFetchWithError(`${API}/power/forecast-error?zone=${zone}&series=solar`, { deps: [zone] })
+  const { data: load, error: loadErr } = useFetchWithError(`${API}/power/forecast-error?zone=${zone}&series=load`, { deps: [zone] })
+  const { data: wind, error: windErr } = useFetchWithError(`${API}/power/forecast-error?zone=${zone}&series=wind`, { deps: [zone] })
+  const { data: solar, error: solarErr } = useFetchWithError(`${API}/power/forecast-error?zone=${zone}&series=solar`, { deps: [zone] })
 
+  // Ephemeral strip: absence of forecast-error data is a normal state and stays
+  // silent — but a FETCH error must not masquerade as "nothing to report".
+  if (loadErr && windErr && solarErr)
+    return (
+      <div className="px-4 py-2 border-t border-border/30 font-mono text-[9px] text-red-400">
+        forecast vs actual // fetch error
+      </div>
+    )
   if (!load?.available && !wind?.available && !solar?.available) return null
 
   return (

--- a/frontend/src/components/GenerationMixPanel.jsx
+++ b/frontend/src/components/GenerationMixPanel.jsx
@@ -43,7 +43,15 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
         <div className="font-mono text-[10px] text-red-400">GENERATION MIX // FETCH ERROR</div>
       </div>
     )
-  if (!data?.available && !loading) return null
+  // Never vanish silently: say why there is no chart instead of rendering nothing.
+  if (!data?.available && !loading)
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          GENERATION MIX · {zone === 'DE_LU' ? 'DE-LU' : zone} — {data?.reason || 'no generation data for this zone yet.'}
+        </div>
+      </div>
+    )
 
   const rows = data?.data ?? []
   const latest = data?.latest

--- a/frontend/src/components/HydroReservoirPanel.jsx
+++ b/frontend/src/components/HydroReservoirPanel.jsx
@@ -31,17 +31,47 @@ function BandTag({ zone }) {
  * Weekly reservoir filling (ENTSO-E A72) for the hydro zones — Nordics, Alps,
  * Iberia, France. Southern Norway alone stores ~20 TWh; these levels move
  * power prices continent-wide. Descriptive: filling vs its own seasonal norm.
+ *
+ * With a `zone` prop the panel becomes the zone-desk variant: it shows only
+ * that zone's row (plus the band tag) and renders NOTHING for non-hydro zones
+ * — structural absence (NL has no A72 reservoirs), not a data gap, so silence
+ * is the honest state there.
  */
-export default function HydroReservoirPanel() {
-  const { data, loading } = useFetchWithError(`${API}/power/hydro`, { deps: [] })
+export default function HydroReservoirPanel({ zone = null }) {
+  const { data, loading, error } = useFetchWithError(`${API}/power/hydro`, { deps: [] })
 
-  if (!data?.available && !loading) return null
-  const zones = data?.zones ?? []
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">HYDRO RESERVOIRS // FETCH ERROR</div>
+      </div>
+    )
+  }
+
+  const allZones = data?.zones ?? []
+  const isHydroZone = zone == null || allZones.some((z) => z.zone === zone)
+
+  if (!data?.available && !loading) {
+    // Zone-desk variant on a non-hydro zone can't distinguish "no A72 zone"
+    // from "collector empty" without data — stay quiet only when scoped.
+    if (zone != null) return null
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          HYDRO RESERVOIRS — {data?.reason || 'no reservoir data yet.'}
+        </div>
+      </div>
+    )
+  }
+
+  if (zone != null && !loading && !isHydroZone) return null  // structural absence, not a gap
+
+  const zones = zone == null ? allZones : allZones.filter((z) => z.zone === zone)
 
   return (
     <Panel
       id="hydro-reservoirs"
-      title="HYDRO RESERVOIRS · WEEKLY FILLING"
+      title={zone == null ? 'HYDRO RESERVOIRS · WEEKLY FILLING' : `HYDRO RESERVOIR · ${zones[0]?.zone_label ?? zone}`}
       freshness={data}
       info="ENTSO-E A72 stored hydro energy per zone (TWh), published weekly. 'vs normal' compares the newest week against the SAME calendar week in the zone's own prior years — reservoir levels are seasonal, so only a same-week band is meaningful. Descriptive: a filling level vs its norm, not a price forecast."
       collapsible

--- a/frontend/src/components/ImbalancePanel.jsx
+++ b/frontend/src/components/ImbalancePanel.jsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ReferenceLine,
+} from 'recharts'
+import { fmtTs, CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+function zoneLabel(zone) {
+  return zone === 'DE_LU' ? 'DE-LU' : zone
+}
+
+function ResToggle({ res, onChange }) {
+  return (
+    <div className="flex gap-1">
+      {['hourly', 'qh'].map((r) => (
+        <button
+          key={r}
+          onClick={() => onChange(r)}
+          className={`font-mono text-[9px] tracking-wider px-1.5 py-0.5 rounded border transition-colors ${
+            res === r
+              ? 'border-cyan-glow/40 text-cyan-glow'
+              : 'border-border text-neutral-600 hover:text-neutral-400'
+          }`}
+        >
+          {r === 'qh' ? '15-MIN' : 'HOURLY'}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Imbalance prices (ENTSO-E A85; reBAP for DE-LU) — what being out of balance
+ * actually costs. This is the intraday stress gauge that day-ahead daily means
+ * smooth away: ±1000 €/MWh quarter-hours are invisible everywhere else on the
+ * desk. Descriptive, not a forecast.
+ */
+export default function ImbalancePanel({ zone = 'DE_LU' }) {
+  const [res, setRes] = useState('hourly')
+  const url = `${API}/power/imbalance?zone=${zone}&days=7&resolution=${res}`
+  const { data, loading, error } = useFetchWithError(url, {
+    deps: [zone, res],
+    pollMs: POLL_SLOW_MS,
+  })
+
+  const zl = zoneLabel(zone)
+
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">IMBALANCE // FETCH ERROR</div>
+      </div>
+    )
+  }
+
+  // Never vanish silently — A85 coverage varies by zone; say so.
+  if (!data?.available && !loading) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          IMBALANCE · {zl} — {data?.reason || 'no imbalance-price series yet.'}
+        </div>
+      </div>
+    )
+  }
+
+  const rows = (data?.data ?? []).map((p) => ({ x: p.ts_utc, price: p.price }))
+  const latest = data?.latest
+  const peak = data?.peak
+  const latestColor = latest == null ? '#737373' : Math.abs(latest) >= 300 ? '#fb923c' : '#a3a3a3'
+
+  return (
+    <Panel
+      id="power-imbalance"
+      freshness={data}
+      title={`IMBALANCE PRICE · ${zl}`}
+      info="ENTSO-E A85 imbalance settlement price (reBAP for DE-LU via the country EIC) — the price of being out of balance, settled per 15 minutes where the market does. This is where grid stress prices first; day-ahead daily means smooth it away. All times UTC. Descriptive, not a forecast."
+      collapsible
+      headerRight={
+        <div className="flex items-center gap-2">
+          <ResToggle res={res} onChange={setRes} />
+          {latest != null && (
+            <span className="font-mono text-[10px]" style={{ color: latestColor }}>
+              {latest.toFixed(0)} €/MWh
+            </span>
+          )}
+        </div>
+      }
+    >
+      {loading && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Loading imbalance prices…
+        </div>
+      )}
+
+      {!loading && data?.available && (
+        <>
+          <div className="px-4 pt-2">
+            <ResponsiveContainer width="100%" height={160}>
+              <LineChart data={rows} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
+                <XAxis
+                  dataKey="x"
+                  tickFormatter={fmtTs}
+                  tick={{ fontSize: 9, fill: '#525252' }}
+                  minTickGap={60}
+                />
+                <YAxis
+                  tick={{ fontSize: 9, fill: '#525252' }}
+                  width={44}
+                  tickFormatter={(v) => `${v}`}
+                />
+                <ReferenceLine y={0} stroke="#2a2a3a" strokeDasharray="2 2" />
+                <Tooltip
+                  contentStyle={CHART_TOOLTIP_STYLE}
+                  formatter={(v) => [`${v.toFixed(1)} €/MWh`, 'imbalance']}
+                  labelFormatter={fmtTs}
+                />
+                <Line
+                  type="stepAfter"
+                  dataKey="price"
+                  stroke="#22d3ee"
+                  strokeWidth={1}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="px-4 py-2 font-mono text-[9px] text-neutral-700">
+            last {data?.days}d · window peak {peak?.price?.toFixed(0)} €/MWh ({peak ? fmtTs(peak.ts_utc) : '—'})
+            {res === 'qh' ? ' · raw 15-min settlement points' : ' · hourly means'}
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/InsightsStrip.jsx
+++ b/frontend/src/components/InsightsStrip.jsx
@@ -14,8 +14,14 @@ function timeAgo(iso) {
 // gridstatus-style "insights" strip: the latest anomaly-radar items as compact,
 // horizontally-scrolling cards, with a "More →" into the full ALERTS radar.
 export default function InsightsStrip({ onMore }) {
-  const { data } = useFetchWithError(`${API}/alerts?limit=12`)
+  const { data, error } = useFetchWithError(`${API}/alerts?limit=12`)
   const items = (Array.isArray(data) ? data : []).slice(0, 8)
+  // Ephemeral strip: empty is the documented normal state and stays silent —
+  // but a FETCH error must not masquerade as "nothing to report".
+  if (error)
+    return (
+      <div className="font-mono text-[9px] text-red-400 px-1 py-0.5">insights // fetch error</div>
+    )
   if (items.length === 0) return null
   return (
     <div className="border border-border bg-surface rounded overflow-hidden shadow-sm">

--- a/frontend/src/components/NarrativeHero.jsx
+++ b/frontend/src/components/NarrativeHero.jsx
@@ -12,8 +12,14 @@ const sig = (z) => `${z >= 0 ? '+' : ''}${z.toFixed(1)}σ`
 const list = (zs, n = 3) => zs.slice(0, n).map((z) => z.zone_label || z.zone).join(', ')
 
 export default function NarrativeHero() {
-  const { data } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
+  const { data, error } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
   const zones = data?.zones || []
+  // Ephemeral strip: empty is the documented normal state and stays silent —
+  // but a FETCH error must not masquerade as "nothing to report".
+  if (error)
+    return (
+      <div className="font-mono text-[9px] text-red-400 px-1 py-0.5">europe right now // fetch error</div>
+    )
   if (!data?.available || zones.length === 0) return null
 
   const withPrice = zones.filter((z) => z.price_close != null)

--- a/frontend/src/components/PowerLoadForecastPanel.jsx
+++ b/frontend/src/components/PowerLoadForecastPanel.jsx
@@ -26,7 +26,15 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
         <div className="font-mono text-[10px] text-red-400">LOAD FORECAST // FETCH ERROR</div>
       </div>
     )
-  if (!data?.available && !loading) return null
+  // Never vanish silently: say why there is no chart instead of rendering nothing.
+  if (!data?.available && !loading)
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          LOAD FORECAST · {zone === 'DE_LU' ? 'DE-LU' : zone} — {data?.reason || 'no forecast data for this zone yet.'}
+        </div>
+      </div>
+    )
 
   const rows = data?.data ?? []
   const chart = rows.map((r) => ({

--- a/frontend/src/components/PowerOverviewMatrix.jsx
+++ b/frontend/src/components/PowerOverviewMatrix.jsx
@@ -27,7 +27,7 @@ const COLUMNS = [
 ]
 
 export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
-  const { data } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
+  const { data, loading, error } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
   const [sort, setSort] = useState({ key: 'zone', dir: 'asc' })
 
   const sorted = useMemo(() => {
@@ -45,7 +45,29 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
     return rows
   }, [data, sort])
 
-  if (!data?.available) return null
+  // The all-zones matrix is the default tab's core — it must never be a silent
+  // hole. Loading keeps a quiet placeholder; a fetch error or empty backend
+  // says so instead of rendering nothing.
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">EUROPEAN POWER · ALL ZONES // FETCH ERROR</div>
+      </div>
+    )
+  if (!data?.available && loading)
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-4">
+        <div className="font-mono text-[10px] text-neutral-600 animate-pulse">Loading all zones…</div>
+      </div>
+    )
+  if (!data?.available)
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          EUROPEAN POWER · ALL ZONES — no zone data yet; check back shortly.
+        </div>
+      </div>
+    )
 
   const toggle = (key) => setSort((s) => ({ key, dir: s.key === key && s.dir === 'asc' ? 'desc' : 'asc' }))
   const arrow = (key) => (sort.key === key ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : '')

--- a/frontend/src/components/RecordChip.jsx
+++ b/frontend/src/components/RecordChip.jsx
@@ -24,8 +24,14 @@ function fmt(r) {
  * rendering is the normal state, not a data gap.
  */
 export default function RecordChip({ zone = 'DE_LU' }) {
-  const { data } = useFetchWithError(`${API}/power/records?zone=${zone}`, { deps: [zone], pollMs: POLL_SLOW_MS })
+  const { data, error } = useFetchWithError(`${API}/power/records?zone=${zone}`, { deps: [zone], pollMs: POLL_SLOW_MS })
   const fresh = (data?.records ?? []).filter((r) => r.fresh)
+  // Ephemeral strip: empty is the documented normal state and stays silent —
+  // but a FETCH error must not masquerade as "nothing to report".
+  if (error)
+    return (
+      <div className="font-mono text-[9px] text-red-400 px-1 py-0.5">records // fetch error</div>
+    )
   if (fresh.length === 0) return null
 
   return (

--- a/frontend/src/components/RecordsPanel.jsx
+++ b/frontend/src/components/RecordsPanel.jsx
@@ -1,0 +1,104 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+
+const API = '/api'
+
+function zoneLabel(zone) {
+  return zone === 'DE_LU' ? 'DE-LU' : zone
+}
+
+const SERIES_LABELS = {
+  'price.dayahead': 'Day-ahead hour',
+  'price.dayahead.qh': 'Day-ahead quarter-hour',
+  'imbalance.price.qh': 'Imbalance quarter-hour',
+  'load.actual': 'Load hour',
+  'residual.actual': 'Residual-load hour',
+}
+
+/**
+ * All-time records per series for the selected zone — the archive behind the
+ * ephemeral RecordChip (which only surfaces records set in the last 7 days).
+ * Recomputed nightly by SQL min/max over the canonical store; "all-time" means
+ * within our coverage. Descriptive archive facts, not signals.
+ */
+export default function RecordsPanel({ zone = 'DE_LU' }) {
+  const url = `${API}/power/records?zone=${zone}`
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone] })
+
+  const zl = zoneLabel(zone)
+
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">RECORDS // FETCH ERROR</div>
+      </div>
+    )
+  }
+
+  if (!data?.available && !loading) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          RECORDS · {zl} — {data?.reason || 'no records computed yet.'}
+        </div>
+      </div>
+    )
+  }
+
+  const records = data?.records ?? []
+
+  return (
+    <Panel
+      id="power-records"
+      title={`ALL-TIME RECORDS · ${zl}`}
+      info="All-time extremes per series for this zone — highest/lowest day-ahead hour, quarter-hour, load and residual load — recomputed nightly from the canonical hourly store. 'All-time' means within our coverage (deep history varies by zone). FRESH marks records set in the last 7 days. Descriptive archive facts."
+      collapsible
+    >
+      {loading && !data ? (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">
+          Loading records…
+        </div>
+      ) : (
+        <div className="px-2 py-2 overflow-x-auto">
+          <table className="w-full font-mono text-[11px]">
+            <thead>
+              <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                <th className="text-left px-2 py-1">Series</th>
+                <th className="text-left px-2 py-1">Kind</th>
+                <th className="text-right px-2 py-1">Value</th>
+                <th className="text-right px-2 py-1">Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {records.map((r) => (
+                <tr key={`${r.series}-${r.kind}`} className="border-t border-border/30">
+                  <td className="px-2 py-1.5 text-neutral-300">
+                    {SERIES_LABELS[r.series] || r.series}
+                  </td>
+                  <td className={`px-2 py-1.5 ${r.kind === 'max' ? 'text-orange-400' : 'text-cyan-glow'}`}>
+                    {r.kind === 'max' ? 'HIGHEST' : 'LOWEST'}
+                  </td>
+                  <td className="px-2 py-1.5 text-right text-neutral-200 font-bold">
+                    {r.value.toLocaleString('en-US')}{' '}
+                    <span className="text-[9px] text-neutral-600 font-normal">{r.unit}</span>
+                  </td>
+                  <td className="px-2 py-1.5 text-right text-neutral-500">
+                    {r.date}
+                    {r.fresh && (
+                      <span className="ml-1.5 font-mono text-[8px] tracking-wide border border-amber-500/40 text-amber-400 rounded px-1 py-0.5">
+                        FRESH
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="px-2 pt-2 font-mono text-[9px] text-neutral-700">
+            recomputed nightly · all-time within coverage
+          </div>
+        </div>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/SeriesExplorer.jsx
+++ b/frontend/src/components/SeriesExplorer.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
@@ -12,12 +12,76 @@ const API = '/api'
 const COLOR_A = '#22d3ee'
 const COLOR_B = '#a78bfa'
 
+// Friendly names for the canonical series the desk itself charts; everything
+// else (gen.<fuel>, flow.<zone>) gets a generated label so the raw-key dump
+// the catalog returns stays readable.
+const SERIES_LABELS = {
+  'price.dayahead': 'Day-ahead price · hourly',
+  'price.dayahead.qh': 'Day-ahead price · 15-min',
+  'imbalance.price': 'Imbalance price · hourly',
+  'imbalance.price.qh': 'Imbalance price · 15-min',
+  'load.actual': 'Load · actual',
+  'load.forecast': 'Load · TSO forecast',
+  'residual.actual': 'Residual load · actual',
+  'residual.forecast': 'Residual load · TSO forecast',
+  'generation.forecast': 'Generation · TSO forecast',
+  'hydro.reservoir': 'Hydro reservoir filling · weekly',
+  'wind.actual': 'Wind · actual',
+  'solar.actual': 'Solar · actual',
+}
+
+const GROUP_ORDER = ['price', 'imbalance', 'load', 'residual', 'generation', 'wind', 'solar', 'gen', 'flow', 'hydro']
+const GROUP_LABELS = {
+  price: 'Prices', imbalance: 'Imbalance', load: 'Load', residual: 'Residual load',
+  generation: 'Generation forecast', wind: 'Wind', solar: 'Solar',
+  gen: 'Generation mix (per fuel)', flow: 'Cross-border flows (hourly)', hydro: 'Hydro',
+}
+
+function seriesLabel(s) {
+  if (SERIES_LABELS[s.key]) return SERIES_LABELS[s.key]
+  if (s.key.startsWith('flow.')) return `Flow ↔ ${s.key.slice(5).replace('_', '-')}`
+  if (s.key.startsWith('gen.')) return `Generation · ${s.key.slice(4)}`
+  return s.key
+}
+
+function groupedSeries(seriesList) {
+  const groups = new Map()
+  for (const s of seriesList) {
+    const prefix = s.key.split('.')[0]
+    if (!groups.has(prefix)) groups.set(prefix, [])
+    groups.get(prefix).push(s)
+  }
+  const order = [...GROUP_ORDER.filter((g) => groups.has(g)), ...[...groups.keys()].filter((g) => !GROUP_ORDER.includes(g))]
+  return order.map((g) => ({
+    group: GROUP_LABELS[g] || g,
+    items: groups.get(g).slice().sort((a, b) => a.key.localeCompare(b.key)),
+  }))
+}
+
+// Explorer selection is shareable: s/vs/res live in the URL query (zone+range
+// already travel via the global ViewState spine). replaceState so browsing the
+// catalog doesn't spam the history stack.
+function readParam(name, fallback) {
+  if (typeof window === 'undefined') return fallback
+  return new URLSearchParams(window.location.search).get(name) || fallback
+}
+
 export default function SeriesExplorer() {
-  const [series, setSeries] = useState('price.dayahead')
+  const [series, setSeries] = useState(() => readParam('s', 'price.dayahead'))
   const { zone, setZone, range } = useViewState()  // primary zone + range = the global spine
-  const [compareZone, setCompareZone] = useState('')  // '' = off (local to the explorer)
+  const [compareZone, setCompareZone] = useState(() => readParam('vs', ''))  // '' = off
   const [spread, setSpread] = useState(false)  // Δ (A−B) instead of two lines
-  const [resolution, setResolution] = useState('daily')
+  const [resolution, setResolution] = useState(() => readParam('res', 'daily'))
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const setOrDelete = (k, v, def) => (v && v !== def ? params.set(k, v) : params.delete(k))
+    setOrDelete('s', series, 'price.dayahead')
+    setOrDelete('vs', compareZone, '')
+    setOrDelete('res', resolution, 'daily')
+    const qs = params.toString()
+    history.replaceState(null, '', `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`)
+  }, [series, compareZone, resolution])
 
   const { data: catalog } = useFetchWithError(`${API}/v1/series/catalog`)
   const start = rangeStart(range)
@@ -68,7 +132,15 @@ export default function SeriesExplorer() {
       <div className="flex flex-wrap items-center gap-2 px-4 py-2.5 border-b border-border/50">
         <select value={series} onChange={(e) => setSeries(e.target.value)}
           className="font-mono text-[11px] bg-[#0a0a12] border border-border rounded px-2 py-1 text-neutral-300">
-          {seriesList.map((s) => <option key={s.key} value={s.key}>{s.key}</option>)}
+          {groupedSeries(seriesList).map(({ group, items }) => (
+            <optgroup key={group} label={group}>
+              {items.map((s) => (
+                <option key={s.key} value={s.key}>
+                  {seriesLabel(s)}{s.unit ? ` (${s.unit})` : ''}
+                </option>
+              ))}
+            </optgroup>
+          ))}
         </select>
         <select value={zone} onChange={(e) => setZone(e.target.value)}
           className="font-mono text-[11px] bg-[#0a0a12] border border-cyan-500/40 text-cyan-300 rounded px-2 py-1">
@@ -126,12 +198,12 @@ export default function SeriesExplorer() {
                 {showSpread ? (
                   <>
                     <ReferenceLine y={0} stroke="#444" />
-                    <Line type="monotone" dataKey="d" stroke="#fbbf24" dot={false} strokeWidth={1.4} connectNulls />
+                    <Line type="monotone" dataKey="d" stroke="#fbbf24" dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />
                   </>
                 ) : (
                   <>
-                    <Line type="monotone" dataKey="a" stroke={COLOR_A} dot={false} strokeWidth={1.4} connectNulls />
-                    {comparing && <Line type="monotone" dataKey="b" stroke={COLOR_B} dot={false} strokeWidth={1.4} connectNulls />}
+                    <Line type="monotone" dataKey="a" stroke={COLOR_A} dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />
+                    {comparing && <Line type="monotone" dataKey="b" stroke={COLOR_B} dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />}
                   </>
                 )}
               </LineChart>

--- a/frontend/src/utils/chart.js
+++ b/frontend/src/utils/chart.js
@@ -16,6 +16,17 @@ export function fmtHour(h) {
   return `${String(h).padStart(2, '0')}h`
 }
 
+// UTC timestamp label for hourly/15-min series ("Jul 11, 14:00 UTC") — every
+// time on this desk is UTC, so the label must not drift with the viewer's zone.
+export function fmtTs(iso) {
+  const d = new Date(iso)
+  if (isNaN(d)) return String(iso)
+  return d.toLocaleString('en-US', {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    hour12: false, timeZone: 'UTC',
+  }) + ' UTC'
+}
+
 // Sequential color ramp (dark → cyan → amber) for choropleth fills. t in [0,1].
 const _RAMP = [
   [0.0, [18, 22, 38]],


### PR DESCRIPTION
PR-A des Verbesserungsplans (Datentiefe sichtbar machen) — das Backend war dem Produkt davongelaufen.

**Neue Endpoints** (beide mit as_of/age_days/stale, an freshness-SPECS gekoppelt und per Test gepinnt):
- `GET /api/power/flows/hourly?zone=&hours=` — löst die Borders einer Zone in BEIDEN kanonischen Sortier-Richtungen aus dem canonical store auf und normalisiert das Vorzeichen auf „positiv = gewählte Zone exportiert" (Vorzeichen-Flip per Test gepinnt).
- `GET /api/power/imbalance?zone=&resolution=hourly|qh` — A85/reBAP stündlich oder als rohe 15-min-Settlements, mit ehrlicher Begründung wo A85 keine Abdeckung hat.

**UI:**
- CrossBorderFlowPanel: DAILY⇄HOURLY-Toggle, nicht mehr `defaultCollapsed`, ehrlicher Leerzustand.
- Neues ImbalancePanel (POWER→PRICES, Anker `power-imbalance` = Drill-Down-Ziel des `imbalance_extreme`-Radars) + neues RecordsPanel (ANALYTICS, Archiv hinter dem ephemeren RecordChip).
- HydroReservoirPanel mit `zone`-Prop im Zonen-Desk: Hydro-Zonen zeigen ihre Zeile+Band-Tag, Nicht-Hydro-Zonen rendern nichts (strukturelle Abwesenheit ≠ Datenlücke, im Code dokumentiert).
- **Stilles Verschwinden beendet:** GenerationMix/LoadForecast/OverviewMatrix/Flows sagen jetzt, WARUM sie leer sind; die ephemeren Strips behalten Stille als Normalzustand, schlucken aber keine Fetch-FEHLER mehr.
- SeriesExplorer: Katalog gruppiert mit Klartext-Labels statt Roh-Key-Dump; `s/vs/res` in der URL (merged mit zone/range) → teilbare Explorer-Views; Linien ohne Animation.

**Verifikation:** ruff + 748 Tests grün (5 neue Endpoint-Tests); E2E lokal gegen echte Flows-Daten (DE-LU importierte live 0,86 GW aus FR, Hourly-Serie 197 Punkte im Explorer gerendert); Headless-Screenshots POWER + EXPLORE (Permalink-Roundtrip via URL-Init verifiziert); Leerzustände real beobachtet (Imbalance/LoadForecast auf Dev-DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)