### PR TITLE
A75: pumped-storage pumping is load, not generation — stop averaging the two

### DIFF
--- a/backend/power/entsoe_grid.py
+++ b/backend/power/entsoe_grid.py
@@ -122,6 +122,41 @@ def parse_load(xml_text: str) -> dict[str, float]:
     return {day: sum(vals) / len(vals) for day, vals in by_day.items() if vals}
 
 
+#: Suffix marking a CONSUMPTION series in a parsed A75 result. ENTSO-E publishes
+#: storage technologies TWICE in the same document: once as generation
+#: (inBiddingZone_Domain) and once as consumption (outBiddingZone_Domain) —
+#: pumped storage (B10) pumping is the common case. Keying only on psrType, as
+#: this parser did until 2026-07-12, silently AVERAGED the two into one
+#: meaningless number (measured on DE-LU 2026-06: generation 1253 MW, pumping
+#: 1579 MW → stored 1416 MW) and let pumping inflate reported generation, which
+#: in turn made the A75 coverage guard (backend/power/coverage.py) too generous.
+CONSUMPTION_SUFFIX = "_CONS"
+
+
+def _series_psr_key(ts) -> str | None:
+    """psrType of one TimeSeries, suffixed when the series is CONSUMPTION.
+
+    Direction comes from the domain element: outBiddingZone_Domain = energy
+    leaving the zone's grid into the unit (pumping / charging).
+    """
+    psr = next((e.text for e in ts.iter() if _localname(e.tag) == "psrType"), None)
+    if psr is None:
+        return None
+    is_consumption = any(
+        _localname(e.tag).startswith("outBiddingZone_Domain") for e in ts.iter()
+    )
+    return f"{psr}{CONSUMPTION_SUFFIX}" if is_consumption else psr
+
+
+def is_consumption_key(psr_key: str) -> bool:
+    return psr_key.endswith(CONSUMPTION_SUFFIX)
+
+
+def base_psr(psr_key: str) -> str:
+    """'B10_CONS' → 'B10'."""
+    return psr_key[: -len(CONSUMPTION_SUFFIX)] if is_consumption_key(psr_key) else psr_key
+
+
 def parse_generation_by_type(xml_text: str) -> dict[str, dict[str, float]]:
     """Parse an A75 GL_MarketDocument into {YYYY-MM-DD: {psrType: daily_mean_mw}}.
 
@@ -147,9 +182,7 @@ def parse_generation_by_type(xml_text: str) -> dict[str, dict[str, float]]:
     for ts in root.iter():
         if _localname(ts.tag) != "TimeSeries":
             continue
-        psr = next(
-            (e.text for e in ts.iter() if _localname(e.tag) == "psrType"), None
-        )
+        psr = _series_psr_key(ts)
         if psr is None:
             continue
         for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
@@ -248,7 +281,7 @@ def parse_generation_hourly(xml_text: str) -> dict[str, dict[str, dict[int, floa
     for ts in root.iter():
         if _localname(ts.tag) != "TimeSeries":
             continue
-        psr = next((e.text for e in ts.iter() if _localname(e.tag) == "psrType"), None)
+        psr = _series_psr_key(ts)
         if psr is None:
             continue
         for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
@@ -657,12 +690,16 @@ async def ingest_grid(
     # range queries + export. Reuses build_hourly_forecast for the residual shape.
     if load_hourly_by_day:
         upsert_day_hours(db, "load.actual", zone, load_hourly_by_day, unit="MW")
-    gen_series: dict[str, dict[str, dict[int, float]]] = {}  # psr → {day → {hour → mw}}
+    # Generation and CONSUMPTION (pumped-storage pumping) are distinct series —
+    # the document publishes both under the same psrType and they must never be
+    # merged (see CONSUMPTION_SUFFIX).
+    gen_series: dict[str, dict[str, dict[int, float]]] = {}  # psr_key → {day → {hour → mw}}
     for day, by_psr in gen_hourly_by_day.items():
         for psr, hours in by_psr.items():
             gen_series.setdefault(psr, {})[day] = hours
-    for psr, day_hours in gen_series.items():
-        upsert_day_hours(db, f"gen.{psr}", zone, day_hours, unit="MW")
+    for psr_key, day_hours in gen_series.items():
+        prefix = "consumption" if is_consumption_key(psr_key) else "gen"
+        upsert_day_hours(db, f"{prefix}.{base_psr(psr_key)}", zone, day_hours, unit="MW")
     resid_by_day: dict[str, dict[int, float]] = {}
     for day, load_hours in load_hourly_by_day.items():
         if day not in gen_hourly_by_day:
@@ -698,11 +735,17 @@ def _upsert_generation_mix(
     new rows are inserted. Readable labels from PSR_LABELS are used; unknown
     codes fall back to the raw code string.
 
+    CONSUMPTION series (pumped-storage pumping) are EXCLUDED: the mix is what the
+    zone generated, and counting pumping as generation inflated both the mix and
+    the generation total that backend/power/coverage.py divides by load.
+
     Note: does NOT call db.commit() — the caller (ingest_grid) commits once
     after both _upsert_grid and _upsert_generation_mix complete.
     """
     for day, psr_map in gen_by_day.items():
         for code, mean_mw in psr_map.items():
