### PR TITLE
The consumption contamination was wider than pumped storage — it reached residual load

### DIFF
--- a/backend/gas/entsoe.py
+++ b/backend/gas/entsoe.py
@@ -111,6 +111,13 @@ def parse_generation(xml_text: str) -> dict[str, float]:
         psr = next((e.text for e in ts.iter() if _localname(e.tag) == "psrType"), None)
         if psr is not None and psr != PSR_FOSSIL_GAS:
             continue
+        # DIRECTION filter. A75 publishes B04 in BOTH directions for some zones
+        # (NL, PT, IE-SEM verified in prod): generation (inBiddingZone) and the
+        # plants' own consumption (outBiddingZone). Summing both inflated power
+        # burn — the MEASURED demand leg of the gas balance — by the consumption
+        # of the very plants whose burn we are counting.
+        if any(_localname(e.tag).startswith("outBiddingZone_Domain") for e in ts.iter()):
+            continue
         for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
             start_el = next((e for e in period.iter() if _localname(e.tag) == "start"), None)
             res_el = next((e for e in period.iter() if _localname(e.tag) == "resolution"), None)

--- a/backend/scripts/repair_storage_series.py
+++ b/backend/scripts/repair_storage_series.py
@@ -37,16 +37,26 @@ from sqlalchemy import text
 
 from backend.database import SessionLocal
 from backend.gas import raw_cache
-from backend.models.energy import PowerGenMix
+from backend.models.energy import PowerGenMix, PowerGrid
 from backend.power.entsoe_grid import (
     PSR_LABELS,
+    PSR_SOLAR,
+    PSR_WIND_OFFSHORE,
+    PSR_WIND_ONSHORE,
     base_psr,
     is_consumption_key,
     parse_generation_by_type,
     parse_generation_hourly,
 )
-from backend.power.hourly_store import upsert_day_hours
+from backend.power.hourly_store import day_hour_ts, read_hourly, upsert_day_hours
 from backend.power.zones import POWER_ZONES
+
+#: Codes whose corruption propagated BEYOND the mix: wind and solar feed
+#: PowerGrid.wind_mw / solar_mw and hence residual load — and therefore the
+#: renewable share, the Dunkelflaute flag and every residual z-score. Verified in
+#: prod: IE-SEM carries 38,374 hourly wind-CONSUMPTION points (2021-2025), so its
+#: wind was averaged with a real consumption series for four straight years.
+RENEWABLE_CODES = {PSR_SOLAR, PSR_WIND_OFFSHORE, PSR_WIND_ONSHORE}
 
 logger = logging.getLogger("repair_storage_series")
 
@@ -124,17 +134,70 @@ def repair_zone_month(db, zone: str, eic: str, month: date, *, dry_run: bool = F
             else:
                 row.gen_mw = by_psr[code]
             daily_written += 1
+    # Wind/solar corruption propagated into residual load — repair that too, or
+    # the Dunkelflaute detector keeps reading a zone that never existed.
+    grid_days = 0
+    if codes & RENEWABLE_CODES:
+        grid_days = _repair_residual(db, zone, daily, hourly)
+
     db.commit()
     return {
         "cached": True, "storage": True,
-        "hourly": hourly_written, "daily": daily_written, "codes": sorted(codes),
+        "hourly": hourly_written, "daily": daily_written,
+        "grid_days": grid_days, "codes": sorted(codes),
     }
+
+
+def _repair_residual(db, zone: str, daily: dict, hourly: dict) -> int:
+    """Recompute wind/solar/residual from the corrected generation.
+
+    Load is untouched by the parser bug (A65 has no consumption twin), so it is
+    read back from the canonical store rather than re-parsed.
+    """
+    days = 0
+    for day, by_psr in daily.items():
+        row = (
+            db.query(PowerGrid)
+            .filter(PowerGrid.date == day, PowerGrid.zone == zone)
+            .first()
+        )
+        if row is None:
+            continue
+        wind = by_psr.get(PSR_WIND_OFFSHORE, 0.0) + by_psr.get(PSR_WIND_ONSHORE, 0.0)
+        solar = by_psr.get(PSR_SOLAR, 0.0)
+        row.wind_mw = wind or None
+        row.solar_mw = solar or None
+        row.residual_mw = (
+            round(row.load_mw - wind - solar, 2) if row.load_mw is not None else None
+        )
+        days += 1
+
+    # Hourly residual = load − wind − solar, hour by hour.
+    load_by_ts = dict(read_hourly(db, "load.actual", zone))
+    resid: dict[str, dict[int, float]] = {}
+    for day, by_psr in hourly.items():
+        hours: dict[int, float] = {}
+        for hour in range(24):
+            ts = day_hour_ts(day, hour)
+            load = load_by_ts.get(ts)
+            if load is None:
+                continue
+            renew = sum(
+                by_psr.get(code, {}).get(hour, 0.0)
+                for code in (PSR_WIND_OFFSHORE, PSR_WIND_ONSHORE, PSR_SOLAR)
+            )
+            hours[hour] = round(load - renew, 2)
+        if hours:
+            resid[day] = hours
+    if resid:
+        upsert_day_hours(db, "residual.actual", zone, resid, unit="MW")
+    return days
 
 
 def run(db, start: date, end: date, *, dry_run: bool = False) -> dict:
     months = _months(start, end)
     total = {"zone_months": 0, "missing_cache": 0, "no_storage": 0,
-             "repaired": 0, "hourly": 0, "daily": 0}
+             "repaired": 0, "hourly": 0, "daily": 0, "grid_days": 0}
     processed = 0
     for zone, cfg in POWER_ZONES.items():
         for month in months:
