### PR TITLE
"Normal" was 120 days, and in March that mostly meant "it is March"

### DIFF
--- a/backend/power/baseline.py
+++ b/backend/power/baseline.py
@@ -1,0 +1,63 @@
+"""How long is "normal"? — the one window every "vs its own norm" on the desk uses.
+
+The desk's most-repeated claim is a comparison: "€142/MWh, +2.4σ vs its norm",
+"wind 2.8σ below normal", ELEVATED instead of CALM. Every one of those sentences is
+a z-score against a trailing window, and the length of that window decides what the
+word "normal" means. It had never been measured. It was 120 days.
+
+WHAT 120 DAYS ACTUALLY SAID
+---------------------------
+A 120-day window ending in March is built from November, December, January and
+February. Comparing a March day against it does not measure whether the day is
+unusual — it measures that it is March. Backtested over 8 zones × 2 years, the
+mean z-score by calendar month (which should be ~0 in every month, since an average
+March day is not an anomaly):
+
+                          Jan    Apr    Jul    Oct    swing
+    solar     120d      -0.49  +1.43  +0.44  -1.32     3.30   ← the season, not the sun
+    load      120d      +1.01  -1.21  -0.01  +0.78     2.51
+    price     120d      +0.68  -0.68  +0.37  +0.16     1.36
+    residual  120d      +0.69  -0.74  +0.27  +0.17     1.48
+
+An average March day was being reported as +2.0σ of solar. The desk was calling the
+seasons and labelling them anomalies. In the headline state this showed up as: on a
+November day the desk was non-CALM 25% of the time, on a February day 4% — a 21-point
+swing driven by nothing but the calendar.
+
+At 30 days every one of those biases roughly halves (solar 3.30 → 1.53, load 2.51 →
+1.37, residual 1.48 → 0.87, wind 1.06 → 0.65, price 1.36 → 0.92; state swing 21 → 12
+points) while the share of days flagged barely moves. A short window tracks the season
+instead of straddling it, and — the reason a seasonal baseline is NOT the answer here —
+it also tracks the FLEET.
+
+WHY NOT COMPARE AGAINST THE SAME WEEK IN PRIOR YEARS
+----------------------------------------------------
+That is the obvious fix and it is worse, because Europe keeps building. Measured the
+same way, a same-calendar-window-in-prior-years baseline puts solar at a mean of
++1.26σ and calls 31% of ALL days more than 2σ above normal — it is not reading the
+weather, it is reading Germany's installed capacity. Residual load inherits the same
+trend with the opposite sign (mean −0.43σ). Rescaling prior years to this year's level
+was tried and is unstable (it moved Spanish solar from +0.2σ to −3.1σ).
+
+A trailing window has neither problem: 30 days ago the fleet was the same size.
+
+(Reservoir hydro is the exception that proves the rule — it is SO seasonal that a
+trailing window is useless, and its own module compares against the same ISO week in
+prior years. It can, because hydro capacity does not change. See entsoe_hydro.py::
+same_week_band.)
+
+The residue is honest and disclosed: solar still carries ~1.5σ of seasonal swing at 30
+days, because within a month the spring sun really does climb. Every response ships
+`baseline_days` so the window is never implicit.
+"""
+
+from __future__ import annotations
+
+#: The trailing window every "vs its own norm" on the power desk measures against —
+#: the situation hero, the driver card, the overview matrix. ONE window: two different
+#: definitions of "normal" on the same screen is how a desk loses an analyst's trust.
+#:
+#: 30 days, chosen by the backtest above: it halves the seasonal bias of the 120-day
+#: window it replaces, keeps the flag rate stable, and never falls below MIN_BASELINE_N
+#: (every zone has 31-32 days of price and grid history in any 30-day window).
+BASELINE_DAYS = 30

--- a/backend/power/drivers.py
+++ b/backend/power/drivers.py
@@ -35,13 +35,9 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
 
 from backend.models.energy import PowerFlow, PowerGrid, PowerPriceDaily
+from backend.power.baseline import BASELINE_DAYS
 from backend.power.zones import POWER_ZONES
 from backend.signals.detectors.base import trailing_zscore
-
-#: Trailing window each driver's "vs its own norm" is measured against. Matches
-#: the situation hero (routes/power.py::SITUATION_BASELINE_DAYS) on purpose — two
-#: different windows on the same screen is how a desk loses an analyst's trust.
-BASELINE_DAYS = 120
 
 #: A day is an ANALOG of today when its residual load sits within this band. Not
 #: a model — a filter on the record.

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -45,6 +45,7 @@ from backend.models.energy import (
     PowerLoadForecast,
     PowerPriceDaily,
 )
