### PR TITLE
Base and Peak — speak the language the market actually trades in

### DIFF
--- a/backend/power/products.py
+++ b/backend/power/products.py
@@ -1,0 +1,172 @@
+"""Base, Peak, Off-peak — the language the market actually speaks.
+
+Europe trades Base and Peak. Every quote, every hedge, every broker run is
+base/peak. Obsyd knew only "daily mean" (which happens to be Base) and a raw
+24-hour shape: the PEAK PRICE — the number a trader reads first — was not on the
+desk at all, and neither was the peak premium that says whether the tightness is
+in the evening ramp or across the whole day.
+
+WHICH CLOCK
+-----------
+Two different clocks are in play and conflating them is a real error:
+
+  * the CANONICAL STORE is UTC, always. Nothing here changes that.
+  * the PRODUCTS are defined in CET/CEST. EPEX/EEX Peak is 08:00-20:00 CET,
+    Monday to Friday, and the delivery DAY of a continental day-ahead product
+    runs midnight-to-midnight CET.
+
+So the products are computed on the CET delivery day, not on the UTC calendar
+day. This matters: the last two hours of a UTC day belong to the NEXT CET
+delivery day, so bucketing prices by UTC date silently mixes two delivery days
+together. (PowerPriceDaily still buckets by UTC date — see the caveat on
+`negative_hours` below.)
+
+Zones whose civil time is not CET (FI, GR, RO, BG in EET; PT and IE-SEM in
+WET/WEST) still trade against CET-defined products, so the CET definition is
+applied everywhere and said out loud rather than guessed per zone.
+
+NEGATIVE HOURS, HONESTLY
+------------------------
+`negative_hours` here is counted on the CET DELIVERY day. PowerPriceDaily's
+long-standing `negative_hours` column counts them on the UTC calendar day, so the
+two can differ by the hours that straddle midnight. That is a known discrepancy,
+not a bug in this module: the delivery-day count is the one the market means.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from backend.power.hourly_store import read_hourly
+from backend.power.zones import POWER_ZONES
+
+#: The clock the products are defined in. EPEX/EEX Base and Peak are CET/CEST
+#: products; the desk speaks that language even for zones whose civil time is not.
+MARKET_TZ = ZoneInfo("Europe/Brussels")
+
+#: Peak = 08:00 (inclusive) to 20:00 (exclusive) local, Monday to Friday.
+PEAK_START_HOUR = 8
+PEAK_END_HOUR = 20
+
+PRICE_SERIES = "price.dayahead"
+
+#: The evening ramp is the steepest rise across this many consecutive hours.
+RAMP_HOURS = 3
+
+
+def market_day(ts_utc: int) -> tuple[str, int, int]:
+    """(delivery day YYYY-MM-DD, local hour 0-23, weekday 0-6) in market time."""
+    local = datetime.fromtimestamp(ts_utc, tz=timezone.utc).astimezone(MARKET_TZ)
+    return local.strftime("%Y-%m-%d"), local.hour, local.weekday()
+
+
+def is_peak_hour(hour: int, weekday: int) -> bool:
+    return weekday < 5 and PEAK_START_HOUR <= hour < PEAK_END_HOUR
+
+
+def _ramp(hours: dict[int, float]) -> float | None:
+    """Steepest rise across RAMP_HOURS consecutive hours — the evening ramp, in
+    €/MWh. None when the day is too short to measure one (DST, partial data)."""
+    ordered = [hours[h] for h in sorted(hours)]
+    if len(ordered) <= RAMP_HOURS:
+        return None
+    return max(
+        ordered[i + RAMP_HOURS] - ordered[i]
+        for i in range(len(ordered) - RAMP_HOURS)
+    )
+
+
+def day_products(hours: dict[int, float], weekday: int) -> dict:
+    """Base / Peak / Off-peak for one delivery day. Pure.
+
+    `hours` maps LOCAL hour → price. A day with no peak hours at all (a weekend)
+    reports peak=None rather than 0: the product simply does not exist that day.
+    """
+    if not hours:
+        return {}
+    values = list(hours.values())
+    peak_values = [p for h, p in hours.items() if is_peak_hour(h, weekday)]
+    off_values = [p for h, p in hours.items() if not is_peak_hour(h, weekday)]
+
+    base = sum(values) / len(values)
+    peak = sum(peak_values) / len(peak_values) if peak_values else None
+    off = sum(off_values) / len(off_values) if off_values else None
+
+    return {
+        "base": round(base, 2),
+        "peak": round(peak, 2) if peak is not None else None,
+        "off_peak": round(off, 2) if off is not None else None,
+        # The premium is what says whether tightness sits in the working day or
+        # across the clock. Undefined (not 1.0) when base is zero or negative —
+        # a ratio through zero is a number, not a meaning.
+        "peak_premium": (
+            round(peak / base, 3) if peak is not None and base > 0 else None
+        ),
+        "peak_hours": len(peak_values),
+        "hours": len(values),
+        "negative_hours": sum(1 for p in values if p < 0),
+        "min": round(min(values), 2),
+        "max": round(max(values), 2),
+        "evening_ramp": (lambda r: round(r, 2) if r is not None else None)(_ramp(hours)),
+        "weekend": weekday >= 5,
+    }
+
+
+def compute_products(db: Session, zone: str, days: int = 30) -> dict:
+    """Base/Peak/Off-peak per CET delivery day for one zone."""
+    if zone not in POWER_ZONES:
+        return {"available": False, "zone": zone, "reason": f"Unknown zone {zone}."}
+
+    # Read a day extra on each side: a CET delivery day straddles two UTC days.
+    start_ts = int((datetime.now(timezone.utc) - timedelta(days=days + 1)).timestamp())
+    points = read_hourly(db, PRICE_SERIES, zone, start_ts=start_ts)
+    if not points:
+        return {
+            "available": False, "zone": zone,
+            "reason": f"No hourly day-ahead prices for {POWER_ZONES[zone]['label']} yet.",
+        }
+
+    by_day: dict[str, dict[int, float]] = {}
+    weekday_of: dict[str, int] = {}
+    for ts, price in points:
+        day, hour, weekday = market_day(ts)
+        by_day.setdefault(day, {})[hour] = price
+        weekday_of[day] = weekday
+
+    rows = []
+    for day in sorted(by_day):
+        p = day_products(by_day[day], weekday_of[day])
+        if p:
+            rows.append({"date": day, **p})
+    # The first day is usually a partial one (we read an extra day of UTC hours
+    # to cover the CET boundary); a base built from four hours is not a base.
+    rows = [r for r in rows if r["hours"] >= 20][-days:]
+    if not rows:
+        return {
+            "available": False, "zone": zone,
+            "reason": "Not enough hourly prices to form a delivery day yet.",
+        }
+
+    latest = rows[-1]
+    return {
+        "available": True,
+        "zone": zone,
+        "zone_label": POWER_ZONES[zone]["label"],
+        "unit": "EUR/MWh",
+        "days": days,
+        "market_tz": "CET/CEST",
+        "peak_definition": f"{PEAK_START_HOUR:02d}:00–{PEAK_END_HOUR:02d}:00 CET, Mon–Fri",
+        "as_of": latest["date"],
+        "latest": latest,
+        "data": rows,
+        "note": (
+            "Base, Peak and Off-peak on the CET DELIVERY day — the clock the products "
+            "are defined in (EPEX/EEX Peak is 08:00–20:00 CET, Mon–Fri). The canonical "
+            "store stays UTC; only these products are re-bucketed. negative_hours here "
+            "counts the delivery day, which can differ from the UTC-day count in "
+            "PowerPriceDaily by the hours that straddle midnight."
+        ),
+    }

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1415,6 +1415,28 @@ async def get_flows_hourly(
     }
 
 
+# ─── Products: Base / Peak / Off-peak, in market time ─────────────────────────
+
+
+@router.get("/products")
+def get_products(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+):
+    """Base, Peak and Off-peak per CET delivery day — the products Europe actually
+    trades. The desk could show a daily mean (which is Base) and a raw 24h shape,
+    but not the peak price a trader reads first. Free tier, descriptive.
+
+    Computed on the CET delivery day, not the UTC calendar day: the products are
+    defined in CET (EPEX Peak = 08:00–20:00 CET, Mon–Fri). See
+    backend/power/products.py.
+    """
+    from backend.power.products import compute_products
+
+    return compute_products(db, _resolve_zone(zone), days=days)
+
+
 # ─── Drivers: why is this zone expensive today? ───────────────────────────────
 
 

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -1,0 +1,161 @@
+"""Base / Peak / Off-peak in market time.
+
+The tests are mostly about the CLOCK. The store is UTC; the products are CET. Get
+that wrong and every peak price on the desk is quietly built from the wrong hours
+— which is exactly what bucketing by UTC date does.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.power.hourly_store import upsert_hourly
+from backend.power.products import (
+    compute_products,
+    day_products,
+    is_peak_hour,
+    market_day,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db):
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _utc(s: str) -> int:
+    return int(datetime.fromisoformat(s).replace(tzinfo=timezone.utc).timestamp())
+
+
+# ─── the clock ────────────────────────────────────────────────────────────────
+
+
+def test_the_last_utc_hours_belong_to_the_next_delivery_day():
+    """THE bug that bucketing by UTC date hides: 22:00 UTC in summer is already
+    midnight in CET, i.e. the next delivery day."""
+    assert market_day(_utc("2026-07-15T21:00"))[0] == "2026-07-15"  # 23:00 CEST
+    assert market_day(_utc("2026-07-15T22:00"))[0] == "2026-07-16"  # 00:00 CEST
+    # winter: CET = UTC+1, so the boundary moves an hour
+    assert market_day(_utc("2026-01-15T22:00"))[0] == "2026-01-15"  # 23:00 CET
+    assert market_day(_utc("2026-01-15T23:00"))[0] == "2026-01-16"  # 00:00 CET
+
+
+def test_local_hour_is_market_time_not_utc():
+    day, hour, weekday = market_day(_utc("2026-07-15T06:00"))  # 08:00 CEST
+    assert (day, hour) == ("2026-07-15", 8)
+    assert weekday == 2  # a Wednesday
+    assert is_peak_hour(hour, weekday) is True
+
+
+def test_peak_is_weekdays_only():
+    assert is_peak_hour(12, 4) is True    # Friday noon
+    assert is_peak_hour(12, 5) is False   # Saturday noon — no peak product exists
+    assert is_peak_hour(7, 2) is False    # before 08:00
+    assert is_peak_hour(20, 2) is False   # 20:00 is exclusive
+
+
+# ─── the products ─────────────────────────────────────────────────────────────
+
+
+def test_base_peak_offpeak_split_a_weekday():
+    hours = {h: (100.0 if 8 <= h < 20 else 40.0) for h in range(24)}
+    p = day_products(hours, weekday=2)
+    assert p["peak"] == 100.0 and p["peak_hours"] == 12
+    assert p["off_peak"] == 40.0
+    assert p["base"] == pytest.approx((100 * 12 + 40 * 12) / 24)
+    assert p["peak_premium"] == pytest.approx(100.0 / 70.0, rel=1e-3)
+
+
+def test_a_weekend_has_no_peak_product_rather_than_a_zero():
+    hours = {h: 50.0 for h in range(24)}
+    p = day_products(hours, weekday=6)
+    assert p["weekend"] is True
+    assert p["peak"] is None and p["peak_premium"] is None, "the product does not exist"
+    assert p["off_peak"] == 50.0 and p["base"] == 50.0
+
+
+def test_peak_premium_is_undefined_through_a_zero_base():
+    """A ratio through zero is a number, not a meaning — a day whose base is 0
+    (or negative) gets no premium."""
+    hours = {h: (60.0 if 8 <= h < 20 else -60.0) for h in range(24)}
+    p = day_products(hours, weekday=1)
+    assert p["base"] == 0.0
+    assert p["peak_premium"] is None
+
+
+def test_evening_ramp_is_the_steepest_three_hour_rise():
+    hours = {h: 30.0 for h in range(24)}
+    hours[17], hours[18], hours[19], hours[20] = 40.0, 90.0, 150.0, 160.0
+    p = day_products(hours, weekday=1)
+    assert p["evening_ramp"] == pytest.approx(hours[20] - hours[17])
+
+
+def test_negative_hours_are_counted_on_the_delivery_day():
+    hours = {h: (-5.0 if h < 6 else 50.0) for h in range(24)}
+    p = day_products(hours, weekday=1)
+    assert p["negative_hours"] == 6
+
+
+# ─── DB-backed ────────────────────────────────────────────────────────────────
+
+
+def _seed_prices(db, zone="DE_LU", days=5, peak=120.0, off=40.0):
+    """Prices keyed by UTC hour, shaped so the PEAK sits in CET peak hours."""
+    now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    start = now - timedelta(days=days)
+    points = []
+    ts = int(start.timestamp())
+    for i in range(days * 24):
+        t = ts + i * 3600
+        _day, hour, weekday = market_day(t)
+        points.append((t, peak if is_peak_hour(hour, weekday) else off))
+    upsert_hourly(db, "price.dayahead", zone, points, unit="EUR/MWh")
+
+
+def test_compute_products_reads_peak_from_market_hours(db_session):
+    _seed_prices(db_session)
+    out = compute_products(db_session, "DE_LU", days=5)
+    assert out["available"] is True
+    assert out["market_tz"] == "CET/CEST"
+
+    weekdays = [r for r in out["data"] if not r["weekend"]]
+    assert weekdays, "the window must contain at least one weekday"
+    for r in weekdays:
+        assert r["peak"] == 120.0, "the peak product reads the CET peak hours"
+        assert r["off_peak"] == 40.0
+        assert r["peak_hours"] == 12
+
+
+def test_partial_days_are_dropped_not_averaged(db_session):
+    """We read an extra UTC day to cover the CET boundary; a 'base' built from
+    four hours is not a base."""
+    _seed_prices(db_session, days=3)
+    out = compute_products(db_session, "DE_LU", days=3)
+    assert all(r["hours"] >= 20 for r in out["data"])
+
+
+def test_unknown_and_empty_zones_are_honest(db_session):
+    assert compute_products(db_session, "ZZ")["available"] is False
+    out = compute_products(db_session, "FR")
+    assert out["available"] is False and "No hourly day-ahead prices" in out["reason"]
+
+
+def test_route(db_session):
+    _seed_prices(db_session)
+    body = _client(db_session).get("/api/power/products?zone=DE_LU&days=5").json()
+    assert body["available"] is True
+    assert "CET" in body["peak_definition"]
+    assert body["latest"]["base"] is not None

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,7 @@ import ImbalancePanel from './components/ImbalancePanel'
 import RecordsPanel from './components/RecordsPanel'
 import BordersPanel from './components/BordersPanel'
 import DriversPanel from './components/DriversPanel'
