### PR TITLE
The border layer: prices and flows finally meet

### DIFF
--- a/backend/power/borders.py
+++ b/backend/power/borders.py
@@ -1,0 +1,300 @@
+"""The border layer — where the price series and the flow series finally meet.
+
+Obsyd has stored day-ahead prices for 37 zones and hourly cross-border flows for
+45 borders, and until now nothing in the codebase ever joined them. So the desk
+could say DE-LU is at €140 and FR at €55, but never that the two cleared apart
+for 61% of last month's hours, that the interconnector sat at its own historical
+rail in 18% of them, or that power physically ran from the expensive zone to the
+cheap one in 4%.
+
+WHAT THESE NUMBERS ARE, AND ARE NOT
+-----------------------------------
+Under SDAC market coupling, two zones clearing at the SAME price means the
+auction had no reason to split them; a spread means it did. It is tempting to
+call that "the interconnector was binding" — and it is wrong to, at least in the
+Core region, which allocates flow-based: there the binding constraint is a
+network element inside the grid, not the border itself, and a spread can appear
+between zones whose own interconnector is half empty.
+
+So every metric here is DESCRIPTIVE STATISTICS on published records:
+  * convergence — how often the two zones cleared at the same price
+  * spread      — how far apart they cleared, and how that ranks in this
+                  border's own history
+  * at the rail — how often the physical flow reached this border's OWN 95th
+                  percentile (an honest proxy: we hold no NTC, and in flow-based
+                  regions no NTC is even published)
+  * counter-price — how often power physically flowed from the expensive zone to
+                  the cheap one. Physically real (loop and transit flows) and
+                  exactly the thing a zonal price map cannot show you.
+None of it is a trade, a forecast, or a claim about causation.
+
+COVERAGE, STATED PLAINLY
+------------------------
+The flow series come from Energy-Charts at COUNTRY level, so a border only gets
+metrics when BOTH sides are priced bidding zones. 26 of 45 borders qualify. The
+other 19 touch a country aggregate that has no single price (IT, DK, NO, SE) or
+no price at all (GB, LU) — they are reported as uncoverable, not hidden.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from backend.models.energy import PowerHourly, SeriesDim, ZoneDim
+from backend.power.zones import POWER_ZONES
+
+#: Two zones "cleared together" when their day-ahead prices differ by less than
+#: this. Not 0.00: SDAC publishes to the cent, and a rounding cent is not a
+#: market split.
+COUPLED_EPS_EUR = 0.5
+
+#: A flow is "at the rail" at or above this percentile of the border's OWN
+#: |flow| history. We hold no NTC — and in flow-based regions ENTSO-E publishes
+#: none — so the border's own realised maximum is the honest reference.
+RAIL_PERCENTILE = 0.95
+
+#: History the rail threshold is measured over.
+RAIL_BASELINE_DAYS = 365
+
+PRICE_SERIES = "price.dayahead"
+
+
+def percentile(values: list[float], q: float) -> float | None:
+    """Nearest-rank percentile. None on an empty list."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    idx = min(int(round(q * (len(ordered) - 1))), len(ordered) - 1)
+    return ordered[idx]
+
+
+def border_metrics(
+    prices_a: dict[int, float],
+    prices_b: dict[int, float],
+    flow: dict[int, float],
+    rail_threshold: float | None,
+) -> dict:
+    """Descriptive statistics for one border over one window. Pure.
+
+    `flow` is keyed the canonical way: net_mw > 0 means zone A exports to B.
+    """
+    hours = sorted(set(prices_a) & set(prices_b))
+    spreads = [prices_a[t] - prices_b[t] for t in hours]
+    abs_spreads = [abs(s) for s in spreads]
+    n = len(hours)
+
+    coupled = sum(1 for s in abs_spreads if s < COUPLED_EPS_EUR)
+    split = [(t, prices_a[t] - prices_b[t]) for t in hours
+             if abs(prices_a[t] - prices_b[t]) >= COUPLED_EPS_EUR]
+
+    # Counter-price: power physically flows FROM the expensive zone TO the cheap
+    # one. Only meaningful in hours the zones actually cleared apart.
+    counter = 0
+    for t, spread in split:
+        f = flow.get(t)
+        if f is None or f == 0:
+            continue
+        a_exports = f > 0
+        a_expensive = spread > 0
+        if a_exports == a_expensive:  # exporting into the cheaper zone
+            counter += 1
+
+    flow_hours = [abs(v) for t, v in flow.items() if t in set(hours)] if hours else []
+    at_rail = (
+        sum(1 for v in flow_hours if rail_threshold and v >= rail_threshold)
+        if rail_threshold else 0
+    )
+
+    # The latest PRICE hour and the latest FLOW hour are not the same hour: the
+    # day-ahead auction publishes into tomorrow, while physical flows only exist
+    # up to now. Reading the flow at the price's timestamp returns None for every
+    # border every afternoon — so each takes its own latest.
+    latest_t = hours[-1] if hours else None
+    latest_spread = prices_a[latest_t] - prices_b[latest_t] if latest_t else None
+    latest_flow_t = max(flow) if flow else None
+    latest_flow = flow[latest_flow_t] if latest_flow_t is not None else None
+
+    return {
+        "hours": n,
+        "convergence_pct": round(100.0 * coupled / n, 1) if n else None,
+        "mean_abs_spread": round(sum(abs_spreads) / n, 2) if n else None,
+        "p95_abs_spread": round(percentile(abs_spreads, 0.95), 2) if abs_spreads else None,
+        "latest_spread": round(latest_spread, 2) if latest_spread is not None else None,
+        "latest_flow_mw": round(latest_flow, 1) if latest_flow is not None else None,
+        "split_hours": len(split),
+        "counter_price_hours": counter,
+        "counter_price_pct": round(100.0 * counter / len(split), 1) if split else None,
+        "at_rail_hours": at_rail,
+        "at_rail_pct": round(100.0 * at_rail / len(flow_hours), 1) if flow_hours else None,
+        "rail_threshold_mw": round(rail_threshold, 1) if rail_threshold else None,
+        "spread_as_of": (
+            datetime.fromtimestamp(latest_t, tz=timezone.utc).isoformat()
+            if latest_t else None
+        ),
+        "flow_as_of": (
+            datetime.fromtimestamp(latest_flow_t, tz=timezone.utc).isoformat()
+            if latest_flow_t is not None else None
+        ),
+        "as_of": (
+            datetime.fromtimestamp(latest_t, tz=timezone.utc).strftime("%Y-%m-%d")
+            if latest_t else None
+        ),
+    }
+
+
+def _flow_rows(db: Session, start_ts: int) -> dict[tuple[str, str], dict[int, float]]:
+    """Every hourly cross-border flow since `start_ts`, keyed by canonical border.
+
+    One query for all borders — the per-border alternative was 26 round trips.
+    """
+    rows = (
+        db.query(SeriesDim.key, ZoneDim.key, PowerHourly.ts_utc, PowerHourly.value)
+        .join(PowerHourly, PowerHourly.series_id == SeriesDim.id)
+        .join(ZoneDim, ZoneDim.id == PowerHourly.zone_id)
+        .filter(SeriesDim.key.like("flow.%"), PowerHourly.ts_utc >= start_ts)
+        .all()
+    )
+    out: dict[tuple[str, str], dict[int, float]] = {}
+    for series_key, from_zone, ts, value in rows:
+        to_zone = series_key[len("flow."):]
+        out.setdefault((from_zone, to_zone), {})[int(ts)] = float(value)
+    return out
+
+
+def _price_rows(db: Session, zones: set[str], start_ts: int) -> dict[str, dict[int, float]]:
+    rows = (
+        db.query(ZoneDim.key, PowerHourly.ts_utc, PowerHourly.value)
+        .join(PowerHourly, PowerHourly.zone_id == ZoneDim.id)
+        .join(SeriesDim, SeriesDim.id == PowerHourly.series_id)
+        .filter(SeriesDim.key == PRICE_SERIES,
+                ZoneDim.key.in_(zones),
+                PowerHourly.ts_utc >= start_ts)
+        .all()
+    )
+    out: dict[str, dict[int, float]] = {}
+    for zone, ts, value in rows:
+        out.setdefault(zone, {})[int(ts)] = float(value)
+    return out
+
+
+def compute_borders(db: Session, days: int = 30, *, now: datetime | None = None) -> dict:
+    """Every border with a price on both sides, ranked by how far apart it clears."""
+    now = now or datetime.now(timezone.utc)
+    window_start = int((now - timedelta(days=days)).timestamp())
+    rail_start = int((now - timedelta(days=RAIL_BASELINE_DAYS)).timestamp())
+
+    all_flows = _flow_rows(db, rail_start)
+    if not all_flows:
+        return {"available": False,
+                "reason": "No cross-border flow series yet — check back shortly."}
+
+    priced = set(POWER_ZONES)
+    joinable = {b for b in all_flows if b[0] in priced and b[1] in priced}
+    uncoverable = sorted(
+        f"{a}-{b}" for a, b in all_flows if (a, b) not in joinable
+    )
+
+    prices = _price_rows(db, {z for b in joinable for z in b}, window_start)
+
+    out = []
+    for a, b in sorted(joinable):
+        flow_full = all_flows[(a, b)]
+        rail = percentile([abs(v) for v in flow_full.values()], RAIL_PERCENTILE)
+        flow_window = {t: v for t, v in flow_full.items() if t >= window_start}
+        m = border_metrics(
+            prices.get(a, {}), prices.get(b, {}), flow_window, rail
+        )
+        if not m["hours"]:
+            continue
+        out.append({
+            "zone_a": a, "zone_b": b,
+            "label": f"{POWER_ZONES[a]['label']}↔{POWER_ZONES[b]['label']}",
+            "expensive_side": (
+                None if m["latest_spread"] is None or abs(m["latest_spread"]) < COUPLED_EPS_EUR
+                else (a if m["latest_spread"] > 0 else b)
+            ),
+            **m,
+        })
+
+    out.sort(key=lambda r: -(r["mean_abs_spread"] or 0))
+    return {
+        "available": bool(out),
+        "days": days,
+        "unit": "EUR/MWh",
+        "coupled_eps_eur": COUPLED_EPS_EUR,
+        "rail_percentile": RAIL_PERCENTILE,
+        "rail_baseline_days": RAIL_BASELINE_DAYS,
+        "borders": out,
+        "uncoverable_borders": uncoverable,
+        "note": (
+            "Convergence = share of hours the two zones cleared within "
+            f"{COUPLED_EPS_EUR} EUR/MWh. 'At the rail' = physical flow at or above this "
+            "border's own 95th percentile over the last year (we hold no NTC, and "
+            "flow-based regions publish none). Counter-price = power physically ran "
+            "from the expensive zone to the cheap one. Descriptive statistics on "
+            "published records — a spread is not a claim that this interconnector was "
+            "the binding constraint."
+        ),
+    }
+
+
+def compute_spread(db: Session, a: str, b: str, days: int = 30,
+                   *, now: datetime | None = None) -> dict:
+    """One border, hour by hour: both prices, their spread, and the flow."""
+    now = now or datetime.now(timezone.utc)
+    window_start = int((now - timedelta(days=days)).timestamp())
+    rail_start = int((now - timedelta(days=RAIL_BASELINE_DAYS)).timestamp())
+
+    zone_a, zone_b = sorted([a, b])  # canonical border order
+    if zone_a not in POWER_ZONES or zone_b not in POWER_ZONES:
+        return {"available": False, "reason": f"Unknown zone in border {a}-{b}."}
+
+    flows = _flow_rows(db, rail_start)
+    flow_full = flows.get((zone_a, zone_b))
+    if flow_full is None:
+        return {
+            "available": False,
+            "zone_a": zone_a, "zone_b": zone_b,
+            "reason": (
+                f"No flow series for {zone_a}-{zone_b}. Energy-Charts publishes flows at "
+                "country level, so borders touching a sub-zoned market (Italian zones, "
+                "DK1/DK2, Nordic zones) or an unpriced neighbour (GB, LU) have none."
+            ),
+        }
+
+    prices = _price_rows(db, {zone_a, zone_b}, window_start)
+    rail = percentile([abs(v) for v in flow_full.values()], RAIL_PERCENTILE)
+    flow_window = {t: v for t, v in flow_full.items() if t >= window_start}
+    m = border_metrics(prices.get(zone_a, {}), prices.get(zone_b, {}), flow_window, rail)
+    if not m["hours"]:
+        return {
+            "available": False, "zone_a": zone_a, "zone_b": zone_b,
+            "reason": "No overlapping price hours for this border in the window.",
+        }
+
+    pa, pb = prices.get(zone_a, {}), prices.get(zone_b, {})
+    series = [
+        {
+            "ts_utc": datetime.fromtimestamp(t, tz=timezone.utc).isoformat(),
+            "price_a": round(pa[t], 2),
+            "price_b": round(pb[t], 2),
+            "spread": round(pa[t] - pb[t], 2),
+            "flow_mw": round(flow_window[t], 1) if t in flow_window else None,
+        }
+        for t in sorted(set(pa) & set(pb))
+    ]
+    return {
+        "available": True,
+        "zone_a": zone_a, "zone_b": zone_b,
+        "label": f"{POWER_ZONES[zone_a]['label']}↔{POWER_ZONES[zone_b]['label']}",
+        "unit": "EUR/MWh",
+        "days": days,
+        "note": (
+            f"spread = {POWER_ZONES[zone_a]['label']} − {POWER_ZONES[zone_b]['label']}; "
+            f"flow > 0 = {POWER_ZONES[zone_a]['label']} exports. Descriptive."
+        ),
+        "data": series,
+        **m,
+    }

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1415,6 +1415,43 @@ async def get_flows_hourly(
     }
 
 
