### PR TITLE
The desk said 90-day norm while computing 120 — ship the window, do not restate it

### DIFF
--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -56,6 +56,13 @@ from backend.signals.detectors.base import severity_from_zscore, trailing_zscore
 #: beyond a day signals a frozen collector rather than normal publication lag.
 SITUATION_STALE_DAYS = 1
 
+#: Trailing window the hero's and the overview's z-scores are measured against.
+#: Shipped in every situation/overview response as `baseline_days` — the UI
+#: MUST render that number rather than restate it, because restating it is
+#: exactly how the product ended up telling users "~90-day norm" while the code
+#: had been computing 120 (caught 2026-07-12).
+SITUATION_BASELINE_DAYS = 120
+
 router = APIRouter(prefix="/api/power", tags=["power"])
 
 _ZONE_KEYS = list(POWER_ZONES.keys())
@@ -594,7 +601,11 @@ def get_power_overview(db: Session = Depends(get_db)):
             "renewable_reliable": grid.get("renewable_share_reliable"),
             "dunkelflaute": grid.get("dunkelflaute"),
         })
-    return {"available": bool(zones), "zones": zones}
+    return {
+        "available": bool(zones),
+        "zones": zones,
+        "baseline_days": SITUATION_BASELINE_DAYS,  # the window the z columns use
+    }
 
 
 # ─── Power situation synthesis (the desk top-line) ───────────────────────────
