### PR TITLE
Records: a 0 MW load hour is a gap artifact, a negative residual is a record

### DIFF
--- a/backend/power/records.py
+++ b/backend/power/records.py
@@ -37,6 +37,13 @@ IMBALANCE_MIN_PLAUSIBLE = -20_000.0
 IMBALANCE_MAX_PLAUSIBLE = 20_000.0
 MW_MIN_PLAUSIBLE = 0.0
 MW_MAX_PLAUSIBLE = 200_000.0
+# No European bidding zone's real load dips below this — a "0 MW load" hour is
+# an ENTSO-E gap artifact, and it produced a live bogus all-time-min record
+# (SI, 2026-07-11) that the radar dutifully celebrated.
+LOAD_MIN_PLAUSIBLE = 100.0
+# Negative residual load is REAL (renewables exceeding load) and exactly the
+# kind of record worth surfacing — the old 0-floor silently discarded it.
+RESIDUAL_MIN_PLAUSIBLE = -100_000.0
 
 
 def _bounds(series_key: str) -> tuple[float, float]:
@@ -44,6 +51,10 @@ def _bounds(series_key: str) -> tuple[float, float]:
         return IMBALANCE_MIN_PLAUSIBLE, IMBALANCE_MAX_PLAUSIBLE
     if series_key.startswith("price."):
         return PRICE_MIN_PLAUSIBLE, PRICE_MAX_PLAUSIBLE
+    if series_key.startswith("load."):
+        return LOAD_MIN_PLAUSIBLE, MW_MAX_PLAUSIBLE
+    if series_key.startswith("residual."):
+        return RESIDUAL_MIN_PLAUSIBLE, MW_MAX_PLAUSIBLE
     return MW_MIN_PLAUSIBLE, MW_MAX_PLAUSIBLE
 
 

--- a/backend/tests/test_records.py
+++ b/backend/tests/test_records.py
@@ -117,3 +117,41 @@ def test_route_flags_fresh_records(db_session):
 def test_route_empty_is_honest(db_session):
     body = _client(db_session).get("/api/power/records?zone=DE_LU").json()
     assert body["available"] is False
+
+
+def test_zero_load_hour_is_a_gap_artifact_not_a_record(db_session):
+    """A '0 MW load' hour is an ENTSO-E data gap; it produced a live bogus
+    all-time-min record (SI 2026-07-11). The guard must skip it and record the
+    smallest PLAUSIBLE hour instead."""
+    import time as _time
+
+    from backend.power.hourly_store import upsert_hourly
+    from backend.power.records import compute_records
+
+    now = (int(_time.time()) // 3600) * 3600
+    upsert_hourly(db_session, "load.actual", "SI", [
+        (now - 3 * 3600, 0.0),       # gap artifact
+        (now - 2 * 3600, 640.0),     # real minimum
+        (now - 1 * 3600, 1_800.0),
+    ], unit="MW")
+    rows = compute_records(db_session)
+    mins = [r for r in rows if r.series_key == "load.actual" and r.kind == "min"]
+    assert len(mins) == 1 and mins[0].value == 640.0
+
+
+def test_negative_residual_is_a_real_record(db_session):
+    """Renewables exceeding load is real — the old 0-floor silently discarded
+    the most interesting residual records."""
+    import time as _time
+
+    from backend.power.hourly_store import upsert_hourly
+    from backend.power.records import compute_records
+
+    now = (int(_time.time()) // 3600) * 3600
+    upsert_hourly(db_session, "residual.actual", "DE_LU", [
+        (now - 2 * 3600, -3_200.0),
+        (now - 1 * 3600, 41_000.0),
+    ], unit="MW")
+    rows = compute_records(db_session)
+    mins = [r for r in rows if r.series_key == "residual.actual" and r.kind == "min"]
+    assert len(mins) == 1 and mins[0].value == -3_200.0


### PR DESCRIPTION
Prod-Smoke-Befund nach #69: Der Radar feierte „SI: new all-time record" für **min load = 0,0 MW** — ein ENTSO-E-Datenloch, das durch den inklusiven 0-Floor rutschte.

- `load.*`: Floor 100 MW (kein EU-Netz hat real weniger — 0-MW-Stunden sind Gap-Artefakte).
- `residual.*`: Floor auf −100 GW GEÖFFNET — negatives Residual (EE > Last) ist real und genau der Record, der eine Story ist; der alte 0-Floor hat ihn stillschweigend verworfen.
- Bounds greifen in SQL → der nächtliche Recompute ersetzt die Bogus-Zeile von selbst; nach dem Deploy stoße ich den Recompute einmal manuell an.

🤖 Generated with [Claude Code](https://claude.com/claude-code)