### PR TITLE
data[] has two roots, and we only ever read one

### DIFF
--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -27,7 +27,7 @@ from backend.models.energy import (
     PowerPriceDaily,
     SeriesDim,
 )
-from backend.models.gas import GasBalance
+from backend.models.gas import GasBalance, GasStorageCountry
 from backend.models.prices import EIAPrice, FREDSeries
 from backend.models.sentiment import GDELTVolume
 from backend.models.vessels import VesselPosition
@@ -60,6 +60,11 @@ SPECS: list[FreshnessSpec] = [
     # Delivery-date probes (product-critical — the ones that were unmonitored).
     FreshnessSpec("power_flows", PowerFlow, "date", timedelta(days=3), is_date_string=True),
     FreshnessSpec("gas_balance", GasBalance, "date", timedelta(days=3), is_date_string=True),
+    # The per-country layer rides the SAME payload as the EU aggregate, so if it goes stale
+    # while gas_balance does not, the country walk broke — not the feed. That is worth being
+    # able to tell apart, which is why it gets its own probe rather than sharing one.
+    FreshnessSpec("gas_storage_country", GasStorageCountry, "date", timedelta(days=3),
+                  is_date_string=True),
     FreshnessSpec("ttf", EnergyPrice, "date", timedelta(days=4),
                   is_date_string=True, filter_col="symbol", filter_val="TTF"),
     FreshnessSpec("copper", EnergyPrice, "date", timedelta(days=4),

--- a/backend/gas/gie.py
+++ b/backend/gas/gie.py
@@ -4,9 +4,19 @@ Field names verified against the live API (they differ from older clients —
 ALSI uses `inventory` as a {lng, gwh} dict, not `lngInventory`; the day is
 `gasDayStart`). One free GIE key (x-key header) covers both services.
 
-Access pattern: GET {base}?date=YYYY-MM-DD returns one row per aggregate code;
-we keep code == "eu". Raw payloads are disk-cached so a re-run never re-hits
-the API. AGSI gasInStorage is already TWh; ALSI inventory.gwh → TWh.
+Access pattern: GET {base}?date=YYYY-MM-DD returns a TREE — `data[]` holds two or three
+ROOTS (`eu`, `ne`, and for ALSI `ai`), each with country children, each of those with
+operators, each of those with individual facilities. We keep the `eu` aggregate row (the
+EU headline every panel has always shown) AND, since the country layer landed, one row per
+country under the whitelisted roots. See COUNTRY_ROOTS for why that whitelist exists and
+what reading only `eu` had been quietly deleting.
+
+Still on the floor, deliberately: 78 operators and 137 individual storages with
+coordinates, type and injection/withdrawal capacity, under `children[].children[]`.
+
+Raw payloads are disk-cached so a re-run never re-hits the API — which is what makes the
+country layer a pure reprocessing job over 2023→today at zero API calls. AGSI gasInStorage
+is already TWh; ALSI inventory.gwh → TWh.
 """
 
 from __future__ import annotations
@@ -20,13 +30,28 @@ from sqlalchemy.orm import Session
 from backend.config import settings
 from backend.gas import raw_cache
 from backend.gas.units import coerce_float
-from backend.models.gas import GasLng, GasStorage
+from backend.models.gas import GasLng, GasLngCountry, GasStorage, GasStorageCountry
 
 logger = logging.getLogger(__name__)
 
 AGSI_BASE = "https://agsi.gie.eu/api"
 ALSI_BASE = "https://alsi.gie.eu/api"
 EU_CODE = "eu"
+
+#: The payload roots whose children are REAL countries.
+#:
+#: `data[]` has never been one row. It has always been two or three, and we only ever read
+#: the first. `eu` carries the 20 member states; `ne` carries Non-EU — which is where UKRAINE
+#: (77 TWh in storage) and the real post-Brexit GB* live. The `GB` sitting under `eu` is
+#: "United Kingdom (Pre-Brexit)" and is nothing but dashes. Reading only `eu` therefore threw
+#: away the two most trade-relevant non-member countries in the file, every day, since 2023.
+#:
+#: And the obvious fix — "just walk data[] instead of the eu row" — is ALSO wrong, which is
+#: why this is a whitelist and not a loop. ALSI carries a third root, `ai` ("Additional
+#: Information"), holding `ES*` "Spain (1)": a DUPLICATE of Spain, which already appears
+#: under `eu`. On 2026-06-20 that is eu→ES sendOut 343.8 AND ai→ES* sendOut 395.7. Walking
+#: every root double-counts Spain in every LNG total. `ai` is excluded on purpose.
+COUNTRY_ROOTS = ("eu", "ne")
 
 
 def _gie_headers() -> dict:
@@ -55,11 +80,30 @@ def _eu_row(payload: dict) -> dict | None:
     return None
 
 
+def country_rows(payload: dict) -> list[tuple[str, dict]]:
+    """[(region, country_row)] for every country under a whitelisted root. Pure.
+
+    One level down only: the operator and facility levels (78 operators, 137 storages with
+    coordinates, type and injection/withdrawal capacity) sit under `children[].children[]`
+    and are deliberately left there for a follow-on PR.
+    """
+    out: list[tuple[str, dict]] = []
+    for root in payload.get("data", []):
+        region = root.get("code")
+        if region not in COUNTRY_ROOTS:
+            continue  # `ai` is a duplicate of Spain — see COUNTRY_ROOTS
+        for child in root.get("children", []) or []:
+            if child.get("code"):
+                out.append((region, child))
+    return out
+
+
 async def ingest_storage(db: Session, days: list[str], *, overwrite: bool = False) -> dict:
-    """AGSI EU storage → gas_storage."""
-    written = 0
+    """AGSI storage → gas_storage (EU aggregate) AND gas_storage_country, one payload."""
+    written = countries = 0
     for day in days:
-        eu = _eu_row(await _fetch_day(AGSI_BASE, "agsi", day, overwrite=overwrite))
+        payload = await _fetch_day(AGSI_BASE, "agsi", day, overwrite=overwrite)
+        eu = _eu_row(payload)
         if not eu:
             continue  # data gap — no silent fill
         _upsert_storage(
@@ -70,31 +114,98 @@ async def ingest_storage(db: Session, days: list[str], *, overwrite: bool = Fals
             withdrawal_gwh=coerce_float(eu.get("withdrawal")),
             fill_pct=coerce_float(eu.get("full")),
         )
+        countries += upsert_storage_countries(db, day, payload)
         written += 1
     db.commit()
-    logger.info("gie.ingest_storage: %d/%d days", written, len(days))
-    return {"days": len(days), "written": written}
+    logger.info("gie.ingest_storage: %d/%d days, %d country rows", written, len(days), countries)
+    return {"days": len(days), "written": written, "countries": countries}
 
 
 async def ingest_lng(db: Session, days: list[str], *, overwrite: bool = False) -> dict:
-    """ALSI EU LNG send-out + inventory → gas_lng."""
-    written = 0
+    """ALSI LNG → gas_lng (EU aggregate) AND gas_lng_country, one payload."""
+    written = countries = 0
     for day in days:
-        eu = _eu_row(await _fetch_day(ALSI_BASE, "alsi", day, overwrite=overwrite))
+        payload = await _fetch_day(ALSI_BASE, "alsi", day, overwrite=overwrite)
+        eu = _eu_row(payload)
         if not eu:
             continue
-        inv = eu.get("inventory")
-        inv_gwh = coerce_float(inv.get("gwh")) if isinstance(inv, dict) else None
         _upsert_lng(
             db,
             day,
-            send_out_gwh=coerce_float(eu.get("sendOut")),                       # GWh/d (primary LNG supply)
-            inventory_twh=(inv_gwh / 1000.0) if inv_gwh is not None else None,  # GWh → TWh
+            send_out_gwh=coerce_float(eu.get("sendOut")),   # GWh/d (primary LNG supply)
+            inventory_twh=_inventory_twh(eu),
         )
+        countries += upsert_lng_countries(db, day, payload)
         written += 1
     db.commit()
-    logger.info("gie.ingest_lng: %d/%d days", written, len(days))
-    return {"days": len(days), "written": written}
+    logger.info("gie.ingest_lng: %d/%d days, %d country rows", written, len(days), countries)
+    return {"days": len(days), "written": written, "countries": countries}
+
+
+def _inventory_twh(row: dict) -> float | None:
+    """ALSI reports inventory as a {lng, gwh} dict, not a scalar."""
+    inv = row.get("inventory")
+    gwh = coerce_float(inv.get("gwh")) if isinstance(inv, dict) else None
+    return (gwh / 1000.0) if gwh is not None else None
+
+
+def upsert_storage_countries(db: Session, day: str, payload: dict) -> int:
+    """Per-country AGSI rows from an already-fetched payload. No network.
+
+    Flushes before returning: `Session.get()` does not see rows that are still pending, so
+    without it a second pass over the same day inserts duplicates instead of updating —
+    which is the difference between a re-readable history and a corrupt one.
+    """
+    n = 0
+    for region, row in country_rows(payload):
+        code = row["code"]
+        existing = db.get(GasStorageCountry, (day, code))
+        values = {
+            "region": region,
+            "name": row.get("name"),
+            "stock_twh": coerce_float(row.get("gasInStorage")),
+            "injection_gwh": coerce_float(row.get("injection")),
+            "withdrawal_gwh": coerce_float(row.get("withdrawal")),
+            "fill_pct": coerce_float(row.get("full")),
+            "working_gas_twh": coerce_float(row.get("workingGasVolume")),
+            "injection_capacity_gwh": coerce_float(row.get("injectionCapacity")),
+            "withdrawal_capacity_gwh": coerce_float(row.get("withdrawalCapacity")),
+            "trend": coerce_float(row.get("trend")),
+            "status": row.get("status"),
+        }
+        if existing:
+            for k, v in values.items():
+                setattr(existing, k, v)
+        else:
+            db.add(GasStorageCountry(date=day, country=code, **values))
+        n += 1
+    db.flush()
+    return n
+
+
+def upsert_lng_countries(db: Session, day: str, payload: dict) -> int:
+    """Per-country ALSI rows from an already-fetched payload. No network."""
+    n = 0
+    for region, row in country_rows(payload):
+        code = row["code"]
+        dtmi = row.get("dtmi")
+        dtmi_gwh = coerce_float(dtmi.get("gwh")) if isinstance(dtmi, dict) else None
+        existing = db.get(GasLngCountry, (day, code))
+        values = {
+            "region": region,
+            "name": row.get("name"),
+            "send_out_gwh": coerce_float(row.get("sendOut")),
+            "inventory_twh": _inventory_twh(row),
+            "dtmi_twh": (dtmi_gwh / 1000.0) if dtmi_gwh is not None else None,
+        }
+        if existing:
+            for k, v in values.items():
+                setattr(existing, k, v)
+        else:
+            db.add(GasLngCountry(date=day, country=code, **values))
+        n += 1
+    db.flush()
+    return n
 
 
 def _upsert_storage(db, day, *, stock_twh, injection_gwh, withdrawal_gwh, fill_pct):

--- a/backend/models/gas.py
+++ b/backend/models/gas.py
@@ -65,6 +65,56 @@ class GasLng(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
+class GasStorageCountry(Base):
+    """AGSI storage PER COUNTRY — the level a power desk actually needs.
+
+    "EU storage is 51% full" is nearly useless to anyone reading a bidding zone: gas is not
+    fungible across borders, and the EU number averages a full Germany with an empty
+    Ukraine. The per-country rows have been inside every payload we fetched since 2023 and
+    were thrown away at read time (`gie._eu_row` kept only `code == "eu"`).
+
+    `region` records WHICH root of the payload the row came from, because that is a fact
+    about the data and not an implementation detail: `eu` is the EU aggregate's children,
+    `ne` is Non-EU — and `ne` is where Ukraine (77 TWh) and the real post-Brexit GB live.
+    Dropping it, as the old code did, silently deleted the two most trade-relevant
+    non-member countries in the file.
+    """
+
+    __tablename__ = "gas_storage_country"
+
+    date: Mapped[str] = mapped_column(String, primary_key=True)
+    country: Mapped[str] = mapped_column(String, primary_key=True)   # "DE", "UA", "GB*"
+    region: Mapped[str] = mapped_column(String)                      # "eu" | "ne"
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
+    stock_twh: Mapped[float | None] = mapped_column(Float, nullable=True)
+    injection_gwh: Mapped[float | None] = mapped_column(Float, nullable=True)
+    withdrawal_gwh: Mapped[float | None] = mapped_column(Float, nullable=True)
+    fill_pct: Mapped[float | None] = mapped_column(Float, nullable=True)
+    # The capacity columns the EU-only schema never had — what makes a fill % readable as a
+    # volume, and the only honest way to show TWh (beside the country's OWN working gas).
+    working_gas_twh: Mapped[float | None] = mapped_column(Float, nullable=True)
+    injection_capacity_gwh: Mapped[float | None] = mapped_column(Float, nullable=True)
+    withdrawal_capacity_gwh: Mapped[float | None] = mapped_column(Float, nullable=True)
+    trend: Mapped[float | None] = mapped_column(Float, nullable=True)
+    status: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class GasLngCountry(Base):
+    """ALSI LNG send-out + inventory PER COUNTRY. Same story as GasStorageCountry."""
+
+    __tablename__ = "gas_lng_country"
+
+    date: Mapped[str] = mapped_column(String, primary_key=True)
+    country: Mapped[str] = mapped_column(String, primary_key=True)
+    region: Mapped[str] = mapped_column(String)                      # "eu" | "ne" — never "ai"
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
+    send_out_gwh: Mapped[float | None] = mapped_column(Float, nullable=True)
+    inventory_twh: Mapped[float | None] = mapped_column(Float, nullable=True)
+    dtmi_twh: Mapped[float | None] = mapped_column(Float, nullable=True)   # declared max inventory
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
 # ─── Phase 2-4 seams: created, unpopulated in Phase 1 ────────────────────────
 
 

--- a/backend/routes/gas.py
+++ b/backend/routes/gas.py
@@ -15,7 +15,14 @@ from sqlalchemy.orm import Session
 from backend.collectors.freshness import freshness_meta
 from backend.database import get_db
 from backend.gas import validation
-from backend.models.gas import GasBalance, GasDemandModel, GasLng, GasPowerBurn, GasStorage
+from backend.models.gas import (
+    GasBalance,
+    GasDemandModel,
+    GasLng,
+    GasPowerBurn,
+    GasStorage,
+    GasStorageCountry,
+)
 
 router = APIRouter(prefix="/api/gas", tags=["gas"])
 
@@ -52,6 +59,78 @@ async def get_supply(days: int = Query(90, ge=1, le=1500), db: Session = Depends
     if not rows:
         return {"available": False, "reason": "no flow/lng data yet — run gas_backfill"}
     return {"available": True, "from": date_from, "to": date_to, "data": rows, **_panel_freshness(rows)}
+
+
+@router.get("/storage/countries")
+def get_storage_countries(
+    days: int = Query(90, ge=1, le=1500),
+    country: str | None = Query(None, description="ISO code, e.g. DE, UA, GB*"),
+    db: Session = Depends(get_db),
+):
+    """Storage per country — the level a power desk can actually use.
+
+    "EU storage is 51% full" averages a full Germany with an empty Ukraine, and gas does not
+    flow freely across those borders. The per-country rows were in every payload we fetched
+    since 2023 and were discarded at read time.
+
+    NOTE ON TOTALS: this deliberately returns no cross-country sum. Coverage is a property of
+    who reports to GIE, so an "all countries" TWh figure would be an absolute value we cannot
+    completely capture — the desk's oldest data rule. The EU aggregate at /api/gas/storage IS
+    that total, computed by GIE, and it is the only honest one. Fill % is a ratio inside a
+    single complete country row, and is safe to compare across them.
+    """
+    date_from, date_to = _window(days)
+    q = (
+        db.query(GasStorageCountry)
+        .filter(GasStorageCountry.date >= date_from, GasStorageCountry.date <= date_to)
+    )
+    if country:
+        q = q.filter(GasStorageCountry.country == country)
+    rows = q.order_by(GasStorageCountry.date.asc(), GasStorageCountry.country.asc()).all()
+    if not rows:
+        return {
+            "available": False,
+            "reason": (
+                f"no per-country AGSI rows for {country} yet"
+                if country else
+                "no per-country AGSI data yet — run backfill_gie_countries (cache-only)"
+            ),
+        }
+
+    latest_date = rows[-1].date
+    latest = sorted(
+        (r for r in rows if r.date == latest_date),
+        key=lambda r: (r.fill_pct is None, -(r.fill_pct or 0.0)),
+    )
+    return {
+        "available": True,
+        "data": [
+            {
+                "date": r.date, "country": r.country, "region": r.region, "name": r.name,
+                "stock_twh": r.stock_twh, "fill_pct": r.fill_pct,
+                "injection_gwh": r.injection_gwh, "withdrawal_gwh": r.withdrawal_gwh,
+                "working_gas_twh": r.working_gas_twh,
+                "withdrawal_capacity_gwh": r.withdrawal_capacity_gwh,
+            }
+            for r in rows
+        ],
+        "latest": [
+            {
+                "country": r.country, "region": r.region, "name": r.name,
+                "fill_pct": r.fill_pct, "stock_twh": r.stock_twh,
+                "working_gas_twh": r.working_gas_twh,
+                "withdrawal_capacity_gwh": r.withdrawal_capacity_gwh,
+            }
+            for r in latest
+        ],
+        "note": (
+            "Per-country fill from GIE AGSI. Fill % is a ratio within one country and is "
+            "comparable across them; TWh is only meaningful beside that country's own working "
+            "gas volume. No cross-country total is given — the EU aggregate (/api/gas/storage) "
+            "is GIE's own, and the only complete one. `ne` marks non-EU reporters (UA, GB*)."
+        ),
+        **_panel_freshness(rows),
+    }
 
 
 @router.get("/storage")

--- a/backend/scripts/backfill_gie_countries.py
+++ b/backend/scripts/backfill_gie_countries.py
@@ -1,0 +1,120 @@
+"""Re-read three years of gas payloads we already own, and keep the 90% we threw away.
+
+`gie._eu_row` kept one row out of a tree: the EU aggregate. The 23 countries under it —
+including Ukraine, whose 77 TWh of storage is arguably the most trade-relevant number in the
+whole file — were parsed, discarded, and forgotten, every day since 2023-01-01. The payloads
+themselves were never lost: they are on disk in the raw cache, 164 MB of AGSI and 54 MB of
+ALSI. So this is not a backfill. It is a re-read.
+
+CACHE-ONLY BY DESIGN: ZERO API CALLS. A day whose payload is missing from the cache is
+COUNTED and reported, never fetched. It keeps no country rows until someone backfills that
+day — which is honest and visible, and infinitely preferable to a script that quietly hammers
+GIE for three years of history it was told it already had.
+
+    python -m backend.scripts.backfill_gie_countries --dry-run
+    python -m backend.scripts.backfill_gie_countries --start 2023-01-01
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import text
+
+from backend.database import SessionLocal, init_db
+from backend.gas import raw_cache
+from backend.gas.gie import upsert_lng_countries, upsert_storage_countries
+
+logger = logging.getLogger(__name__)
+
+#: Checkpoint the WAL every N days. This is load-bearing, not tidiness: the API process holds
+#: long-lived readers, so SQLite cannot checkpoint on its own while a long batch job writes,
+#: and an unbounded WAL is exactly how the 2026-07-07 disk incident began.
+CHECKPOINT_EVERY = 50
+
+SOURCES = (
+    ("agsi", upsert_storage_countries),
+    ("alsi", upsert_lng_countries),
+)
+
+
+def _days(start: date, end: date) -> list[date]:
+    out, d = [], start
+    while d <= end:
+        out.append(d)
+        d += timedelta(days=1)
+    return out
+
+
+def run(db, start: date, end: date, *, dry_run: bool = False) -> dict:
+    total = {"days": 0, "missing_cache": 0, "storage_rows": 0, "lng_rows": 0}
+    written_days = 0
+
+    for day in _days(start, end):
+        iso = day.isoformat()
+        total["days"] += 1
+        touched = False
+
+        for source, upsert in SOURCES:
+            payload = raw_cache.read_cached(source, f"{source}_{iso}", day)
+            if payload is None:
+                total["missing_cache"] += 1
+                continue  # COUNTED, never fetched
+            if dry_run:
+                touched = True
+                continue
+            n = upsert(db, iso, payload)
+            total["storage_rows" if source == "agsi" else "lng_rows"] += n
+            touched = True
+
+        if touched and not dry_run:
+            db.commit()
+            written_days += 1
+            if written_days % CHECKPOINT_EVERY == 0:
+                db.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
+                logger.info("gie countries: %s — %d days re-read (WAL checkpointed)",
+                            iso, written_days)
+
+    if not dry_run:
+        db.commit()
+        db.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
+    return total
+
+
+def main(argv: list[str]) -> int:
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    p = argparse.ArgumentParser(description="Re-read cached AGSI/ALSI payloads into the country tables")
+    p.add_argument("--start", default="2023-01-01")
+    p.add_argument("--end", default=date.today().isoformat())
+    p.add_argument("--dry-run", action="store_true", help="report coverage, write nothing")
+    args = p.parse_args(argv[1:])
+
+    start = datetime.strptime(args.start, "%Y-%m-%d").date()
+    end = datetime.strptime(args.end, "%Y-%m-%d").date()
+
+    # The country tables are new; a script run outside the app never saw the startup that
+    # creates them. create_all is idempotent and touches nothing that already exists.
+    init_db()
+
+    db = SessionLocal()
+    try:
+        result = run(db, start, end, dry_run=args.dry_run)
+    finally:
+        db.close()
+
+    logger.info("backfill_gie_countries complete: %s", result)
+    if result["missing_cache"]:
+        logger.warning(
+            "%d source-days had no cached payload — those days have no country rows and were "
+            "NOT fetched. Run the daily ingest for them if you want them.",
+            result["missing_cache"],
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/tests/test_gas_gie_countries.py
+++ b/backend/tests/test_gas_gie_countries.py
@@ -1,0 +1,215 @@
+"""`data[]` has two roots, and we only ever read one.
+
+The GIE payload has always been a tree. `_eu_row` took the single row whose code is "eu" and
+threw the rest away — which meant Ukraine (77 TWh of storage) and the real post-Brexit GB
+were parsed and deleted, every day, since 2023.
+
+The obvious fix is to walk `data[]` instead. That fix is ALSO wrong, and these tests exist
+because it is: ALSI carries a third root, `ai`, holding a DUPLICATE of Spain.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.gas.gie import (
+    COUNTRY_ROOTS,
+    country_rows,
+    upsert_lng_countries,
+    upsert_storage_countries,
+)
+from backend.models.gas import GasLngCountry, GasStorage, GasStorageCountry
+
+
+def _agsi_payload() -> dict:
+    """The real shape, trimmed: an `eu` root AND a `ne` root. Verified on disk 2026-06-20."""
+    return {
+        "data": [
+            {
+                "code": "eu", "name": "EU", "gasInStorage": "580.1", "full": "51.2",
+                "injection": "3100.0", "withdrawal": "40.0",
+                "children": [
+                    {"code": "DE", "name": "Germany", "gasInStorage": "94.7003",
+                     "full": "38.37", "injection": "900.1", "withdrawal": "0",
+                     "workingGasVolume": "246.8", "injectionCapacity": "2500.0",
+                     "withdrawalCapacity": "3100.0", "trend": "0.36", "status": "E"},
+                    # Pre-Brexit GB: present under `eu`, and nothing but dashes.
+                    {"code": "GB", "name": "United Kingdom (Pre-Brexit)",
+                     "gasInStorage": "-", "full": "-", "injection": "-", "withdrawal": "-"},
+                ],
+            },
+            {
+                "code": "ne", "name": "Non-EU",
+                "children": [
+                    {"code": "UA", "name": "Ukraine", "gasInStorage": "77.0359",
+                     "full": "24.07", "injection": "120.0", "withdrawal": "0"},
+                    {"code": "GB*", "name": "United Kingdom (Post-Brexit)",
+                     "gasInStorage": "1.7912", "full": "18.16"},
+                ],
+            },
+        ]
+    }
+
+
+def _alsi_payload() -> dict:
+    """ALSI's THIRD root: `ai` → ES*, a duplicate of a country already under `eu`."""
+    return {
+        "data": [
+            {
+                "code": "eu", "name": "EU", "sendOut": "2100.0",
+                "children": [
+                    {"code": "ES", "name": "Spain", "sendOut": "343.8",
+                     "inventory": {"gwh": "12000"}, "dtmi": {"gwh": "35000"}},
+                ],
+            },
+            {"code": "ne", "name": "Non-EU",
+             "children": [{"code": "GB*", "name": "United Kingdom (Post-Brexit)",
+                           "sendOut": "-", "inventory": {"gwh": "-"}}]},
+            {"code": "ai", "name": "Additional Information",
+             "children": [{"code": "ES*", "name": "Spain (1)", "sendOut": "395.7"}]},
+        ]
+    }
+
+
+# ─── the roots ────────────────────────────────────────────────────────────────
+
+
+def test_non_eu_root_is_not_dropped():
+    """THE bug. Ukraine holds 77 TWh and lives under `ne`. Reading only the `eu` root
+    deleted it — and the real GB — from every day of the record since 2023.
+
+    A fixture with only the `eu` root cannot express this bug; it would be no test at all."""
+    by_code = {row["code"]: (region, row) for region, row in country_rows(_agsi_payload())}
+
+    assert "UA" in by_code, "Ukraine is under `ne` and must survive"
+    region, ua = by_code["UA"]
+    assert region == "ne"
+    assert ua["gasInStorage"] == "77.0359"
+
+
+def test_alsi_additional_information_root_is_excluded():
+    """The trap in the OBVIOUS fix. "Just walk data[] instead of the eu row" pulls in ALSI's
+    `ai` root, which holds ES* "Spain (1)" — a duplicate of the Spain already under `eu`.
+    Walking every root double-counts Spain in every LNG total."""
+    codes = [row["code"] for _region, row in country_rows(_alsi_payload())]
+
+    assert codes.count("ES") == 1
+    assert "ES*" not in codes, "`ai` is a duplicate of Spain, not a country"
+    assert "ai" not in COUNTRY_ROOTS
+
+
+def test_pre_brexit_and_post_brexit_gb_are_different_countries():
+    """`eu` carries a hollowed-out "GB (Pre-Brexit)" of pure dashes; the live UK is `GB*`
+    under `ne`. Confuse them and Britain reads as an empty country."""
+    by_code = {row["code"]: row for _r, row in country_rows(_agsi_payload())}
+
+    assert by_code["GB"]["gasInStorage"] == "-", "the pre-Brexit row is a placeholder"
+    assert by_code["GB*"]["gasInStorage"] == "1.7912"
+
+
+# ─── the writes ───────────────────────────────────────────────────────────────
+
+
+def test_country_rows_carry_the_capacity_the_eu_schema_never_had(db_session):
+    upsert_storage_countries(db_session, "2026-06-20", _agsi_payload())
+    db_session.commit()
+
+    de = db_session.get(GasStorageCountry, ("2026-06-20", "DE"))
+    assert de.stock_twh == pytest.approx(94.7003)
+    assert de.fill_pct == pytest.approx(38.37)
+    assert de.working_gas_twh == pytest.approx(246.8), "the denominator that makes TWh readable"
+    assert de.withdrawal_capacity_gwh == pytest.approx(3100.0)
+    assert de.region == "eu"
+
+
+def test_the_dash_marker_becomes_none_not_zero(db_session):
+    """A country reporting "-" has no data. Storing it as 0.0 would say it is empty."""
+    upsert_storage_countries(db_session, "2026-06-20", _agsi_payload())
+    db_session.commit()
+
+    gb = db_session.get(GasStorageCountry, ("2026-06-20", "GB"))
+    assert gb.stock_twh is None and gb.fill_pct is None
+
+
+def test_lng_countries_land_without_the_duplicate(db_session):
+    upsert_lng_countries(db_session, "2026-06-20", _alsi_payload())
+    db_session.commit()
+
+    rows = db_session.query(GasLngCountry).filter_by(date="2026-06-20").all()
+    assert {r.country for r in rows} == {"ES", "GB*"}
+    es = db_session.get(GasLngCountry, ("2026-06-20", "ES"))
+    assert es.send_out_gwh == pytest.approx(343.8), "the eu figure, not the ai duplicate"
+    assert es.inventory_twh == pytest.approx(12.0), "GWh → TWh"
+
+
+def test_reprocessing_the_same_day_twice_does_not_duplicate(db_session):
+    for _ in range(2):
+        upsert_storage_countries(db_session, "2026-06-20", _agsi_payload())
+    db_session.commit()
+
+    assert db_session.query(GasStorageCountry).filter_by(date="2026-06-20").count() == 4
+
+
+# ─── the thing that must NOT change ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_eu_aggregate_is_untouched(db_session, monkeypatch):
+    """The residual engine (`gas/balance.py::compute_balance`) reads GasStorage.injection and
+    .withdrawal as its `actual_delta` — the number the code itself calls "this is the
+    product". Re-basing it while adding a country layer would move the product silently."""
+    import backend.gas.gie as gie
+
+    async def _fake_fetch(base, source, day, *, overwrite=False):
+        return _agsi_payload()
+
+    monkeypatch.setattr(gie, "_fetch_day", _fake_fetch)
+    await gie.ingest_storage(db_session, ["2026-06-20"])
+
+    eu = db_session.get(GasStorage, "2026-06-20")
+    assert eu.stock_twh == pytest.approx(580.1)
+    assert eu.injection_gwh == pytest.approx(3100.0)
+    assert eu.fill_pct == pytest.approx(51.2)
+    # …and the countries arrived alongside it, from the same payload, in the same pass.
+    assert db_session.query(GasStorageCountry).count() == 4
+
+
+# ─── the reprocessor ──────────────────────────────────────────────────────────
+
+
+def test_the_reprocessor_counts_missing_days_instead_of_fetching(db_session, monkeypatch):
+    """Zero API calls is the whole premise: the payloads are already on disk. A cache miss
+    must be COUNTED and reported, never quietly turned into three years of GIE requests."""
+    from backend.gas import raw_cache
+    from backend.scripts import backfill_gie_countries as bf
+
+    monkeypatch.setattr(raw_cache, "read_cached", lambda *a, **k: None)
+
+    def _explode(*a, **k):
+        raise AssertionError("the reprocessor must never hit the network")
+
+    monkeypatch.setattr("httpx.AsyncClient", _explode)
+
+    from datetime import date
+
+    out = bf.run(db_session, date(2026, 6, 1), date(2026, 6, 3))
+    assert out["days"] == 3
+    assert out["missing_cache"] == 6, "3 days × 2 sources, all counted"
+    assert out["storage_rows"] == 0
+
+
+def test_the_reprocessor_writes_the_countries_it_finds(db_session, monkeypatch):
+    from datetime import date
+
+    from backend.gas import raw_cache
+    from backend.scripts import backfill_gie_countries as bf
+
+    monkeypatch.setattr(
+        raw_cache, "read_cached",
+        lambda source, key, day: _agsi_payload() if source == "agsi" else _alsi_payload(),
+    )
+    out = bf.run(db_session, date(2026, 6, 20), date(2026, 6, 20))
+
+    assert out["missing_cache"] == 0
+    assert out["storage_rows"] == 4
+    assert out["lng_rows"] == 2, "ES + GB*, never the ai duplicate"
+    assert db_session.get(GasStorageCountry, ("2026-06-20", "UA")).stock_twh == pytest.approx(77.0359)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import PriceTicker from './components/PriceTicker'
 import AlertRulesPanel from './components/AlertRulesPanel'
 import GasBalancePanel from './components/GasBalancePanel'
 import GasStoragePanel from './components/GasStoragePanel'
+import GasStorageCountriesPanel from './components/GasStorageCountriesPanel'
 import GasSupplyPanel from './components/GasSupplyPanel'
 import GasDemandPanel from './components/GasDemandPanel'
 import PowerDayAheadPanel from './components/PowerDayAheadPanel'
@@ -540,6 +541,13 @@ function Dashboard() {
               </ErrorBoundary>
               <ErrorBoundary name="gas-demand">
                 <GasDemandPanel />
+              </ErrorBoundary>
+            </div>
+
+            {/* Row 3: which country is actually short — the EU average hides it */}
+            <div className="mt-3">
+              <ErrorBoundary name="gas-storage-countries">
+                <GasStorageCountriesPanel />
               </ErrorBoundary>
             </div>
           </>

--- a/frontend/src/components/GasStorageCountriesPanel.jsx
+++ b/frontend/src/components/GasStorageCountriesPanel.jsx
@@ -1,0 +1,164 @@
+import { useState } from 'react'
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { useViewState } from '../context/ViewStateContext'
+import { rangeDays } from '../utils/ranges'
+import {
+  ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
+} from 'recharts'
+import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+
+const API = '/api'
+
+/**
+ * Storage per country — the level a power desk can act on.
+ *
+ * "EU storage is 51% full" averages a full Germany with an empty Ukraine, and gas does not
+ * flow freely across those borders. These rows were inside every payload we fetched since
+ * 2023 and were thrown away at read time.
+ *
+ * TWh is deliberately shown only beside that country's OWN working gas volume: coverage is a
+ * property of who reports to GIE, so a cross-country sum would be an absolute we cannot
+ * completely capture. Fill % is a ratio inside one complete row, so it compares safely.
+ */
+export default function GasStorageCountriesPanel() {
+  const { range } = useViewState()
+  const [selected, setSelected] = useState(null)
+  const { data, loading, error } = useFetchWithError(
+    `${API}/gas/storage/countries?days=${rangeDays(range)}`, { deps: [range] },
+  )
+
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">STORAGE BY COUNTRY // FETCH ERROR</div>
+      </div>
+    )
+  }
+  if (!data?.available && !loading) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          STORAGE BY COUNTRY — {data?.reason || 'no per-country AGSI data yet.'}
+        </div>
+      </div>
+    )
+  }
+
+  const latest = data?.latest ?? []
+  const history = (data?.data ?? []).filter((r) => r.country === selected)
+  const shown = selected && history.length > 1 ? history : null
+
+  return (
+    <Panel
+      id="gas-storage-countries"
+      freshness={data}
+      title="GAS STORAGE BY COUNTRY · AGSI"
+      info={data?.note || 'Fill % per country. Gas is not fungible across borders — the EU average hides which country is actually short.'}
+      collapsible
+      headerRight={
+        latest.length > 0 && (
+          <span className="font-mono text-[10px] text-neutral-600">{latest.length} countries</span>
+        )
+      }
+    >
+      {loading && !data ? (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">Loading countries…</div>
+      ) : (
+        <>
+          <div className="px-2 py-2 overflow-x-auto">
+            <table className="w-full font-mono text-[11px]">
+              <thead>
+                <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                  <th className="text-left px-2 py-1">Country</th>
+                  <th className="text-right px-2 py-1">Fill</th>
+                  <th className="px-2 py-1"></th>
+                  <th className="text-right px-2 py-1" title="In storage, beside this country's own working gas volume">Stock / capacity</th>
+                  <th className="text-right px-2 py-1" title="Maximum daily withdrawal — how fast this country can actually draw on it">Max draw</th>
+                </tr>
+              </thead>
+              <tbody>
+                {latest.map((r) => {
+                  const pct = r.fill_pct
+                  const isSel = selected === r.country
+                  return (
+                    <tr
+                      key={r.country}
+                      onClick={() => setSelected(isSel ? null : r.country)}
+                      className={`border-t border-border/30 cursor-pointer hover:bg-white/[0.02] ${isSel ? 'bg-white/[0.03]' : ''}`}
+                    >
+                      <td className="px-2 py-1.5 text-neutral-300">
+                        {r.name || r.country}
+                        {r.region === 'ne' && (
+                          <span className="ml-1.5 text-[9px] text-amber-500/70" title="Non-EU reporter">NON-EU</span>
+                        )}
+                      </td>
+                      <td className={`px-2 py-1.5 text-right ${
+                        pct == null ? 'text-neutral-700' : pct < 30 ? 'text-orange-400' : 'text-neutral-200'
+                      }`}>
+                        {pct != null ? `${pct.toFixed(1)}%` : '—'}
+                      </td>
+                      <td className="px-2 py-1.5 w-28">
+                        {pct != null && (
+                          <div className="h-1.5 bg-neutral-900 rounded-sm">
+                            <div
+                              className="h-1.5 rounded-sm"
+                              style={{
+                                width: `${Math.max(0, Math.min(100, pct))}%`,
+                                background: pct < 30 ? '#fb923c' : '#22d3ee',
+                                opacity: 0.75,
+                              }}
+                            />
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-2 py-1.5 text-right text-neutral-400">
+                        {r.stock_twh != null ? `${r.stock_twh.toFixed(1)}` : '—'}
+                        {r.working_gas_twh != null && (
+                          <span className="text-neutral-700"> / {r.working_gas_twh.toFixed(0)} TWh</span>
+                        )}
+                      </td>
+                      <td className="px-2 py-1.5 text-right text-neutral-500">
+                        {r.withdrawal_capacity_gwh != null
+                          ? `${(r.withdrawal_capacity_gwh / 1000).toFixed(1)} TWh/d`
+                          : '—'}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {shown && (
+            <div className="px-2 pb-2">
+              <div className="px-2 pb-1 font-mono text-[9px] text-neutral-600 uppercase tracking-wider">
+                {selected} · fill % over time
+              </div>
+              <ResponsiveContainer width="100%" height={130}>
+                <LineChart data={shown} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
+                  <XAxis dataKey="date" tickFormatter={fmtDate} tick={{ fontSize: 8, fill: '#737373' }} minTickGap={50} />
+                  <YAxis domain={[0, 100]} tick={{ fontSize: 8, fill: '#737373' }} width={30}
+                    tickFormatter={(v) => `${v}%`} />
+                  <ReferenceLine y={30} stroke="#fb923c" strokeDasharray="4 4" strokeOpacity={0.4} />
+                  <Tooltip contentStyle={CHART_TOOLTIP_STYLE} labelFormatter={fmtDate}
+                    formatter={(v) => [v == null ? '—' : `${Number(v).toFixed(1)}%`, 'fill']} />
+                  <Line type="monotone" dataKey="fill_pct" stroke="#22d3ee" strokeWidth={1.4}
+                    dot={false} connectNulls isAnimationActive={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          <div className="px-4 pb-2 font-mono text-[9px] text-neutral-700 leading-relaxed">
+            Click a country for its history. No cross-country total is shown on purpose: coverage
+            is a property of who reports to GIE, and the EU aggregate above is the only complete
+            one. TWh is only readable beside a country&apos;s own capacity — a full Austria holds
+            less than a quarter-full Ukraine.
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
Tier 2, item 2.7. **Zero new API calls** — the data has been on disk since 2023.

## The bug

Every AGSI/ALSI payload is a **tree**: `data[]` holds two or three **roots**, each with country children, each with operators, each with individual facilities. `gie._eu_row` took the single row whose `code == "eu"` and dropped the rest. The countries were fetched, parsed, and deleted — every day, since 2023-01-01.

The `ne` root is not a footnote. It is where **Ukraine** lives:

| | fill | in storage | working gas |
|---|---:|---:|---:|
| Italy | 65 % | 132 TWh | 203 TWh |
| Germany | 38 % | 95 TWh | 247 TWh |
| **Ukraine** *(was invisible)* | **24 %** | **77 TWh** | **320 TWh** — the largest reservoir in Europe |

The real post-Brexit **GB\*** is there too. Meanwhile the `GB` sitting *under* `eu` is "United Kingdom (Pre-Brexit)" and is nothing but dashes. **We have been reading the placeholder and discarding the country.**

## And the obvious fix is also wrong

*"Just walk `data[]` instead of the `eu` row"* pulls in ALSI's **third** root, `ai` ("Additional Information"), holding `ES*` "Spain (1)" — a **duplicate** of the Spain already under `eu`. On 2026-06-20 that is `eu→ES sendOut 343.8` **and** `ai→ES* sendOut 395.7`. That fix double-counts Spain in every LNG total.

So `COUNTRY_ROOTS` is a **whitelist**, not a loop, and a test pins it.

## Zero API calls

The payloads were never lost — 164 MB of AGSI and 54 MB of ALSI sit in the raw cache. This is not a backfill, it is a **re-read**: `backfill_gie_countries` walked **1,290 days in 12 seconds** and wrote 29,210 storage and 17,724 LNG rows without touching the network. A day missing from the cache is **counted and reported, never fetched** (the `repair_storage_series` doctrine), and the WAL is checkpointed every 50 days — an unbounded WAL is how the 2026-07-07 disk incident began.

## What the panel will and will not say

Fill % is a ratio inside one complete country row, so it compares across countries. **TWh appears only beside that country's own working gas volume**, and there is deliberately **no cross-country total**: coverage is a property of who reports to GIE, so an "all countries" sum would be an absolute value we cannot completely capture. The EU aggregate is GIE's own, it is the only complete total, and **it stays exactly as it was** — a test pins it byte-for-byte, because `gas/balance.py` reads its injection/withdrawal as the residual the code itself calls *"this is the product"*.

## Verification

`ruff` clean · **859 passed** (10 new) · eslint clean · vite build green. Driven end-to-end on a local server against the real re-read data: 23 countries sorted by fill, Ukraine present with 12 days of history, `country=ZZ` → honest empty state, `/api/gas/storage` byte-identical, `/api/gas/balance` still reads.

Facility level (78 operators, 137 storages with coordinates, type and injection/withdrawal capacity) is sitting one `children[]` deeper, deliberately left for a follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)