### PR TITLE
Hotfix: /situation 500'd for a zone with generation but no load

### DIFF
--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -837,10 +837,16 @@ def build_power_situation(
             seg += f" ({price['z']:+.1f}σ)"
         parts.append(seg + _age_suffix(price))
     if grid["available"]:
-        seg = f"residual {grid['residual_gw']:.0f} GW"
-        if grid["z"] is not None:
-            seg += f" ({grid['z']:+.1f}σ)"
-        parts.append(seg + _age_suffix(grid))
+        # A zone can have generation but no published load (IE-SEM since
+        # 2025-10-23) — there is then no residual to state, and saying so is the
+        # whole point. Formatting it anyway is what 500'd the endpoint.
+        if grid["residual_gw"] is not None:
+            seg = f"residual {grid['residual_gw']:.0f} GW"
+            if grid["z"] is not None:
+                seg += f" ({grid['z']:+.1f}σ)"
+            parts.append(seg + _age_suffix(grid))
+        else:
+            parts.append("residual n/a — no published load for this zone")
     if spark["available"]:
         parts.append(f"spark €{spark['spark_spread']:+.0f}/MWh" + _age_suffix(spark))
     headline = f"{zone_label} · " + " · ".join(parts) if parts else f"{zone_label} · no power data yet"

--- a/backend/tests/test_power_situation.py
+++ b/backend/tests/test_power_situation.py
@@ -8,7 +8,7 @@ from the series' own history, never a forecast.
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -28,7 +28,10 @@ def _clear_dependency_overrides():
 
 # ─── helpers ─────────────────────────────────────────────────────────────────
 
-_TODAY = date.today()
+# UTC, not local: the routes bucket on datetime.utcnow().date(). With a local
+# date.today() these tests fail for the two hours between local and UTC midnight
+# (CEST is UTC+2) — a flake that only ever fires in the middle of the night.
+_TODAY = datetime.now(timezone.utc).date()
 
 
 def _price_series(closes: list[float], neg_hours: list[int] | None = None) -> list[dict]:
@@ -171,7 +174,7 @@ def test_situation_flags_stale_data():
 def test_situation_fresh_data_not_stale():
     price = _price_series([50.0, 51.0, 52.0])  # ends _TODAY
     grid = _flat_grid([45_000.0, 46_000.0, 47_000.0])
-    s = build_power_situation("DE_LU", price, grid, None, today=date.today())
+    s = build_power_situation("DE_LU", price, grid, None, today=_TODAY)
     assert s["stale"] is False
     assert s["age_days"] == 0
 
@@ -216,7 +219,7 @@ def test_component_freshness_fields_on_fresh_data():
     grid = _flat_grid([45_000.0, 46_000.0, 47_000.0])
     spark = {"spark_spread": 5.0, "power_price": 52.0, "gas_price": 30.0,
              "date": date.today().isoformat()}
-    s = build_power_situation("DE_LU", price, grid, spark, today=date.today())
+    s = build_power_situation("DE_LU", price, grid, spark, today=_TODAY)
 
     for comp in ("price", "grid", "spark"):
         assert s[comp]["as_of"] is not None
@@ -503,3 +506,20 @@ def test_no_frontend_panel_restates_the_baseline_window():
             if claim in text:
                 offenders.append(f"{f.name}: {claim!r}")
     assert not offenders, f"panels restating a baseline window: {offenders}"
+
+
+def test_zone_with_generation_but_no_load_does_not_crash_the_headline():
+    """IE-SEM publishes wind but stopped publishing A65 load on 2025-10-23. The
+    honest residual is None — and formatting None into the headline 500'd
+    /api/power/situation in production for exactly that zone."""
+    today = date(2026, 7, 12)
+    price = _series_ending(today, 3, lambda i: {"close": 50.0, "negative_hours": 0})
+    grid = _series_ending(
+        today, 3,
+        lambda i: {"residual_mw": None, "renewable_share": None, "dunkelflaute": False},
+    )
+    s = build_power_situation("IE_SEM", price, grid, None, today=today)
+
+    assert s["grid"]["residual_gw"] is None
+    assert "no published load" in s["headline"]
+    assert s["state"] in ("CALM", "ELEVATED", "STRESSED")


### PR DESCRIPTION
**Mein eigener Fehler aus #78.** Die Residuallast ehrlich auf `None` zu setzen, wenn keine Last publiziert wird, hat den Headline-Formatter stehen lassen: `f"residual {None:.0f} GW"` → TypeError → **`/api/power/situation` lieferte 500** für genau die Zone, um die es ging: IE-SEM (keine A65-Last seit 2025-10-23).

Die Overview überlebte, weil sie die Zahl nie formatiert — deshalb war der Deploy-Check grün und nur der Zonen-Endpoint kaputt. Genau die Lücke, die ein „health: 200" nicht schließt.

Die Headline sagt jetzt „residual n/a — no published load for this zone", statt umzufallen. Das war ohnehin der Punkt der Übung: die fehlende Zahl **benennen**, sie weder erfinden noch daran sterben.

Nebenbei ein latenter Flake, den das aufgedeckt hat: `test_power_situation` baute sein Fenster aus einem **lokalen** `date.today()`, während die Routes auf `datetime.utcnow().date()` bucketen. Zwischen lokaler und UTC-Mitternacht (CEST = UTC+2) widersprechen sich die beiden — ein Flake, der nur mitten in der Nacht feuern kann. Und heute Nacht tat er es.

ruff + 774 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)