### PR TITLE
Borders: hold the year-long rail statistic for six hours, and say when it was taken

### DIFF
--- a/backend/power/borders.py
+++ b/backend/power/borders.py
@@ -187,6 +187,36 @@ def _flow_rows(db: Session, start_ts: int) -> dict[tuple[str, str], dict[int, fl
     return out
 
 
+#: The rail thresholds are a 365-day statistic: they move by hours-old data about
+#: as much as a coastline moves by one wave. Ranking a year of flows still costs
+#: ~1.4 s, so the result is held for this long and the response says WHEN it was
+#: computed. (Unlike the situation hero, where caching would have let a stale
+#: as_of masquerade as fresh, nothing here is a freshness claim.)
+RAIL_CACHE_TTL_SECONDS = 6 * 3600
+
+_rail_cache: dict[str, object] = {"computed_at": None, "values": {}}
+
+
+def rail_thresholds_cached(db: Session, start_ts: int, *, now: datetime | None = None):
+    """(thresholds, computed_at) — recomputed at most every RAIL_CACHE_TTL_SECONDS."""
+    now = now or datetime.now(timezone.utc)
+    computed_at = _rail_cache["computed_at"]
+    if (
+        computed_at is None
+        or (now - computed_at).total_seconds() >= RAIL_CACHE_TTL_SECONDS
+    ):
+        _rail_cache["values"] = _rail_thresholds(db, start_ts)
+        _rail_cache["computed_at"] = now
+        computed_at = now
+    return _rail_cache["values"], computed_at
+
+
+def reset_rail_cache() -> None:
+    """Test isolation."""
+    _rail_cache["computed_at"] = None
+    _rail_cache["values"] = {}
+
+
 def _rail_thresholds(db: Session, start_ts: int) -> dict[tuple[str, str], float]:
     """The RAIL_PERCENTILE of |flow| per border, computed in SQL.
 
@@ -257,7 +287,7 @@ def compute_borders(db: Session, days: int = 30, *, now: datetime | None = None)
     if not window_flows:
         return {"available": False,
                 "reason": "No cross-border flow series yet — check back shortly."}
-    rails = _rail_thresholds(db, rail_start)
+    rails, rails_at = rail_thresholds_cached(db, rail_start, now=now)
 
     priced = set(POWER_ZONES)
     joinable = {b for b in window_flows if b[0] in priced and b[1] in priced}
@@ -292,6 +322,7 @@ def compute_borders(db: Session, days: int = 30, *, now: datetime | None = None)
         "coupled_eps_eur": COUPLED_EPS_EUR,
         "rail_percentile": RAIL_PERCENTILE,
         "rail_baseline_days": RAIL_BASELINE_DAYS,
+        "rail_computed_at": rails_at.isoformat(),
         "borders": out,
         "uncoverable_borders": uncoverable,
         "note": (
@@ -331,7 +362,7 @@ def compute_spread(db: Session, a: str, b: str, days: int = 30,
         }
 
     prices = _price_rows(db, {zone_a, zone_b}, window_start)
-    rail = _rail_thresholds(db, rail_start).get((zone_a, zone_b))
+    rail = rail_thresholds_cached(db, rail_start, now=now)[0].get((zone_a, zone_b))
     m = border_metrics(prices.get(zone_a, {}), prices.get(zone_b, {}), flow_window, rail)
     if not m["hours"]:
         return {

--- a/backend/tests/test_borders.py
+++ b/backend/tests/test_borders.py
@@ -33,10 +33,14 @@ def _client(db):
 
 @pytest.fixture(autouse=True)
 def _clear_overrides():
+    from backend.power.borders import reset_rail_cache
+
+    reset_rail_cache()  # the rail cache is module-level; never leak it between tests
     yield
     from backend.main import app
 
     app.dependency_overrides.clear()
+    reset_rail_cache()
 
 
 def _hours(n: int, end: datetime = _NOW) -> list[int]:
@@ -201,3 +205,37 @@ def test_sql_rail_threshold_equals_the_python_percentile(db_session):
     sql = _rail_thresholds(db_session, min(ts))
     py = percentile([abs(v) for v in values], RAIL_PERCENTILE)
     assert sql[("DE_LU", "FR")] == pytest.approx(py)
+
+
+def test_rail_cache_recomputes_only_after_its_ttl(db_session):
+    """The rail threshold is a 365-day statistic — it must not be re-ranked on
+    every request (that cost 1.4s on prod), and it must not go stale forever."""
+    from datetime import timedelta
+
+    from backend.power.borders import (
+        RAIL_CACHE_TTL_SECONDS,
+        rail_thresholds_cached,
+        reset_rail_cache,
+    )
+
+    reset_rail_cache()
+    ts = _hours(30)
+    upsert_hourly(db_session, "flow.FR", "DE_LU", [(t, 1_000.0) for t in ts], unit="MW")
+
+    t0 = datetime(2026, 7, 12, 8, 0, tzinfo=timezone.utc)
+    first, at1 = rail_thresholds_cached(db_session, min(ts), now=t0)
+    assert first[("DE_LU", "FR")] == 1_000.0 and at1 == t0
+
+    # New, much larger flows arrive — inside the TTL the cached value must hold.
+    upsert_hourly(db_session, "flow.FR", "DE_LU",
+                  [(t + 3600 * 100, 9_000.0) for t in ts], unit="MW")
+    cached, at2 = rail_thresholds_cached(db_session, min(ts),
+                                         now=t0 + timedelta(seconds=RAIL_CACHE_TTL_SECONDS - 1))
+    assert cached[("DE_LU", "FR")] == 1_000.0, "still the cached value"
+    assert at2 == t0, "and the response says when it was computed"
+
+    fresh, at3 = rail_thresholds_cached(db_session, min(ts),
+                                        now=t0 + timedelta(seconds=RAIL_CACHE_TTL_SECONDS))
+    assert fresh[("DE_LU", "FR")] == 9_000.0, "past the TTL it recomputes"
+    assert at3 > at2
+    reset_rail_cache()


### PR DESCRIPTION
Die letzten 1,4 s von `/api/power/borders` sind SQLite, das ein **Jahr** |Fluss| rankt, um je Grenze das 95. Perzentil zu finden. Diese Zahl bewegt sich durch eine Stunde neuer Daten etwa so stark wie eine Küstenlinie durch eine Welle.

Sie wird jetzt **6 h gehalten** — und die Response liefert `rail_computed_at`, damit die Alterung **sichtbar** ist statt angenommen.

Das ist bewusst die **umgekehrte Entscheidung** wie bei `/overview`, wo ich einen Cache abgelehnt habe: dort hätte ein gecachter Wert ein veraltetes `as_of` als frisch ausgeben können. Hier ist nichts eine Frische-Aussage — es ist eine 365-Tage-Statistik, und der Zeitstempel macht sie prüfbar.

Der Cache ist modul-global, also setzt die Test-Fixture ihn um **jeden** Test herum zurück: ein warmer Cache, der zwischen Tests leckt, ist der Weg, wie eine Suite aus den falschen Gründen grün wird.

ruff + 790 Tests grün (1 neuer: TTL hält, TTL läuft ab, Zeitstempel wandert mit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)