@@ -834,6 +845,9 @@ def build_power_situation(
         "stale": stale,
         "age_days": age_days,
         "state": state,
+        # The window every z below was measured against. Shipped so the UI can
+        # STATE it instead of guessing it (it guessed "~90" for a 120-day window).
+        "baseline_days": SITUATION_BASELINE_DAYS,
         "price": price,
         "grid": grid,
         "spark": spark,
@@ -883,7 +897,7 @@ def load_power_situation(db: Session, zone: str) -> dict:
     CALM/ELEVATED/STRESSED) without going through HTTP.
     """
     resolved_zone = _resolve_zone(zone)
-    date_from, date_to = _window(120)
+    date_from, date_to = _window(SITUATION_BASELINE_DAYS)
 
     price_rows = (
         db.query(PowerPriceDaily)
@@ -957,7 +971,7 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
     from backend.power.coverage import coverage_min_ratio
     from backend.signals.detectors.power import forced_outage_totals_now
 
-    date_from, date_to = _window(120)
+    date_from, date_to = _window(SITUATION_BASELINE_DAYS)
     today = datetime.utcnow().date()
 
     # 1. Day-ahead price stats, all zones in one scan.

--- a/backend/tests/test_power_situation.py
+++ b/backend/tests/test_power_situation.py
@@ -472,3 +472,34 @@ def test_weekend_old_spark_does_not_stale_the_situation():
     assert s["spark"]["age_days"] == 2
     assert s["spark"]["stale"] is False
     assert s["stale"] is False
+
+
+def test_situation_ships_the_baseline_window_it_actually_used():
+    """The UI must be able to STATE the window instead of guessing it. It guessed
+    '~90-day' for a 120-day window until 2026-07-12; the number now travels with
+    the data."""
+    from backend.routes.power import SITUATION_BASELINE_DAYS
+
+    price = _price_series([50.0, 51.0, 52.0])
+    grid = _flat_grid([45_000.0, 46_000.0, 47_000.0])
+    s = build_power_situation("DE_LU", price, grid, None)
+    assert s["baseline_days"] == SITUATION_BASELINE_DAYS
+
+
+def test_no_frontend_panel_restates_the_baseline_window():
+    """Regression guard for the class of bug, not the instance: a hardcoded
+    '90-day norm' in a power panel silently contradicted the code. Panels must
+    render `baseline_days` / `baseline_n` from the response instead."""
+    from pathlib import Path
+
+    components = Path(__file__).resolve().parents[2] / "frontend" / "src" / "components"
+    offenders = []
+    for f in components.glob("*.jsx"):
+        text = f.read_text()
+        # dormant non-power verticals are out of scope (crypto/equities glossaries)
+        if f.name in {"CryptoPanel.jsx", "RelatedEquitiesPanel.jsx"}:
+            continue
+        for claim in ("90-day norm", "~90-day norm", "90d norm"):
+            if claim in text:
+                offenders.append(f"{f.name}: {claim!r}")
+    assert not offenders, f"panels restating a baseline window: {offenders}"

--- a/frontend/src/components/HowToRead.jsx
+++ b/frontend/src/components/HowToRead.jsx
@@ -5,7 +5,7 @@ import Panel from './Panel'
 // repeat users can tuck it away, but it can always be re-opened. Teaches both what
 // Obsyd shows AND the market terms, in plain language.
 const TERMS = [
-  ['State (CALM / ELEVATED / STRESSED)', 'how far something sits from its OWN recent history — a deviation, not a forecast. STRESSED ≈ ≥3σ from its ~90-day norm; ELEVATED ≈ ≥2σ or a flag.'],
+  ['State (CALM / ELEVATED / STRESSED)', 'how far something sits from its OWN recent history — a deviation, not a forecast. STRESSED ≈ ≥3σ from its trailing norm; ELEVATED ≈ ≥2σ or a flag. Each panel states the exact window it measured against.'],
   ['Residual load', 'electricity demand minus wind & solar — the demand that gas / coal / nuclear must cover. It is the biggest driver of the power price.'],
   ['Spark spread', 'the profit margin of a gas-fired power plant: power price − gas cost. Positive = worth running; negative = uneconomic.'],
   ['Dunkelflaute', 'a “dark lull”: wind + solar together cover under 15% of demand — thermal plants carry the grid, prices tend to firm.'],

--- a/frontend/src/components/PowerOverviewMatrix.jsx
+++ b/frontend/src/components/PowerOverviewMatrix.jsx
@@ -4,7 +4,8 @@ import { POLL_FAST_MS } from '../utils/poll'
 
 // Single-glance overview — read all bidding zones at once, colour-first, like
 // Electricity Maps / Grid Status. Colour encodes how far each metric sits from its
-// own ~90-day norm, so the European power picture reads in one second. Click a zone
+// own trailing norm (the window is whatever /overview reports as baseline_days), so the
+// European power picture reads in one second. Click a zone
 // to drill into its detail; click a column header to sort. Descriptive, not a forecast.
 const API = '/api'
 
@@ -131,7 +132,7 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
         </table>
       </div>
       <div className="px-3 py-1 border-t border-border/40 font-mono text-[8px] text-neutral-700 leading-snug">
-        Colour = how far each metric sits from its own ~90-day norm (grey normal · amber elevated · red extreme). Descriptive, not a forecast.
+        Colour = how far each metric sits from its own {data.baseline_days ? `${data.baseline_days}-day` : 'trailing'} norm (grey normal · amber elevated · red extreme). Descriptive, not a forecast.
       </div>
     </div>
   )

--- a/frontend/src/components/PowerSituationHeader.jsx
+++ b/frontend/src/components/PowerSituationHeader.jsx
@@ -9,9 +9,12 @@ const API = '/api'
 
 // Plain-language legend for the descriptive desk state (Posture B: a deviation
 // vs the zone's own history, never a forecast). Mirrors the backend derivation.
-const STATE_LEGEND =
+// The baseline window is NOT restated here — it comes from the response
+// (`baseline_days`). Restating it is how the UI ended up claiming a "~90-day
+// norm" for a window the backend had been computing over 120 days.
+const stateLegend = (baselineDays) =>
   'How far this zone sits from its own recent history — a deviation, not a forecast. ' +
-  'STRESSED: day-ahead price or residual load ≥3σ from its ~90-day norm. ' +
+  `STRESSED: day-ahead price or residual load ≥3σ from its ${baselineDays ? `${baselineDays}-day` : 'trailing'} norm. ` +
   'ELEVATED: ≥2σ, or a Dunkelflaute (wind+solar <15% of load) / negative-price flag. ' +
   'CALM: within ~2σ and no flags.'
 
@@ -106,7 +109,7 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
         <div className="flex items-center gap-2 shrink-0">
           <span className={`w-1.5 h-1.5 rounded-full ${st.dot} ${data.state === 'STRESSED' ? 'animate-pulse' : ''}`} />
           <span className={`font-mono text-[11px] font-bold tracking-wider ${st.text}`}>{data.state}</span>
-          <InfoPopover text={STATE_LEGEND} />
+          <InfoPopover text={stateLegend(data.baseline_days)} />
           {data.stale ? (
             // Show the age of the OLDEST lagging component — top-level age_days
             // tracks the newest date, which reads "0d" when only one series hangs.

--- a/frontend/src/components/ReferenceBand.jsx
+++ b/frontend/src/components/ReferenceBand.jsx
@@ -1,8 +1,10 @@
 // "Is this high or low?" — the single biggest legibility win from the comparable
 // dashboards (PortWatch / Trading Economics). A bare number teaches nothing; the
 // same number placed on its own recent range does. Given a z-score (deviation vs
-// the metric's ~90-day history), render a compact Low—Normal—High track with a
-// marker, so magnitude reads at a glance. Descriptive, never a forecast.
+// the metric's own trailing history) plus the baseline's ACTUAL n, render a
+// compact Low—Normal—High track with a marker, so magnitude reads at a glance.
+// The "vs Nd" caption prints the n the backend really used — never a guess.
+// Descriptive, never a forecast.
 
 // z → position across a −3σ…+3σ track (clamped).
 function pos(z) {


### PR DESCRIPTION
Stufe 0 des Produkt-Tiefe-Audits, Fehler 2/3.

**Der Fehler:** Hero, All-Zonen-Matrix und das How-to-read-Glossar sagten dem Nutzer, die z-Werte seien gegen eine „**~90-day norm**" gemessen. Der Code rechnet `_window(120)`, die Radar-Detektoren rechnen 45. Ein aufmerksamer Analyst findet das in fünf Minuten — und danach ist jede andere Zahl auf dem Desk auch verdächtig.

**Der Fix — die Ursache, nicht die Instanz:** Die Zahl reist jetzt mit den Daten. `SITUATION_BASELINE_DAYS` ist die eine Quelle, `/situation` und `/overview` liefern sie als `baseline_days`, die Panels *rendern* sie statt sie zu behaupten. `HowToRead` (hat keine Response) nennt gar kein Fenster mehr und verweist auf die Panels, die ihr exaktes angeben. `ReferenceBand` war übrigens schon ehrlich — es druckt das echte n („vs 101d").

Ein Test verbietet, dass ein Power-Panel je wieder ein Baseline-Fenster im Text wiederholt — damit kann die Fehlerklasse beim nächsten Konstanten-Tuning nicht zurückkommen.

Live am laufenden Server verifiziert: beide Endpoints liefern `baseline_days=120`, `price.baseline_n=101`.

ruff + 757 Tests grün, ESLint auf allen berührten Dateien sauber, Build grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)