### PR TITLE
No load, no residual: stop inventing a negative residual load out of a missing number

### DIFF
--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -380,25 +380,34 @@ def _grid_row_values(
 ) -> dict:
     """Derive residual_mw, renewable_share, and dunkelflaute flag for one row.
 
-    None wind_mw / solar_mw are treated as 0 (they can be stored None when
-    genuinely near-zero during ingest failures). Value-based so the bulk
-    overview loader can feed column tuples without hydrating ORM entities.
+    Residual load is DEMAND minus renewables. Without a load there is no demand,
+    so there is no residual and no renewable share — they are None, not zero.
+    Coercing a missing load to 0.0 made the desk render `residual = −(wind+solar)`
+    and a 0% renewable share out of nothing: IE-SEM stopped publishing A65 load on
+    2025-10-23 and the desk has been showing it a NEGATIVE residual load ever since.
+
+    None wind_mw / solar_mw ARE treated as 0 — those are genuinely near-zero or
+    absent generation, which is a real physical statement, unlike a missing load.
+    Value-based so the bulk overview loader can feed column tuples without
+    hydrating ORM entities.
     """
     wind = wind_mw or 0.0
     solar = solar_mw or 0.0
-    load = load_mw or 0.0
+    has_load = load_mw is not None and load_mw > 0
 
-    residual_mw = load - wind - solar
-    renewable_share = (wind + solar) / load if load > 0 else 0.0
-    dunkelflaute = renewable_share < DUNKELFLAUTE_THRESHOLD
+    residual_mw = round(load_mw - wind - solar, 2) if has_load else None
+    renewable_share = round((wind + solar) / load_mw, 4) if has_load else None
+    # A Dunkelflaute is a statement about the share of load renewables cover.
+    # With no load, we cannot make it — so we don't.
+    dunkelflaute = renewable_share < DUNKELFLAUTE_THRESHOLD if has_load else False
 
     return {
         "date": date,
         "load_mw": load_mw,
         "wind_mw": wind_mw,
         "solar_mw": solar_mw,
-        "residual_mw": round(residual_mw, 2),
-        "renewable_share": round(renewable_share, 4),
+        "residual_mw": residual_mw,
+        "renewable_share": renewable_share,
         "dunkelflaute": dunkelflaute,
     }
 

--- a/backend/tests/test_power_grid_route.py
+++ b/backend/tests/test_power_grid_route.py
@@ -108,12 +108,22 @@ def test_null_wind_and_solar_treated_as_zero():
     assert d["dunkelflaute"] is True
 
 
-def test_zero_load_no_division_error():
-    """load_mw=0 → renewable_share = 0.0, no ZeroDivisionError."""
-    row = _make_row(load_mw=0.0, wind_mw=0.0, solar_mw=0.0)
+def test_no_load_means_no_residual_and_no_share():
+    """Residual load is demand minus renewables. With no demand there is no
+    residual — it is None, not zero, and certainly not negative.
+
+    This is live on prod: IE-SEM stopped publishing A65 load on 2025-10-23, and
+    coercing the missing load to 0.0 made the desk render residual = −(wind+solar)
+    — a NEGATIVE residual load — plus a 0% renewable share, out of nothing."""
+    row = _make_row(load_mw=None, wind_mw=1_090.0, solar_mw=0.0)
     d = _compute_grid_row(row)
-    assert d["renewable_share"] == pytest.approx(0.0)
-    assert d["residual_mw"] == pytest.approx(0.0)
+    assert d["residual_mw"] is None, "no load → no residual (it read −1090 MW)"
+    assert d["renewable_share"] is None
+    assert d["dunkelflaute"] is False, "cannot claim a Dunkelflaute without a load"
+
+    # A stored zero load is an ENTSO-E gap, not a grid with no demand.
+    zero = _compute_grid_row(_make_row(load_mw=0.0, wind_mw=0.0, solar_mw=0.0))
+    assert zero["residual_mw"] is None and zero["renewable_share"] is None
 
 
 # ─── route integration tests ──────────────────────────────────────────────────


### PR DESCRIPTION
Gefunden bei der Verifikation der Reparatur-Runde 2 — und aus derselben Familie wie alles heute: **eine Zahl zeigen, die man nicht belegen kann.**

**Der Fehler:** `_grid_row_values` las eine fehlende Last stillschweigend als `0.0` und rechnete dann `residual = 0 − wind − solar`. Eine Zone, die Erzeugung publiziert aber keine Last, bekam damit eine **negative Residuallast** und einen 0-%-Renewable-Share — beides aus dem Nichts erfunden.

**Und das ist real:** IE-SEM publiziert seit **2025-10-23** keine A65-Last mehr. Das Desk zeigt ihr seitdem eine Residuallast von **−1,09 GW**. Neun Monate lang eine Zahl, die es nicht geben kann, präsentiert mit derselben Selbstsicherheit wie eine gemessene.

**Der Fix:** Residuallast und Renewable-Share sind `None`, wenn es keine Last gibt — und es wird keine Dunkelflaute behauptet: der Flag ist eine Aussage über den *Anteil der Last*, den Erneuerbare decken, und ohne Last gibt es nichts, worüber er eine Aussage machen könnte. Fehlende Wind-/Solarwerte zählen weiterhin als 0 — abwesende Erzeugung ist eine echte physikalische Aussage, eine abwesende Last nicht. Das Frontend rendert `null` bereits überall als „—".

Der alte Test schrieb die alte Lüge fest (Last 0 → Residual 0); er pinnt jetzt das ehrliche Verhalten, mit IE-SEMs echten Zahlen darin.

ruff + 773 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)