+# ─── Borders: where the price series and the flow series finally meet ─────────
+
+
+@router.get("/borders")
+def get_borders(
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+):
+    """Every border with a day-ahead price on BOTH sides: how often the two zones
+    cleared together, how far apart they cleared, how often the physical flow sat
+    at this border's own historical rail, and how often power ran from the
+    expensive zone to the cheap one. Free tier.
+
+    Descriptive statistics on published records. A price spread is NOT a claim
+    that this interconnector was the binding constraint — the Core region clears
+    flow-based, where the constraint is a network element, not the border.
+    See backend/power/borders.py.
+    """
+    from backend.power.borders import compute_borders
+
+    return compute_borders(db, days=days)
+
+
+@router.get("/spread")
+def get_spread(
+    a: str = Query(..., description="Zone A, e.g. DE_LU"),
+    b: str = Query(..., description="Zone B, e.g. FR"),
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+):
+    """One border, hour by hour: both day-ahead prices, their spread, and the
+    physical flow across it. Free tier, descriptive."""
+    from backend.power.borders import compute_spread
+
+    return compute_spread(db, a, b, days=days)
+
+
 # ─── Imbalance prices (free) ──────────────────────────────────────────────────
 
 

--- a/backend/tests/test_borders.py
+++ b/backend/tests/test_borders.py
@@ -1,0 +1,187 @@
+"""The border layer: prices × flows.
+
+The metrics are descriptive statistics, and the tests pin exactly that — above
+all, that a spread is never turned into a claim about a binding constraint, and
+that a border we cannot cover is REPORTED rather than quietly dropped.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.power.borders import (
+    COUPLED_EPS_EUR,
+    border_metrics,
+    compute_borders,
+    compute_spread,
+    percentile,
+)
+from backend.power.hourly_store import upsert_hourly
+
+_NOW = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def _client(db):
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _hours(n: int, end: datetime = _NOW) -> list[int]:
+    base = int(end.timestamp()) // 3600 * 3600
+    return [base - i * 3600 for i in range(n - 1, -1, -1)]
+
+
+# ─── pure metrics ─────────────────────────────────────────────────────────────
+
+
+def test_percentile_nearest_rank():
+    assert percentile([1.0, 2.0, 3.0, 4.0], 0.95) == 4.0
+    assert percentile([], 0.95) is None
+
+
+def test_fully_coupled_border_is_100_percent_convergence():
+    ts = _hours(24)
+    a = {t: 50.0 for t in ts}
+    b = {t: 50.0 for t in ts}          # same clearing price every hour
+    m = border_metrics(a, b, {t: 1000.0 for t in ts}, rail_threshold=2000.0)
+    assert m["convergence_pct"] == 100.0
+    assert m["split_hours"] == 0
+    assert m["counter_price_pct"] is None, "no split hours → no counter-price statement"
+    assert m["mean_abs_spread"] == 0.0
+
+
+def test_a_cent_of_rounding_is_not_a_market_split():
+    ts = _hours(10)
+    m = border_metrics({t: 50.0 for t in ts}, {t: 50.01 for t in ts}, {}, None)
+    assert m["convergence_pct"] == 100.0, f"< {COUPLED_EPS_EUR} EUR is the same price"
+
+
+def test_counter_price_hours_are_flow_from_expensive_to_cheap():
+    """The metric that a zonal price map structurally cannot show: power running
+    the 'wrong' way. A exports (flow > 0) while A is the EXPENSIVE zone."""
+    ts = _hours(4)
+    a = {t: 100.0 for t in ts}   # A expensive
+    b = {t: 40.0 for t in ts}    # B cheap
+    flow = {ts[0]: 800.0, ts[1]: 800.0, ts[2]: -500.0, ts[3]: -500.0}
+    m = border_metrics(a, b, flow, rail_threshold=1000.0)
+    assert m["split_hours"] == 4
+    assert m["counter_price_hours"] == 2, "the two hours A exported into the cheaper zone"
+    assert m["counter_price_pct"] == 50.0
+
+
+def test_at_the_rail_uses_the_borders_own_history():
+    ts = _hours(4)
+    a = {t: 60.0 for t in ts}
+    b = {t: 55.0 for t in ts}
+    flow = {ts[0]: 300.0, ts[1]: 900.0, ts[2]: 1000.0, ts[3]: 100.0}
+    m = border_metrics(a, b, flow, rail_threshold=900.0)
+    assert m["at_rail_hours"] == 2
+    assert m["at_rail_pct"] == 50.0
+    assert m["rail_threshold_mw"] == 900.0
+
+
+def test_no_rail_threshold_means_no_rail_claim():
+    ts = _hours(3)
+    m = border_metrics({t: 60.0 for t in ts}, {t: 50.0 for t in ts},
+                       {t: 9_999.0 for t in ts}, rail_threshold=None)
+    assert m["at_rail_hours"] == 0
+
+
+# ─── DB-backed ────────────────────────────────────────────────────────────────
+
+
+def _seed_border(db, zone_a="DE_LU", zone_b="FR", hours=48, price_a=90.0, price_b=45.0,
+                 flow_mw=1_500.0):
+    ts = _hours(hours)
+    upsert_hourly(db, "price.dayahead", zone_a, [(t, price_a) for t in ts], unit="EUR/MWh")
+    upsert_hourly(db, "price.dayahead", zone_b, [(t, price_b) for t in ts], unit="EUR/MWh")
+    # canonical: series flow.<B> under zone <A>; net > 0 = A exports to B
+    upsert_hourly(db, f"flow.{zone_b}", zone_a, [(t, flow_mw) for t in ts], unit="MW")
+
+
+def test_compute_borders_ranks_by_spread_and_names_the_expensive_side(db_session):
+    _seed_border(db_session)
+    out = compute_borders(db_session, days=7, now=_NOW)
+    assert out["available"] is True
+    row = next(r for r in out["borders"] if (r["zone_a"], r["zone_b"]) == ("DE_LU", "FR"))
+    assert row["mean_abs_spread"] == 45.0
+    assert row["expensive_side"] == "DE_LU"
+    assert row["convergence_pct"] == 0.0, "the zones never cleared together"
+    # DE-LU exports 1.5 GW while being the expensive zone → every split hour counts
+    assert row["counter_price_pct"] == 100.0
+
+
+def test_borders_report_what_they_cannot_cover(db_session):
+    """Energy-Charts flows are country-level, so a border touching IT/DK/NO/SE/GB
+    has no priced counterpart. Those must be NAMED, not silently dropped — the
+    absence is a coverage fact the user has to be able to see."""
+    _seed_border(db_session)
+    ts = _hours(24)
+    upsert_hourly(db_session, "flow.IT", "AT", [(t, 500.0) for t in ts], unit="MW")
+
+    out = compute_borders(db_session, days=7, now=_NOW)
+    assert "AT-IT" in out["uncoverable_borders"]
+    assert all(r["zone_b"] != "IT" for r in out["borders"])
+
+
+def test_compute_spread_is_order_independent_and_signs_from_a(db_session):
+    _seed_border(db_session)
+    fwd = compute_spread(db_session, "DE_LU", "FR", days=7, now=_NOW)
+    rev = compute_spread(db_session, "FR", "DE_LU", days=7, now=_NOW)
+    assert fwd["zone_a"] == rev["zone_a"] == "DE_LU", "canonical border order"
+    assert fwd["data"][-1]["spread"] == 45.0
+    assert fwd["data"][-1]["flow_mw"] == 1_500.0
+
+
+def test_spread_on_a_border_without_flows_is_honest(db_session):
+    _seed_border(db_session)  # seeds DE_LU-FR only
+    out = compute_spread(db_session, "DE_LU", "NL", days=7, now=_NOW)
+    assert out["available"] is False
+    assert "country level" in out["reason"]
+
+
+def test_borders_route(db_session):
+    _seed_border(db_session)
+    body = _client(db_session).get("/api/power/borders?days=7").json()
+    assert body["available"] is True
+    assert body["coupled_eps_eur"] == COUPLED_EPS_EUR
+    assert "not a claim" in body["note"], "the honesty caveat travels with the data"
+
+
+def test_spread_route(db_session):
+    _seed_border(db_session)
+    body = _client(db_session).get("/api/power/spread?a=FR&b=DE_LU&days=7").json()
+    assert body["available"] is True and body["zone_a"] == "DE_LU"
+    assert len(body["data"]) > 0
+
+
+def test_borders_empty_is_unavailable(db_session):
+    out = compute_borders(db_session, days=7, now=_NOW)
+    assert out["available"] is False and "reason" in out
+
+
+def test_latest_flow_is_the_latest_FLOW_hour_not_the_latest_price_hour():
+    """The day-ahead auction publishes into tomorrow; physical flows only exist
+    up to now. Reading the flow at the newest PRICE timestamp returned None for
+    every border every afternoon."""
+    ts = _hours(6)
+    prices = {t: 100.0 for t in ts}
+    prices_b = {t: 60.0 for t in ts}
+    flow = {t: 700.0 for t in ts[:-2]}      # flows stop two hours before the prices do
+
+    m = border_metrics(prices, prices_b, flow, rail_threshold=1000.0)
+    assert m["latest_flow_mw"] == 700.0, "must not read the flow at a future price hour"
+    assert m["spread_as_of"] > m["flow_as_of"], "prices reach further than flows"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,6 +32,7 @@ import OutagePanel from './components/OutagePanel'
 import RecordChip from './components/RecordChip'
 import ImbalancePanel from './components/ImbalancePanel'
 import RecordsPanel from './components/RecordsPanel'
+import BordersPanel from './components/BordersPanel'
 import PowerOverviewMatrix from './components/PowerOverviewMatrix'
 import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
@@ -695,6 +696,11 @@ function Dashboard() {
             </div>
             <ErrorBoundary name="insights">
               <InsightsStrip onMore={() => goToTab('alerts')} />
+            </ErrorBoundary>
+            {/* The border layer: prices × flows. A zone map shows WHERE power is
+                expensive; only the borders show whether the market is coupled. */}
+            <ErrorBoundary name="borders">
+              <BordersPanel />
             </ErrorBoundary>
             <ErrorBoundary name="hydro">
               <HydroReservoirPanel />

--- a/frontend/src/components/BordersPanel.jsx
+++ b/frontend/src/components/BordersPanel.jsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+import {
+  ResponsiveContainer, ComposedChart, Line, Bar, XAxis, YAxis, Tooltip, ReferenceLine, CartesianGrid,
+} from 'recharts'
+import { fmtTs, CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+// Convergence reads as "how coupled is this border": all-green = the two zones
+// clear as one market; low = they clear apart, and the spread is the story.
+function convergenceColor(pct) {
+  if (pct == null) return 'text-neutral-700'
+  if (pct >= 80) return 'text-emerald-400'
+  if (pct >= 40) return 'text-amber-400'
+  return 'text-orange-400'
+}
+
+function SpreadChart({ a, b }) {
+  const { data, loading } = useFetchWithError(
+    `${API}/power/spread?a=${a}&b=${b}&days=14`, { deps: [a, b] },
+  )
+  if (loading && !data) {
+    return <div className="px-4 py-6 font-mono text-[10px] text-neutral-600 animate-pulse">Loading border…</div>
+  }
+  if (!data?.available) {
+    return (
+      <div className="px-4 py-3 font-mono text-[10px] text-neutral-500">
+        {data?.reason || 'No data for this border.'}
+      </div>
+    )
+  }
+  const rows = (data.data ?? []).map((p) => ({
+    x: p.ts_utc, spread: p.spread, flow: p.flow_mw != null ? p.flow_mw / 1000 : null,
+  }))
+  return (
+    <div className="px-2 pt-3 pb-1 border-t border-border/40">
+      <div className="px-2 pb-1 font-mono text-[9px] text-neutral-600">
+        {data.label} · spread (€/MWh, line) vs physical flow (GW, bars) · {data.note}
+      </div>
+      <ResponsiveContainer width="100%" height={180}>
+        <ComposedChart data={rows} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
+          <XAxis dataKey="x" tickFormatter={fmtTs} tick={{ fontSize: 8, fill: '#737373' }} minTickGap={70} />
+          <YAxis yAxisId="s" tick={{ fontSize: 8, fill: '#737373' }} width={40} />
+          <YAxis yAxisId="f" orientation="right" tick={{ fontSize: 8, fill: '#525252' }} width={34} />
+          <ReferenceLine yAxisId="s" y={0} stroke="#444" />
+          <Tooltip
+            contentStyle={CHART_TOOLTIP_STYLE}
+            labelFormatter={fmtTs}
+            formatter={(v, n) => [
+              n === 'spread' ? `${Number(v).toFixed(1)} €/MWh` : `${Number(v).toFixed(2)} GW`,
+              n === 'spread' ? 'spread (A−B)' : 'flow (A→B)',
+            ]}
+          />
+          <Bar yAxisId="f" dataKey="flow" fill="#334155" isAnimationActive={false} />
+          <Line yAxisId="s" type="monotone" dataKey="spread" stroke="#fbbf24" strokeWidth={1.4}
+            dot={false} connectNulls isAnimationActive={false} />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * The border layer: day-ahead prices joined to physical flows, per interconnector.
+ *
+ * Descriptive statistics only. A spread is NOT a claim that this interconnector
+ * was the binding constraint — the Core region clears flow-based, where the
+ * constraint is a network element inside the grid, not the border itself. The
+ * backend caption says so and travels with the data.
+ */
+export default function BordersPanel() {
+  const [open, setOpen] = useState(null)  // "A|B" of the expanded border
+  const { data, loading, error } = useFetchWithError(`${API}/power/borders?days=30`, {
+    pollMs: POLL_SLOW_MS,
+  })
+
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">BORDERS // FETCH ERROR</div>
+      </div>
+    )
+  }
+  if (!data?.available && !loading) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          BORDERS — {data?.reason || 'no border data yet.'}
+        </div>
+      </div>
+    )
+  }
+
+  const borders = data?.borders ?? []
+  const uncoverable = data?.uncoverable_borders ?? []
+
+  return (
+    <Panel
+      id="power-borders"
+      title="BORDERS · PRICE CONVERGENCE & CONGESTION"
+      info={data?.note || 'Prices joined to physical flows, per border.'}
+      collapsible
+      headerRight={
+        borders.length > 0 && (
+          <span className="font-mono text-[9px] text-neutral-600">
+            {borders.length} borders · last {data?.days}d
+          </span>
+        )
+      }
+    >
+      {loading && !data ? (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">Loading borders…</div>
+      ) : (
+        <>
+          <div className="px-2 py-2 overflow-x-auto">
+            <table className="w-full font-mono text-[11px]">
+              <thead>
+                <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                  <th className="text-left px-2 py-1">Border</th>
+                  <th className="text-right px-2 py-1" title="Share of hours the two zones cleared at the same price">Coupled</th>
+                  <th className="text-right px-2 py-1" title="Mean absolute day-ahead spread over the window">Ø spread</th>
+                  <th className="text-right px-2 py-1" title="Latest spread; the expensive side is named">Now</th>
+                  <th className="text-right px-2 py-1" title="Share of hours the physical flow reached this border's own 95th percentile">At rail</th>
+                  <th className="text-right px-2 py-1" title="Share of split hours where power ran from the expensive zone to the cheap one">Counter</th>
+                </tr>
+              </thead>
+              <tbody>
+                {borders.map((b) => {
+                  const key = `${b.zone_a}|${b.zone_b}`
+                  const isOpen = open === key
+                  return (
+                    <tr
+                      key={key}
+                      onClick={() => setOpen(isOpen ? null : key)}
+                      className={`border-t border-border/30 cursor-pointer hover:bg-white/[0.02] ${isOpen ? 'bg-white/[0.03]' : ''}`}
+                    >
+                      <td className="px-2 py-1.5 text-neutral-300">
+                        {isOpen ? '▾ ' : '▸ '}{b.label}
+                      </td>
+                      <td className={`px-2 py-1.5 text-right ${convergenceColor(b.convergence_pct)}`}>
+                        {b.convergence_pct != null ? `${b.convergence_pct.toFixed(0)}%` : '—'}
+                      </td>
+                      <td className="px-2 py-1.5 text-right text-neutral-200">
+                        {b.mean_abs_spread != null ? `€${b.mean_abs_spread.toFixed(0)}` : '—'}
+                      </td>
+                      <td className="px-2 py-1.5 text-right text-neutral-400">
+                        {b.latest_spread == null ? '—'
+                          : b.expensive_side == null ? 'coupled'
+                            : `€${Math.abs(b.latest_spread).toFixed(0)} · ${b.expensive_side === b.zone_a ? b.label.split('↔')[0] : b.label.split('↔')[1]} dearer`}
+                      </td>
+                      <td className="px-2 py-1.5 text-right text-neutral-400">
+                        {b.at_rail_pct != null ? `${b.at_rail_pct.toFixed(0)}%` : '—'}
+                      </td>
+                      <td className={`px-2 py-1.5 text-right ${b.counter_price_pct > 10 ? 'text-orange-400' : 'text-neutral-500'}`}>
+                        {b.counter_price_pct != null ? `${b.counter_price_pct.toFixed(0)}%` : '—'}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {open && <SpreadChart a={open.split('|')[0]} b={open.split('|')[1]} />}
+
+          {uncoverable.length > 0 && (
+            <div className="px-4 py-2 border-t border-border/40 font-mono text-[9px] text-neutral-700 leading-relaxed">
+              No price on both sides, so no metrics ({uncoverable.length}): {uncoverable.join(', ')}.
+              Energy-Charts publishes flows at country level, so a border touching a sub-zoned market
+              (Italian zones, DK1/DK2, Nordic zones) or an unpriced neighbour (GB, LU) cannot be joined
+              to a single price.
+            </div>
+          )}
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
**Tier 1.1 des Produkt-Tiefe-Audits.** Obsyd speichert Day-Ahead-Preise für 37 Zonen und stündliche Cross-Border-Flüsse für 45 Grenzen — und **nichts im Code hat sie je zusammengeführt**. Das Desk konnte sagen, DE-LU steht bei €140 und FR bei €55. Es konnte nicht sagen, dass die beiden in 97 % der Stunden des letzten Monats *auseinander* clearten, dass der Interconnector in 9 % davon an seinem eigenen historischen Anschlag lag, oder dass in 17 Stunden Strom **vom teuren ins billige Gebiet** floss.

Jetzt sagt es alle drei.

- `GET /api/power/borders` — jede Grenze, gerankt danach, wie weit sie auseinander clearet: Kopplungsrate, Ø-Spread, p95, „am Anschlag", Gegenpreis-Stunden.
- `GET /api/power/spread?a=&b=` — eine Grenze, Stunde für Stunde: beide Preise, der Spread, der physische Fluss.
- `BordersPanel` auf EUROPE: Tabelle mit aufklappbarem Spread-vs-Fluss-Chart.

**An echten Daten (DE-LU↔FR, 30 Tage):** gekoppelt 2,9 % der Stunden, Ø-Spread 20,3 €, p95 60,5 €, am Anschlag 9 %, Gegenpreis 17 von 560 Split-Stunden.

**Was diese Zahlen NICHT sind** — und der Code sagt es laut: Ein Spread ist **keine** Behauptung, dass dieser Interconnector die bindende Restriktion war. Die Core-Region cleart flow-based; die Restriktion ist ein Netzelement *im* Netz, nicht die Grenze — ein Spread kann zwischen Zonen auftreten, deren eigener Interconnector halb leer ist. Der Caveat reist im `note`-Feld der Response mit.

„Am Anschlag" misst gegen das **eigene 95. Perzentil** der Grenze über ein Jahr, nicht gegen eine NTC: wir haben keine, und flow-based-Regionen publizieren keine. Das zu sagen ist ehrlicher, als eine Zahl zu borgen, die es nicht gibt.

**Abdeckung wird genannt, nicht versteckt:** Energy-Charts liefert Flüsse auf Länderebene, also haben nur **26 von 45** Grenzen einen Preis auf beiden Seiten. Die anderen 19 berühren einen sub-zonierten Markt (IT-Zonen, DK1/DK2, Nordics) oder einen unbepreisten Nachbarn (GB, LU) — sie stehen namentlich in Response und Panel.

**Ein Bug, an echten Daten gefunden:** Der „letzte Fluss" wurde zum Zeitstempel des letzten *Preises* gelesen. Die Day-Ahead-Auktion publiziert ins Morgen, physische Flüsse enden im Jetzt — also meldete jede Grenze jeden Nachmittag einen Null-Fluss. Jede Größe nimmt jetzt ihre eigene letzte Stunde (per Test gepinnt).

ruff + 788 Tests grün (14 neue), ESLint sauber, Build grün, Headless-Screenshot verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)