### PR TITLE
Why is this zone expensive today? — the driver card

### DIFF
--- a/backend/power/drivers.py
+++ b/backend/power/drivers.py
@@ -1,0 +1,297 @@
+"""Why is this zone expensive today? — a ranked driver card.
+
+The situation hero already prints three numbers side by side (price z, residual z,
+spark) and a list of flags. It never says WHICH condition is doing the work, nor
+how today compares to physically similar days. So the question a power analyst
+asks first every single morning — "why is FR €40 over DE today?" — is answered by
+scrolling six panels and eyeballing.
+
+This decomposes today into the conditions that CO-OCCUR with the price, each
+ranked by how far it sits from its own norm, and then places today against the
+most physically similar days in the zone's own history.
+
+POSTURE B, ENFORCED IN THE WORDING
+----------------------------------
+Every sentence is co-occurrence, never causation, never a forecast:
+
+    "€142/MWh WHILE wind sits 2.8σ below its norm, 6.1 GW (5% of the fleet) is
+     forced offline and the zone is importing 3.2 GW."
+
+Not "because". The analog line is the same discipline — it reports what similar
+days CLEARED, in the past tense, with the sample size attached:
+
+    "The 34 days whose residual load was within 1 GW of today's cleared at €95 on
+     average (p10-p90: €61-€140). Today is €142."
+
+That is a statement about the record, not about tomorrow. There is no model here,
+no LLM, and no claim that any driver caused any price.
+"""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from backend.models.energy import PowerFlow, PowerGrid, PowerPriceDaily
+from backend.power.zones import POWER_ZONES
+from backend.signals.detectors.base import trailing_zscore
+
+#: Trailing window each driver's "vs its own norm" is measured against. Matches
+#: the situation hero (routes/power.py::SITUATION_BASELINE_DAYS) on purpose — two
+#: different windows on the same screen is how a desk loses an analyst's trust.
+BASELINE_DAYS = 120
+
+#: A day is an ANALOG of today when its residual load sits within this band. Not
+#: a model — a filter on the record.
+ANALOG_BAND_MW = 1_000.0
+
+#: Below this many analogs we say so instead of quoting a mean of four days.
+ANALOG_MIN_N = 10
+
+#: Drivers below this |z| are not worth a sentence — they are just Tuesday.
+NOTABLE_Z = 1.0
+
+
+def _fmt_gw(mw: float) -> str:
+    return f"{mw / 1000:.1f} GW"
+
+
+def _driver(key: str, label: str, value: float | None, unit: str,
+            history: list[float], *, invert: bool = False) -> dict | None:
+    """One driver with its deviation from its own trailing norm.
+
+    `invert` marks drivers where LOW is the notable direction (wind, solar): the
+    sentence then reads "below its norm" rather than "above".
+    """
+    if value is None:
+        return None
+    stat = trailing_zscore(value, history) if len(history) >= 2 else None
+    if stat is None:
+        # Too little history, or a baseline with zero variance. The VALUE is still
+        # a fact — only the deviation is unknowable. Dropping the driver entirely
+        # would hide a real number; claiming a z would invent one.
+        return {
+            "key": key, "label": label,
+            "value": round(value, 2), "unit": unit,
+            "z": None, "baseline_mean": None, "baseline_n": len(history),
+            "direction": None, "notable": False, "inverted": invert,
+        }
+    z, mean, _std, n = stat
+    return {
+        "key": key,
+        "label": label,
+        "value": round(value, 2),
+        "unit": unit,
+        "z": round(z, 2),
+        "baseline_mean": round(mean, 2),
+        "baseline_n": n,
+        "direction": "below" if z < 0 else "above",
+        "notable": abs(z) >= NOTABLE_Z,
+        "inverted": invert,
+    }
+
+
+def net_position_by_day(db: Session, zone: str, start: str) -> dict[str, float]:
+    """Net physical export of `zone` per day since `start`, summed over its borders.
+
+    Positive = the zone exported on net. ONE query for the whole window — the
+    per-day version meant 30 round trips per request. Country-level flows, so
+    sub-zones have none: they get no net-position driver rather than a
+    fabricated zero.
+    """
+    rows = (
+        db.query(PowerFlow.date, PowerFlow.from_zone, PowerFlow.to_zone, PowerFlow.net_mw)
+        .filter(PowerFlow.date >= start,
+                (PowerFlow.from_zone == zone) | (PowerFlow.to_zone == zone))
+        .all()
+    )
+    out: dict[str, float] = {}
+    for day, from_zone, _to_zone, net_mw in rows:
+        out[day] = out.get(day, 0.0) + (net_mw if from_zone == zone else -net_mw)
+    return out
+
+
+def _analogs(db: Session, zone: str, residual_mw: float, today: str) -> dict:
+    """The days whose residual load was closest to today's — and what they cleared.
+
+    A filter on the record, not a model: same zone, residual within ANALOG_BAND_MW,
+    excluding today itself.
+    """
+    from backend.power.borders import percentile
+
+    rows = (
+        db.query(PowerGrid.date, PowerGrid.residual_mw, PowerPriceDaily.mean_price)
+        .join(PowerPriceDaily,
+              (PowerPriceDaily.date == PowerGrid.date)
+              & (PowerPriceDaily.zone == PowerGrid.zone))
+        .filter(PowerGrid.zone == zone,
+                PowerGrid.date != today,
+                PowerGrid.residual_mw.isnot(None),
+                PowerPriceDaily.mean_price.isnot(None))
+        .all()
+    )
+    prices = [
+        float(price) for _d, resid, price in rows
+        if abs(float(resid) - residual_mw) <= ANALOG_BAND_MW
+    ]
+    if len(prices) < ANALOG_MIN_N:
+        return {
+            "n": len(prices),
+            "band_mw": ANALOG_BAND_MW,
+            "enough": False,
+            "reason": (
+                f"Only {len(prices)} day(s) in this zone's record had a residual load "
+                f"within {_fmt_gw(ANALOG_BAND_MW)} of today's — too few to quote a norm."
+            ),
+        }
+    return {
+        "n": len(prices),
+        "band_mw": ANALOG_BAND_MW,
+        "enough": True,
+        "mean_price": round(sum(prices) / len(prices), 2),
+        "p10": round(percentile(prices, 0.10), 2),
+        "p90": round(percentile(prices, 0.90), 2),
+    }
+
+
+def compute_drivers(db: Session, zone: str, *, today: _date | None = None) -> dict:
+    """Today's price, the conditions co-occurring with it, ranked, plus analogs."""
+    if zone not in POWER_ZONES:
+        return {"available": False, "zone": zone, "reason": f"Unknown zone {zone}."}
+    today = today or datetime.now(timezone.utc).date()
+    start = (today - timedelta(days=BASELINE_DAYS)).isoformat()
+
+    grid = (
+        db.query(PowerGrid)
+        .filter(PowerGrid.zone == zone, PowerGrid.date >= start)
+        .order_by(PowerGrid.date.asc())
+        .all()
+    )
+    prices = (
+        db.query(PowerPriceDaily)
+        .filter(PowerPriceDaily.zone == zone, PowerPriceDaily.date >= start)
+        .order_by(PowerPriceDaily.date.asc())
+        .all()
+    )
+    if not grid or not prices:
+        return {
+            "available": False, "zone": zone,
+            "reason": f"No price/grid history for {POWER_ZONES[zone]['label']} yet.",
+        }
+
+    latest_grid, latest_price = grid[-1], prices[-1]
+    as_of = max(latest_grid.date, latest_price.date)
+
+    price_stat = _driver(
+        "price", "Day-ahead price", latest_price.mean_price, "EUR/MWh",
+        [p.mean_price for p in prices[:-1] if p.mean_price is not None],
+    )
+
+    drivers: list[dict] = []
+    d = _driver("residual", "Residual load", latest_grid.residual_mw, "MW",
+                [g.residual_mw for g in grid[:-1] if g.residual_mw is not None])
+    if d:
+        drivers.append(d)
+    d = _driver("wind", "Wind generation", latest_grid.wind_mw, "MW",
+                [g.wind_mw for g in grid[:-1] if g.wind_mw is not None], invert=True)
+    if d:
+        drivers.append(d)
+    d = _driver("solar", "Solar generation", latest_grid.solar_mw, "MW",
+                [g.solar_mw for g in grid[:-1] if g.solar_mw is not None], invert=True)
+    if d:
+        drivers.append(d)
+
+    net_by_day = net_position_by_day(db, zone, start)
+    net = net_by_day.get(latest_grid.date)
+    if net is not None:
+        history = [v for d_, v in sorted(net_by_day.items()) if d_ != latest_grid.date]
+        d = _driver("net_position", "Net export position", net, "MW", history)
+        if d:
+            drivers.append(d)
+
+    # Forced outages are a LEVEL, not a deviation — there is no hourly outage
+    # history in the store yet (that is the outage-time-series work), so this
+    # carries no z and says so by omitting one.
+    from backend.signals.detectors.power import forced_outage_mw_now, installed_capacity_mw
+
+    forced_mw, _rows = forced_outage_mw_now(db, zone)
+    installed = installed_capacity_mw(db, zone)
+    outage = None
+    if forced_mw > 0:
+        outage = {
+            "key": "forced_outages",
+            "label": "Forced outages",
+            "value": round(forced_mw, 1),
+            "unit": "MW",
+            "z": None,
+            "fleet_pct": round(100.0 * forced_mw / installed, 1) if installed else None,
+            "notable": True,
+        }
+
+    # Most-deviant first; a driver without a trustworthy baseline sinks to the end
+    # rather than pretending to a rank it cannot claim.
+    drivers.sort(key=lambda x: (x["z"] is None, -abs(x["z"] or 0.0)))
+
+    analogs = (
+        _analogs(db, zone, latest_grid.residual_mw, latest_grid.date)
+        if latest_grid.residual_mw is not None else
+        {"enough": False, "n": 0, "reason": "No residual load for this zone."}
+    )
+
+    return {
+        "available": True,
+        "zone": zone,
+        "zone_label": POWER_ZONES[zone]["label"],
+        "as_of": as_of,
+        "baseline_days": BASELINE_DAYS,
+        "price": price_stat,
+        "drivers": drivers,
+        "outage": outage,
+        "analogs": analogs,
+        "headline": _headline(zone, price_stat, drivers, outage),
+        "note": (
+            "Conditions that CO-OCCUR with today's price, ranked by how far each sits "
+            "from its own norm. Descriptive: no driver is claimed to have caused the "
+            "price, and no forecast is made."
+        ),
+    }
+
+
+def _headline(zone: str, price: dict | None, drivers: list[dict], outage: dict | None) -> str:
+    """Template text. Co-occurrence ('WHILE'), never causation ('because')."""
+    label = POWER_ZONES[zone]["label"]
+    if price is None or price["value"] is None:
+        return f"{label} · no price today."
+
+    head = f"{label} cleared at €{price['value']:.0f}/MWh"
+    if price["z"] is not None:
+        head += f" ({price['z']:+.1f}σ vs its {BASELINE_DAYS}d norm)"
+
+    parts = []
+    for d in drivers:
+        if not d["notable"]:
+            continue
+        if d["key"] == "net_position":
+            # A signed number the reader has to decode reads worse than the word
+            # for what it means.
+            verb = "exporting" if d["value"] >= 0 else "importing"
+            parts.append(
+                f"the zone is {verb} {_fmt_gw(abs(d['value']))} "
+                f"({abs(d['z']):.1f}σ {d['direction']} its norm)"
+            )
+            continue
+        val = _fmt_gw(d["value"]) if d["unit"] == "MW" else f"{d['value']:.0f} {d['unit']}"
+        parts.append(f"{d['label'].lower()} is {val}, {abs(d['z']):.1f}σ {d['direction']} its norm")
+    if outage:
+        seg = f"{_fmt_gw(outage['value'])} is forced offline"
+        if outage["fleet_pct"] is not None:
+            seg += f" ({outage['fleet_pct']:.0f}% of the fleet)"
+        parts.append(seg)
+
+    if not parts:
+        return head + " — nothing is far from its norm today."
+    return head + " WHILE " + ", ".join(parts[:-1]) + (
+        f" and {parts[-1]}" if len(parts) > 1 else parts[0]
+    ) + "."

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1415,6 +1415,26 @@ async def get_flows_hourly(
     }
 
 