@@ -149,6 +212,7 @@ def run(db, start: date, end: date, *, dry_run: bool = False) -> dict:
             total["repaired"] += 1
             total["hourly"] += res.get("hourly", 0)
             total["daily"] += res.get("daily", 0)
+            total["grid_days"] += res.get("grid_days", 0)
             processed += 1
             if not dry_run and processed % CHECKPOINT_EVERY == 0:
                 # Bound the WAL: the API holds long-lived readers, so a long batch

--- a/backend/tests/test_gas_entsoe.py
+++ b/backend/tests/test_gas_entsoe.py
@@ -18,10 +18,16 @@ def _a75(ts_blocks: str, ns: str = "urn:iec62325.351:tc57wg16:451-6:generationlo
     return f'<?xml version="1.0"?><GL_MarketDocument xmlns="{ns}"><type>A75</type>{ts_blocks}</GL_MarketDocument>'
 
 
-def _ts(start, end, mw, n=24, res="PT60M", psr="B04"):
+def _ts(start, end, mw, n=24, res="PT60M", psr="B04", direction="in"):
+    """`direction="out"` = outBiddingZone_Domain, i.e. the plants' own CONSUMPTION."""
     pts = "".join(f"<Point><position>{i + 1}</position><quantity>{mw}</quantity></Point>" for i in range(n))
+    domain = (
+        "<outBiddingZone_Domain.mRID>10Y1001A1001A82H</outBiddingZone_Domain.mRID>"
+        if direction == "out"
+        else "<inBiddingZone_Domain.mRID>10Y1001A1001A82H</inBiddingZone_Domain.mRID>"
+    )
     return (
-        f"<TimeSeries><MktPSRType><psrType>{psr}</psrType></MktPSRType>"
+        f"<TimeSeries><MktPSRType><psrType>{psr}</psrType></MktPSRType>{domain}"
         f"<Period><timeInterval><start>{start}</start><end>{end}</end></timeInterval>"
         f"<resolution>{res}</resolution>{pts}</Period></TimeSeries>"
     )
@@ -130,3 +136,16 @@ def test_token_required(monkeypatch):
     monkeypatch.setattr(entsoe.settings, "entsoe_api_token", None)
     with pytest.raises(RuntimeError):
         entsoe._token()
+
+
+def test_power_burn_ignores_plant_own_consumption():
+    """A75 publishes B04 in BOTH directions for some zones (NL, PT, IE-SEM
+    verified in prod): generation and the plants' own consumption. Summing both
+    inflated power burn — the MEASURED demand leg of the gas balance — by the
+    consumption of the very plants whose burn we are counting."""
+    xml = _a75(
+        _ts("2026-04-01T04:00Z", "2026-04-02T04:00Z", 5000)                      # generation
+        + _ts("2026-04-01T04:00Z", "2026-04-02T04:00Z", 400, direction="out")    # own consumption
+    )
+    assert entsoe.parse_generation(xml) == {"2026-04-01": 120.0}, \
+        "120 GWh of generation — the 9.6 GWh of consumption must not be added to it"

--- a/backend/tests/test_repair_storage_series.py
+++ b/backend/tests/test_repair_storage_series.py
@@ -111,3 +111,58 @@ def test_dry_run_writes_nothing(db_session, tmp_path, monkeypatch):
 ])
 def test_storage_psrs_detects_only_two_directional_types(codes, expected):
     assert rss.storage_psrs({"2026-04-01": codes}) == expected
