### PR TITLE
Repair the storage history the old A75 parser wrote — without rewriting 30M rows

### DIFF
--- a/backend/scripts/repair_storage_series.py
+++ b/backend/scripts/repair_storage_series.py
@@ -1,0 +1,190 @@
+"""Repair the storage series corrupted by the pre-2026-07-12 A75 parser.
+
+    python -m backend.scripts.repair_storage_series --start 2021-01-01
+    python -m backend.scripts.repair_storage_series --dry-run
+
+ENTSO-E publishes storage technologies TWICE in one A75 document — generation
+(inBiddingZone) and consumption (outBiddingZone). The parser keyed only on
+psrType, so the two were averaged into one number that describes neither, and
+the pumping half was counted as generation (inflating both the mix and the
+generation total the coverage guard divides by load).
+
+The parser is fixed; this repairs the HISTORY it wrote. A full grid re-parse
+would do it too, but it rewrites every series for every zone-month (~30M row
+upserts) — far too heavy for a VPS whose disk headroom is measured in single
+gigabytes. This touches ONLY the storage rows: ~1M hourly points and ~43k daily
+rows across the 22 zones that have pumped storage.
+
+Cache-only by design: every A75 document is already on disk (raw_cache), so this
+makes ZERO API calls. Zone-months whose document is missing are counted and
+reported rather than fetched — they simply keep their old (wrong) storage rows
+until someone backfills them, which is honest and visible.
+
+The WAL is checkpointed every CHECKPOINT_EVERY zone-months: the API process
+holds long-lived readers, so without this the write-ahead log grows unbounded
+through a long batch job — which is exactly how a 2026-07-07-class disk incident
+starts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date, datetime
+
+from sqlalchemy import text
+
+from backend.database import SessionLocal
+from backend.gas import raw_cache
+from backend.models.energy import PowerGenMix
+from backend.power.entsoe_grid import (
+    PSR_LABELS,
+    base_psr,
+    is_consumption_key,
+    parse_generation_by_type,
+    parse_generation_hourly,
+)
+from backend.power.hourly_store import upsert_day_hours
+from backend.power.zones import POWER_ZONES
+
+logger = logging.getLogger("repair_storage_series")
+
+CACHE_SOURCE = "entsoe_genmix"
+CHECKPOINT_EVERY = 50  # zone-months
+
+
+def _months(start: date, end: date) -> list[date]:
+    out, cur = [], start.replace(day=1)
+    while cur <= end:
+        out.append(cur)
+        cur = date(cur.year + 1, 1, 1) if cur.month == 12 else date(cur.year, cur.month + 1, 1)
+    return out
+
+
+def storage_psrs(day_map: dict[str, dict[str, float]]) -> set[str]:
+    """PSR codes that appear as CONSUMPTION anywhere in the document.
+
+    Only these were corrupted: a psrType published in one direction only was
+    always parsed correctly. Returned as base codes (B10, not B10_CONS).
+    """
+    return {
+        base_psr(key)
+        for by_psr in day_map.values()
+        for key in by_psr
+        if is_consumption_key(key)
+    }
+
+
+def repair_zone_month(db, zone: str, eic: str, month: date, *, dry_run: bool = False) -> dict:
+    """Rewrite the storage rows for one zone-month from its cached A75 document."""
+    payload = raw_cache.read_cached(CACHE_SOURCE, f"{eic}_{month:%Y-%m}", month)
+    if payload is None:
+        return {"cached": False}
+    xml = payload.get("xml", "")
+    if not xml:
+        return {"cached": False}
+
+    daily = parse_generation_by_type(xml)
+    codes = storage_psrs(daily)
+    if not codes:
+        return {"cached": True, "storage": False}
+    if dry_run:
+        return {"cached": True, "storage": True, "codes": sorted(codes), "days": len(daily)}
+
+    hourly = parse_generation_hourly(xml)
+    hourly_written = 0
+    for code in codes:
+        for prefix, key in (("gen", code), ("consumption", f"{code}_CONS")):
+            day_hours = {
+                day: by_psr[key]
+                for day, by_psr in hourly.items()
+                if key in by_psr
+            }
+            if day_hours:
+                hourly_written += upsert_day_hours(
+                    db, f"{prefix}.{code}", zone, day_hours, unit="MW"
+                )
+
+    # Daily mix: the generation leg only (pumping is load, not generation).
+    daily_written = 0
+    for day, by_psr in daily.items():
+        for code in codes:
+            if code not in by_psr:
+                continue
+            label = PSR_LABELS.get(code, code)
+            row = (
+                db.query(PowerGenMix)
+                .filter(PowerGenMix.date == day, PowerGenMix.zone == zone,
+                        PowerGenMix.psr_type == label)
+                .first()
+            )
+            if row is None:
+                db.add(PowerGenMix(date=day, zone=zone, psr_type=label, gen_mw=by_psr[code]))
+            else:
+                row.gen_mw = by_psr[code]
+            daily_written += 1
+    db.commit()
+    return {
+        "cached": True, "storage": True,
+        "hourly": hourly_written, "daily": daily_written, "codes": sorted(codes),
+    }
+
+
+def run(db, start: date, end: date, *, dry_run: bool = False) -> dict:
+    months = _months(start, end)
+    total = {"zone_months": 0, "missing_cache": 0, "no_storage": 0,
+             "repaired": 0, "hourly": 0, "daily": 0}
+    processed = 0
+    for zone, cfg in POWER_ZONES.items():
+        for month in months:
+            total["zone_months"] += 1
+            res = repair_zone_month(db, zone, cfg["eic"], month, dry_run=dry_run)
+            if not res.get("cached"):
+                total["missing_cache"] += 1
+                continue
+            if not res.get("storage"):
+                total["no_storage"] += 1
+                continue
+            total["repaired"] += 1
+            total["hourly"] += res.get("hourly", 0)
+            total["daily"] += res.get("daily", 0)
+            processed += 1
+            if not dry_run and processed % CHECKPOINT_EVERY == 0:
+                # Bound the WAL: the API holds long-lived readers, so a long batch
+                # job would otherwise grow it without limit (disk-incident class).
+                db.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
+                logger.info("repair: %s %s — %d zone-months repaired (WAL checkpointed)",
+                            zone, month.strftime("%Y-%m"), total["repaired"])
+    return total
+
+
+def main(argv: list[str]) -> int:
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    p = argparse.ArgumentParser(description="Repair pumped-storage series written by the old A75 parser")
+    p.add_argument("--start", default="2015-01-01")
+    p.add_argument("--end", default=date.today().isoformat())
+    p.add_argument("--dry-run", action="store_true", help="report what would be repaired")
+    args = p.parse_args(argv[1:])
+
+    start = datetime.strptime(args.start, "%Y-%m-%d").date()
+    end = datetime.strptime(args.end, "%Y-%m-%d").date()
+
+    db = SessionLocal()
+    try:
+        result = run(db, start, end, dry_run=args.dry_run)
+    finally:
+        db.close()
+    logger.info("repair_storage_series complete: %s", result)
+    if result["missing_cache"]:
+        logger.warning(
+            "%d zone-months had no cached A75 document — their storage rows keep the "
+            "old (wrong) values until those months are backfilled.",
+            result["missing_cache"],
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/tests/test_repair_storage_series.py
+++ b/backend/tests/test_repair_storage_series.py
@@ -1,0 +1,113 @@
+"""The one-off repair of the storage rows the old A75 parser corrupted.
+
+The parser fix (2026-07-12) stops NEW rows being wrong; this script rewrites the
+HISTORY. It must (a) read only from the raw cache — never the network, (b) touch
+ONLY storage rows, (c) leave a zone-month with no cached document alone and SAY
+so rather than silently pretending it was repaired.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from backend.gas import raw_cache
+from backend.models.energy import PowerGenMix
+from backend.power.hourly_store import read_hourly, upsert_day_hours
+from backend.scripts import repair_storage_series as rss
+from backend.tests.test_power_grid import _a75_gen, _gen_ts
+
+_MONTH = date(2026, 4, 1)
+_DE_EIC = "10Y1001A1001A82H"
+
+
+def _cache_a75(tmp_path, monkeypatch, xml: str, eic: str = _DE_EIC) -> None:
+    monkeypatch.setattr(raw_cache, "DATA_ROOT", tmp_path)
+    raw_cache.write_cached(rss.CACHE_SOURCE, f"{eic}_{_MONTH:%Y-%m}", _MONTH, {"xml": xml})
+
+
+def _doc_with_pumping() -> str:
+    return _a75_gen(
+        _gen_ts("B10", "2026-04-01T00:00Z", 1_253.0, direction="in")
+        + _gen_ts("B10", "2026-04-01T00:00Z", 1_579.0, direction="out")
+        + _gen_ts("B16", "2026-04-01T00:00Z", 8_000.0)
+    )
+
+
+def test_repairs_the_averaged_value_and_adds_the_pumping_series(db_session, tmp_path, monkeypatch):
+    # The corrupted state the old parser left behind: one averaged B10 number,
+    # counted as generation, and no consumption series at all.
+    upsert_day_hours(db_session, "gen.B10", "DE_LU", {"2026-04-01": {h: 1_416.0 for h in range(24)}},
+                     unit="MW")
+    db_session.add(PowerGenMix(date="2026-04-01", zone="DE_LU",
+                               psr_type="Hydro Pumped Storage", gen_mw=1_416.0))
+    db_session.commit()
+    _cache_a75(tmp_path, monkeypatch, _doc_with_pumping())
+
+    res = rss.repair_zone_month(db_session, "DE_LU", _DE_EIC, _MONTH)
+    assert res["storage"] is True and res["codes"] == ["B10"]
+
+    assert read_hourly(db_session, "gen.B10", "DE_LU")[0][1] == 1_253.0
+    assert read_hourly(db_session, "consumption.B10", "DE_LU")[0][1] == 1_579.0
+    mix = db_session.query(PowerGenMix).filter_by(
+        date="2026-04-01", zone="DE_LU", psr_type="Hydro Pumped Storage").one()
+    assert mix.gen_mw == 1_253.0
+
+
+def test_leaves_non_storage_series_untouched(db_session, tmp_path, monkeypatch):
+    """Only psrTypes published in BOTH directions were corrupted. Everything else
+    must be left exactly as it is — this is a repair, not a re-ingest."""
+    db_session.add(PowerGenMix(date="2026-04-01", zone="DE_LU",
+                               psr_type="Solar", gen_mw=1.0))  # deliberately absurd
+    db_session.commit()
+    _cache_a75(tmp_path, monkeypatch, _doc_with_pumping())
+
+    rss.repair_zone_month(db_session, "DE_LU", _DE_EIC, _MONTH)
+
+    solar = db_session.query(PowerGenMix).filter_by(
+        date="2026-04-01", zone="DE_LU", psr_type="Solar").one()
+    assert solar.gen_mw == 1.0, "the repair must not rewrite series it did not corrupt"
+    assert read_hourly(db_session, "gen.B16", "DE_LU") == []
+
+
+def test_document_without_pumping_is_a_no_op(db_session, tmp_path, monkeypatch):
+    _cache_a75(tmp_path, monkeypatch,
+               _a75_gen(_gen_ts("B16", "2026-04-01T00:00Z", 8_000.0)))
+    res = rss.repair_zone_month(db_session, "DE_LU", _DE_EIC, _MONTH)
+    assert res == {"cached": True, "storage": False}
+
+
+def test_missing_cache_is_reported_not_fetched(db_session, tmp_path, monkeypatch):
+    """No cached document → no repair, and the run must COUNT it. Silently
+    skipping would leave wrong rows behind while claiming success."""
+    monkeypatch.setattr(raw_cache, "DATA_ROOT", tmp_path)  # empty cache
+    res = rss.repair_zone_month(db_session, "DE_LU", _DE_EIC, _MONTH)
+    assert res == {"cached": False}
+
+    total = rss.run(db_session, date(2026, 4, 1), date(2026, 4, 30))
+    assert total["missing_cache"] == total["zone_months"] > 0
+    assert total["repaired"] == 0
+
+
+def test_run_counts_repaired_zone_months(db_session, tmp_path, monkeypatch):
+    _cache_a75(tmp_path, monkeypatch, _doc_with_pumping())
+    total = rss.run(db_session, date(2026, 4, 1), date(2026, 4, 30))
+    assert total["repaired"] == 1  # only DE_LU has a cached document
+    assert total["hourly"] == 48   # 24 generation + 24 pumping points
+    assert total["daily"] == 1
+
+
+def test_dry_run_writes_nothing(db_session, tmp_path, monkeypatch):
+    _cache_a75(tmp_path, monkeypatch, _doc_with_pumping())
+    res = rss.repair_zone_month(db_session, "DE_LU", _DE_EIC, _MONTH, dry_run=True)
+    assert res["storage"] is True
+    assert read_hourly(db_session, "gen.B10", "DE_LU") == []
+    assert db_session.query(PowerGenMix).count() == 0
+
+
+@pytest.mark.parametrize("codes,expected", [
+    ({"B10": 1.0, "B10_CONS": 2.0, "B16": 3.0}, {"B10"}),
+    ({"B16": 3.0}, set()),
+])
+def test_storage_psrs_detects_only_two_directional_types(codes, expected):
+    assert rss.storage_psrs({"2026-04-01": codes}) == expected