+# ─── Drivers: why is this zone expensive today? ───────────────────────────────
+
+
+@router.get("/drivers")
+def get_drivers(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    db: Session = Depends(get_db),
+):
+    """The conditions co-occurring with today's price in one zone, ranked by how
+    far each sits from its own norm — plus what physically similar days cleared.
+
+    Descriptive (Posture B): the wording is co-occurrence ("price €142 WHILE wind
+    is 2.8σ below norm"), never causation, and the analogs report what similar
+    days DID clear, never what tomorrow will. See backend/power/drivers.py.
+    """
+    from backend.power.drivers import compute_drivers
+
+    return compute_drivers(db, _resolve_zone(zone))
+
+
 # ─── Borders: where the price series and the flow series finally meet ─────────
 
 

--- a/backend/tests/test_drivers.py
+++ b/backend/tests/test_drivers.py
@@ -1,0 +1,180 @@
+"""The driver card: what co-occurs with today's price, ranked.
+
+The tests exist mostly to hold the LANGUAGE honest. A driver card is one careless
+sentence away from being a causal claim, and one careless mean away from being a
+forecast. So: co-occurrence wording, a sample-size floor on the analogs, and no
+driver invented where the data is absent.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.models.energy import PowerFlow, PowerGrid, PowerPriceDaily
+from backend.power.drivers import (
+    ANALOG_MIN_N,
+    compute_drivers,
+    net_position_by_day,
+)
+
+_TODAY = date(2026, 7, 12)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db):
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+# Real baselines have variance; a constant one has no z at all (and that case is
+# pinned separately below). The default seed therefore wobbles.
+def _seed(db, zone="DE_LU", days=60, *, price=lambda i: 60.0 + (i % 7), load=50_000.0,
+          wind=lambda i: 10_000.0 + (i % 5) * 400, solar=lambda i: 5_000.0 + (i % 3) * 200):
+    for i in range(days):
+        d = (_TODAY - timedelta(days=days - 1 - i)).isoformat()
+        w, s = wind(i), solar(i)
+        db.add(PowerGrid(date=d, zone=zone, load_mw=load, wind_mw=w, solar_mw=s,
+                         residual_mw=load - w - s))
+        db.add(PowerPriceDaily(date=d, zone=zone, mean_price=price(i),
+                               min_price=0.0, max_price=200.0, negative_hours=0))
+    db.commit()
+
+
+def test_a_calm_day_says_nothing_is_far_from_its_norm(db_session):
+    """Today lands ON each baseline's mean — the card must then say so plainly
+    rather than dressing up noise as a driver."""
+    _seed(db_session,
+          price=lambda i: 63.0 if i == 59 else 60.0 + (i % 7),        # mean of 60..66
+          wind=lambda i: 10_800.0 if i == 59 else 10_000.0 + (i % 5) * 400,
+          solar=lambda i: 5_200.0 if i == 59 else 5_000.0 + (i % 3) * 200)
+    out = compute_drivers(db_session, "DE_LU", today=_TODAY)
+    assert out["available"] is True
+    assert "nothing is far from its norm" in out["headline"], out["headline"]
+    assert all(not d["notable"] for d in out["drivers"])
+
+
+def test_the_headline_is_co_occurrence_never_causation(db_session):
+    """The whole point of the card, and the one line where Posture B can die."""
+    # Wind collapses on the last day; price spikes with it.
+    _seed(db_session, wind=lambda i: 2_000.0 if i == 59 else 12_000.0 + (i % 5) * 300,
+          price=lambda i: 190.0 if i == 59 else 55.0 + (i % 4))
+    out = compute_drivers(db_session, "DE_LU", today=_TODAY)
+    h = out["headline"]
+
+    assert " WHILE " in h
+    for forbidden in ("because", "caused", "due to", "will ", "expect"):
+        assert forbidden not in h.lower(), f"causal/predictive wording leaked: {forbidden!r}"
+    assert "wind generation is" in h.lower() and "below its norm" in h.lower()
+
+
+def test_drivers_are_ranked_by_distance_from_their_own_norm(db_session):
+    # Wind moves a lot on the last day, solar barely.
+    _seed(db_session,
+          wind=lambda i: 1_000.0 if i == 59 else 12_000.0 + (i % 5) * 300,
+          solar=lambda i: 5_000.0 if i == 59 else 5_000.0 + (i % 3) * 100)
+    out = compute_drivers(db_session, "DE_LU", today=_TODAY)
+    zs = [abs(d["z"]) for d in out["drivers"]]
+    assert zs == sorted(zs, reverse=True), "most-deviant driver first"
+    assert out["drivers"][0]["key"] in ("wind", "residual")
+
+
+def test_analogs_refuse_to_quote_a_norm_from_too_few_days(db_session):
+    """A mean of four days dressed up as a norm is worse than no number."""
+    # Every day has a different residual → today's ±1 GW band catches almost nothing.
+    _seed(db_session, days=20, wind=lambda i: 1_000.0 * i)
+    out = compute_drivers(db_session, "DE_LU", today=_TODAY)
+    assert out["analogs"]["enough"] is False
+    assert out["analogs"]["n"] < ANALOG_MIN_N
+    assert "too few" in out["analogs"]["reason"]
+
+
+def test_analogs_report_what_similar_days_cleared(db_session):
+    """Past tense, with the sample size — a statement about the record."""
+    _seed(db_session, days=60, price=lambda i: 100.0 if i < 59 else 142.0,
+          wind=lambda i: 10_000.0, solar=lambda i: 5_000.0)  # same residual every day
+    out = compute_drivers(db_session, "DE_LU", today=_TODAY)
+    a = out["analogs"]
+    assert a["enough"] is True and a["n"] >= ANALOG_MIN_N
+    assert a["mean_price"] == 100.0, "what the similar days DID clear — past tense"
+    assert a["p10"] == 100.0 and a["p90"] == 100.0
+    assert out["price"]["value"] == 142.0
+
+
+def test_no_flows_no_net_position_driver(db_session):
+    """Country-level flows: a sub-zone gets no net-position driver rather than a
+    fabricated zero."""
+    _seed(db_session)
+    out = compute_drivers(db_session, "DE_LU", today=_TODAY)
+    assert all(d["key"] != "net_position" for d in out["drivers"])
+
+
+def test_net_position_sums_both_border_directions(db_session):
+    _seed(db_session)
+    day = _TODAY.isoformat()
+    # DE_LU exports 1 GW to FR, and imports 400 MW from BE (BE→DE_LU is +400 for BE)
+    db_session.add(PowerFlow(date=day, from_zone="DE_LU", to_zone="FR", net_mw=1_000.0))
+    db_session.add(PowerFlow(date=day, from_zone="BE", to_zone="DE_LU", net_mw=400.0))
+    db_session.commit()
+
+    net = net_position_by_day(db_session, "DE_LU", day)
+    assert net[day] == 600.0, "1000 exported − 400 imported"
+
+
+def test_unknown_zone_is_honest(db_session):
+    out = compute_drivers(db_session, "ZZ", today=_TODAY)
+    assert out["available"] is False and "Unknown zone" in out["reason"]
+
+
+def test_empty_zone_is_honest(db_session):
+    out = compute_drivers(db_session, "FR", today=_TODAY)
+    assert out["available"] is False and "No price/grid history" in out["reason"]
+
+
+def test_route(db_session):
+    _seed(db_session)
+    body = _client(db_session).get("/api/power/drivers?zone=DE_LU").json()
+    assert body["available"] is True
+    assert "no driver is claimed to have caused the price" in body["note"]
+
+
+def test_a_flat_baseline_yields_a_value_but_no_deviation(db_session):
+    """Zero variance → no z exists. The driver must still report its VALUE (a
+    fact) while claiming no deviation (which would be invented), and it must sink
+    below the drivers that do have a baseline."""
+    _seed(db_session, days=60,
+          wind=lambda i: 9_000.0,                       # perfectly flat → no z
+          solar=lambda i: 5_000.0 + (i % 5) * 300)      # varies → has a z
+    out = compute_drivers(db_session, "DE_LU", today=_TODAY)
+
+    wind = next(d for d in out["drivers"] if d["key"] == "wind")
+    assert wind["value"] == 9_000.0
+    assert wind["z"] is None and wind["notable"] is False
+    assert out["drivers"][-1]["key"] == "wind", "no baseline → ranked last, not first"
+
+
+def test_net_position_is_worded_as_import_or_export_not_a_signed_number(db_session):
+    """"net export position is -7.5 GW" makes the reader decode a sign. Say the
+    word: the zone is importing 7.5 GW."""
+    _seed(db_session)
+    for i in range(40):
+        d = (_TODAY - timedelta(days=39 - i)).isoformat()
+        # normally a big exporter; today it flips to importing
+        net = -7_500.0 if i == 39 else 3_000.0 + (i % 5) * 200
+        db_session.add(PowerFlow(date=d, from_zone="DE_LU", to_zone="FR", net_mw=net))
+    db_session.commit()
+
+    out = compute_drivers(db_session, "DE_LU", today=_TODAY)
+    assert "the zone is importing 7.5 GW" in out["headline"], out["headline"]
+    assert "-7.5" not in out["headline"]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ import RecordChip from './components/RecordChip'
 import ImbalancePanel from './components/ImbalancePanel'
 import RecordsPanel from './components/RecordsPanel'
 import BordersPanel from './components/BordersPanel'
+import DriversPanel from './components/DriversPanel'
 import PowerOverviewMatrix from './components/PowerOverviewMatrix'
 import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
@@ -567,6 +568,11 @@ function Dashboard() {
             </ErrorBoundary>
             <ErrorBoundary name="record-chip">
               <RecordChip zone={energyZone} />
+            </ErrorBoundary>
+            {/* "Why is this zone expensive today?" — the conditions co-occurring
+                with the price, ranked. The hero says WHAT; this says WHAT ELSE. */}
+            <ErrorBoundary name="power-drivers">
+              <DriversPanel zone={energyZone} />
             </ErrorBoundary>
 
             {/* PRICES — day-ahead + spark spread */}

--- a/frontend/src/components/DriversPanel.jsx
+++ b/frontend/src/components/DriversPanel.jsx
@@ -1,0 +1,138 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_FAST_MS } from '../utils/poll'
+import ReferenceBand from './ReferenceBand'
+
+const API = '/api'
+
+function fmtValue(d) {
+  if (d.value == null) return '—'
+  // The net position is signed; say the word instead of making the reader decode it.
+  if (d.key === 'net_position') {
+    return `${d.value >= 0 ? 'exp' : 'imp'} ${Math.abs(d.value / 1000).toFixed(1)} GW`
+  }
+  if (d.unit === 'MW') return `${(d.value / 1000).toFixed(1)} GW`
+  if (d.unit === 'EUR/MWh') return `€${d.value.toFixed(0)}`
+  return `${d.value.toFixed(0)} ${d.unit}`
+}
+
+/**
+ * "Why is this zone expensive today?" — the conditions that CO-OCCUR with the
+ * price, ranked by how far each sits from its own norm, plus what physically
+ * similar days actually cleared.
+ *
+ * Posture B lives or dies in the wording here: the backend writes the sentence
+ * (template-based, never an LLM) and it says WHILE, never because. This panel
+ * renders it; it does not compose claims of its own.
+ */
+export default function DriversPanel({ zone = 'DE_LU' }) {
+  const { data, loading, error } = useFetchWithError(
+    `${API}/power/drivers?zone=${zone}`, { deps: [zone], pollMs: POLL_FAST_MS },
+  )
+
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">DRIVERS // FETCH ERROR</div>
+      </div>
+    )
+  }
+  if (!data?.available && !loading) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          DRIVERS — {data?.reason || 'no driver data yet.'}
+        </div>
+      </div>
+    )
+  }
+
+  const drivers = data?.drivers ?? []
+  const outage = data?.outage
+  const a = data?.analogs
+
+  return (
+    <Panel
+      id="power-drivers"
+      title={`DRIVERS · ${data?.zone_label ?? zone}`}
+      info={data?.note || 'Conditions co-occurring with today’s price.'}
+      freshness={data}
+      collapsible
+    >
+      {loading && !data ? (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">Loading drivers…</div>
+      ) : (
+        <>
+          {/* The sentence the backend wrote. Co-occurrence, never causation. */}
+          <div className="px-4 pt-3 pb-2">
+            <p className="font-mono text-[13px] leading-relaxed text-neutral-300">{data.headline}</p>
+          </div>
+
+          <div className="px-2 pb-1 overflow-x-auto">
+            <table className="w-full font-mono text-[11px]">
+              <thead>
+                <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                  <th className="text-left px-2 py-1">Condition</th>
+                  <th className="text-right px-2 py-1">Today</th>
+                  <th className="text-right px-2 py-1">vs own norm</th>
+                  <th className="text-left px-2 py-1 w-40">Where it sits</th>
+                </tr>
+              </thead>
+              <tbody>
+                {drivers.map((d) => (
+                  <tr key={d.key} className="border-t border-border/30">
+                    <td className={`px-2 py-1.5 ${d.notable ? 'text-neutral-200' : 'text-neutral-500'}`}>
+                      {d.label}
+                    </td>
+                    <td className="px-2 py-1.5 text-right text-neutral-200">{fmtValue(d)}</td>
+                    <td className={`px-2 py-1.5 text-right ${
+                      d.z == null ? 'text-neutral-700'
+                        : Math.abs(d.z) >= 2 ? 'text-orange-400'
+                          : d.notable ? 'text-amber-400' : 'text-neutral-500'
+                    }`}>
+                      {d.z == null ? 'no baseline' : `${d.z >= 0 ? '+' : ''}${d.z.toFixed(1)}σ`}
+                    </td>
+                    <td className="px-2 py-1.5">
+                      {d.z != null && <ReferenceBand z={d.z} baselineN={d.baseline_n} />}
+                    </td>
+                  </tr>
+                ))}
+                {outage && (
+                  <tr className="border-t border-border/30">
+                    <td className="px-2 py-1.5 text-neutral-200">{outage.label}</td>
+                    <td className="px-2 py-1.5 text-right text-orange-400">
+                      {(outage.value / 1000).toFixed(1)} GW
+                    </td>
+                    <td className="px-2 py-1.5 text-right text-neutral-500">
+                      {outage.fleet_pct != null ? `${outage.fleet_pct.toFixed(0)}% of fleet` : '—'}
+                    </td>
+                    <td className="px-2 py-1.5 font-mono text-[9px] text-neutral-700">
+                      level, not a deviation
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Analogs: what similar days DID clear. Past tense, sample size attached. */}
+          <div className="px-4 py-2 border-t border-border/40 font-mono text-[10px] leading-relaxed">
+            {a?.enough ? (
+              <span className="text-neutral-400">
+                The <span className="text-neutral-200">{a.n}</span> days whose residual load was
+                within {(a.band_mw / 1000).toFixed(1)} GW of today’s cleared at{' '}
+                <span className="text-neutral-200">€{a.mean_price.toFixed(0)}</span> on average
+                (p10–p90: €{a.p10.toFixed(0)}–€{a.p90.toFixed(0)}).
+                {data.price?.value != null && (
+                  <> Today is <span className="text-cyan-glow">€{data.price.value.toFixed(0)}</span>.</>
+                )}
+              </span>
+            ) : (
+              <span className="text-neutral-600">{a?.reason || 'No comparable days yet.'}</span>
+            )}
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
**Tier 1.2 des Produkt-Tiefe-Audits.** Der Situation-Hero druckt drei Zahlen nebeneinander und eine Flag-Liste. Er sagt nie, **welche** Bedingung die Arbeit macht — und nie, wie sich heute gegen physikalisch ähnliche Tage einordnet. Die Frage, die ein Analyst jeden Morgen als erste stellt, wurde bisher durch Scrollen über sechs Panels beantwortet.

`GET /api/power/drivers` zerlegt den Tag in die Bedingungen, die mit dem Preis **ko-auftreten** — Residuallast, Wind, Solar, Netto-Position, Forced Outages — jede gerankt nach ihrem Abstand zur eigenen Norm, und stellt heute dann gegen die Tage aus der eigenen Historie der Zone, deren Residuallast heute am nächsten kam.

**An echten Daten liest es sich wie ein Desk:**

> „DE-LU cleared at €119/MWh (+0,7σ vs its 120d norm) **WHILE** the zone is importing 7.5 GW (1,5σ below its norm), residual load is 37.0 GW, 1,3σ above its norm and wind generation is 2.2 GW, 1,3σ below its norm."

> „The **12 days** whose residual load was within 1.0 GW of today's **cleared at €103** on average (p10–p90: €71–€145). Today is €111."

**Posture B steckt in der Formulierung — und die Tests sind vor allem dafür da, sie zu halten:** Der Satz sagt WHILE, nie „because". Ein Test verbietet, dass irgendein kausales oder prognostisches Wort („because", „caused", „due to", „will", „expect") die Headline erreicht. Die Analoga berichten, was ähnliche Tage geclearet **haben** — Vergangenheit, mit Stichprobengröße — und **verweigern** eine Norm unter zehn Tagen, weil ein Mittelwert aus vier Tagen im Norm-Gewand schlimmer ist als keine Zahl.

**Zwei Dinge, die die Implementierung nicht fälscht:**
- Ein Treiber, dessen Baseline **keine Varianz** hat, bekommt seinen **Wert** (eine Tatsache) mit `z=null` und sinkt ans Ende des Rankings. Ihn wegzuwerfen würde eine echte Zahl verstecken; ein z zu behaupten würde eine erfinden.
- **Forced Outages tragen gar kein z** — es gibt noch keine stündliche Outage-Historie im Store — also zeigt die Karte den Level und sagt „level, not a deviation", statt eine Baseline zu fabrizieren.

Die Netto-Position sagt „the zone is **importing** 7.5 GW", nicht „net export position is −7,5 GW": eine vorzeichenbehaftete Zahl, die der Leser dekodieren muss, ist ein schlechterer Satz als das Wort für das, was sie bedeutet.

ruff + 802 Tests grün (12 neue), ESLint sauber, Build grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)