### PR TITLE
Ask ENTSO-E which borders exist, instead of drawing them on a map

### DIFF
--- a/backend/power/border_registry.py
+++ b/backend/power/border_registry.py
@@ -1,0 +1,123 @@
+"""Which borders actually exist — discovered from ENTSO-E, not drawn on a map.
+
+The desk had no border list. `zones.py::POWER_BORDERS` was seven hand-written pairs, dead
+since the A11 ingest was deleted (fb19ab3), and it still listed a border to GB — which is not
+a zone we carry. Cross-border flows, meanwhile, were discovered from whatever Fraunhofer
+Energy-Charts happened to return, which is COUNTRY-level: the 18 sub-zones (NO1-5, SE1-4,
+DK1/2, IT_*) therefore had no border data at all, and DE_LU-DK1 existed only as an aggregate
+`flow.DK` with no price behind it.
+
+This list was SWEPT, not authored: every one of the 666 zone pairs was asked, and 63
+answered. That matters, because a map lies in both directions and quietly:
+
+    IT_SICILIA - IT_SUD       looks obvious. Does not exist.
+    IT_SICILIA - IT_CALABRIA  does.
+    IE_SEM                    has NO scheduled-exchange border at all — its only neighbour
+                              is GB, which left ENTSO-E's publication after Brexit.
+
+Non-existent pairs answer with a clean Acknowledgement, so the sweep is safe and cheap and
+can be re-run whenever a zone is added: backend/scripts/probe_entsoe.py --doctype a09.
+
+Swept 2026-07-13 against a 2-day window. 63 borders, 36 of 37 zones — every sub-zone included,
+and with them the INTERNAL borders no country-level source can ever provide (NO1-NO2, SE3-SE4,
+IT_NORD-IT_CENTRO_NORD). Pairs are canonical: sorted, so `(a, b)` with a < b, matching the
+`flow.<TO>` under `<FROM>` convention in energy_charts_flows.py.
+"""
+
+from __future__ import annotations
+
+from backend.power.zones import ZONE_REGISTRY
+
+SCHEDULED_BORDERS: list[tuple[str, str]] = [
+    ("AT", "CH"),
+    ("AT", "CZ"),
+    ("AT", "DE_LU"),
+    ("AT", "HU"),
+    ("AT", "IT_NORD"),
+    ("AT", "SI"),
+    ("BE", "DE_LU"),
+    ("BE", "FR"),
+    ("BE", "NL"),
+    ("BG", "GR"),
+    ("BG", "RO"),
+    ("CH", "DE_LU"),
+    ("CH", "FR"),
+    ("CH", "IT_NORD"),
+    ("CZ", "DE_LU"),
+    ("CZ", "PL"),
+    ("CZ", "SK"),
+    ("DE_LU", "DK1"),
+    ("DE_LU", "DK2"),
+    ("DE_LU", "FR"),
+    ("DE_LU", "NL"),
+    ("DE_LU", "NO2"),
+    ("DE_LU", "PL"),
+    ("DE_LU", "SE4"),
+    ("DK1", "DK2"),
+    ("DK1", "NL"),
+    ("DK1", "NO2"),
+    ("DK1", "SE3"),
+    ("DK2", "SE4"),
+    ("ES", "FR"),
+    ("ES", "PT"),
+    ("FI", "SE1"),
+    ("FI", "SE3"),
+    ("FR", "IT_NORD"),
+    ("GR", "IT_SUD"),
+    ("HR", "HU"),
+    ("HR", "SI"),
+    ("HU", "RO"),
+    ("HU", "SI"),
+    ("HU", "SK"),
+    ("IT_CALABRIA", "IT_SICILIA"),
+    ("IT_CALABRIA", "IT_SUD"),
+    ("IT_CENTRO_NORD", "IT_CENTRO_SUD"),
+    ("IT_CENTRO_NORD", "IT_NORD"),
+    ("IT_CENTRO_SUD", "IT_SARDEGNA"),
+    ("IT_CENTRO_SUD", "IT_SUD"),
+    ("IT_NORD", "SI"),
+    ("NL", "NO2"),
+    ("NO1", "NO2"),
+    ("NO1", "NO3"),
+    ("NO1", "NO5"),
+    ("NO1", "SE3"),
+    ("NO2", "NO5"),
+    ("NO3", "NO4"),
+    ("NO3", "NO5"),
+    ("NO3", "SE2"),
+    ("NO4", "SE1"),
+    ("NO4", "SE2"),
+    ("PL", "SE4"),
+    ("PL", "SK"),
+    ("SE1", "SE2"),
+    ("SE2", "SE3"),
+    ("SE3", "SE4"),
+]
+
+
+#: The one zone ENTSO-E publishes no scheduled exchange for. Named, not silently absent —
+#: a zone that simply fails to appear looks like a bug; a zone that is listed here as
+#: unbordered is a fact about the data.
+ZONES_WITHOUT_BORDERS = ("IE_SEM",)
+
+
+def directed_pairs() -> list[tuple[str, str]]:
+    """Every border in BOTH directions — A09 is a directed query and the net is the
+    difference between them. (a, b) and (b, a) for each canonical pair."""
+    return [p for a, b in SCHEDULED_BORDERS for p in ((a, b), (b, a))]
+
+
+def borders_for(zone: str) -> list[tuple[str, str]]:
+    """The canonical borders `zone` participates in."""
+    return [(a, b) for a, b in SCHEDULED_BORDERS if zone in (a, b)]
+
+
+def counterparties(zone: str) -> list[str]:
+    return sorted(b if a == zone else a for a, b in borders_for(zone))
+
+
+# A pseudo-zone in this list is how `flow.DK` / `flow.NO` / `flow.GB` happened: series that
+# exist in the store with no price, no zone, and nothing to join to. Fail at import.
+_unknown = {z for pair in SCHEDULED_BORDERS for z in pair} - set(ZONE_REGISTRY)
+if _unknown:  # pragma: no cover - a broken registry must not start the app
+    raise RuntimeError(f"border registry references non-zones: {sorted(_unknown)}")