### PR DESCRIPTION
Nachzug zu #73 (Parser-Fix) — und ein Ops-Befund.

**Warum kein voller Re-Parse:** Ich habe auf Prod einen `power_backfill --sources grid` gestartet, um die Historie zu korrigieren. Der schreibt jede Serie jedes Zonen-Monats neu (~30 Mio. Upserts). Ergebnis: Disk von 70 % → **90 %**, während ValueKicks bekannter 5-GB-Transient darunter zyklierte, und ein WAL von **439 MB** (der API-Prozess hält Langzeit-Reader, also kann SQLite nicht checkpointen). Das ist exakt der Eröffnungszug des 2026-07-07-Incidents — für eine Reparatur, die nur die Speicher-Zeilen braucht. Abgebrochen, WAL truncated, Disk wieder bei 79 %.

**Was dieses Skript stattdessen tut:** nur die betroffenen Zeilen — ~1 Mio. Stundenpunkte und ~43k Tageszeilen über die 22 Zonen mit Pumpspeicher. Ausschließlich aus dem Raw-Cache (0 API-Calls): `gen.<psr>` bekommt das Erzeugungs-Bein, `consumption.<psr>` wird angelegt, die Tages-Mix-Zeile korrigiert. Serien, die es nicht kaputtgemacht hat, fasst es nicht an (per Test gepinnt).

**Zwei Eigenschaften, die der Incident gelehrt hat:**
- WAL wird alle 50 Zonen-Monate gecheckpointet — sonst wächst das Log durch einen langen Batch-Job unbegrenzt.
- Ein Zonen-Monat ohne gecachtes Dokument wird **gezählt und gemeldet**, nie still übersprungen: seine Zeilen bleiben falsch, und der Operator muss das wissen.

**Am echten Cache verifiziert**, nicht am Fixture: DE-LU 2026-06-15 las **1380,0 MW** (der gemittelte Bug-Wert) und liest jetzt **1417,5** — das Erzeugungs-Bein, exakt wie im Dokument — mit dem Pump-Bein als eigener Serie.

ruff + 770 Tests grün (8 neue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)