+
+
+# ── the contamination reached residual load, not just the mix ─────────────────
+# Verified in prod: IE-SEM carries 38,374 hourly wind-CONSUMPTION points across
+# 2021-2025, so its wind was averaged with a real consumption series for four
+# years — and wind feeds PowerGrid.wind_mw → residual → renewable share →
+# the Dunkelflaute flag. Repairing gen.B19 alone would leave all of that wrong.
+
+
+def _doc_with_wind_consumption() -> str:
+    return _a75_gen(
+        _gen_ts("B19", "2026-04-01T00:00Z", 4_000.0, direction="in")    # wind generating
+        + _gen_ts("B19", "2026-04-01T00:00Z", 600.0, direction="out")   # wind farm consuming
+        + _gen_ts("B16", "2026-04-01T00:00Z", 1_000.0)                  # solar
+    )
+
+
+def test_repair_recomputes_wind_solar_and_residual(db_session, tmp_path, monkeypatch):
+    from backend.models.energy import PowerGrid
+    from backend.power.hourly_store import upsert_day_hours as upsert
+
+    # Corrupted state: wind stored as the mean of generation and consumption
+    # (4000+600)/2 = 2300 → residual overstated by 1700 MW.
+    db_session.add(PowerGrid(date="2026-04-01", zone="DE_LU", load_mw=50_000.0,
+                             wind_mw=2_300.0, solar_mw=1_000.0, residual_mw=46_700.0))
+    upsert(db_session, "load.actual", "DE_LU",
+           {"2026-04-01": {h: 50_000.0 for h in range(24)}}, unit="MW")
+    db_session.commit()
+    _cache_a75(tmp_path, monkeypatch, _doc_with_wind_consumption())
+
+    res = rss.repair_zone_month(db_session, "DE_LU", _DE_EIC, _MONTH)
+    assert res["grid_days"] == 1
+
+    row = db_session.query(PowerGrid).filter_by(date="2026-04-01", zone="DE_LU").one()
+    assert row.wind_mw == 4_000.0, "the generation leg, not the average"
+    assert row.solar_mw == 1_000.0
+    assert row.residual_mw == 45_000.0  # 50000 − 4000 − 1000
+    assert read_hourly(db_session, "residual.actual", "DE_LU")[0][1] == 45_000.0
+
+
+def test_repair_leaves_residual_alone_when_only_storage_is_affected(db_session, tmp_path, monkeypatch):
+    """A pumped-storage-only document must not touch wind/solar/residual —
+    pumping is not a renewable and never entered the residual."""
+    from backend.models.energy import PowerGrid
+
+    db_session.add(PowerGrid(date="2026-04-01", zone="DE_LU", load_mw=50_000.0,
+                             wind_mw=9_999.0, solar_mw=8_888.0, residual_mw=31_113.0))
+    db_session.commit()
+    _cache_a75(tmp_path, monkeypatch, _doc_with_pumping())
+
+    res = rss.repair_zone_month(db_session, "DE_LU", _DE_EIC, _MONTH)
+    assert res["grid_days"] == 0
+
+    row = db_session.query(PowerGrid).filter_by(date="2026-04-01", zone="DE_LU").one()
+    assert (row.wind_mw, row.solar_mw, row.residual_mw) == (9_999.0, 8_888.0, 31_113.0)


### PR DESCRIPTION
Nachzug zu #73/#76. Die Reparatur der Speicher-Historie hat erst sichtbar gemacht, **wie weit** die Blindheit des alten Parsers wirklich reichte: ENTSO-E publiziert eine `outBiddingZone`-Verbrauchsserie für **19 psrTypes**, nicht nur für Pumpspeicher — auch für **Wind, Solar und Gas**. Der Parser mittelte jede davon mit ihrem Erzeugungs-Zwilling.

**1. Wind und Solar speisen die Residuallast.** Und damit den Renewable-Share, den Dunkelflaute-Flag und jeden Residual-z-Wert. Auf Prod gemessen:
- **IE-SEM: 38.374 stündliche Wind-Verbrauchspunkte über 2021–2025** — dort wurde Wind vier Jahre lang mit einer echten Verbrauchsserie gemittelt.
- **FR:** an den Tagen mit Verbrauchsserie war der gespeicherte Windwert **7–20 % zu hoch**.

`gen.B19` allein zu reparieren hätte die abgeleiteten Zeilen weiter lügen lassen. Das Reparatur-Skript rechnet jetzt Wind, Solar und Residuallast (täglich *und* stündlich) neu — und fasst sie bewusst **nicht** an, wenn nur Speicher betroffen war (Pumpen ging nie in die Residuallast ein). Beides per Test gepinnt.

**2. Der Power-Burn hat einen eigenen Parser** (`backend/gas/entsoe.py`), der zwar den psrType filterte, aber **nicht die Richtung** — er addierte also den Eigenverbrauch der Gaskraftwerke zur Gaserzeugung. Das ist das *gemessene* Nachfrage-Bein der Gasbilanz, aufgebläht um den Verbrauch genau der Anlagen, deren Verbrennung es zählt. Auf Prod verifiziert: B04-Verbrauch existiert in NL (94 MW Mittel), PT, IE-SEM, DE-LU.

Die Last ist von alldem unberührt (A65 hat keinen Verbrauchs-Zwilling) — die Reparatur liest sie aus dem canonical store zurück, statt sie neu zu parsen.

ruff + 773 Tests grün (4 neue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)