### PR TITLE
Start recording what is offline, because ENTSO-E does not

### DIFF
--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -87,6 +87,12 @@ SPECS += [
     # the daily grain keeps its own power_flows spec above.
     FreshnessSpec("flows_hourly", PowerPriceDaily, "", timedelta(days=3),
                   hourly_series="flow.FR"),
+    # The outage snapshot is the ONE series that cannot be backfilled: A77 takes an
+    # unavailability down once it is over, so an hour the recorder missed is gone for
+    # good. It must therefore be the tightest window on the desk — a day of silence is
+    # a day of history destroyed, not a late delivery to catch up on.
+    FreshnessSpec("outage_snapshot", PowerPriceDaily, "", timedelta(days=1),
+                  hourly_series="outage.offline"),
 ]
 
 # Per-enabled-zone day-ahead + grid freshness (was DE_LU-hardcoded — every enabled

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -310,6 +310,26 @@ async def _run_outages():
         db.close()
 
 
+async def _run_outage_snapshot():
+    """Write down how much capacity is offline RIGHT NOW, every hour.
+
+    A77 is a notice board, not an archive — an unavailability comes down once it is
+    over, so there is no history of what was offline last month and none can be
+    recovered. Every hour nobody records is destroyed. Cheap: a local aggregation over
+    already-ingested events, no network. See backend/power/outage_history.py.
+    """
+    from backend.power.outage_history import snapshot_outages
+
+    db = SessionLocal()
+    try:
+        result = snapshot_outages(db)
+        logger.info("outage snapshot: %s", result)
+    except Exception as exc:
+        logger.error("_run_outage_snapshot failed: %s", exc)
+    finally:
+        db.close()
+
+
 async def _run_hydro_weekly():
     """Refresh weekly reservoir filling (ENTSO-E A72) for the hydro zones.
     Current year with overwrite=True — the raw cache is write-once and would
@@ -358,6 +378,10 @@ def start_scheduler():
     # Generation unavailability (A77): rolling window, every 6 h — forced outages
     # land intraday and are the desk's reason to exist.
     scheduler.add_job(_run_outages, CronTrigger(hour="1,7,13,19", minute=15), id="outages_6h", **JOB_DEFAULTS)
+    # Snapshot what is offline, HOURLY. ENTSO-E takes an unavailability down once it is
+    # over, so the only history that will ever exist is the one we write ourselves —
+    # at :45, after the 6h ingest has landed. Local read + upsert, no network.
+    scheduler.add_job(_run_outage_snapshot, CronTrigger(minute=45), id="outage_snapshot_hourly", **JOB_DEFAULTS)
     # All-time records: nightly at 23:45, after the 22:30 power ingest.
     scheduler.add_job(_run_records_nightly, CronTrigger(hour=23, minute=45), id="records_nightly", **JOB_DEFAULTS)
 

--- a/backend/power/outage_history.py
+++ b/backend/power/outage_history.py
@@ -1,0 +1,107 @@
+"""Write down what is offline right now, because ENTSO-E will not remember it.
+
+THE FINDING THAT MADE THIS NECESSARY
+------------------------------------
+The desk wanted to give forced outages a z-score ("6.7 GW offline, 2.1σ above normal")
+and to compute a capacity margin. Both need a HISTORY of how much capacity was offline.
+There isn't one, and it cannot be recovered. Counting the currently-published events by
+the month they were running in, on prod:
+
+    running in 2026-07 (now)   1013 events across 19 zones
+    running in 2026-06          33
+    running in 2026-05          15
+    running in 2026-03           5
+
+A77 is a NOTICE BOARD, not an archive: a TSO publishes an unavailability while it is
+pending or running, and once it is over it comes down. Every day nobody writes it down
+is a day of history destroyed. This module writes it down.
+
+WHY ONLY THE CURRENT HOUR
+-------------------------
+The obvious shortcut — on each run, expand the published events across the last 24 hours
+— produces a series that is quietly WRONG, and wrong in one direction. An outage that
+ended six hours ago has already left the notice board, so the hours it was running in get
+recomputed WITHOUT it. Backfilling from a feed that has already forgotten is how you build
+a history that systematically undercounts exactly the events worth recording.
+
+So each run records the one hour it can honestly speak for: this one. Run hourly, the
+series fills in with no gaps and no fiction. A missed run leaves a hole, and a hole is
+the correct representation of an hour nobody looked.
+
+WHAT THE NUMBERS DO AND DO NOT MEAN
+-----------------------------------
+`outage.offline` is ALL published unavailability (planned + forced); `outage.forced` is
+the A54 subset — the desk's headline, because planned maintenance is priced in months
+ahead and a forced trip is not.
+
+Neither is comparable ACROSS zones, and nothing here should ever be used to build a
+cross-zone capacity margin. Publication completeness is a property of the TSO, not of the
+fleet: Czechia has published 6,633 events and Germany — with the largest fleet in Europe —
+94. A margin computed from that would say the German system is never tight. Per zone,
+against that zone's OWN history, the series is honest: the coverage is stable within a
+zone even where it is thin, so the delta stays true. That is the same rule the desk
+applies to every proxy it publishes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from backend.power.hourly_store import upsert_hourly
+from backend.power.zones import POWER_ZONES
+from backend.signals.detectors.power import latest_outage_revisions
+
+#: All published unavailability, planned and forced.
+SERIES_OFFLINE = "outage.offline"
+
+#: The A54 subset: forced. What the desk leads with.
+SERIES_FORCED = "outage.forced"
+
+FORCED = "A54"
+
+
+def offline_mw_at(rows, at_iso: str) -> tuple[float, float]:
+    """(all offline MW, forced offline MW) at one instant, from latest-revision rows.
+
+    Pure. `rows` must already be revision-resolved — a withdrawn latest revision hides
+    the event, and filtering on status before ranking would let an older active revision
+    win and fabricate gigawatts.
+    """
+    total = forced = 0.0
+    for r in rows:
+        if r.status != "active" or r.nominal_mw is None:
+            continue
+        if not (r.start_utc <= at_iso <= r.end_utc):
+            continue
+        mw = r.nominal_mw - (r.available_mw or 0.0)
+        total += mw
+        if r.business_type == FORCED:
+            forced += mw
+    return total, forced
+
+
+def snapshot_outages(db: Session, *, now: datetime | None = None) -> dict:
+    """Record this hour's offline capacity for every zone. Idempotent within the hour."""
+    now = now or datetime.now(timezone.utc)
+    hour = now.replace(minute=0, second=0, microsecond=0)
+    ts = int(hour.timestamp())
+    at_iso = hour.strftime("%Y-%m-%dT%H:%MZ")
+
+    written = 0
+    zones_with_outages = 0
+    for zone in POWER_ZONES:
+        rows = latest_outage_revisions(db, zone, ending_after=at_iso)
+        if not rows:
+            continue
+        total, forced = offline_mw_at(rows, at_iso)
+        # A zone with published events but nothing running right now records a ZERO, not
+        # a gap: "nothing was offline" is a fact, and a baseline built only from the hours
+        # something WAS offline would have no floor to measure against.
+        written += upsert_hourly(db, SERIES_OFFLINE, zone, [(ts, total)], unit="MW")
+        written += upsert_hourly(db, SERIES_FORCED, zone, [(ts, forced)], unit="MW")
+        zones_with_outages += 1
+
+    db.commit()
+    return {"hour": at_iso, "zones": zones_with_outages, "points": written}