+import ProductsPanel from './components/ProductsPanel'
 import PowerOverviewMatrix from './components/PowerOverviewMatrix'
 import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
@@ -580,6 +581,11 @@ function Dashboard() {
               <SectionLabel>PRICES</SectionLabel>
               <ErrorBoundary name="power-dayahead">
                 <PowerDayAheadPanel zone={energyZone} />
+              </ErrorBoundary>
+              {/* Base / Peak: the products Europe actually trades. The daily mean
+                  IS base; the peak price was simply not on the desk before. */}
+              <ErrorBoundary name="power-products">
+                <ProductsPanel zone={energyZone} />
               </ErrorBoundary>
               <ErrorBoundary name="power-imbalance">
                 <ImbalancePanel zone={energyZone} />

--- a/frontend/src/components/ProductsPanel.jsx
+++ b/frontend/src/components/ProductsPanel.jsx
@@ -1,0 +1,146 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+import {
+  ResponsiveContainer, ComposedChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
+} from 'recharts'
+import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+/**
+ * Base / Peak / Off-peak on the CET delivery day — the products Europe trades.
+ *
+ * The premium is the number to read: below 1.0 means the PEAK product is cheaper
+ * than off-peak, which is what solar does to a summer market. The desk could not
+ * say that before — it only knew a daily mean.
+ */
+export default function ProductsPanel({ zone = 'DE_LU' }) {
+  const { data, loading, error } = useFetchWithError(
+    `${API}/power/products?zone=${zone}&days=30`, { deps: [zone], pollMs: POLL_SLOW_MS },
+  )
+
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">BASE / PEAK // FETCH ERROR</div>
+      </div>
+    )
+  }
+  if (!data?.available && !loading) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          BASE / PEAK — {data?.reason || 'no hourly prices yet.'}
+        </div>
+      </div>
+    )
+  }
+
+  const rows = data?.data ?? []
+  const latest = data?.latest
+  const chart = rows.map((r) => ({
+    date: r.date, base: r.base, peak: r.peak, off: r.off_peak,
+  }))
+
+  return (
+    <Panel
+      id="power-products"
+      title={`BASE / PEAK · ${data?.zone_label ?? zone}`}
+      info={data?.note || 'Base, Peak and Off-peak on the CET delivery day.'}
+      freshness={data}
+      collapsible
+      headerRight={
+        latest && (
+          <div className="flex items-center gap-3 font-mono text-[10px]">
+            <span className="text-neutral-500">Base <span className="text-neutral-200">€{latest.base.toFixed(0)}</span></span>
+            {latest.peak != null && (
+              <span className="text-neutral-500">Peak <span className="text-neutral-200">€{latest.peak.toFixed(0)}</span></span>
+            )}
+            {latest.peak_premium != null && (
+              <span className={latest.peak_premium < 1 ? 'text-amber-400' : 'text-neutral-400'}>
+                ×{latest.peak_premium.toFixed(2)}
+              </span>
+            )}
+          </div>
+        )
+      }
+    >
+      {loading && !data ? (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">Loading products…</div>
+      ) : (
+        <>
+          <div className="px-2 pt-3">
+            <ResponsiveContainer width="100%" height={170}>
+              <ComposedChart data={chart} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
+                <XAxis dataKey="date" tickFormatter={fmtDate} tick={{ fontSize: 8, fill: '#737373' }} minTickGap={50} />
+                <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={40} />
+                <ReferenceLine y={0} stroke="#444" />
+                <Tooltip
+                  contentStyle={CHART_TOOLTIP_STYLE}
+                  labelFormatter={fmtDate}
+                  formatter={(v, n) => [v == null ? '—' : `€${Number(v).toFixed(1)}`, n]}
+                />
+                <Line type="monotone" dataKey="base" name="base" stroke="#94a3b8" strokeWidth={1.4}
+                  dot={false} isAnimationActive={false} />
+                <Line type="monotone" dataKey="peak" name="peak" stroke="#fbbf24" strokeWidth={1.4}
+                  dot={false} connectNulls={false} isAnimationActive={false} />
+                <Line type="monotone" dataKey="off" name="off-peak" stroke="#22d3ee" strokeWidth={1}
+                  dot={false} isAnimationActive={false} />
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="px-2 py-2 overflow-x-auto">
+            <table className="w-full font-mono text-[11px]">
+              <thead>
+                <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                  <th className="text-left px-2 py-1">Delivery day</th>
+                  <th className="text-right px-2 py-1">Base</th>
+                  <th className="text-right px-2 py-1">Peak</th>
+                  <th className="text-right px-2 py-1">Off-peak</th>
+                  <th className="text-right px-2 py-1" title="Peak ÷ Base. Below 1.0 = the peak product is cheaper than off-peak.">Premium</th>
+                  <th className="text-right px-2 py-1" title="Steepest 3-hour rise of the day">Ramp</th>
+                  <th className="text-right px-2 py-1">Neg h</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.slice(-10).reverse().map((r) => (
+                  <tr key={r.date} className="border-t border-border/30">
+                    <td className="px-2 py-1.5 text-neutral-300">
+                      {r.date}
+                      {r.weekend && <span className="ml-1.5 text-[9px] text-neutral-700">WE</span>}
+                    </td>
+                    <td className="px-2 py-1.5 text-right text-neutral-200">€{r.base.toFixed(0)}</td>
+                    <td className="px-2 py-1.5 text-right text-amber-400">
+                      {r.peak != null ? `€${r.peak.toFixed(0)}` : '—'}
+                    </td>
+                    <td className="px-2 py-1.5 text-right text-cyan-glow">€{r.off_peak.toFixed(0)}</td>
+                    <td className={`px-2 py-1.5 text-right ${
+                      r.peak_premium == null ? 'text-neutral-700'
+                        : r.peak_premium < 1 ? 'text-amber-400' : 'text-neutral-400'
+                    }`}>
+                      {r.peak_premium != null ? `×${r.peak_premium.toFixed(2)}` : '—'}
+                    </td>
+                    <td className="px-2 py-1.5 text-right text-neutral-500">
+                      {r.evening_ramp != null ? `€${r.evening_ramp.toFixed(0)}` : '—'}
+                    </td>
+                    <td className={`px-2 py-1.5 text-right ${r.negative_hours > 0 ? 'text-orange-400' : 'text-neutral-700'}`}>
+                      {r.negative_hours || '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="px-4 pb-2 font-mono text-[9px] text-neutral-700 leading-relaxed">
+            {data.peak_definition}. Weekends have no peak product. A premium below ×1.00 means the
+            peak product cleared BELOW off-peak — what midday solar does to a summer market.
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
**Tier 1.3 des Produkt-Tiefe-Audits.** Europa handelt **Base und Peak**. Jedes Quote, jeder Hedge, jede Broker-Runde. Obsyd kannte nur „Tagesmittel" (das zufällig *Base* ist) und eine rohe 24h-Kurve — **der Peak-Preis, die Zahl, die ein Trader zuerst liest, stand gar nicht auf dem Desk**, und die Premium-Kennzahl auch nicht.

`GET /api/power/products` liefert Base, Peak, Off-Peak, Peak-Premium, die steilste 3h-Rampe und die Negativstunden **pro Liefertag**.

## Zwei Uhren — und sie zu vermischen ist der Fehler
Der canonical store ist UTC und bleibt UTC. Die **Produkte** sind CET: EPEX/EEX-Peak ist 08:00–20:00 CET, Mo–Fr, und ein kontinentaler Liefertag läuft Mitternacht bis Mitternacht CET. Die letzten zwei Stunden eines UTC-Tages gehören also zum **nächsten Liefertag** — nach UTC-Datum zu bucketen vermischt still zwei davon. An echten DE-LU-Preisen gemessen: **die Base verschiebt sich um bis zu 2,07 €/MWh** zwischen den beiden Definitionen.

Zonen mit anderer Zivilzeit (FI, GR, PT, IE) handeln trotzdem gegen CET-definierte Produkte — die CET-Definition gilt überall und wird **ausgesprochen**, nicht pro Zone geraten.

## Was es sofort zeigt (echte Juli-Daten, DE-LU)
**Peak 61–94 € gegen Off-Peak 111–155 € — ein Premium von ×0,44 bis ×0,76.** Das Peak-Produkt cleart **unter** Off-Peak, weil das 08:00–20:00-Fenster genau dort liegt, wo Mittags-Solar den Preis zerdrückt, während die teuren Abendstunden außerhalb fallen. Das konnte das Desk gestern nicht sagen.

## Verweigerungen, die einen Namen verdienen
- **Wochenende:** `peak = null`, nicht 0 — das Produkt *existiert* an dem Tag nicht.
- **Base ≤ 0:** kein Premium — ein Verhältnis durch Null ist eine Zahl, keine Bedeutung.
- **Teiltage** (wir lesen einen UTC-Tag extra, um die CET-Grenze abzudecken) werden verworfen — eine Base aus vier Stunden ist keine Base.
- `negative_hours` zählt hier den **Liefertag**; die Spalte in `PowerPriceDaily` zählt den UTC-Tag. Die beiden können um die Mitternachtsstunden differieren — **dokumentiert, nicht überklebt**.

ruff + 815 Tests grün (12 neue, überwiegend über die Uhr), ESLint sauber, Build grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)