### PR TITLE
Drivers: an immaterial outage does not belong in the headline

### DIFF
--- a/backend/power/drivers.py
+++ b/backend/power/drivers.py
@@ -53,6 +53,13 @@ ANALOG_MIN_N = 10
 #: Drivers below this |z| are not worth a sentence — they are just Tuesday.
 NOTABLE_Z = 1.0
 
+#: An outage earns a place in the HEADLINE only above this share of the fleet (or,
+#: where no A68 fleet is known, this many MW). "0.1 GW is forced offline (0% of the
+#: fleet)" is noise in a sentence that is supposed to be signal — the table still
+#: shows it.
+HEADLINE_OUTAGE_FLEET_PCT = 1.0
+HEADLINE_OUTAGE_MW = 500.0
+
 
 def _fmt_gw(mw: float) -> str:
     return f"{mw / 1000:.1f} GW"
@@ -259,6 +266,14 @@ def compute_drivers(db: Session, zone: str, *, today: _date | None = None) -> di
     }
 
 
+def _outage_is_headline_worthy(outage: dict) -> bool:
+    """Material enough to say out loud. Below this it stays in the table, where a
+    small number is context rather than clutter."""
+    if outage["fleet_pct"] is not None:
+        return outage["fleet_pct"] >= HEADLINE_OUTAGE_FLEET_PCT
+    return outage["value"] >= HEADLINE_OUTAGE_MW
+
+
 def _headline(zone: str, price: dict | None, drivers: list[dict], outage: dict | None) -> str:
     """Template text. Co-occurrence ('WHILE'), never causation ('because')."""
     label = POWER_ZONES[zone]["label"]
@@ -284,7 +299,7 @@ def _headline(zone: str, price: dict | None, drivers: list[dict], outage: dict |
             continue
         val = _fmt_gw(d["value"]) if d["unit"] == "MW" else f"{d['value']:.0f} {d['unit']}"
         parts.append(f"{d['label'].lower()} is {val}, {abs(d['z']):.1f}σ {d['direction']} its norm")
-    if outage:
+    if outage and _outage_is_headline_worthy(outage):
         seg = f"{_fmt_gw(outage['value'])} is forced offline"
         if outage["fleet_pct"] is not None:
             seg += f" ({outage['fleet_pct']:.0f}% of the fleet)"

--- a/backend/tests/test_drivers.py
+++ b/backend/tests/test_drivers.py
@@ -178,3 +178,30 @@ def test_net_position_is_worded_as_import_or_export_not_a_signed_number(db_sessi
     out = compute_drivers(db_session, "DE_LU", today=_TODAY)
     assert "the zone is importing 7.5 GW" in out["headline"], out["headline"]
     assert "-7.5" not in out["headline"]
+
+
+def test_an_immaterial_outage_stays_out_of_the_headline(db_session):
+    """FR reported "0.1 GW is forced offline (0% of the fleet)" in prod — noise in
+    a sentence that is supposed to be signal. It belongs in the table, not the
+    headline."""
+    from datetime import datetime, timezone
+    from datetime import timedelta as td
+
+    from backend.models.energy import InstalledCapacity, PowerOutage
+
+    _seed(db_session)
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    db_session.add(InstalledCapacity(zone="DE_LU", year=2026, psr_type="Solar",
+                                     capacity_mw=100_000.0))
+    db_session.add(PowerOutage(mrid="tiny", revision=1, doc_type="A77", zone="DE_LU",
+                               business_type="A54", psr_type="B14", unit_name="U",
+                               unit_eic="11W", location="DE",
+                               nominal_mw=100.0, available_mw=0.0,
+                               start_utc=(now - td(days=1)).strftime(fmt),
+                               end_utc=(now + td(days=1)).strftime(fmt), status="active"))
+    db_session.commit()
+
+    out = compute_drivers(db_session, "DE_LU", today=_TODAY)
+    assert out["outage"]["value"] == 100.0, "still reported as a level"
+    assert "forced offline" not in out["headline"], out["headline"]


### PR DESCRIPTION
Prod-Verifikation, Frankreich: „…and **0.1 GW is forced offline (0% of the fleet)**."

Ein Satz, der Signal tragen soll, sollte nicht mit einer Zahl enden, die auf null rundet.

Ein Ausfall kommt jetzt nur noch in die Headline, wenn er **≥ 1 % der bekannten Flotte** ausmacht (oder ≥ 500 MW, wo keine A68-Flotte bekannt ist). In der **Tabelle** bleibt er in jedem Fall — dort ist eine kleine Zahl Kontext, kein Lärm.

ruff + 803 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)