### PR TITLE
Capture rate: what a MWh of each technology actually earned

### DIFF
--- a/backend/power/capture.py
+++ b/backend/power/capture.py
@@ -1,0 +1,261 @@
+"""Capture rate — what a solar MWh actually earned.
+
+The desk can say a zone had 180 negative-price hours. It cannot say what a solar
+MWh was WORTH, and that is the number the European power market argues about most:
+the capture price (the generation-weighted average price a technology achieved)
+and the capture RATE, or value factor, which is that price divided by the plain
+baseload price.
+
+    "DE-LU solar captured €31/MWh in June — 62% of baseload. Wind onshore: 88%."
+
+An asset owner, a PPA desk, anyone modelling a merit order asks this first. No
+free European tool publishes it per bidding zone, and Obsyd has held both legs at
+hourly resolution — price.dayahead × gen.<psr> — for months without ever
+multiplying them together.
+
+WHAT IT IS
+----------
+    capture_price(fuel, month) = Σ(price_h × gen_h) / Σ(gen_h)
+    baseload_price(month)      = mean(price_h) over ALL hours of the month
+    value_factor               = capture_price / baseload_price
+
+Both are realised, backward-looking averages of published auction prices. There is
+no model and no forecast: this is arithmetic on the record. The declining value
+factor of solar IS the cannibalisation story, told in the market's own numbers.
+
+THE DENOMINATOR IS THE WHOLE MONTH, AND THAT IS THE ENTIRE POINT
+----------------------------------------------------------------
+Solar's value factor is below 1.00 *because* it only produces in the hours it
+produces in — and those hours, thanks to solar itself, are the cheap ones. Divide
+by the mean price of solar's OWN hours and you have compared midday against midday:
+the factor snaps back toward 1.00 and the cannibalisation vanishes from the number
+that exists to show it. The baseload reference is the month's base product — every
+hour, the same denominator for every technology.
+
+The corollary is that an hour with no generation row is an hour with no output. For
+solar at 03:00 that is simply true, and it costs the average nothing (0 × price = 0).
+For a fuel whose FEED broke it would be a lie — so the sample guard counts DAYS, not
+hours: a technology must appear on MIN_DAYS distinct days of the month. Solar is
+absent every night and present every day; a broken feed is absent for whole days.
+That is the difference the guard is built to see.
+
+FURTHER CAVEATS THAT TRAVEL WITH THE NUMBER
+-------------------------------------------
+* A month whose price series is itself a fragment is reported as absent, not averaged
+  into a headline (MIN_PRICE_HOURS).
+* A month whose baseload is zero or negative gets no value factor: dividing through
+  zero produces a number, not a meaning.
+* These are day-ahead revenues only. Real assets also earn (or lose) in intraday,
+  balancing and their PPA — the capture price is the market's mark, not a P&L.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from backend.models.energy import PowerHourly, SeriesDim, ZoneDim
+from backend.power.entsoe_grid import PSR_LABELS
+from backend.power.zones import POWER_ZONES
+
+PRICE_SERIES = "price.dayahead"
+
+#: The technologies worth a capture rate. Solar and wind are the point (their
+#: value factor is the cannibalisation story); nuclear and gas are the contrast —
+#: dispatchable fleets capture ABOVE baseload because they run when it is dear.
+CAPTURE_FUELS = ["B16", "B18", "B19", "B14", "B04"]
+
+#: Below this many priced hours a month is a fragment, not a month.
+MIN_PRICE_HOURS = 24 * 20
+
+#: A technology must show up on this many distinct days of the month. Counting days
+#: rather than hours is what lets solar (absent every night, present every day) pass
+#: while a broken feed (absent for whole days) does not.
+MIN_DAYS = 20
+
+#: A monthly figure is legitimately weeks behind — on the 1st of a month the newest
+#: complete month just ended. Only a feed that failed to deliver a whole month is
+#: stale, so the window is wider than any daily panel's and deliberately so.
+STALE_AFTER_DAYS = 45
+
+
+def _day(ts: int) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+
+
+def _window_start(today: date, months: int) -> int:
+    """First instant of the calendar month `months` months before this one.
+
+    Capture is a monthly figure, so the window has to be cut on month boundaries. A
+    rolling `31 × months`-day window would start mid-month, and that first partial
+    month is then always a fragment: ask for 1 month and you get nothing at all.
+    """
+    total = today.year * 12 + (today.month - 1) - months
+    return int(
+        datetime(total // 12, total % 12 + 1, 1, tzinfo=timezone.utc).timestamp()
+    )
+
+
+def capture_metrics(prices: dict[int, float], generation: dict[int, float]) -> dict | None:
+    """Capture price and value factor for one fuel over one month. Pure.
+
+    ``prices`` is every priced hour of the month; ``generation`` only the hours the
+    technology produced in. An hour missing from ``generation`` is an hour of no
+    output — it moves neither sum. The baseload denominator is the mean over ALL of
+    ``prices``, which is what makes a value factor below 1.00 mean cannibalisation
+    rather than nothing at all.
+    """
+    if not prices:
+        return None
+    hours = sorted(h for h in generation if h in prices)
+    gen = [generation[h] for h in hours]
+    total_gen = sum(gen)
+    if total_gen <= 0:
+        return None  # a technology that produced nothing has no capture price
+
+    px = [prices[h] for h in hours]
+    capture = sum(p * g for p, g in zip(px, gen)) / total_gen
+    baseload = sum(prices.values()) / len(prices)
+    return {
+        "hours": len(hours),
+        "days": len({_day(h) for h in hours}),
+        "generation_gwh": round(total_gen / 1000.0, 1),  # hourly MW → MWh → GWh
+        "capture_price": round(capture, 2),
+        "baseload_price": round(baseload, 2),
+        # A ratio through zero is a number, not a meaning.
+        "value_factor": round(capture / baseload, 3) if baseload > 0 else None,
+        # The share of a technology's OWN output that landed in negative-price hours —
+        # the sharpest single line of the cannibalisation story.
+        "negative_gen_pct": round(
+            100.0 * sum(g for p, g in zip(px, gen) if p < 0) / total_gen, 1
+        ),
+    }
+
+
+def _series_by_month(
+    db: Session, zone: str, series_keys: list[str], start_ts: int
+) -> dict[str, dict[str, dict[int, float]]]:
+    """{series_key: {YYYY-MM: {ts: value}}} — one query for the price and every fuel.
+
+    Filtering on the integer ids rather than on ``series_dim.key`` is not a
+    micro-optimisation: ``power_hourly`` is WITHOUT ROWID on (series_id, zone_id,
+    ts_utc), so ids hit the clustered key and a join on the text key scans 28M rows.
+    """
+    sids = {
+        sid: key
+        for sid, key in db.query(SeriesDim.id, SeriesDim.key)
+        .filter(SeriesDim.key.in_(series_keys))
+        .all()
+    }
+    zid = db.query(ZoneDim.id).filter(ZoneDim.key == zone).scalar()
+    if not sids or zid is None:
+        return {}
+    rows = (
+        db.query(PowerHourly.series_id, PowerHourly.ts_utc, PowerHourly.value)
+        .filter(
+            PowerHourly.series_id.in_(sids),
+            PowerHourly.zone_id == zid,
+            PowerHourly.ts_utc >= start_ts,
+        )
+        .all()
+    )
+    out: dict[str, dict[str, dict[int, float]]] = {}
+    for sid, ts, value in rows:
+        month = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m")
+        out.setdefault(sids[sid], {}).setdefault(month, {})[int(ts)] = float(value)
+    return out
+
+
+def compute_capture(
+    db: Session, zone: str, months: int = 24, *, today: date | None = None
+) -> dict:
+    """Capture price and value factor per technology per month for one zone."""
+    if zone not in POWER_ZONES:
+        return {"available": False, "zone": zone, "reason": f"Unknown zone {zone}."}
+
+    today = today or datetime.now(timezone.utc).date()
+    keys = [PRICE_SERIES] + [f"gen.{f}" for f in CAPTURE_FUELS]
+    data = _series_by_month(db, zone, keys, _window_start(today, months))
+    label = POWER_ZONES[zone]["label"]
+
+    # Only COMPLETE months. The running month would be a month-to-date figure wearing
+    # a month's label — the reader would put a 12-day July next to a full June and read
+    # a trend that is really a calendar artefact. It appears once it has finished.
+    running = today.strftime("%Y-%m")
+    price_by_month = {
+        m: p
+        for m, p in data.get(PRICE_SERIES, {}).items()
+        if m < running and len(p) >= MIN_PRICE_HOURS
+    }
+    if not price_by_month:
+        return {
+            "available": False,
+            "zone": zone,
+            "reason": f"No complete month of hourly day-ahead prices for {label} yet.",
+        }
+
+    fuels = []
+    for fuel in CAPTURE_FUELS:
+        gen_by_month = data.get(f"gen.{fuel}", {})
+        rows = []
+        for month in sorted(gen_by_month):
+            prices = price_by_month.get(month)
+            if not prices:
+                continue
+            m = capture_metrics(prices, gen_by_month[month])
+            # Days, not hours: solar is absent every night and present every day.
+            if m is None or m["days"] < MIN_DAYS:
+                continue
+            rows.append({"month": month, **m})
+        if rows:
+            fuels.append(
+                {
+                    "psr": fuel,
+                    "label": PSR_LABELS.get(fuel, fuel),
+                    "latest": rows[-1],
+                    "data": rows,
+                }
+            )
+
+    if not fuels:
+        return {
+            "available": False,
+            "zone": zone,
+            "reason": (
+                f"No complete month of generation data for {label} yet — a capture price "
+                "needs a technology's output and the price in the same hours."
+            ),
+        }
+
+    # Worst value factor first: the cannibalised technology is the one being asked about.
+    fuels.sort(key=lambda f: f["latest"]["value_factor"] or 0)
+    latest_month = max(f["latest"]["month"] for f in fuels)
+    prices = price_by_month[latest_month]
+
+    # as_of is the newest hour the numbers were actually built from, per the
+    # convention every panel shares — not the month label, which is only a caption.
+    as_of = _day(max(prices))
+    age_days = (today - date.fromisoformat(as_of)).days
+    return {
+        "available": True,
+        "zone": zone,
+        "zone_label": label,
+        "unit": "EUR/MWh",
+        "months": months,
+        "min_days": MIN_DAYS,
+        "latest_month": latest_month,
+        "as_of": as_of,
+        "age_days": age_days,
+        "stale": age_days > STALE_AFTER_DAYS,
+        "baseload_price": round(sum(prices.values()) / len(prices), 2),
+        "fuels": fuels,
+        "note": (
+            "Capture price = the generation-weighted average day-ahead price a technology "
+            "actually achieved; value factor = capture price ÷ the month's baseload price "
+            "(the mean of ALL hours). Realised and backward-looking: arithmetic on published "
+            "auction results, not a model and not a forecast. Below 1.00 the technology "
+            "earned less than baseload — for solar and wind, that is cannibalisation. "
+            "Day-ahead only: real assets also earn in intraday, balancing and their PPA."
+        ),
+    }

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1437,6 +1437,24 @@ def get_products(
     return compute_products(db, _resolve_zone(zone), days=days)
 
 
+@router.get("/capture")
+def get_capture(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    months: int = Query(24, ge=1, le=120),
+    db: Session = Depends(get_db),
+):
+    """What a solar (or wind, or gas) MWh actually earned: the generation-weighted
+    capture price per fuel per month, and the value factor against baseload.
+
+    The metric the European power market argues about most, and which no free EU
+    tool publishes per bidding zone. Realised arithmetic on published auction
+    results — not a model. See backend/power/capture.py.
+    """
+    from backend.power.capture import compute_capture
+
+    return compute_capture(db, _resolve_zone(zone), months=months)
+
+
 # ─── Drivers: why is this zone expensive today? ───────────────────────────────
 
 

--- a/backend/tests/test_capture.py
+++ b/backend/tests/test_capture.py
@@ -1,0 +1,223 @@
+"""Capture rate: what a MWh of each technology actually earned.
+
+The arithmetic is trivial; the honesty is not. Every test here guards one of the
+three ways a capture rate quietly becomes a lie — the wrong denominator, too small
+a sample, a division through zero — and the first of those is the one that matters:
+divide solar by the mean of its OWN (midday) hours and the cannibalisation the
+number exists to show disappears from it.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.power.capture import (
+    MIN_DAYS,
+    STALE_AFTER_DAYS,
+    capture_metrics,
+    compute_capture,
+)
+from backend.power.hourly_store import upsert_hourly
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db):
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+_T0 = int(datetime(2026, 3, 2, tzinfo=timezone.utc).timestamp())  # a Monday, 00:00 UTC
+
+
+def _hours(day: int, values: dict[int, float]) -> dict[int, float]:
+    """{hour-of-day: value} → {unix ts: value} on day `day` of the window."""
+    return {_T0 + day * 86400 + h * 3600: v for h, v in values.items()}
+
+
+# ─── the denominator ──────────────────────────────────────────────────────────
+
+
+def test_solar_that_generates_only_in_cheap_hours_captures_below_baseload():
+    """The cannibalisation story in one day."""
+    prices = _hours(0, {h: (100.0 if h < 12 else 20.0) for h in range(24)})
+    solar = _hours(0, {h: (0.0 if h < 12 else 1_000.0) for h in range(24)})
+    m = capture_metrics(prices, solar)
+
+    assert m["capture_price"] == 20.0
+    assert m["baseload_price"] == 60.0
+    assert m["value_factor"] == pytest.approx(1 / 3, rel=1e-3)
+
+
+def test_hours_with_no_generation_row_do_not_move_the_denominator():
+    """THE bug real data caught. ENTSO-E writes no row for solar at 03:00 — there is
+    no output to report. If those hours were dropped from the baseload too, solar
+    would be measured against midday prices, the value factor would snap back to 1.00
+    and the cannibalisation would vanish from the very number built to show it.
+
+    The denominator is the month's BASE product: every hour, same for every fuel."""
+    prices = _hours(0, {h: (100.0 if h < 12 else 20.0) for h in range(24)})
+    solar_no_rows = _hours(0, {h: 1_000.0 for h in range(12, 24)})   # nights absent
+    solar_zero_rows = _hours(0, {h: (0.0 if h < 12 else 1_000.0) for h in range(24)})
+
+    absent = capture_metrics(prices, solar_no_rows)
+    zeroed = capture_metrics(prices, solar_zero_rows)
+
+    assert absent["baseload_price"] == 60.0, "the whole day, not just the sunlit half"
+    assert absent["capture_price"] == zeroed["capture_price"]
+    assert absent["value_factor"] == zeroed["value_factor"], (
+        "a missing row and an explicit zero are the same physical fact"
+    )
+    assert absent["hours"] == 12 and zeroed["hours"] == 24
+
+
+def test_a_dispatchable_fleet_captures_above_baseload():
+    prices = _hours(0, {h: (100.0 if h < 12 else 20.0) for h in range(24)})
+    gas = _hours(0, {h: (1_000.0 if h < 12 else 0.0) for h in range(24)})   # runs when dear
+    m = capture_metrics(prices, gas)
+    assert m["value_factor"] == pytest.approx(100.0 / 60.0, rel=1e-3)
+
+
+def test_no_value_factor_through_a_zero_baseload():
+    prices = _hours(0, {0: 50.0, 1: -50.0})
+    gen = _hours(0, {0: 100.0, 1: 100.0})
+    m = capture_metrics(prices, gen)
+    assert m["baseload_price"] == 0.0
+    assert m["value_factor"] is None, "a ratio through zero is a number, not a meaning"
+
+
+def test_negative_generation_share_is_the_technologys_own_output():
+    prices = _hours(0, {0: -5.0, 1: 50.0, 2: 50.0, 3: 50.0})
+    gen = _hours(0, {0: 300.0, 1: 100.0, 2: 100.0, 3: 100.0})
+    assert capture_metrics(prices, gen)["negative_gen_pct"] == 50.0  # 300 of 600 MWh
+
+
+def test_a_technology_that_produced_nothing_has_no_capture_price():
+    prices = _hours(0, {0: 50.0})
+    assert capture_metrics(prices, _hours(0, {0: 0.0})) is None
+    assert capture_metrics(prices, {}) is None
+    assert capture_metrics({}, _hours(0, {0: 100.0})) is None
+
+
+# ─── DB-backed ────────────────────────────────────────────────────────────────
+
+
+def _seed(db, zone="DE_LU", days=75, *, solar_days=None):
+    """Solar produces in the cheap half of the day and writes NO row at night — the
+    real ENTSO-E shape. Gas runs in the dear half. 75 days back guarantees at least
+    one COMPLETE calendar month; capture is a monthly figure.
+
+    `solar_days`: if set, solar only appears on that many days — a broken feed.
+    """
+    now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    start = now - timedelta(days=days)
+    price_pts, solar_pts, gas_pts = [], [], []
+    for i in range(days * 24):
+        t = int((start + timedelta(hours=i)).timestamp())
+        cheap = (i % 24) < 12
+        price_pts.append((t, 20.0 if cheap else 100.0))
+        if cheap and (solar_days is None or i // 24 < solar_days):
+            solar_pts.append((t, 1_000.0))          # nothing at all outside daylight
+        if not cheap:
+            gas_pts.append((t, 800.0))
+    upsert_hourly(db, "price.dayahead", zone, price_pts, unit="EUR/MWh")
+    upsert_hourly(db, "gen.B16", zone, solar_pts, unit="MW")
+    upsert_hourly(db, "gen.B04", zone, gas_pts, unit="MW")
+
+
+def test_solar_with_no_night_rows_still_reads_as_cannibalised(db_session):
+    """End to end, on the shape the store actually holds."""
+    _seed(db_session)
+    out = compute_capture(db_session, "DE_LU", months=3)
+    assert out["available"] is True
+
+    by_psr = {f["psr"]: f for f in out["fuels"]}
+    solar, gas = by_psr["B16"]["latest"], by_psr["B04"]["latest"]
+
+    assert solar["value_factor"] == pytest.approx(1 / 3, rel=0.05), "20 ÷ 60, not 20 ÷ 20"
+    assert gas["value_factor"] > 1.0
+    # Solar was priced at 20 in every hour it produced, yet is measured against 60:
+    # the night hours it never saw are in the denominator, where they belong.
+    assert solar["capture_price"] == 20.0
+    assert solar["baseload_price"] == gas["baseload_price"] == 60.0
+    assert solar["days"] >= MIN_DAYS, "present every day, absent every night"
+    assert out["fuels"][0]["psr"] == "B16", "the cannibalised technology leads the table"
+    assert out["min_days"] == MIN_DAYS
+    assert "not a model and not a forecast" in out["note"]
+
+
+def test_a_technology_absent_for_whole_days_is_dropped(db_session):
+    """The guard counts DAYS precisely so it can tell a night apart from an outage:
+    solar missing every night still passes; a feed missing for whole days does not."""
+    _seed(db_session, solar_days=5)
+    out = compute_capture(db_session, "DE_LU", months=3)
+    assert [f["psr"] for f in out["fuels"]] == ["B04"], "gas survives, the broken feed does not"
+
+
+def test_a_fragment_of_a_month_is_not_a_month(db_session):
+    """A capture rate quoted from two days is a headline waiting to be wrong."""
+    _seed(db_session, days=2)
+    out = compute_capture(db_session, "DE_LU", months=3)
+    assert out["available"] is False
+    assert "No complete month of hourly day-ahead prices" in out["reason"]
+
+
+def test_asking_for_one_month_returns_one_month(db_session):
+    """A rolling 31-day window starts mid-month, so its oldest month is always a
+    fragment — and `months=1` would return nothing at all. The window is cut on
+    calendar boundaries because the figure is a calendar figure."""
+    _seed(db_session)
+    out = compute_capture(db_session, "DE_LU", months=1)
+    assert out["available"] is True
+    assert out["fuels"][0]["latest"]["month"] == out["latest_month"]
+
+
+def test_the_running_month_is_not_reported_as_a_month(db_session):
+    """A month-to-date wearing a month's label invites the reader to compare a
+    12-day July against a full June and see a trend that is really the calendar."""
+    _seed(db_session)
+    running = datetime.now(timezone.utc).strftime("%Y-%m")
+    out = compute_capture(db_session, "DE_LU", months=6)
+
+    assert out["latest_month"] < running
+    assert all(r["month"] < running for f in out["fuels"] for r in f["data"])
+
+
+def test_freshness_is_the_newest_hour_used_not_the_month_label(db_session):
+    """The panel convention: as_of is a date, and it is the newest hour the numbers
+    were actually built from. A monthly figure is legitimately weeks behind — a month
+    only completes once — so it goes stale on a wider window than any daily panel."""
+    _seed(db_session)
+    out = compute_capture(db_session, "DE_LU", months=3)
+
+    assert date.fromisoformat(out["as_of"]), "an ISO date, not '2026-06'"
+    assert out["as_of"].startswith(out["latest_month"])
+    assert out["age_days"] >= 0 and out["stale"] is False
+
+    later = date.fromisoformat(out["as_of"]) + timedelta(days=STALE_AFTER_DAYS + 1)
+    assert compute_capture(db_session, "DE_LU", months=3, today=later)["stale"] is True
+
+
+def test_unknown_and_empty_zones_are_honest(db_session):
+    assert compute_capture(db_session, "ZZ")["available"] is False
+    out = compute_capture(db_session, "FR")
+    assert out["available"] is False and "No complete month" in out["reason"]
+
+
+def test_route(db_session):
+    _seed(db_session)
+    body = _client(db_session).get("/api/power/capture?zone=DE_LU&months=3").json()
+    assert body["available"] is True
+    assert body["baseload_price"] == 60.0
+    assert body["fuels"][0]["latest"]["capture_price"] is not None

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,6 +32,7 @@ import OutagePanel from './components/OutagePanel'
 import RecordChip from './components/RecordChip'
 import ImbalancePanel from './components/ImbalancePanel'
 import RecordsPanel from './components/RecordsPanel'
+import CapturePanel from './components/CapturePanel'
 import BordersPanel from './components/BordersPanel'
 import DriversPanel from './components/DriversPanel'
 import ProductsPanel from './components/ProductsPanel'
@@ -675,6 +676,11 @@ function Dashboard() {
             <div className="mt-3">
               <ErrorBoundary name="merit-order">
                 <MeritOrderScatter zone={energyZone} />
+              </ErrorBoundary>
+            </div>
+            <div className="mt-3">
+              <ErrorBoundary name="power-capture">
+                <CapturePanel zone={energyZone} />
               </ErrorBoundary>
             </div>
             <div className="mt-3">

--- a/frontend/src/components/CapturePanel.jsx
+++ b/frontend/src/components/CapturePanel.jsx
@@ -1,0 +1,187 @@
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+import {
+  ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine, Legend,
+} from 'recharts'
+import { CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+/** One colour per technology, held across the table and the chart. */
+const FUEL_COLOR = {
+  B16: '#fbbf24',  // solar
+  B19: '#22d3ee',  // wind onshore
+  B18: '#38bdf8',  // wind offshore
+  B14: '#a78bfa',  // nuclear
+  B04: '#f87171',  // fossil gas
+}
+
+/**
+ * Capture rate — what a MWh of each technology actually earned.
+ *
+ * The value factor is the whole point: below 1.00 the technology earned less than
+ * the plain baseload price, because it produces in the hours it made cheap. That is
+ * cannibalisation, in the market's own numbers, and no free European tool publishes
+ * it per bidding zone.
+ */
+export default function CapturePanel({ zone = 'DE_LU' }) {
+  const { data, loading, error } = useFetchWithError(
+    `${API}/power/capture?zone=${zone}&months=36`, { deps: [zone], pollMs: POLL_SLOW_MS },
+  )
+
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">CAPTURE RATE // FETCH ERROR</div>
+      </div>
+    )
+  }
+  if (!data?.available && !loading) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          CAPTURE RATE — {data?.reason || 'no complete month of prices and generation yet.'}
+        </div>
+      </div>
+    )
+  }
+
+  const fuels = data?.fuels ?? []
+
+  // One row per month, one column per technology: the value-factor history.
+  const months = [...new Set(fuels.flatMap((f) => f.data.map((r) => r.month)))].sort()
+  const chart = months.map((month) => {
+    const row = { month }
+    for (const f of fuels) {
+      const hit = f.data.find((r) => r.month === month)
+      if (hit) row[f.psr] = hit.value_factor
+    }
+    return row
+  })
+  const worst = fuels[0]?.latest
+
+  return (
+    <Panel
+      id="power-capture"
+      title={`CAPTURE RATE · ${data?.zone_label ?? zone}`}
+      info={data?.note || 'Generation-weighted price each technology achieved, vs. baseload.'}
+      freshness={data}
+      collapsible
+      headerRight={
+        worst && (
+          <div className="flex items-center gap-3 font-mono text-[10px]">
+            <span className="text-neutral-500">
+              Baseload <span className="text-neutral-200">€{data.baseload_price?.toFixed(0)}</span>
+            </span>
+            {worst.value_factor != null && (
+              <span className="text-neutral-500">
+                {fuels[0].label} <span className="text-amber-400">×{worst.value_factor.toFixed(2)}</span>
+              </span>
+            )}
+            <span className="text-neutral-600">{data.latest_month}</span>
+          </div>
+        )
+      }
+    >
+      {loading && !data ? (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">Loading capture rates…</div>
+      ) : (
+        <>
+          <div className="px-2 py-2 overflow-x-auto">
+            <table className="w-full font-mono text-[11px]">
+              <thead>
+                <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                  <th className="text-left px-2 py-1">Technology</th>
+                  <th className="text-right px-2 py-1" title="Generation-weighted average day-ahead price it achieved">Capture</th>
+                  <th className="text-right px-2 py-1" title="Capture price ÷ the month's baseload price. Below 1.00 = earned less than baseload.">Value factor</th>
+                  <th className="px-2 py-1"></th>
+                  <th className="text-right px-2 py-1" title="Share of this technology's own output that landed in negative-price hours">Neg. output</th>
+                  <th className="text-right px-2 py-1">Volume</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fuels.map((f) => {
+                  const L = f.latest
+                  const vf = L.value_factor
+                  const color = FUEL_COLOR[f.psr] || '#94a3b8'
+                  return (
+                    <tr key={f.psr} className="border-t border-border/30">
+                      <td className="px-2 py-1.5 text-neutral-300">
+                        <span className="inline-block w-1.5 h-1.5 rounded-full mr-2" style={{ background: color }} />
+                        {f.label}
+                      </td>
+                      <td className="px-2 py-1.5 text-right text-neutral-200">€{L.capture_price.toFixed(1)}</td>
+                      <td className={`px-2 py-1.5 text-right ${
+                        vf == null ? 'text-neutral-700' : vf < 1 ? 'text-amber-400' : 'text-cyan-glow'
+                      }`}>
+                        {vf != null ? `×${vf.toFixed(2)}` : '—'}
+                      </td>
+                      {/* The bar reads against 1.00: left of the line = earned below baseload. */}
+                      <td className="px-2 py-1.5 w-32">
+                        {vf != null && (
+                          <div className="relative h-1.5 bg-neutral-900 rounded-sm">
+                            <div className="absolute inset-y-0 left-1/2 w-px bg-neutral-600" />
+                            <div
+                              className="absolute inset-y-0 rounded-sm"
+                              style={{
+                                background: color,
+                                opacity: 0.7,
+                                ...(vf < 1
+                                  ? { right: '50%', width: `${Math.min(50, (1 - vf) * 50)}%` }
+                                  : { left: '50%', width: `${Math.min(50, (vf - 1) * 50)}%` }),
+                              }}
+                            />
+                          </div>
+                        )}
+                      </td>
+                      <td className={`px-2 py-1.5 text-right ${L.negative_gen_pct > 0 ? 'text-orange-400' : 'text-neutral-700'}`}>
+                        {L.negative_gen_pct > 0 ? `${L.negative_gen_pct.toFixed(1)}%` : '—'}
+                      </td>
+                      <td className="px-2 py-1.5 text-right text-neutral-500">{L.generation_gwh.toFixed(0)} GWh</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {chart.length > 1 && (
+            <div className="px-2 pb-2">
+              <div className="px-2 pb-1 font-mono text-[9px] text-neutral-600 uppercase tracking-wider">
+                Value factor by month
+              </div>
+              <ResponsiveContainer width="100%" height={170}>
+                <LineChart data={chart} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
+                  <XAxis dataKey="month" tick={{ fontSize: 8, fill: '#737373' }} minTickGap={40} />
+                  <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={34}
+                    tickFormatter={(v) => `×${v.toFixed(1)}`} />
+                  {/* Baseload itself. Everything below this line earned less than the base product. */}
+                  <ReferenceLine y={1} stroke="#525252" strokeDasharray="4 4" />
+                  <Tooltip
+                    contentStyle={CHART_TOOLTIP_STYLE}
+                    formatter={(v, n) => [v == null ? '—' : `×${Number(v).toFixed(2)}`, n]}
+                  />
+                  <Legend wrapperStyle={{ fontSize: 9, color: '#737373' }} iconSize={6} />
+                  {fuels.map((f) => (
+                    <Line key={f.psr} type="monotone" dataKey={f.psr} name={f.label}
+                      stroke={FUEL_COLOR[f.psr] || '#94a3b8'} strokeWidth={1.4}
+                      dot={false} connectNulls isAnimationActive={false} />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          <div className="px-4 pb-2 font-mono text-[9px] text-neutral-700 leading-relaxed">
+            Realised day-ahead revenue per MWh, not a forecast. A factor below ×1.00 means the
+            technology earned less than the month&apos;s baseload price — it produces in the hours it
+            made cheap. Day-ahead only: assets also earn in intraday, balancing and their PPA.
+            Months where a technology is absent for whole days are dropped (≥{data.min_days} days required).
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
## What

The desk could say a zone had 180 negative-price hours. It could not say what a solar MWh was **worth** — the most-argued-about derived number in the European power market, and one no free EU tool publishes per bidding zone. Both legs have sat in `power_hourly` for months (`price.dayahead` × `gen.<psr>`) without ever being multiplied together.

```
capture_price(fuel, month) = Σ(price_h × gen_h) / Σ(gen_h)
value_factor               = capture_price ÷ the month's baseload price
```

Realised arithmetic on published auction results — no model, no forecast (Posture B). Real NL data, June 2026, baseload €104.68:

| Technology | Capture | Value factor | Neg. output |
|---|---:|---:|---:|
| Solar | €71.76 | **×0.69** | 8.7 % |
| Wind onshore | €81.13 | ×0.78 | 10.2 % |
| Wind offshore | €91.53 | ×0.87 | 6.9 % |
| Nuclear | €100.26 | ×0.96 | 7.8 % |
| Fossil gas | €134.34 | ×1.28 | 2.8 % |

Textbook merit order, straight out of our own store. The declining value factor of solar *is* the cannibalisation story, told in the market's own numbers.

## Three things real data forced

Each has a test named after the failure it prevents.

1. **The denominator is the whole month, not the fuel's own hours.** ENTSO-E writes no row for solar at 03:00, so "the mean price of its own hours" is the mean price of *midday*. Measure solar against that and the value factor snaps back toward 1.00 — deleting the cannibalisation from the very number built to show it. My first draft did exactly this, and real data caught it: NL solar didn't even appear.
2. **A missing generation row is an hour of no output** (it moves neither sum). For a fuel whose *feed* broke, that would be a lie — so the sample guard counts **days, not hours**: solar is absent every night and present every day; a broken feed is absent for whole days. That is the difference the guard is built to see.
3. **Calendar-cut window, running month excluded.** A rolling 31×n-day window makes its oldest month a fragment — `months=1` returned nothing at all. And a month-to-date wearing a month's label invites the reader to put a 12-day July next to a full June and read a trend that is really the calendar.

No value factor through a zero or negative baseload: a ratio through zero is a number, not a meaning.

## Surface

`GET /api/power/capture?zone=&months=` — id-first query against the WITHOUT ROWID clustered key (a `series_dim.key` filter would scan 28M rows). Carries the standard `as_of`/`age_days`/`stale` triple; a monthly figure is legitimately weeks behind, so it goes stale on a wider window (45 d) than any daily panel, deliberately.

`CapturePanel` in the ANALYTICS tab: table ranked worst-factor-first, bar reading against ×1.00 (left of the line = earned below baseload), plus the value-factor curve by month — the cannibalisation trend itself.

## Verification

- `ruff` clean; **829 passed**, 1 skipped; eslint clean on the new file; vite build green.
- Driven end-to-end against a local server: real NL/FR data (table above), `months=1/3/36`, unknown zone, empty zone, `months=0/999/abc` → 422, and the running month confirmed excluded. 5–13 ms per zone.
- Local dev DB holds only one month, so the multi-month curve can only be seen on prod — verified there after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)