+from backend.power.baseline import BASELINE_DAYS
 from backend.power.coverage import renewable_share_reliable
 from backend.power.energy_charts_flows import ATTRIBUTION
 from backend.power.entsoe_grid import PSR_LABELS
@@ -57,11 +58,14 @@ from backend.signals.detectors.base import severity_from_zscore, trailing_zscore
 SITUATION_STALE_DAYS = 1
 
 #: Trailing window the hero's and the overview's z-scores are measured against.
+#: One definition of "normal" for the whole desk — see backend/power/baseline.py for
+#: what the window length actually does to the claims (it was 120 days, and a 120-day
+#: window in March was mostly reporting that it is March).
 #: Shipped in every situation/overview response as `baseline_days` — the UI
 #: MUST render that number rather than restate it, because restating it is
 #: exactly how the product ended up telling users "~90-day norm" while the code
 #: had been computing 120 (caught 2026-07-12).
-SITUATION_BASELINE_DAYS = 120
+SITUATION_BASELINE_DAYS = BASELINE_DAYS
 
 router = APIRouter(prefix="/api/power", tags=["power"])
 

--- a/backend/tests/test_baseline.py
+++ b/backend/tests/test_baseline.py
@@ -1,0 +1,101 @@
+"""What does "normal" mean on this desk?
+
+Every "+2.4σ vs its norm" on the site is a z-score against ONE trailing window, and the
+length of that window decides what the word means. It was 120 days, which in March is
+built from November through February — so an average March day was reported as +2.0σ of
+solar. The desk was calling the seasons and labelling them anomalies.
+
+These tests pin the PROPERTY that fixes it (a window must not mistake the calendar for
+an event), not the number that currently encodes it.
+
+WHY THE SERIES BELOW HAS WEATHER IN IT
+--------------------------------------
+The first version of this test used a clean sine wave — a season and nothing else — and
+it said a SHORTER window was worse. That is true, and it is a trap: with no noise, the
+only variation inside a window IS the seasonal drift, so it lands in the denominator,
+and shrinking the window shrinks numerator and denominator together. Real power series
+are a season with a large day-to-day weather term on top, and that term is what fills
+the denominator. Only then does a shorter window help — which is exactly what the
+backtest on 8 real zones showed (solar: 12.4% of ordinary days flagged >2σ at 120 days,
+9.1% at 30). A test whose model of the world omits the weather will confidently defend
+the bug.
+"""
+from __future__ import annotations
+
+import math
+import random
+import statistics
+
+from backend.power.baseline import BASELINE_DAYS
+from backend.signals.detectors.base import MIN_BASELINE_N, trailing_zscore
+
+OLD_WINDOW = 120
+
+
+def _season_plus_weather(days: int, *, seed: int = 7) -> list[float]:
+    """A quantity with a strong season AND real day-to-day weather — and NO anomaly.
+
+    Solar output, near enough: an annual swing of ±100 around 200, with ±40 of weather
+    on any given day. Nothing in this series is an event, so an honest baseline should
+    almost never call one.
+    """
+    rng = random.Random(seed)
+    return [
+        200 + 100 * math.sin(2 * math.pi * d / 365.0) + rng.gauss(0, 40)
+        for d in range(days)
+    ]
+
+
+def _z(series: list[float], day: int, window: int) -> float | None:
+    stat = trailing_zscore(series[day], series[day - window : day])
+    return None if stat is None else stat[0]
+
+
+def _false_alarms(series: list[float], window: int) -> tuple[float, float]:
+    """(mean |z|, share of days beyond 2σ) over a year of ordinary days."""
+    zs = [abs(z) for d in range(365, len(series)) if (z := _z(series, d, window)) is not None]
+    return statistics.fmean(zs), sum(1 for z in zs if z > 2) / len(zs)
+
+
+def test_the_old_window_called_ordinary_days_anomalies():
+    """The defect, reproduced: on a year in which nothing whatsoever happens, the
+    120-day window flags more than a tenth of all days as 2σ events."""
+    _mean, rate = _false_alarms(_season_plus_weather(1200), OLD_WINDOW)
+    assert rate > 0.10, "if this stops holding, the old window was not the problem"
+
+
+def test_the_desks_window_calls_them_ordinary():
+    """The same year, the same non-events, measured against the window in production."""
+    series = _season_plus_weather(1200)
+    new_mean, new_rate = _false_alarms(series, BASELINE_DAYS)
+    old_mean, old_rate = _false_alarms(series, OLD_WINDOW)
+
+    assert new_rate < old_rate * 0.75, "the false-alarm rate must fall materially"
+    assert new_mean < old_mean * 0.85, "and the whole distribution with it, not just the tail"
+
+
+def test_a_real_anomaly_still_reads_as_one():
+    """The goal is not a quiet desk, it is a right one. A day that genuinely breaks the
+    pattern must still be flagged — a window can always be made silent by making it
+    useless."""
+    series = _season_plus_weather(1200)
+    day = 900
+    series[day] = 20.0  # the sun goes out
+
+    z = _z(series, day, BASELINE_DAYS)
+    assert z is not None and z < -2.0, "a short window must not be a blind window"
+
+
+def test_the_window_never_starves_the_baseline():
+    """Shortening the window shortens the sample. It must still clear the minimum the
+    z-score refuses to work below — on prod every zone has 31-32 days of price and grid
+    history inside any 30-day window, so there is room, but not a lot of it."""
+    assert BASELINE_DAYS > MIN_BASELINE_N
+
+
+def test_one_window_for_the_whole_desk():
+    """Two definitions of "normal" on one screen is how a desk loses an analyst."""
+    from backend.power.drivers import BASELINE_DAYS as drivers_window
+    from backend.routes.power import SITUATION_BASELINE_DAYS as hero_window
+
+    assert drivers_window == hero_window == BASELINE_DAYS