+            if is_consumption_key(code):
+                continue
             label = PSR_LABELS.get(code, code)
             existing = (
                 db.query(PowerGenMix)

--- a/backend/tests/test_power_grid.py
+++ b/backend/tests/test_power_grid.py
@@ -105,14 +105,23 @@ def _a75_gen(
     )
 
 
-def _gen_ts(psr: str, start: str, mw: float, n: int = 24, res: str = "PT60M") -> str:
+def _gen_ts(psr: str, start: str, mw: float, n: int = 24, res: str = "PT60M",
+            direction: str = "in") -> str:
+    """One A75 TimeSeries. `direction="out"` marks it as CONSUMPTION
+    (outBiddingZone_Domain) — how ENTSO-E publishes pumped-storage pumping."""
     pts = "".join(
         f"<Point><position>{i + 1}</position><quantity>{mw}</quantity></Point>"
         for i in range(n)
     )
+    domain = (
+        "<outBiddingZone_Domain.mRID>10Y1001A1001A82H</outBiddingZone_Domain.mRID>"
+        if direction == "out"
+        else "<inBiddingZone_Domain.mRID>10Y1001A1001A82H</inBiddingZone_Domain.mRID>"
+    )
     return (
         f"<TimeSeries>"
         f"<MktPSRType><psrType>{psr}</psrType></MktPSRType>"
+        f"{domain}"
         f"<Period>"
         f"<timeInterval><start>{start}</start></timeInterval>"
         f"<resolution>{res}</resolution>"
@@ -257,3 +266,79 @@ async def test_ingest_grid_empty_days(db_session, monkeypatch):
     monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", SecretStr("test-token"))
     result = await grid_mod.ingest_grid(db_session, [])
     assert result == {"days": 0, "written": 0}
+
+
+# ── pumped storage: generation vs consumption must never be merged ────────────
+# ENTSO-E publishes B10 TWICE in one A75 document — inBiddingZone (generating)
+# and outBiddingZone (pumping). Keying only on psrType averaged them into one
+# meaningless number. Measured on the real cached DE-LU document (2026-06):
+# generation 1253 MW, pumping 1579 MW → the store held 1416 MW.
+
+
+def test_parse_genmix_splits_pumped_storage_generation_from_pumping():
+    xml = _a75_gen(
+        _gen_ts("B10", "2026-04-01T00:00Z", 1_253.0, direction="in")
+        + _gen_ts("B10", "2026-04-01T00:00Z", 1_579.0, direction="out")
+        + _gen_ts("B16", "2026-04-01T00:00Z", 8_000.0)
+    )
+    result = grid_mod.parse_generation_by_type(xml)["2026-04-01"]
+    assert result["B10"] == 1_253.0, "generation leg"
+    assert result["B10_CONS"] == 1_579.0, "pumping leg, kept separate"
+    assert result["B16"] == 8_000.0
+    assert 1_416.0 not in result.values(), "the old averaged-together value must be gone"
+
+
+def test_parse_generation_hourly_splits_pumped_storage():
+    xml = _a75_gen(
+        _gen_ts("B10", "2026-04-01T00:00Z", 1_253.0, direction="in")
+        + _gen_ts("B10", "2026-04-01T00:00Z", 1_579.0, direction="out")
+    )
+    day = grid_mod.parse_generation_hourly(xml)["2026-04-01"]
+    assert day["B10"][0] == 1_253.0
+    assert day["B10_CONS"][0] == 1_579.0
+
+
+def test_consumption_key_helpers():
+    assert grid_mod.is_consumption_key("B10_CONS") is True
+    assert grid_mod.is_consumption_key("B10") is False
+    assert grid_mod.base_psr("B10_CONS") == "B10"
+    assert grid_mod.base_psr("B16") == "B16"
+
+
+async def test_ingest_keeps_pumping_out_of_the_generation_mix(db_session, monkeypatch):
+    """Pumping is load on the grid, not generation. It must land in its own
+    series and must NOT enter PowerGenMix — counting it as generation inflated
+    the mix AND the generation total that coverage.py divides by load, making
+    the A75 coverage guard too generous."""
+    from pydantic import SecretStr
+
+    from backend.models.energy import PowerGenMix
+    from backend.power.coverage import generation_total_mw
+    from backend.power.hourly_store import read_hourly
+
+    load_xml = _a65(_load_ts("2026-04-01T00:00Z", 55_000.0))
+    gen_xml = _a75_gen(
+        _gen_ts("B16", "2026-04-01T00:00Z", 8_000.0)
+        + _gen_ts("B10", "2026-04-01T00:00Z", 1_253.0, direction="in")    # generating
+        + _gen_ts("B10", "2026-04-01T00:00Z", 1_579.0, direction="out")   # pumping
+    )
+
+    async def fake_fetch(eic, month_start, doctype, extra_params, *, overwrite=False):
+        return {"A65": load_xml, "A75": gen_xml}.get(doctype, "")
+
+    monkeypatch.setattr(grid_mod, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", SecretStr("test-token"))
+    await grid_mod.ingest_grid(db_session, ["2026-04-01"])
+
+    mix = {
+        r.psr_type: r.gen_mw
+        for r in db_session.query(PowerGenMix).filter_by(date="2026-04-01", zone="DE_LU")
+    }
+    assert mix["Hydro Pumped Storage"] == 1_253.0, "generation leg only"
+    assert not any("_CONS" in k or "consumption" in k.lower() for k in mix), \
+        "pumping must not appear in the mix"
+    # Generation total (the coverage-guard numerator) counts 8000 + 1253, not the pumping.
+    assert generation_total_mw(db_session, "2026-04-01", "DE_LU") == 9_253.0
+
+    assert read_hourly(db_session, "gen.B10", "DE_LU")[0][1] == 1_253.0
+    assert read_hourly(db_session, "consumption.B10", "DE_LU")[0][1] == 1_579.0


### PR DESCRIPTION
Stufe 0 des Produkt-Tiefe-Audits, Fehler 1/3 — der einzige, der veröffentlichte Zahlen verfälscht.

**Der Fehler:** ENTSO-E veröffentlicht Speicher-Technologien ZWEIMAL im selben A75-Dokument — als Erzeugung (`inBiddingZone_Domain`) und als Verbrauch (`outBiddingZone_Domain`). Beide Parser keyten nur auf `psrType` → beide Serien landeten im selben Topf und wurden **gemittelt**.

Am echten gecachten DE-LU-Dokument (2026-06-15) nachgerechnet:

| | |
|---|---|
| B10 Erzeugung | 1.417 MW |
| B10 Pumpen | 1.343 MW |
| **gespeichert war** | **1.380 MW — das Mittel, physikalisch bedeutungslos** |

Schlimmer: Pumpverbrauch zählte als **Erzeugung**. Die Erzeugungssumme, durch die `coverage.py` die Last teilt, war dadurch **2,3 % zu hoch** — der Coverage-Guard, dessen einzige Aufgabe es ist, unglaubwürdige Renewable-Share-Zahlen zu unterdrücken, lief selbst auf einem aufgeblähten Zähler.

**Der Fix:** Richtung kommt jetzt aus dem Domain-Element. Verbrauchs-Serien bekommen eine eigene kanonische Serie `consumption.<psr>` und sind aus `PowerGenMix` ausgeschlossen — der Mix ist wieder das, was die Zone *erzeugt* hat. Nebeneffekt: Pumpspeicher-Pumpen wird zum ersten Mal sichtbar (der fehlende Akteur hinter Negativpreisen und Abendrampe).

**Historie:** wird durch Re-Parse aus dem Raw-Cache korrigiert (`power_backfill --sources grid`) — 0 API-Calls, die Dokumente liegen auf Platte. Läuft nach dem Merge auf Prod.

ruff + 755 Tests grün (4 neue, u. a. der Regressionstest mit den echten Zahlen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)