--- a/backend/power/zones.py
+++ b/backend/power/zones.py
@@ -17,7 +17,10 @@ Per-zone metadata:
                  (None where not yet mapped; completed with the flows generalization)
 
 Cross-border flows: sourced from Fraunhofer Energy-Charts /cbpf (CC BY 4.0,
-energy_charts_flows.py). POWER_BORDERS below is only the /flows route summary list.
+energy_charts_flows.py), which is COUNTRY-level. The border ADJACENCY list lives in
+backend/power/border_registry.py and was swept from ENTSO-E rather than authored — a
+hand-drawn one lived here for a year, went dead with the A11 ingest, and still listed a
+border to GB, which is not a zone.
 """
 
 from __future__ import annotations
@@ -85,15 +88,3 @@ POWER_ZONES: dict[str, dict] = {k: ZONE_REGISTRY[k] for k in ENABLED_ZONES}
 
 # Default zone: DE_LU when enabled, else the first enabled zone.
 DEFAULT_ZONE = "DE_LU" if "DE_LU" in POWER_ZONES else ENABLED_ZONES[0]
-
-# Real cross-border pairs for the /flows route summary (Energy-Charts /cbpf, CC BY 4.0).
-# Block 2 will derive this from the registry; kept explicit for the current 3 zones.
-POWER_BORDERS: list[tuple[str, str]] = [
-    ("BE", "DE_LU"),
-    ("BE", "NL"),
-    ("CH", "DE_LU"),
-    ("CH", "FR"),
-    ("DE_LU", "FR"),
-    ("DE_LU", "NL"),
-    ("FR", "GB"),
-]

--- a/backend/scripts/probe_entsoe.py
+++ b/backend/scripts/probe_entsoe.py
@@ -1,0 +1,231 @@
+"""Ask ENTSO-E what it actually has, before we write code that assumes.
+
+Three times in Tier 1 the data refused the plan: the seasonal baseline was defeated by
+fleet growth, A77 turned out to hold no history at all, and a query that answered in 13 ms
+on the dev database took 7.8 s on prod. Every one of those was cheap to discover and
+expensive to discover late. So: probe first, in a script that anyone can re-run, and write
+the finding down.
+
+READ-ONLY BY CONSTRUCTION. This never touches the database and never writes the raw cache —
+a probe that populates the cache would poison the ingest that follows it with documents
+fetched under exploratory parameters.
+
+    python -m backend.scripts.probe_entsoe --doctype a09 --dry-run
+    python -m backend.scripts.probe_entsoe --doctype a09     # the border discovery sweep
+    python -m backend.scripts.probe_entsoe --doctype a25
+    python -m backend.scripts.probe_entsoe --doctype a71
+
+WHY A09 SWEEPS EVERY PAIR INSTEAD OF A GEOGRAPHIC GUESS
+-------------------------------------------------------
+Because guessing is wrong in both directions, and quietly. IT_SICILIA↔IT_SUD looks obvious
+on a map and does not exist; IT_SICILIA↔IT_CALABRIA does. A hand-authored adjacency list is
+how `zones.py::POWER_BORDERS` ended up listing a border to GB, which is not a zone we carry.
+Non-existent pairs answer with a clean Acknowledgement, so the full sweep is safe, cheap
+(one small window per pair) and it is the only version of this list that cannot be wrong.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import xml.etree.ElementTree as ET
+from collections import Counter
+
+import httpx
+
+from backend.config import settings
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _token
+from backend.power.zones import ZONE_REGISTRY
+
+#: ENTSO-E's published ceiling is ~400 requests/minute. Stay far under it: this script is a
+#: courtesy caller on a free public API, and a ban costs the whole desk, not just the probe.
+THROTTLE_SECONDS = 0.35
+
+#: A 2-day window is enough to answer "does this border exist at all" and keeps every
+#: response small. Coverage over TIME is a separate question, answered by the ingest.
+PROBE_START = "202607010000"
+PROBE_END = "202607030000"
+
+SCHEDULED_EXCHANGE_DOCTYPE = "A09"
+NET_POSITION_DOCTYPE = "A25"
+NET_POSITION_BUSINESS_TYPE = "B09"  # NOT the psrType B09 (= "Geothermal")
+UNIT_REGISTRY_DOCTYPE = "A71"
+UNIT_REGISTRY_PROCESS_TYPE = "A33"
+
+
+async def _get(client: httpx.AsyncClient, params: dict) -> tuple[int, str]:
+    resp = await client.get(ENTSOE_BASE, params={"securityToken": _token(), **params})
+    return resp.status_code, resp.text
+
+
+def _root_name(xml_text: str) -> str:
+    try:
+        return _localname(ET.fromstring(xml_text).tag)
+    except ET.ParseError:
+        return "unparseable"
+
+
+def _has_data(xml_text: str) -> bool:
+    """An Acknowledgement_MarketDocument is ENTSO-E politely saying "nothing here"."""
+    return _root_name(xml_text).endswith("Publication_MarketDocument")
+
+
+def _points(xml_text: str) -> int:
+    return sum(1 for e in ET.fromstring(xml_text).iter() if _localname(e.tag) == "Point")
+
+
+# ── A09: the border discovery sweep ───────────────────────────────────────────────────
+
+
+async def probe_a09(dry_run: bool) -> int:
+    zones = sorted(ZONE_REGISTRY)
+    pairs = [(a, b) for i, a in enumerate(zones) for b in zones[i + 1 :]]
+    print(f"# A09 scheduled exchanges — sweeping {len(pairs)} zone pairs "
+          f"({len(pairs) * THROTTLE_SECONDS / 60:.1f} min at {THROTTLE_SECONDS}s each)")
+    if dry_run:
+        print(f"# dry run: would probe {pairs[0]} … {pairs[-1]}")
+        return 0
+
+    found: list[tuple[str, str]] = []
+    async with httpx.AsyncClient(timeout=90) as client:
+        for i, (a, b) in enumerate(pairs):
+            try:
+                status, xml = await _get(client, {
+                    "documentType": SCHEDULED_EXCHANGE_DOCTYPE,
+                    "contract_MarketAgreement.Type": "A05",
+                    "out_Domain": ZONE_REGISTRY[a]["eic"],
+                    "in_Domain": ZONE_REGISTRY[b]["eic"],
+                    "periodStart": PROBE_START, "periodEnd": PROBE_END,
+                })
+            except httpx.HTTPError as exc:
+                print(f"  !! {a}->{b}: {exc}", file=sys.stderr)
+                continue
+            if status == 200 and _has_data(xml):
+                found.append((a, b))
+                print(f"  ✓ {a}-{b}  ({_points(xml)} points)")
+            await asyncio.sleep(THROTTLE_SECONDS)
+            if (i + 1) % 100 == 0:
+                print(f"  … {i + 1}/{len(pairs)} probed, {len(found)} borders so far",
+                      file=sys.stderr)
+
+    print(f"\n# {len(found)} borders answered. Paste into backend/power/border_registry.py:\n")
+    print("SCHEDULED_BORDERS: list[tuple[str, str]] = [")
+    for a, b in found:
+        print(f'    ("{a}", "{b}"),')
+    print("]")
+
+    covered = {z for pair in found for z in pair}
+    missing = sorted(set(ZONE_REGISTRY) - covered)
+    if missing:
+        print(f"\n# Zones with NO scheduled-exchange border: {', '.join(missing)}")
+    return 0
+
+
+# ── A25: which zones publish a market net position ────────────────────────────────────
+
+
+async def probe_a25(dry_run: bool) -> int:
+    zones = sorted(ZONE_REGISTRY)
+    print(f"# A25/B09 market net position — probing {len(zones)} zones")
+    if dry_run:
+        return 0
+
+    answered, empty = [], []
+    async with httpx.AsyncClient(timeout=180) as client:
+        for zone in zones:
+            eic = ZONE_REGISTRY[zone]["eic"]
+            try:
+                status, xml = await _get(client, {
+                    "documentType": NET_POSITION_DOCTYPE,
+                    "businessType": NET_POSITION_BUSINESS_TYPE,
+                    "contract_MarketAgreement.Type": "A01",  # mandatory — rejected without it
+                    "in_Domain": eic, "out_Domain": eic,
+                    "periodStart": PROBE_START, "periodEnd": PROBE_END,
+                })
+            except httpx.HTTPError as exc:
+                print(f"  !! {zone}: {exc}", file=sys.stderr)
+                continue
+            if status == 200 and _has_data(xml):
+                # The sign lives in the domain PAIR, not in the quantity: a TimeSeries whose
+                # out_Domain is the zone is an EXPORT block, one whose in_Domain is the zone
+                # is an IMPORT block. Count both — a zone showing only one kind would mean
+                # the sweep window caught it never flipping, not that it cannot.
+                blocks = Counter()
+                for ts in ET.fromstring(xml).iter():
+                    if _localname(ts.tag) != "TimeSeries":
+                        continue
+                    out_ = next((e.text for e in ts.iter()
+                                 if _localname(e.tag) == "out_Domain.mRID"), None)
+                    blocks["export" if out_ == eic else "import"] += 1
+                answered.append(zone)
+                print(f"  ✓ {zone:16s} {_points(xml):4d} points  "
+                      f"{blocks['export']} export / {blocks['import']} import blocks")
+            else:
+                empty.append(zone)
+                print(f"  – {zone:16s} no data")
+            await asyncio.sleep(THROTTLE_SECONDS)
+
+    print(f"\n# {len(answered)}/{len(zones)} zones publish A25. No coverage: "
+          f"{', '.join(empty) or 'none'}")
+    return 0
+
+
+# ── A71/A33: the production-unit registry ─────────────────────────────────────────────
+
+
+async def probe_a71(dry_run: bool) -> int:
+    zones = sorted(ZONE_REGISTRY)
+    print(f"# A71/A33 production units — probing {len(zones)} zones (slow: up to ~9s each)")
+    if dry_run:
+        return 0
+
+    total_units = 0
+    async with httpx.AsyncClient(timeout=180) as client:
+        for zone in zones:
+            try:
+                status, xml = await _get(client, {
+                    "documentType": UNIT_REGISTRY_DOCTYPE,
+                    "processType": UNIT_REGISTRY_PROCESS_TYPE,
+                    "in_Domain": ZONE_REGISTRY[zone]["eic"],
+                    "periodStart": "202601010000", "periodEnd": "202601020000",
+                })
+            except httpx.HTTPError as exc:
+                print(f"  !! {zone}: {exc}", file=sys.stderr)
+                continue
+            if status == 200 and _has_data(xml):
+                root = ET.fromstring(xml)
+                nominals = [float(e.text) for e in root.iter()
+                            if _localname(e.tag) == "nominalP" and e.text]
+                psrs = Counter(e.text for e in root.iter()
+                               if _localname(e.tag) == "psrType" and e.text)
+                total_units += len(nominals)
+                print(f"  ✓ {zone:16s} {len(nominals):4d} units  "
+                      f"{sum(nominals):9,.0f} MW  psr={dict(psrs)}")
+            else:
+                print(f"  – {zone:16s} no data")
+            await asyncio.sleep(THROTTLE_SECONDS)
+
+    print(f"\n# {total_units} published units across the registry.")
+    print("# NOTE: this is the >~100 MW publication threshold, NOT the installed fleet (A68).")
+    return 0
+
+
+PROBES = {"a09": probe_a09, "a25": probe_a25, "a71": probe_a71}
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--doctype", required=True, choices=sorted(PROBES))
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print what would be probed, make no requests")
+    args = ap.parse_args(argv[1:])
+
+    if not settings.entsoe_api_token and not args.dry_run:
+        print("ENTSOE_API_TOKEN is not set.", file=sys.stderr)
+        return 1
+    return asyncio.run(PROBES[args.doctype](args.dry_run))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/tests/test_border_registry.py
+++ b/backend/tests/test_border_registry.py
@@ -1,0 +1,96 @@
+"""Which borders exist is a question for ENTSO-E, not for a map.
+
+The desk has been bitten by hand-drawn geography twice. `zones.py::POWER_BORDERS` listed a
+border to GB — not a zone we carry — and stayed there for a year after the ingest that used it
+was deleted. And Energy-Charts, being country-level, produced series named `flow.DK`,
+`flow.NO`, `flow.IT`, `flow.GB`, `flow.LU`: pseudo-zones that sit in the store today with no
+price behind them and nothing to join to.
+
+These tests exist so the swept registry cannot become the third instance.
+"""
+from __future__ import annotations
+
+from backend.power import zones
+from backend.power.border_registry import (
+    SCHEDULED_BORDERS,
+    ZONES_WITHOUT_BORDERS,
+    borders_for,
+    counterparties,
+    directed_pairs,
+)
+from backend.power.zones import ZONE_REGISTRY
+
+SUB_ZONES = [
+    "DK1", "DK2",
+    "NO1", "NO2", "NO3", "NO4", "NO5",
+    "SE1", "SE2", "SE3", "SE4",
+    "IT_NORD", "IT_CENTRO_NORD", "IT_CENTRO_SUD", "IT_SUD",
+    "IT_SICILIA", "IT_SARDEGNA", "IT_CALABRIA",
+]
+
+
+def test_no_pseudo_zone_can_enter_the_border_registry():
+    """`flow.DK` / `flow.NO` / `flow.GB` are real series in the store today, under keys that
+    are not zones: country aggregates with no price and nothing to join. Every side of every
+    border here must be a zone we actually carry."""
+    for a, b in SCHEDULED_BORDERS:
+        assert a in ZONE_REGISTRY, f"{a} is not a bidding zone"
+        assert b in ZONE_REGISTRY, f"{b} is not a bidding zone"
+
+
+def test_the_sub_zones_have_borders_at_last():
+    """The whole point. All 18 of these had ZERO border data, because Energy-Charts reports
+    Denmark, not DK1 and DK2. If this ever fails, someone has 'simplified' the registry back
+    to country level and silently deleted half of Europe's borders again."""
+    for zone in SUB_ZONES:
+        assert borders_for(zone), f"{zone} has no border"
+
+
+def test_the_internal_borders_no_country_source_can_ever_see():
+    """DK1-DK2, NO1-NO2, SE3-SE4, IT_NORD-IT_CENTRO_NORD are borders WITHIN a country. A
+    country-level feed cannot represent them even in principle — they net to zero."""
+    for pair in [("DK1", "DK2"), ("NO1", "NO2"), ("SE3", "SE4"),
+                 ("IT_CENTRO_NORD", "IT_NORD")]:
+        assert tuple(sorted(pair)) in SCHEDULED_BORDERS
+
+
+def test_geography_is_not_guessable():
+    """Both directions of the trap, in one test. Sicily touches Calabria across the strait,
+    not IT_SUD — and a map-reader would get that backwards. This is why the list was swept."""
+    assert ("IT_CALABRIA", "IT_SICILIA") in SCHEDULED_BORDERS
+    assert ("IT_SICILIA", "IT_SUD") not in SCHEDULED_BORDERS
+    assert counterparties("IT_SICILIA") == ["IT_CALABRIA"]
+
+
+def test_a_zone_with_no_border_is_NAMED_not_silently_absent():
+    """IE_SEM publishes no scheduled exchange: its only neighbour is GB, which left ENTSO-E's
+    publication after Brexit. A zone that merely fails to appear looks like a bug. A zone
+    listed as unbordered is a fact about the data."""
+    assert "IE_SEM" in ZONES_WITHOUT_BORDERS
+    assert not borders_for("IE_SEM")
+    covered = {z for pair in SCHEDULED_BORDERS for z in pair}
+    assert set(ZONE_REGISTRY) - covered == set(ZONES_WITHOUT_BORDERS)
+
+
+def test_pairs_are_canonical_sorted_unique_and_never_self():
+    """The sign convention of the whole border layer rests on this: `net > 0` means the
+    sorted-FIRST zone exports. An unsorted pair silently inverts a flow."""
+    for a, b in SCHEDULED_BORDERS:
+        assert a < b, f"({a}, {b}) is not sorted"
+        assert a != b
+    assert len(set(SCHEDULED_BORDERS)) == len(SCHEDULED_BORDERS)
+
+
+def test_directed_pairs_are_both_ways_because_a09_is_directed():
+    """A09 answers per direction and the net is A→B minus B→A. Query one leg only and a
+    500 MW export reads as an export while 800 MW came the other way."""
+    directed = directed_pairs()
+    assert len(directed) == 2 * len(SCHEDULED_BORDERS)
+    for a, b in SCHEDULED_BORDERS:
+        assert (a, b) in directed and (b, a) in directed
+
+
+def test_the_dead_hand_drawn_border_list_is_gone():
+    """It listed a border to GB and outlived its only consumer by a year. Two competing border
+    lists is exactly how the pseudo-zone series were born."""
+    assert not hasattr(zones, "POWER_BORDERS")