### PR DESCRIPTION
## The defect

Every **"+2.4σ vs its norm"** on the desk — the situation hero, the driver card, the overview matrix — is a z-score against one trailing window. That window was **120 days**, and it had never been measured.

A 120-day window ending in March is built from November, December, January and February. Comparing a March day against it does not measure whether the day is unusual. It measures that it is March.

Backtested on **8 real zones × 2 years**, mean z by calendar month. An average March day is not an anomaly, so every cell should be ~0:

| series | window | Jan | Apr | Jul | Oct | **swing** |
|---|---|---:|---:|---:|---:|---:|
| solar | 120d | −0.49 | **+1.43** | +0.44 | −1.32 | **3.30** |
| load | 120d | **+1.01** | −1.21 | −0.01 | +0.78 | **2.51** |
| residual | 120d | +0.69 | −0.74 | +0.27 | +0.17 | 1.48 |
| price | 120d | +0.68 | −0.68 | +0.37 | +0.16 | 1.36 |

**An average March day was being reported as +2.0σ of solar.** The desk was calling the seasons and labelling them anomalies. In the headline state it surfaced as: non-CALM on **25 % of November days and 4 % of February days** — a 21-point swing driven by nothing but the calendar.

## The fix: 30 days

Every bias roughly halves — solar 3.30 → **1.53**, load 2.51 → **1.37**, residual 1.48 → **0.87**, wind 1.06 → **0.65**, price 1.36 → **0.92**; the state's seasonal swing 21 → **12** points — while the share of days flagged barely moves (non-CALM 11.9 % → 13.5 %). No zone falls under `MIN_BASELINE_N`: every zone has 31–32 days of price and grid history inside any 30-day window (checked on prod).

## Why not the same week in prior years, which is the obvious fix

**Because Europe keeps building.** Measured identically, a prior-years seasonal baseline puts solar at a mean of **+1.26σ** and calls **31 % of all days** more than 2σ above normal — it is not reading the weather, it is reading Germany's installed capacity. Residual load inherits the same trend with the opposite sign (−0.43σ). Rescaling prior years to this year's level was tried and is unstable: it moved Spanish solar from +0.2σ to **−3.1σ**.

A trailing window has neither problem — 30 days ago the fleet was the same size.

*Reservoir hydro is the exception that proves the rule: so seasonal that a trailing window is useless, and its capacity doesn't change, which is exactly why `entsoe_hydro.py::same_week_band` can compare against the same ISO week in prior years and this cannot.*

## Housekeeping

The two window constants were **documented as deliberately equal and separately defined**. They now come from one module (`backend/power/baseline.py`) which carries the measurement, and a test fails if they ever diverge.

## The test earned its own lesson

Built on a clean sine wave, the synthetic test **"proved" a shorter window was worse** — because with no noise, the seasonal drift *is* the standard deviation, so shrinking the window shrinks numerator and denominator together. Real series carry a large day-to-day weather term, and that is what fills the denominator. A test whose model of the world omits the weather will confidently defend the bug. It now has weather in it, and reproduces the real-data result (12.9 % of ordinary days flagged at 120d → 8.3 % at 30d).

`ruff` clean · **835 passed** · the residue is disclosed: solar still carries ~1.5σ of seasonal swing at 30 days, because within a month the spring sun really does climb. Every response ships `baseline_days`, and the UI renders it rather than restating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)