--- a/backend/tests/test_outage_history.py
+++ b/backend/tests/test_outage_history.py
@@ -1,0 +1,178 @@
+"""Recording what is offline, because ENTSO-E will not.
+
+A77 is a notice board, not an archive. These tests pin the two decisions that make the
+recording trustworthy: it never speaks for an hour it did not see, and it inherits the
+revision semantics that keep the outage feed from fabricating gigawatts.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.models.energy import PowerOutage
+from backend.power.hourly_store import read_hourly
+from backend.power.outage_history import (
+    SERIES_FORCED,
+    SERIES_OFFLINE,
+    offline_mw_at,
+    snapshot_outages,
+)
+
+NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%MZ")
+
+
+def _outage(db, mrid, *, zone="DE_LU", revision=1, status="active", bt="A54",
+            nominal=1_000.0, available=0.0, start=None, end=None):
+    row = PowerOutage(
+        mrid=mrid, revision=revision, doc_type="A77", zone=zone, status=status,
+        business_type=bt, nominal_mw=nominal, available_mw=available,
+        start_utc=_iso(start or NOW - timedelta(days=1)),
+        end_utc=_iso(end or NOW + timedelta(days=1)),
+    )
+    db.add(row)
+    return row
+
+
+# ─── the instant ──────────────────────────────────────────────────────────────
+
+
+def test_offline_is_nominal_minus_what_is_still_available():
+    """A unit derated to 300 MW of its 1000 is 700 MW offline, not 1000."""
+    class R:
+        status, business_type, nominal_mw, available_mw = "active", "A54", 1_000.0, 300.0
+        start_utc, end_utc = "2026-07-01T00:00Z", "2026-07-30T00:00Z"
+
+    total, forced = offline_mw_at([R()], "2026-07-13T12:00Z")
+    assert total == forced == 700.0
+
+
+def test_planned_and_forced_are_counted_apart():
+    """Planned maintenance is priced in months ahead; a forced trip is not. The desk
+    leads with the forced number, so it cannot be buried in the total."""
+    def row(bt):
+        class R:
+            status, business_type, nominal_mw, available_mw = "active", bt, 500.0, 0.0
+            start_utc, end_utc = "2026-07-01T00:00Z", "2026-07-30T00:00Z"
+        return R()
+
+    total, forced = offline_mw_at([row("A54"), row("A53")], "2026-07-13T12:00Z")
+    assert total == 1_000.0
+    assert forced == 500.0, "the A53 maintenance must not inflate the forced headline"
+
+
+def test_an_outage_outside_the_hour_is_not_offline_in_it():
+    class R:
+        status, business_type, nominal_mw, available_mw = "active", "A54", 900.0, 0.0
+        start_utc, end_utc = "2026-07-20T00:00Z", "2026-07-25T00:00Z"   # next week
+
+    assert offline_mw_at([R()], "2026-07-13T12:00Z") == (0.0, 0.0)
+
+
+def test_a_withdrawn_event_is_not_offline():
+    class R:
+        status, business_type, nominal_mw, available_mw = "withdrawn", "A54", 900.0, 0.0
+        start_utc, end_utc = "2026-07-01T00:00Z", "2026-07-30T00:00Z"
+
+    assert offline_mw_at([R()], "2026-07-13T12:00Z") == (0.0, 0.0)
+
+
+# ─── the snapshot ─────────────────────────────────────────────────────────────
+
+
+def test_the_snapshot_records_this_hour(db_session):
+    _outage(db_session, "M1", nominal=2_000.0)          # forced, running
+    _outage(db_session, "M2", bt="A53", nominal=500.0)  # planned, running
+    db_session.commit()
+
+    out = snapshot_outages(db_session, now=NOW)
+    assert out["hour"] == "2026-07-13T12:00Z"
+
+    ts = int(NOW.timestamp())
+    offline = dict(read_hourly(db_session, SERIES_OFFLINE, "DE_LU"))
+    forced = dict(read_hourly(db_session, SERIES_FORCED, "DE_LU"))
+    assert offline[ts] == 2_500.0
+    assert forced[ts] == 2_000.0
+
+
+def test_only_the_latest_revision_of_an_event_counts(db_session):
+    """The outage feed's central trap: an event is republished as a new revision, and a
+    withdrawn latest revision must HIDE it. Rank first, filter second — the other order
+    lets an older active revision win and fabricates gigawatts."""
+    _outage(db_session, "M1", revision=1, status="active", nominal=3_000.0)
+    _outage(db_session, "M1", revision=2, status="withdrawn", nominal=3_000.0)
+    db_session.commit()
+
+    snapshot_outages(db_session, now=NOW)
+    forced = dict(read_hourly(db_session, SERIES_FORCED, "DE_LU"))
+    assert forced[int(NOW.timestamp())] == 0.0, "the withdrawal must erase the event"
+
+
+def test_a_quiet_zone_records_a_zero_not_a_gap(db_session):
+    """"Nothing was offline" is a fact. A series that only exists in the hours something
+    broke has no floor to measure the next break against."""
+    _outage(db_session, "M1", start=NOW + timedelta(days=5), end=NOW + timedelta(days=6))
+    db_session.commit()
+
+    snapshot_outages(db_session, now=NOW)
+    assert dict(read_hourly(db_session, SERIES_OFFLINE, "DE_LU"))[int(NOW.timestamp())] == 0.0
+
+
+def test_rerunning_the_same_hour_does_not_double_count(db_session):
+    _outage(db_session, "M1", nominal=1_000.0)
+    db_session.commit()
+
+    snapshot_outages(db_session, now=NOW)
+    snapshot_outages(db_session, now=NOW)
+
+    points = read_hourly(db_session, SERIES_FORCED, "DE_LU")
+    assert len(points) == 1 and points[0][1] == 1_000.0
+
+
+def test_the_recorder_never_speaks_for_an_hour_it_did_not_see(db_session):
+    """The tempting shortcut is to backfill the last 24h on every run. It is wrong in one
+    direction: an outage that ended six hours ago has already left the notice board, so
+    those hours get recomputed WITHOUT it and the history quietly undercounts exactly the
+    events worth recording. Each run writes ONE hour: the one it can speak for."""
+    _outage(db_session, "M1", nominal=1_000.0)
+    db_session.commit()
+
+    snapshot_outages(db_session, now=NOW)
+
+    written = [ts for ts, _ in read_hourly(db_session, SERIES_OFFLINE, "DE_LU")]
+    assert written == [int(NOW.timestamp())], "one hour, not a backfilled window"
+
+
+def test_the_snapshot_is_monitored(db_session):
+    """It is the one series that cannot be backfilled — a day of silence is a day of
+    history destroyed, so it must be the tightest freshness window on the desk."""
+    from backend.collectors.freshness import SPECS
+
+    spec = next(s for s in SPECS if s.key == "outage_snapshot")
+    assert spec.hourly_series == SERIES_OFFLINE
+    assert spec.max_age <= timedelta(days=1)
+    assert spec.max_age <= min(
+        s.max_age for s in SPECS if s.hourly_series and s.key != "outage_snapshot"
+    )
+
+
+def test_the_job_is_scheduled_hourly():
+    import inspect
+
+    from backend.collectors import scheduler
+
+    src = inspect.getsource(scheduler)
+    assert 'id="outage_snapshot_hourly"' in src
+    assert "_run_outage_snapshot, CronTrigger(minute=45)" in src, "hourly, not every 6h"
+
+
+@pytest.mark.parametrize("bt,expected", [("A54", 800.0), ("A53", 0.0)])
+def test_the_forced_series_is_the_a54_subset(db_session, bt, expected):
+    _outage(db_session, "M1", bt=bt, nominal=800.0)
+    db_session.commit()
+    snapshot_outages(db_session, now=NOW)
+    assert dict(read_hourly(db_session, SERIES_FORCED, "DE_LU"))[int(NOW.timestamp())] == expected


### PR DESCRIPTION
Tier 1.5 was *"outages as a time series → the real capacity margin"*. **The data refuses both halves**, and finding out why is the result.

## There is no outage history, and none can be recovered

A77 is a **notice board, not an archive**: a TSO publishes an unavailability while it is pending or running, and takes it down once it is over. Counting the currently-published events by the month they were *running* in, on prod:

| running in | events | zones |
|---|---:|---:|
| 2026-07 (now) | **1013** | 19 |
| 2026-06 | 33 | 13 |
| 2026-05 | 15 | 7 |
| 2026-03 | 5 | 5 |

So a backward-looking capacity margin is impossible, and so is a z-score for outages. The driver card's *"forced outages carry no z — a level, not a deviation"* was never a limitation waiting to be fixed. It was the data being represented correctly.

**Every hour nobody writes down is destroyed.** This starts writing them down: an hourly job recording `outage.offline` (all published unavailability) and `outage.forced` (the A54 subset) per zone into `power_hourly`. In ~30 days a real baseline exists and the z becomes possible *honestly*. It costs nothing to start today and cannot be started retroactively — which is the whole argument for doing it now rather than with the feature that will use it.

## Only the current hour

The obvious shortcut — expand the published events across the last 24 h on each run — produces a series that is wrong, and wrong in one direction. **An outage that ended six hours ago has already left the notice board**, so the hours it was running in get recomputed *without* it: a history that systematically undercounts exactly the events worth recording.

Each run records the one hour it can honestly speak for. A missed hour leaves a hole, and a hole is the correct representation of an hour nobody looked.

## And still no cross-zone margin

Publication completeness is a property of the TSO, not of the fleet: **Czechia has published 6,633 events; Germany — the largest fleet in Europe — 94.** A margin computed across that would report that the German system is never tight.

Per zone, against that zone's *own* history, the series is honest: the coverage is stable within a zone even where it is thin, so the delta stays true. That is the rule the desk already applies to every proxy it publishes (`CLAUDE.md`: never show absolute values that cannot be completely captured), and the module says so where the next person to reach for a margin will read it.

## Verification

Dry-run against a copy of the **real prod events** (9,490 rows): FR 1.78 GW offline / 0.10 forced, NL 1.27 / 0.76, DE-LU 0.78 — reconciling exactly with the direct SQL. Revision semantics inherited from the shared `latest_outage_revisions` helper and pinned by a test (a withdrawn *latest* revision must erase the event; rank-then-filter, or an older active revision wins and fabricates gigawatts).

Freshness window is the **tightest on the desk** (1 day) and a test enforces that, because for this one series a silent day is not a late delivery to catch up on — it is history destroyed.

`ruff` clean · **848 passed** · 13 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)