--- a/docs/findings/2026-07-13-entsoe-a09-a25-a71.md
+++ b/docs/findings/2026-07-13-entsoe-a09-a25-a71.md
@@ -1,0 +1,146 @@
+# ENTSO-E A09 / A25 / A71: what the API actually says
+
+**Probed live against the repo's token, 2026-07-13.** Re-runnable:
+`python -m backend.scripts.probe_entsoe --doctype a09|a25|a71`
+
+Three document types were about to be ingested on the strength of an audit's coverage
+claims. All three claims about **coverage** hold. All three claims about **meaning** were
+wrong — in ways that would have produced numbers that look right and are not.
+
+Tier 1 taught this the expensive way three times: the seasonal baseline was defeated by fleet
+growth, A77 turned out to hold no history at all, and a query that answered in 13 ms on the
+dev database took 7.8 s on prod. Probing first costs an afternoon.
+
+---
+
+## A09 — Scheduled exchanges
+
+### Coverage: confirmed, and larger than hoped
+
+Every one of the 666 zone pairs was asked. **63 borders answered, covering 36 of 37 zones.**
+All 18 sub-zones are in, and with them the **internal** borders no country-level source can
+represent even in principle: NO1–NO2, SE3–SE4, DK1–DK2, IT_NORD–IT_CENTRO_NORD.
+
+The one zone with no border at all is **IE_SEM** — its only neighbour is GB, which left
+ENTSO-E's publication after Brexit. It is named in `border_registry.ZONES_WITHOUT_BORDERS`
+rather than left to silently not appear.
+
+### Geography is not guessable — this is why the list was swept
+
+```
+IT_SICILIA – IT_SUD        looks obvious on a map.  DOES NOT EXIST.
+IT_SICILIA – IT_CALABRIA   is the real one (across the Strait of Messina).
+```
+
+A hand-drawn list gets this backwards, and a hand-drawn list is exactly what
+`zones.py::POWER_BORDERS` was: seven pairs, dead since the A11 ingest was deleted (`fb19ab3`),
+still listing a border to **GB**, which is not a zone we carry. It is now deleted.
+
+Non-existent pairs answer with a clean `Acknowledgement_MarketDocument`, so the sweep is safe
+and can be re-run whenever a zone is added.
+
+### ⚠️ `contract_MarketAgreement.Type` is effectively mandatory
+
+Omit it and **one document carries two TimeSeries** — A01 (day-ahead) *and* A05 (total).
+DE→FR, 2026-07-01/02: 26 points and 71 points, in the same response. A parser that walks all
+TimeSeries **averages day-ahead with total schedules** and produces a quantity that is neither.
+
+→ Use **A05 (total)**. That is the leg comparable to physical flow, and the one that makes
+`loop flow = physical − scheduled` mean anything.
+
+### ⚠️ `curveType` is **A03** — a sparse step function
+
+**This is the load-bearing finding.** A03 publishes a point only where the value *changes*;
+it holds until the next published position, and the last one holds to the end of the Period.
+
+DE→FR, 2026-07-01: published positions `1, 142, 143, 144, 145, 167, …` — **26 of 192 PT15M
+slots.**
+
+Every parser in this repo (`parse_load`, `parse_load_hourly`, `parse_generation_hourly`,
+`parse_imbalance_prices`, `parse_imbalance_quarter_hourly`) assumes **A01**: one point per
+slot, sequential. Feed an A09 document to any of them and **86 % of the timeline is silently
+dropped**, and then an "hourly mean" is computed from the one or two quarter-hours that
+happened to be published. The number that comes out is not wrong by a little.
+
+A new `parse_step_series` is therefore the substance of the A09 ingest, not a detail of it.
+
+### Mixed resolution
+
+**PT15M** on continental borders; **PT60M** on the Nordic ones (SE1→FI, NO1→NO2, SE3→SE4) and
+across all 2023 history. `_RESOLUTION_HOURS` already handles both — but a fixture that only
+covers PT15M cannot prove it.
+
+---
+
+## A25 / B09 — Market net position
+
+### Coverage: confirmed, 34 of 37
+
+`GR`, `IE_SEM`, `CH` answer with a clean *"No matching data found for Data item
+IMPLICIT_ALLOCATION…"*. Everything else answers, all sub-zones included.
+
+`contract_MarketAgreement.Type=A01` is **mandatory** — without it the API replies
+*"Mandatory parameter Contract_MarketAgreement.Type is missing"*.
+
+### ⚠️⚠️ The quantity is an UNSIGNED MAGNITUDE. The sign lives in the DOMAIN PAIR.
+
+Measured on PL, 2026-07-01/02:
+
+```
+TimeSeries blocks: {'EXPORT (out_Domain=PL)': 23, 'IMPORT (in_Domain=PL)': 7}
+172 quantity points, ALL >= 0.   e.g. 1652.2, 1769.7, 1804.8, 1777
+```
+
+The document partitions the timeline into disjoint A03 TimeSeries and **flips the domain pair
+every time the zone flips direction**. A TimeSeries whose `out_Domain.mRID` is the zone is an
+export block; one whose `in_Domain.mRID` is the zone is an import block (the counter-domain is
+the literal string `REGION_CODE-----`).
+
+**A parser that reads `<quantity>` and ignores the domains reports Poland exporting 1.65 GW
+during the hours it was importing.** This is the most dangerous trap in the whole of Tier 2,
+because the output is plausible, well-formed, and inverted.
+
+### Operational
+
+A **one-month** A25 window did not return within 90 s. Fetch weekly windows with a longer
+timeout; do not copy the `httpx.AsyncClient(timeout=90)` default that every other ingest uses.
+
+---
+
+## A71 / A33 — Production-unit registry
+
+### Coverage: confirmed, 37 of 37 — including the 18 zones with no A68
+
+Every zone answers, and per unit the document carries `registeredResource.mRID` (the EIC —
+**exactly the key `PowerOutage.unit_eic` has been writing and never reading**),
+`registeredResource.name`, `psrType`, and `nominalIP_PowerSystemResources.nominalP`.
+
+### ⚠️⚠️ It is NOT the installed fleet, and must never be used as one
+
+```
+DE-LU  A71/A33 :  161 units,   51,973 MW
+DE-LU  A68     :              294,941 MW   (prod, year 2026)
+                              ────────────
+                              factor 5.7
+```
+
+A71/A33 lists only production **units above ENTSO-E's ~100 MW publication threshold**. It is a
+different population, not a smaller sample of the same one.
+
+Firing `forced_outage_severity`'s A68-calibrated 3 %/8 % thresholds against a denominator 5.7×
+too small would fire roughly five times as often — and the 19 A68 zones and the 18 A71 zones
+would then be measuring **different populations under one threshold**. That is precisely the
+cross-zone incomparability `outage_history.py` already forbids in its own docstring ("Czechia
+has published 6,633 events and Germany 94").
+
+**The honest use:** A71/A33 is the same population the A77 outages are drawn from. So report
+`% of the zone's published ≥100 MW units` as its **own** number with its **own** label, and
+leave the A68 denominator alone. Re-calibrating the radar's thresholds is a separate,
+backtestable decision (`backend/scripts/backtest_radar.py` exists for exactly that).
+
+### Side finding
+
+A71/A33 returns `psrType=B03`, which is **not in `PSR_LABELS`** — nor is `B25`, which already
+exists in the store as `gen.B25` / `consumption.B25`. `PSR_LABELS.get(code, code)` degrades
+gracefully; `PSR_LABELS[code]` would raise. Anything joining on a label rather than a code
+inherits that gap, which is one reason the unit registry stores the **raw B-code**.


### PR DESCRIPTION
Tier 2, PR 1 — the spike. Three document types were about to be ingested on the strength of an audit's coverage claims. **All three coverage claims hold. All three claims about *meaning* were wrong** — in ways that produce numbers which look right and are not.

The deliverable is `docs/findings/2026-07-13-entsoe-a09-a25-a71.md` and a re-runnable probe script.

## A09: 63 borders, swept not authored

Every one of the **666 zone pairs** was asked. **63 answered, covering 36 of 37 zones.** All 18 sub-zones are in — and with them the **internal** borders no country-level source can represent even in principle: NO1–NO2, SE3–SE4, DK1–DK2, IT_NORD–IT_CENTRO_NORD.

**IE_SEM has no border at all** (its only neighbour is GB, which left ENTSO-E after Brexit). It is *named* in `ZONES_WITHOUT_BORDERS` rather than left to silently not appear.

**Geography is not guessable, and that is the whole argument for sweeping:**

```
IT_SICILIA – IT_SUD        looks obvious.  DOES NOT EXIST.
IT_SICILIA – IT_CALABRIA   is the real one.
```

A hand-drawn list gets that backwards — and a hand-drawn list is exactly what `POWER_BORDERS` was: seven pairs, **dead since the A11 ingest was deleted (`fb19ab3`)**, still listing a border to **GB**, which is not a zone we carry. Deleted. Two competing border lists is how `flow.DK` / `flow.NO` / `flow.GB` were born — series sitting in the store today with no price behind them and nothing to join to. A test now **fails at import** if a non-zone ever enters this registry.

## What else the token said

| | finding |
|---|---|
| **A09 contract type** | Omit `contract_MarketAgreement.Type` and one document carries **two** TimeSeries — A01 (day-ahead) *and* A05 (total). A parser walking all of them averages the two into a quantity that is neither. |
| **A09 curveType** | **A03 — a sparse step function.** DE→FR publishes **26 of 192** PT15M slots. Every parser in this repo assumes A01 and would drop **86 % of the timeline**, then compute an "hourly mean" from the survivors. |
| **A25 sign** | The quantity is an **unsigned magnitude**; the sign lives in the **domain pair**. PL published **23 export blocks and 7 import blocks** in two days. A parser reading `<quantity>` and ignoring the domains **reports Poland exporting 1.65 GW during the hours it was importing.** |
| **A71/A33** | **Not the installed fleet.** DE-LU: **51,973 MW** published vs **294,941 MW** of A68 — factor **5.7**. It lists only units above the ~100 MW publication threshold. Using it as the outage denominator would fire ~5× as often, with the 19 A68 zones and 18 A71 zones measuring *different populations under one threshold*. |

## The probe script

`probe_entsoe.py` is **read-only by construction**: it never touches the database and never writes the raw cache — a probe that populates the cache would poison the ingest that follows it with documents fetched under exploratory parameters. Throttled to 0.35 s (ENTSO-E's ceiling is ~400/min; a ban costs the whole desk, not just the probe). Non-existent pairs Acknowledge cleanly, so the sweep is safe and re-runnable whenever a zone is added.

`ruff` clean · **867 passed** (8 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)