### PR TITLE
Capture rate: cover hydro, which IS the Nordic and Alpine fleet

### DIFF
--- a/backend/power/capture.py
+++ b/backend/power/capture.py
@@ -61,10 +61,18 @@ from backend.power.zones import POWER_ZONES
 
 PRICE_SERIES = "price.dayahead"
 
-#: The technologies worth a capture rate. Solar and wind are the point (their
-#: value factor is the cannibalisation story); nuclear and gas are the contrast —
-#: dispatchable fleets capture ABOVE baseload because they run when it is dear.
-CAPTURE_FUELS = ["B16", "B18", "B19", "B14", "B04"]
+#: The technologies worth a capture rate. Solar and wind are the point (their value
+#: factor is the cannibalisation story); nuclear and gas are the contrast — dispatchable
+#: fleets capture ABOVE baseload because they run when it is dear. Hydro is BOTH, and
+#: that is why it is here: reservoir (B12) is the most dispatchable plant in Europe and
+#: should out-earn baseload, while run-of-river (B11) must run whatever the price does.
+#: Leaving hydro out would also leave the Nordic and Alpine zones with a table showing
+#: nothing but a peaking gas plant, when hydro IS their fleet.
+#:
+#: Pumped storage (B10) is deliberately absent: it is a consumer as much as a producer,
+#: and a capture price on its generation leg alone would be a half-truth about an asset
+#: whose entire economics is the round trip.
+CAPTURE_FUELS = ["B16", "B18", "B19", "B11", "B12", "B14", "B04"]
 
 #: Below this many priced hours a month is a fragment, not a month.
 MIN_PRICE_HOURS = 24 * 20

--- a/backend/tests/test_capture.py
+++ b/backend/tests/test_capture.py
@@ -157,6 +157,35 @@ def test_solar_with_no_night_rows_still_reads_as_cannibalised(db_session):
     assert "not a model and not a forecast" in out["note"]
 
 
+def test_hydro_is_covered_because_hydro_is_the_nordic_fleet(db_session):
+    """Without hydro, NO5 — a hydro zone — showed one stale line for a peaking gas
+    plant while reservoir and run-of-river sat fully covered in the store. Reservoir
+    is the most dispatchable plant in Europe and should out-earn baseload; run-of-river
+    must run whatever the price does. Pumped storage stays out: it consumes as much as
+    it produces, and a capture price on its generation leg alone is a half-truth."""
+    from backend.power.capture import CAPTURE_FUELS
+
+    assert {"B11", "B12"} <= set(CAPTURE_FUELS)
+    assert "B10" not in CAPTURE_FUELS, "pumped storage is a round trip, not a fuel"
+
+    now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    start = now - timedelta(days=75)
+    prices, reservoir, ror = [], [], []
+    for i in range(75 * 24):
+        t = int((start + timedelta(hours=i)).timestamp())
+        cheap = (i % 24) < 12
+        prices.append((t, 20.0 if cheap else 100.0))
+        reservoir.append((t, 50.0 if cheap else 900.0))   # dispatched into the peak
+        ror.append((t, 400.0))                            # runs regardless
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", prices, unit="EUR/MWh")
+    upsert_hourly(db_session, "gen.B12", "DE_LU", reservoir, unit="MW")
+    upsert_hourly(db_session, "gen.B11", "DE_LU", ror, unit="MW")
+
+    by_psr = {f["psr"]: f["latest"] for f in compute_capture(db_session, "DE_LU", months=3)["fuels"]}
+    assert by_psr["B12"]["value_factor"] > 1.0, "reservoir hydro chooses its hours"
+    assert by_psr["B11"]["value_factor"] == pytest.approx(1.0, rel=1e-3), "run-of-river takes what it gets"
+
+
 def test_a_technology_absent_for_whole_days_is_dropped(db_session):
     """The guard counts DAYS precisely so it can tell a night apart from an outage:
     solar missing every night still passes; a feed missing for whole days does not."""

--- a/frontend/src/components/CapturePanel.jsx
+++ b/frontend/src/components/CapturePanel.jsx
@@ -13,6 +13,8 @@ const FUEL_COLOR = {
   B16: '#fbbf24',  // solar
   B19: '#22d3ee',  // wind onshore
   B18: '#38bdf8',  // wind offshore
+  B11: '#2dd4bf',  // hydro run-of-river
+  B12: '#4ade80',  // hydro reservoir
   B14: '#a78bfa',  // nuclear
   B04: '#f87171',  // fossil gas
 }


### PR DESCRIPTION
Follow-on to #87, found by sweeping all 37 zones on prod.

**NO5 showed one line: a peaking gas plant, stale since May 2025.** Meanwhile `gen.B12` (reservoir) and `gen.B11` (run-of-river) sat in the store with full hourly coverage — 1438 hours in the last 60 days. The zone's actual fleet was right there and the table ignored it. Same story for NO1, NO3, AT, CH.

Hydro belongs in a capture table for exactly the reason it is interesting: it is **both ends of the story at once**.

- **Reservoir (B12)** is the most dispatchable plant in Europe — it should out-earn baseload, the mirror image of solar.
- **Run-of-river (B11)** must run whatever the price does — it takes what it gets, landing near ×1.00.

Both pinned by a test.

**Pumped storage (B10) stays out on purpose:** it consumes as much as it produces, and a capture price on its generation leg alone would be a half-truth about an asset whose entire economics is the round trip.

`ruff` clean, 830 passed, eslint clean, vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)