### PR TITLE
Scheduled exchanges (A09): the 18 sub-zones finally have borders

### DIFF
--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -92,6 +92,10 @@ SPECS += [
     # the daily grain keeps its own power_flows spec above.
     FreshnessSpec("flows_hourly", PowerPriceDaily, "", timedelta(days=3),
                   hourly_series="flow.FR"),
+    # Scheduled exchanges (A09). sched.FR mirrors the flow.FR probe: DE_LU-FR sorts DE_LU
+    # first, so the series exists in every enabled setup that has France.
+    FreshnessSpec("scheduled_exchanges", PowerPriceDaily, "", timedelta(days=3),
+                  hourly_series="sched.FR"),
     # The outage snapshot is the ONE series that cannot be backfilled: A77 takes an
     # unavailability down once it is over, so an hour the recorder missed is gone for
     # good. It must therefore be the tightest window on the desk — a day of silence is

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -180,6 +180,21 @@ async def _run_power_daily():
         except Exception as exc:
             logger.error("power daily ingest_cbpf (Energy-Charts) failed: %s", exc)
 
+        # Scheduled cross-border exchanges (ENTSO-E A09). Bidding-zone-resolved, so this is
+        # the ONLY border grain the 18 sub-zones have — Energy-Charts above reports by country.
+        try:
+            from backend.power.entsoe_exchange import (
+                ingest_scheduled_exchanges,
+                recent_months,
+            )
+
+            result = await ingest_scheduled_exchanges(
+                db, recent_months(7), overwrite=True
+            )
+            logger.info("power daily scheduled exchanges (A09): %s", result)
+        except Exception as exc:
+            logger.error("power daily ingest_scheduled_exchanges failed: %s", exc)
+
         # Spark spread uses POWER_DE (DE-LU) only — SparkSpreadHistory has no zone column.
         try:
             result = await collect_spark_spreads()

--- a/backend/power/borders.py
+++ b/backend/power/borders.py
@@ -145,8 +145,22 @@ def border_metrics(
     }
 
 
-def _flow_dims(db: Session) -> tuple[dict[int, str], dict[int, str]]:
-    """(series_id → counterparty, zone_id → zone key) for the flow series.
+#: The two grains a border can have, and they are NOT the same quantity.
+#:
+#: `flow.*`  — what the wires physically carried (Fraunhofer Energy-Charts, COUNTRY-level, so
+#:             the 18 sub-zones have none).
+#: `sched.*` — what the market agreed to move (ENTSO-E A09, BIDDING-ZONE-level, 63 borders
+#:             including every sub-zone and the internal ones no country feed can express).
+#:
+#: Their difference is loop flow. Merging them into one namespace would make that difference
+#: uncomputable and every existing number ambiguous, so they stay apart and the response says
+#: which grain each border was read from.
+PHYSICAL_PREFIX = "flow."
+SCHEDULED_PREFIX = "sched."
+
+
+def _flow_dims(db: Session, prefix: str = PHYSICAL_PREFIX) -> tuple[dict[int, str], dict[int, str]]:
+    """(series_id → counterparty, zone_id → zone key) for one border grain.
 
     Resolving the ids FIRST is the whole performance story. power_hourly holds
     28.5M rows under a WITHOUT ROWID primary key of (series_id, zone_id, ts_utc);
@@ -155,21 +169,22 @@ def _flow_dims(db: Session) -> tuple[dict[int, str], dict[int, str]]:
     straight into it.
     """
     series = {
-        sid: key[len("flow."):]
+        sid: key[len(prefix):]
         for sid, key in db.query(SeriesDim.id, SeriesDim.key)
-        .filter(SeriesDim.key.like("flow.%")).all()
+        .filter(SeriesDim.key.like(f"{prefix}%")).all()
     }
     zones = dict(db.query(ZoneDim.id, ZoneDim.key).all())
     return series, zones
 
 
-def _flow_rows(db: Session, start_ts: int) -> dict[tuple[str, str], dict[int, float]]:
-    """Every hourly cross-border flow since `start_ts`, keyed by canonical border.
+def _flow_rows(db: Session, start_ts: int,
+               prefix: str = PHYSICAL_PREFIX) -> dict[tuple[str, str], dict[int, float]]:
+    """Every hourly cross-border value of one grain since `start_ts`, by canonical border.
 
     Call this for the DISPLAY window only — the rail threshold, the only thing
     that needs a year of history, is computed in SQL (_rail_thresholds).
     """
-    series, zones = _flow_dims(db)
+    series, zones = _flow_dims(db, prefix)
     if not series:
         return {}
     rows = (
@@ -194,37 +209,39 @@ def _flow_rows(db: Session, start_ts: int) -> dict[tuple[str, str], dict[int, fl
 #: as_of masquerade as fresh, nothing here is a freshness claim.)
 RAIL_CACHE_TTL_SECONDS = 6 * 3600
 
-_rail_cache: dict[str, object] = {"computed_at": None, "values": {}}
+#: Keyed by grain: a scheduled border's own p95 is a different number from a physical one's,
+#: and sharing one cache between them would hand a border the other grain's rail.
+_rail_cache: dict[str, dict] = {}
 
 
-def rail_thresholds_cached(db: Session, start_ts: int, *, now: datetime | None = None):
+def rail_thresholds_cached(db: Session, start_ts: int, *, now: datetime | None = None,
+                           prefix: str = PHYSICAL_PREFIX):
     """(thresholds, computed_at) — recomputed at most every RAIL_CACHE_TTL_SECONDS."""
     now = now or datetime.now(timezone.utc)
-    computed_at = _rail_cache["computed_at"]
+    entry = _rail_cache.get(prefix)
     if (
-        computed_at is None
-        or (now - computed_at).total_seconds() >= RAIL_CACHE_TTL_SECONDS
+        entry is None
+        or (now - entry["computed_at"]).total_seconds() >= RAIL_CACHE_TTL_SECONDS
     ):
-        _rail_cache["values"] = _rail_thresholds(db, start_ts)
-        _rail_cache["computed_at"] = now
-        computed_at = now
-    return _rail_cache["values"], computed_at
+        entry = {"values": _rail_thresholds(db, start_ts, prefix), "computed_at": now}
+        _rail_cache[prefix] = entry
+    return entry["values"], entry["computed_at"]
 
 
 def reset_rail_cache() -> None:
     """Test isolation."""
-    _rail_cache["computed_at"] = None
-    _rail_cache["values"] = {}
+    _rail_cache.clear()
 
 
-def _rail_thresholds(db: Session, start_ts: int) -> dict[tuple[str, str], float]:
+def _rail_thresholds(db: Session, start_ts: int,
+                     prefix: str = PHYSICAL_PREFIX) -> dict[tuple[str, str], float]:
     """The RAIL_PERCENTILE of |flow| per border, computed in SQL.
 
     Nearest-rank, identical to `percentile()` (pinned by test) — SQLite ranks the
     year of flows and returns one row per border instead of hundreds of thousands
     of rows to Python.
     """
-    series, zones = _flow_dims(db)
+    series, zones = _flow_dims(db, prefix)
     if not series:
         return {}
     sql = text("""
@@ -277,41 +294,90 @@ def _price_rows(db: Session, zones: set[str], start_ts: int) -> dict[str, dict[i
     return out
 
 
+def loop_flow(physical: dict[int, float], scheduled: dict[int, float]) -> dict | None:
+    """physical − scheduled, over the hours BOTH grains cover. Pure.
+
+    What the wires carried minus what the market agreed to move. It is not a claim about any
+    single interconnector: in a flow-based region, power scheduled from A to B routes through
+    whatever the physics allows, so the residual is transit and loop flow together. Descriptive.
+
+    Returns None where only one grain exists — which is most sub-zone borders (no physical
+    feed) and a few country ones. An absent number with a reason beats an invented one.
+    """
+    hours = sorted(set(physical) & set(scheduled))
+    if not hours:
+        return None
+    diffs = [physical[h] - scheduled[h] for h in hours]
+    return {
+        "loop_hours": len(hours),
+        "loop_mean_mw": round(sum(diffs) / len(diffs), 1),
+        "loop_p95_mw": round(percentile([abs(d) for d in diffs], 0.95) or 0.0, 1),
+    }
+
+
 def compute_borders(db: Session, days: int = 30, *, now: datetime | None = None) -> dict:
-    """Every border with a price on both sides, ranked by how far apart it clears."""
+    """Every border with a price on both sides, ranked by how far apart it clears.
+
+    Reads BOTH grains and prefers the scheduled one where it exists, because that is the grain
+    that resolves bidding zones: the physical feed is country-level, so it cannot see DK1 from
+    DK2 at all. Where both exist, their difference is reported as loop flow.
+    """
     now = now or datetime.now(timezone.utc)
     window_start = int((now - timedelta(days=days)).timestamp())
     rail_start = int((now - timedelta(days=RAIL_BASELINE_DAYS)).timestamp())
 
-    window_flows = _flow_rows(db, window_start)
-    if not window_flows:
+    physical = _flow_rows(db, window_start, PHYSICAL_PREFIX)
+    scheduled = _flow_rows(db, window_start, SCHEDULED_PREFIX)
+    if not physical and not scheduled:
         return {"available": False,
                 "reason": "No cross-border flow series yet — check back shortly."}
-    rails, rails_at = rail_thresholds_cached(db, rail_start, now=now)
+
+    rails_phys, rails_at = rail_thresholds_cached(db, rail_start, now=now,
+                                                  prefix=PHYSICAL_PREFIX)
+    rails_sched, _ = rail_thresholds_cached(db, rail_start, now=now,
+                                            prefix=SCHEDULED_PREFIX)
 
     priced = set(POWER_ZONES)
-    joinable = {b for b in window_flows if b[0] in priced and b[1] in priced}
-    uncoverable = sorted(
-        f"{a}-{b}" for a, b in window_flows if (a, b) not in joinable
-    )
+    all_borders = set(physical) | set(scheduled)
+    joinable = {b for b in all_borders if b[0] in priced and b[1] in priced}
+    uncoverable = sorted(f"{a}-{b}" for a, b in all_borders if (a, b) not in joinable)
 
     prices = _price_rows(db, {z for b in joinable for z in b}, window_start)
 
     out = []
     for a, b in sorted(joinable):
-        m = border_metrics(
-            prices.get(a, {}), prices.get(b, {}), window_flows[(a, b)], rails.get((a, b))
-        )
+        sched = scheduled.get((a, b))
+        phys = physical.get((a, b))
+        # The scheduled grain is bidding-zone-resolved; the physical one is not. Where both
+        # exist they describe the same border, and the scheduled one is the one that keeps
+        # its meaning for a sub-zone.
+        series = sched if sched else phys
+        source = "scheduled" if sched else "physical"
+        rails = rails_sched if sched else rails_phys
+
+        m = border_metrics(prices.get(a, {}), prices.get(b, {}), series, rails.get((a, b)))
         if not m["hours"]:
             continue
+
+        loops = loop_flow(phys, sched) if (phys and sched) else None
         out.append({
             "zone_a": a, "zone_b": b,
             "label": f"{POWER_ZONES[a]['label']}↔{POWER_ZONES[b]['label']}",
+            "flow_source": source,
             "expensive_side": (
                 None if m["latest_spread"] is None or abs(m["latest_spread"]) < COUPLED_EPS_EUR
                 else (a if m["latest_spread"] > 0 else b)
             ),
             **m,
+            **(loops or {
+                "loop_hours": 0, "loop_mean_mw": None, "loop_p95_mw": None,
+                "loop_reason": (
+                    "no physical flow for this border — Energy-Charts reports by country, so "
+                    "bidding sub-zones have none"
+                    if not phys else
+                    "no scheduled exchange for this border"
+                ),
+            }),
         })
 
     out.sort(key=lambda r: -(r["mean_abs_spread"] or 0))
@@ -327,12 +393,15 @@ def compute_borders(db: Session, days: int = 30, *, now: datetime | None = None)
         "uncoverable_borders": uncoverable,
         "note": (
             "Convergence = share of hours the two zones cleared within "
-            f"{COUPLED_EPS_EUR} EUR/MWh. 'At the rail' = physical flow at or above this "
-            "border's own 95th percentile over the last year (we hold no NTC, and "
-            "flow-based regions publish none). Counter-price = power physically ran "
-            "from the expensive zone to the cheap one. Descriptive statistics on "
-            "published records — a spread is not a claim that this interconnector was "
-            "the binding constraint."
+            f"{COUPLED_EPS_EUR} EUR/MWh. 'At the rail' = flow at or above this border's own "
+            "95th percentile over the last year (we hold no NTC, and flow-based regions "
+            "publish none). Counter-price = power ran from the expensive zone to the cheap "
+            "one. `flow_source` says which grain the border was read from: 'scheduled' is "
+            "ENTSO-E's bidding-zone schedule, 'physical' is the country-level metered flow. "
+            "Loop flow = physical minus scheduled where both exist — transit and loop "
+            "together, NOT a claim about any single interconnector. Descriptive statistics "
+            "on published records; a spread is not a claim that this border was the binding "
+            "constraint."
         ),
     }
 

--- a/backend/power/entsoe_exchange.py
+++ b/backend/power/entsoe_exchange.py
@@ -1,0 +1,255 @@
+"""Scheduled cross-border exchanges (ENTSO-E A09) — and the parser they need.
+
+WHAT THIS CLOSES
+----------------
+The desk's border layer is built on Fraunhofer Energy-Charts, which reports by COUNTRY. So
+the 18 sub-zones — NO1-5, SE1-4, DK1/2, every IT_* — have had **no border data at all**, and
+DE_LU↔DK1 existed only as an aggregate `flow.DK` with no price behind it. A09 answers per
+BIDDING ZONE: 63 borders across 36 of 37 zones, including the internal ones no country-level
+source can represent even in principle (NO1↔NO2, SE3↔SE4, IT_NORD↔IT_CENTRO_NORD).
+
+It also gives the desk a quantity it has never had: **loop flow = physical − scheduled**. What
+the market agreed to move, versus what the wires actually carried.
+
+THE PARSER IS THE POINT (curveType A03)
+---------------------------------------
+Every other ENTSO-E series this repo ingests is curveType A01: one point per slot, sequential.
+A09 is **A03 — a variable-sized block, a step function.** A point is published ONLY where the
+value changes; it HOLDS until the next published position, and the last one holds to the end
+of the Period.
+
+    DE→FR, 2026-07-01: published positions 1, 142, 143, 144, 145, 167, …
+                       — 26 of 192 PT15M slots.
+
+Hand that document to `parse_load_hourly` or `parse_imbalance_quarter_hourly` and 86% of the
+timeline vanishes; the "hourly mean" that comes out is an average of whichever one or two
+quarter-hours happened to be published in that hour. It is not wrong by a little.
+
+`parse_step_series` expands the steps back into a dense grid. A01 is the degenerate case (every
+position published) and still parses, so this is strictly more general than what it replaces.
+
+THE SIGN
+--------
+A09 is DIRECTED: two requests per border, and the net is A→B minus B→A. Quantities are
+non-negative magnitudes per direction — asking one leg only would report a 500 MW export while
+800 MW came the other way.
+
+Stored as `sched.<TO>` under zone `<FROM>` on the canonical SORTED pair, with `net > 0` meaning
+`<FROM>` exports — byte-identical to the `flow.<TO>` convention, so borders.py generalises by
+prefix. Kept in its OWN namespace: scheduled and physical MW are different quantities, and a
+single `flow.*` namespace holding both would make loop flow uncomputable and every existing
+number ambiguous.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from xml.etree import ElementTree as ET
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.gas import raw_cache
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
+from backend.power.border_registry import SCHEDULED_BORDERS
+from backend.power.hourly_store import upsert_hourly
+from backend.power.zones import ZONE_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+#: `A09` is ALSO a docStatus in this codebase (_WITHDRAWN_STATUSES in entsoe_outages.py) and
+#: `B09` is a psrType ("Geothermal"). grep will lie to you; the constants are named.
+SCHEDULED_EXCHANGE_DOCTYPE = "A09"
+
+#: Total scheduled — the leg comparable to physical flow. WITHOUT this parameter one document
+#: carries TWO TimeSeries (A01 day-ahead AND A05 total) and a parser that walks all of them
+#: averages the two into a quantity that is neither.
+CONTRACT_TOTAL = "A05"
+
+#: NOT "entsoe_gen_total_forecast" — that source is already taken by A71 + processType A01
+#: (the day-ahead generation forecast). Sharing it would serve back the wrong document.
+CACHE_SOURCE = "entsoe_scheduled_exchange"
+
+SERIES_PREFIX = "sched."
+
+_RESOLUTION_MINUTES = {"PT60M": 60, "PT30M": 30, "PT15M": 15}
+
+
+def parse_step_series(xml_text: str) -> dict[int, float]:
+    """A09 document → {epoch_hour: MW}, densified and averaged onto the UTC hour grid.
+
+    curveType A03 publishes a point only where the value CHANGES. Each published position
+    HOLDS until the next one, and the final position holds to the Period's end — so the slots
+    between publications are not missing data, they are the same value repeated, and dropping
+    them (as every A01 parser in this repo would) deletes most of the timeline.
+
+    Resolution is mixed in the wild: PT15M on continental borders, PT60M on the Nordic ones
+    and across all 2023 history. Both densify to the same hourly grid.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A09 XML parse error: {exc}") from exc
+
+    by_hour: dict[int, list[float]] = defaultdict(list)
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            for epoch, value in _period_slots(period):
+                by_hour[epoch].append(value)
+
+    # Overlapping TimeSeries (revisions, or several contracts) are averaged per hour, the same
+    # rule parse_imbalance_prices uses. A sum here would double-count a republished period.
+    return {h: sum(v) / len(v) for h, v in by_hour.items()}
+
+
+def _period_slots(period) -> list[tuple[int, float]]:
+    """One Period → [(epoch_hour, MW)] with the step function expanded across every slot."""
+    start_el = next((e for e in period.iter() if _localname(e.tag) == "start"), None)
+    end_el = next((e for e in period.iter() if _localname(e.tag) == "end"), None)
+    res_el = next((e for e in period.iter() if _localname(e.tag) == "resolution"), None)
+    if start_el is None or res_el is None:
+        return []
+    minutes = _RESOLUTION_MINUTES.get((res_el.text or "").strip())
+    start = _parse_utc(start_el.text)
+    if minutes is None or start is None:
+        return []
+
+    published: dict[int, float] = {}
+    for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+        pos = next((e.text for e in point if _localname(e.tag) == "position"), None)
+        qty = next((e.text for e in point if _localname(e.tag) == "quantity"), None)
+        if pos is None or qty is None:
+            continue
+        try:
+            published[int(pos)] = float(qty)
+        except (ValueError, TypeError):
+            continue
+    if not published:
+        return []
+
+    # How many slots the Period actually spans. The last published value holds to the END, so
+    # without the end element we would truncate the series at its final change — which for a
+    # border that settles early in the day is most of the day.
+    end = _parse_utc(end_el.text) if end_el is not None else None
+    if end is not None:
+        total = max(1, int((end - start).total_seconds() // (minutes * 60)))
+    else:
+        total = max(published)
+
+    out: list[tuple[int, float]] = []
+    held: float | None = None
+    for slot in range(1, total + 1):
+        if slot in published:
+            held = published[slot]          # a step
+        if held is None:
+            continue                        # nothing published yet — genuinely absent
+        moment = start + timedelta(minutes=minutes * (slot - 1))
+        hour = moment.replace(minute=0, second=0, microsecond=0)
+        out.append((int(hour.astimezone(timezone.utc).timestamp()), held))
+    return out
+
+
+def _month_bounds(month_start: date) -> tuple[str, str]:
+    nxt = (month_start.replace(day=28) + timedelta(days=4)).replace(day=1)
+    return f"{month_start:%Y%m%d}0000", f"{nxt:%Y%m%d}0000"
+
+
+async def _fetch_exchange_month(
+    out_zone: str, in_zone: str, month_start: date, *, overwrite: bool = False
+) -> str:
+    """One directed border-month of A09, disk-cached. Returns "" on a clean no-data ACK."""
+    out_eic = ZONE_REGISTRY[out_zone]["eic"]
+    in_eic = ZONE_REGISTRY[in_zone]["eic"]
+    period_start, period_end = _month_bounds(month_start)
+
+    async def _do() -> dict:
+        params = {
+            "securityToken": _token(),
+            "documentType": SCHEDULED_EXCHANGE_DOCTYPE,
+            "contract_MarketAgreement.Type": CONTRACT_TOTAL,
+            "out_Domain": out_eic,
+            "in_Domain": in_eic,
+            "periodStart": period_start,
+            "periodEnd": period_end,
+        }
+        async with httpx.AsyncClient(timeout=120) as client:
+            resp = await client.get(ENTSOE_BASE, params=params)
+            if resp.status_code >= 400:
+                # A border with no schedule in this month answers 400 with an Acknowledgement.
+                # That is data, not an error: cache the emptiness so we never ask again.
+                return {"xml": ""}
+            return {"xml": resp.text}
+
+    payload = await raw_cache.fetch_or_cache(
+        CACHE_SOURCE,
+        f"{out_zone}_{in_zone}_{month_start:%Y-%m}",
+        month_start,
+        _do,
+        overwrite=overwrite,
+    )
+    return payload.get("xml", "")
+
+
+async def ingest_scheduled_exchanges(
+    db: Session,
+    months: list[date],
+    *,
+    borders: list[tuple[str, str]] | None = None,
+    overwrite: bool = False,
+) -> dict:
+    """Net scheduled exchange per border-month → `sched.<TO>` under zone `<FROM>`."""
+    if not settings.entsoe_api_token:
+        return {"skipped": "no token"}
+
+    borders = borders or SCHEDULED_BORDERS
+    written = 0
+    covered = 0
+    for a, b in borders:  # canonical, sorted: net > 0 means `a` exports to `b`
+        for month in months:
+            try:
+                a_to_b = parse_step_series(
+                    await _fetch_exchange_month(a, b, month, overwrite=overwrite))
+                b_to_a = parse_step_series(
+                    await _fetch_exchange_month(b, a, month, overwrite=overwrite))
+            except (httpx.HTTPError, ValueError) as exc:
+                logger.warning("scheduled %s-%s %s: %s", a, b, month, exc)
+                continue
+            net = net_exchange(a_to_b, b_to_a)
+            if not net:
+                continue
+            written += upsert_hourly(db, f"{SERIES_PREFIX}{b}", a,
+                                     sorted(net.items()), unit="MW")
+            covered += 1
+    db.commit()
+    return {"borders": len(borders), "border_months": covered, "written": written}
+
+
+def net_exchange(a_to_b: dict[int, float], b_to_a: dict[int, float]) -> dict[int, float]:
+    """Net MW from a's side. Positive = `a` exports.
+
+    Both legs are non-negative magnitudes: A09 reports each direction separately. Storing one
+    leg alone would report a 500 MW export in an hour when 800 MW came the other way, so an
+    hour that appears in only ONE leg still nets against an implicit zero on the other.
+    """
+    return {
+        h: a_to_b.get(h, 0.0) - b_to_a.get(h, 0.0)
+        for h in set(a_to_b) | set(b_to_a)
+    }
+
+
+def months_between(start: date, end: date) -> list[date]:
+    out, m = [], start.replace(day=1)
+    while m <= end:
+        out.append(m)
+        m = (m.replace(day=28) + timedelta(days=4)).replace(day=1)
+    return out
+
+
+def recent_months(days: int, *, today: date | None = None) -> list[date]:
+    today = today or datetime.now(timezone.utc).date()
+    return months_between(today - timedelta(days=days), today)

--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -34,7 +34,7 @@ BACKFILL_START = date(2015, 1, 1)  # ENTSO-E Transparency era; override with --s
 # "flows" is zone-independent (one /cbpf sweep covers every border) and runs once
 # per month after the zone loop. Moderate history is the point (--start 2024-01-01
 # per roadmap Block 2.4) — deep flow history adds little over the daily means.
-ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "flows")
+ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "flows", "scheduled")
 # Small pause between zone-months to stay under ENTSO-E's ~400 req/min token limit.
 THROTTLE_SECONDS = 1.0
 
@@ -139,8 +139,28 @@ async def run_backfill(
             flow_months += 1
             logger.info("power_backfill: flows %s done (%d/%d)", f"{m_start:%Y-%m}", flow_months, len(windows))
 
+    # Scheduled exchanges iterate BORDERS, not zones — so, like flows, they belong after the
+    # zone loop. Putting them inside it would walk 37 zones sleeping through the throttle to
+    # do the same 63 borders 37 times over.
+    sched_months = 0
+    if "scheduled" in sources:
+        from backend.power.entsoe_exchange import ingest_scheduled_exchanges
+
+        for m_start, _m_end in windows:
+            if dry_run:
+                sched_months += 1
+                continue
+            await _with_retry(
+                lambda m=m_start: ingest_scheduled_exchanges(db, [m], overwrite=overwrite),
+                f"scheduled {m_start:%Y-%m}",
+            )
+            sched_months += 1
+            logger.info("power_backfill: scheduled %s done (%d/%d)",
+                        f"{m_start:%Y-%m}", sched_months, len(windows))
+
     return {"zone_months": done, "zones": zones, "months": len(windows),
-            "flow_months": flow_months, "dry_run": dry_run}
+            "flow_months": flow_months, "scheduled_months": sched_months,
+            "dry_run": dry_run}
 
 
 def main(argv: list[str]) -> int:

--- a/backend/tests/test_borders.py
+++ b/backend/tests/test_borders.py
@@ -6,7 +6,7 @@ that a border we cannot cover is REPORTED rather than quietly dropped.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -239,3 +239,92 @@ def test_rail_cache_recomputes_only_after_its_ttl(db_session):
     assert fresh[("DE_LU", "FR")] == 9_000.0, "past the TTL it recomputes"
     assert at3 > at2
     reset_rail_cache()
+
+
+# ─── the scheduled grain (A09) ────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sub_zones(monkeypatch):
+    """DK1/DK2 exist in ZONE_REGISTRY but are not enabled in the test env (which serves the
+    original three). Prod runs all 37. Enable them here so the sub-zone property can be
+    expressed at all — a test that can only see DE_LU/FR/NL cannot prove anything about the
+    zones the A09 ingest exists for."""
+    from backend.power import borders
+    from backend.power.zones import POWER_ZONES as REAL
+    from backend.power.zones import ZONE_REGISTRY
+
+    monkeypatch.setattr(
+        borders, "POWER_ZONES",
+        {**REAL, "DK1": ZONE_REGISTRY["DK1"], "DK2": ZONE_REGISTRY["DK2"]},
+    )
+
+
+def _seed_scheduled(db, zone_a, zone_b, hours=48, price_a=60.0, price_b=95.0,
+                    sched_mw=800.0):
+    """A bidding-zone border that the country-level physical feed cannot see at all."""
+    ts = _hours(hours)
+    upsert_hourly(db, "price.dayahead", zone_a, [(t, price_a) for t in ts], unit="EUR/MWh")
+    upsert_hourly(db, "price.dayahead", zone_b, [(t, price_b) for t in ts], unit="EUR/MWh")
+    upsert_hourly(db, f"sched.{zone_b}", zone_a, [(t, sched_mw) for t in ts], unit="MW")
+
+
+def test_the_sub_zones_finally_have_borders(db_session, sub_zones):
+    """THE point of the A09 ingest. DK1↔DK2 is a border INSIDE Denmark: Energy-Charts reports
+    Denmark as one country, so this border could not exist in the physical grain even in
+    principle. Before A09 it was not merely uncovered — it was unrepresentable."""
+    _seed_scheduled(db_session, "DK1", "DK2")
+
+    out = compute_borders(db_session, days=7, now=_NOW)
+    row = next(r for r in out["borders"] if (r["zone_a"], r["zone_b"]) == ("DK1", "DK2"))
+
+    assert row["flow_source"] == "scheduled"
+    assert row["expensive_side"] == "DK2"
+    assert "DK1-DK2" not in out["uncoverable_borders"]
+
+
+def test_loop_flow_is_physical_minus_scheduled_where_both_exist(db_session):
+    """What the wires carried minus what the market agreed to move. On a border with both
+    grains this is a number no free EU tool publishes."""
+    ts = _hours(24)
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(t, 90.0) for t in ts], unit="EUR/MWh")
+    upsert_hourly(db_session, "price.dayahead", "FR", [(t, 45.0) for t in ts], unit="EUR/MWh")
+    upsert_hourly(db_session, "flow.FR", "DE_LU", [(t, 1_500.0) for t in ts], unit="MW")
+    upsert_hourly(db_session, "sched.FR", "DE_LU", [(t, 1_100.0) for t in ts], unit="MW")
+
+    out = compute_borders(db_session, days=7, now=_NOW)
+    row = next(r for r in out["borders"] if (r["zone_a"], r["zone_b"]) == ("DE_LU", "FR"))
+
+    assert row["flow_source"] == "scheduled", "the bidding-zone grain wins where both exist"
+    assert row["loop_hours"] == 24
+    assert row["loop_mean_mw"] == 400.0, "1500 physical − 1100 scheduled"
+
+
+def test_a_border_with_only_one_grain_says_WHY_it_has_no_loop_flow(db_session, sub_zones):
+    """A missing number with a reason beats an invented one — and a silently absent field
+    reads as a bug rather than as coverage."""
+    _seed_scheduled(db_session, "DK1", "DK2")
+
+    out = compute_borders(db_session, days=7, now=_NOW)
+    row = next(r for r in out["borders"] if (r["zone_a"], r["zone_b"]) == ("DK1", "DK2"))
+
+    assert row["loop_mean_mw"] is None
+    assert "Energy-Charts reports by country" in row["loop_reason"]
+
+
+def test_the_two_grains_never_share_a_rail_threshold(db_session):
+    """"At the rail" is measured against a border's OWN 95th percentile. A scheduled series
+    and a physical one are different quantities, so one cache for both would hand a border the
+    other grain's rail and quietly mis-state congestion."""
+    from backend.power.borders import PHYSICAL_PREFIX, SCHEDULED_PREFIX, rail_thresholds_cached
+
+    ts = _hours(48)
+    upsert_hourly(db_session, "flow.FR", "DE_LU", [(t, 1_000.0) for t in ts], unit="MW")
+    upsert_hourly(db_session, "sched.FR", "DE_LU", [(t, 300.0) for t in ts], unit="MW")
+
+    start = int((_NOW - timedelta(days=365)).timestamp())
+    phys, _ = rail_thresholds_cached(db_session, start, now=_NOW, prefix=PHYSICAL_PREFIX)
+    sched, _ = rail_thresholds_cached(db_session, start, now=_NOW, prefix=SCHEDULED_PREFIX)
+
+    assert phys[("DE_LU", "FR")] == 1_000.0
+    assert sched[("DE_LU", "FR")] == 300.0

--- a/backend/tests/test_scheduled_exchanges.py
+++ b/backend/tests/test_scheduled_exchanges.py
@@ -1,0 +1,192 @@
+"""A09 is a step function, and every other parser in this repo assumes it isn't.
+
+curveType A03 publishes a point only where the value CHANGES. DE→FR publishes 26 of 192 PT15M
+slots for a day. Every existing parser (parse_load, parse_load_hourly, parse_generation_hourly,
+parse_imbalance_*) assumes A01 — one point per slot — so handed an A09 document it drops 86% of
+the timeline and then averages whichever quarter-hours survived into an "hourly mean".
+
+Note what the fixtures below have to look like to catch that. A fixture with dense sequential
+points parses identically under both readings and proves nothing.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.power.entsoe_exchange import (
+    SERIES_PREFIX,
+    net_exchange,
+    parse_step_series,
+)
+from backend.power.hourly_store import read_hourly
+
+DAY = "2026-07-01T00:00Z"
+
+
+def _doc(points: list[tuple[int, float]], *, resolution: str = "PT15M",
+         start: str = DAY, end: str = "2026-07-02T00:00Z") -> str:
+    pts = "".join(
+        f"<Point><position>{pos}</position><quantity>{qty}</quantity></Point>"
+        for pos, qty in points
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<Publication_MarketDocument xmlns="urn:iec62325.351:tc57wg16:451-3:publicationdocument:7:0">
+  <TimeSeries>
+    <curveType>A03</curveType>
+    <Period>
+      <timeInterval><start>{start}</start><end>{end}</end></timeInterval>
+      <resolution>{resolution}</resolution>
+      {pts}
+    </Period>
+  </TimeSeries>
+</Publication_MarketDocument>"""
+
+
+# ─── the step function ────────────────────────────────────────────────────────
+
+
+def test_a_published_value_holds_until_the_next_one():
+    """THE test, on the real DE→FR shape: a TWO-day PT15M period (192 slots) carrying three
+    published positions. An A01 parser sees three quarter-hours and calls the other 189
+    missing. Nothing is missing — the value simply did not change.
+
+    The period length is load-bearing. A one-day fixture has only 96 slots, so positions 142
+    and 192 would never land and the step would never be exercised: the test would pass
+    against a parser that ignores steps entirely. That is not a test, and this file was
+    briefly guilty of it."""
+    hours = parse_step_series(
+        _doc([(1, 1000.0), (142, 400.0), (177, -250.0)], end="2026-07-03T00:00Z"))
+
+    assert len(hours) == 48, "two full days, densified — not 3 slots"
+    values = [v for _h, v in sorted(hours.items())]
+    assert values[0] == 1000.0
+    assert values[10] == 1000.0, "position 1 still holds at 10:00 — it never changed"
+    # position 142 → (142-1)*15min = 35h15 → hour 35. It holds from there until position 177.
+    assert values[36] == 400.0, "the step landed and held"
+    assert values[47] == -250.0, "and the last step holds to the end (a reversed flow)"
+
+
+def test_the_last_point_holds_to_the_end_of_the_period():
+    """A border that settles once in the morning publishes one point. Without reading the
+    Period's `end`, the series would stop at that point instead of running the whole day —
+    truncating most of the day for exactly the quietest borders."""
+    hours = parse_step_series(_doc([(1, 750.0)], resolution="PT60M",
+                                   end="2026-07-01T06:00Z"))
+
+    assert len(hours) == 6, "one published point, six hours of Period"
+    assert all(v == 750.0 for v in hours.values())
+
+
+def test_the_hourly_mean_averages_all_four_quarter_hours_not_just_the_published_ones():
+    """The second-order bug the naive parser produces. In an hour whose value steps from 100
+    to 200 halfway through, the honest hourly figure is 150 — not 200, which is what you get
+    when only the published slot survives."""
+    # PT15M, an hour-long period: slots 1..4. Value steps at slot 3.
+    hours = parse_step_series(
+        _doc([(1, 100.0), (3, 200.0)], end="2026-07-01T01:00Z"))
+
+    assert len(hours) == 1
+    assert list(hours.values())[0] == pytest.approx(150.0), "(100+100+200+200)/4"
+
+
+def test_a_pt60m_nordic_border_parses():
+    """The Nordic borders (SE1→FI, NO1→NO2, SE3→SE4) and all 2023 history are PT60M. A fixture
+    that is only ever PT15M cannot express a resolution bug."""
+    hours = parse_step_series(
+        _doc([(1, 500.0), (3, 800.0)], resolution="PT60M", end="2026-07-01T04:00Z"))
+
+    assert len(hours) == 4
+    assert [v for _h, v in sorted(hours.items())] == [500.0, 500.0, 800.0, 800.0]
+
+
+def test_an_a01_dense_document_still_parses():
+    """A03 is the general case; A01 (a point in every slot) is the degenerate one and must
+    keep working — this parser replaces nothing else if it cannot read a dense document."""
+    hours = parse_step_series(
+        _doc([(i, 100.0 * i) for i in range(1, 5)], end="2026-07-01T01:00Z"))
+
+    assert list(hours.values())[0] == pytest.approx(250.0), "(100+200+300+400)/4"
+
+
+def test_an_empty_document_is_empty_not_an_exception():
+    assert parse_step_series(_doc([])) == {}
+
+
+# ─── the direction ────────────────────────────────────────────────────────────
+
+
+def test_net_is_the_directed_difference_not_a_single_leg():
+    """A09 reports each direction as a non-negative magnitude. Store one leg and an hour with
+    500 MW out and 800 MW in reads as a 500 MW export while the zone was importing 300."""
+    net = net_exchange({100: 500.0}, {100: 800.0})
+    assert net[100] == pytest.approx(-300.0)
+
+
+def test_an_hour_present_in_only_one_leg_nets_against_zero():
+    """No schedule in one direction is a schedule of zero, not an absence — otherwise a
+    one-way hour would silently vanish from the series."""
+    net = net_exchange({100: 600.0}, {})
+    assert net[100] == pytest.approx(600.0)
+    net = net_exchange({}, {100: 600.0})
+    assert net[100] == pytest.approx(-600.0)
+
+
+# ─── the namespace ────────────────────────────────────────────────────────────
+
+
+def test_the_cache_source_is_not_the_genmix_or_the_forecast_cache():
+    """`entsoe_gen_total_forecast` is already taken by A71 + processType A01, and
+    `_fetch_zone_month` silently defaults any non-A65 doctype to the GENMIX cache. Either
+    collision serves back the wrong document, and it looks like a data bug, not a wiring bug."""
+    from backend.power.entsoe_exchange import CACHE_SOURCE
+
+    assert CACHE_SOURCE == "entsoe_scheduled_exchange"
+    assert CACHE_SOURCE not in ("entsoe_genmix", "entsoe_load", "entsoe_gen_total_forecast")
+
+
+def test_scheduled_series_never_land_in_the_physical_flow_namespace(db_session):
+    """Scheduled and physical MW are different quantities. One namespace holding both makes
+    loop flow (physical − scheduled) uncomputable and every existing `flow.*` ambiguous."""
+    import asyncio
+
+    from backend.models.energy import SeriesDim
+    from backend.power import entsoe_exchange as ex
+
+    async def _fake(out_zone, in_zone, month, *, overwrite=False):
+        if (out_zone, in_zone) == ("DK1", "DK2"):
+            return _doc([(1, 400.0)], resolution="PT60M", end="2026-07-01T02:00Z")
+        return _doc([], resolution="PT60M", end="2026-07-01T02:00Z")
+
+    ex._fetch_exchange_month = _fake  # noqa: SLF001
+    from datetime import date
+
+    asyncio.run(ex.ingest_scheduled_exchanges(
+        db_session, [date(2026, 7, 1)], borders=[("DK1", "DK2")]))
+
+    keys = {k for (k,) in db_session.query(SeriesDim.key).all()}
+    assert f"{SERIES_PREFIX}DK2" in keys
+    assert not any(k.startswith("flow.") for k in keys), "physical namespace untouched"
+
+    points = read_hourly(db_session, f"{SERIES_PREFIX}DK2", "DK1")
+    assert [v for _t, v in points] == [400.0, 400.0], "DK1 exports 400 MW to DK2"
+
+
+def test_the_sign_follows_the_canonical_sorted_pair(db_session):
+    """`net > 0` means the sorted-FIRST zone exports — byte-identical to the `flow.<TO>` under
+    `<FROM>` convention. Get this backwards and every border on the desk reads inverted."""
+    import asyncio
+    from datetime import date
+
+    from backend.power import entsoe_exchange as ex
+
+    async def _fake(out_zone, in_zone, month, *, overwrite=False):
+        # DK2 sends 900 MW to DK1: the sorted-first zone (DK1) is IMPORTING.
+        if (out_zone, in_zone) == ("DK2", "DK1"):
+            return _doc([(1, 900.0)], resolution="PT60M", end="2026-07-01T01:00Z")
+        return _doc([], resolution="PT60M", end="2026-07-01T01:00Z")
+
+    ex._fetch_exchange_month = _fake  # noqa: SLF001
+    asyncio.run(ex.ingest_scheduled_exchanges(
+        db_session, [date(2026, 7, 1)], borders=[("DK1", "DK2")]))
+
+    points = read_hourly(db_session, f"{SERIES_PREFIX}DK2", "DK1")
+    assert points[0][1] == pytest.approx(-900.0), "negative = DK1 imports"

--- a/frontend/src/components/BordersPanel.jsx
+++ b/frontend/src/components/BordersPanel.jsx
@@ -126,6 +126,7 @@ export default function BordersPanel() {
                   <th className="text-right px-2 py-1" title="Latest spread; the expensive side is named">Now</th>
                   <th className="text-right px-2 py-1" title="Share of hours the physical flow reached this border's own 95th percentile">At rail</th>
                   <th className="text-right px-2 py-1" title="Share of split hours where power ran from the expensive zone to the cheap one">Counter</th>
+                  <th className="text-right px-2 py-1" title="Physical flow minus scheduled exchange, where both grains exist. Transit and loop flow together — not a claim about this interconnector.">Loop</th>
                 </tr>
               </thead>
               <tbody>
@@ -140,6 +141,11 @@ export default function BordersPanel() {
                     >
                       <td className="px-2 py-1.5 text-neutral-300">
                         {isOpen ? '▾ ' : '▸ '}{b.label}
+                        {/* Which grain the border was read from. `scheduled` is ENTSO-E's
+                            bidding-zone schedule — the only one that can see DK1 from DK2. */}
+                        {b.flow_source === 'scheduled' && (
+                          <span className="ml-1.5 text-[9px] text-cyan-glow/60" title="Read from ENTSO-E scheduled exchanges (bidding-zone resolved)">SCHED</span>
+                        )}
                       </td>
                       <td className={`px-2 py-1.5 text-right ${convergenceColor(b.convergence_pct)}`}>
                         {b.convergence_pct != null ? `${b.convergence_pct.toFixed(0)}%` : '—'}
@@ -157,6 +163,13 @@ export default function BordersPanel() {
                       </td>
                       <td className={`px-2 py-1.5 text-right ${b.counter_price_pct > 10 ? 'text-orange-400' : 'text-neutral-500'}`}>
                         {b.counter_price_pct != null ? `${b.counter_price_pct.toFixed(0)}%` : '—'}
+                      </td>
+                      {/* Absent with a reason, never silently blank: most sub-zone borders have
+                          no physical grain at all, and that is coverage, not a bug. */}
+                      <td className="px-2 py-1.5 text-right text-neutral-500" title={b.loop_reason || undefined}>
+                        {b.loop_mean_mw != null
+                          ? `${b.loop_mean_mw > 0 ? '+' : ''}${(b.loop_mean_mw / 1000).toFixed(1)} GW`
+                          : <span className="text-neutral-700">n/a</span>}
                       </td>
                     </tr>
                   )


### PR DESCRIPTION
Tier 2, PR 3. The biggest coverage win on the desk.

## What was broken

Energy-Charts reports cross-border flows **by country**. So **DK1 and DK2** — two bidding zones with their own prices, inside one country — had **no border between them at all**. Not "uncovered": **unrepresentable**. Same for NO1–5, SE1–4 and every IT_*. DE_LU–DK1 existed only as an aggregate `flow.DK` with no price behind it.

A09 answers **per bidding zone**: 63 borders across 36 of 37 zones. Verified on real June data:

| border | hours | reading |
|---|---:|---|
| DK1↔DK2 | 720 | internal to Denmark — invisible to any country feed |
| SE3↔SE4 | 720 | SE3 exports in **99 %** of them (Sweden's north→south gradient) |
| IT_CALABRIA↔IT_SICILIA | 720 | across the Strait of Messina |
| DE_LU↔FR | 720 | DE exports in only 22 % — French nuclear, as expected |

## The parser is the substance, not a detail

A09 is **curveType A03: a step function.** A point is published only where the value *changes*, it holds until the next one, and the last holds to the Period's end. DE→FR publishes **26 of 192** PT15M slots for a day.

Every other parser in this repo assumes A01 — one point per slot. Measured against the same document:

```
naive A01 parser:    3 hours of 48   → 94% of the timeline LOST
parse_step_series:  48 hours
hour 10:  naive = MISSING           step = 1000 MW
```

**The test fixture had to be built to express that.** A one-day PT15M period has only 96 slots, so positions 142 and 192 never land and the step is never exercised — the test would pass against a parser that ignores steps entirely. This file was briefly guilty of exactly that; it now uses the real two-day shape.

## The sign

A09 is directed and both legs are non-negative magnitudes. Net = A→B minus B→A; asking one leg only reports a 500 MW export in an hour when 800 MW came the other way. **Cross-checked against the physical grain on DE_LU–FR: 89 % of hours agree in sign** (an inverted convention would agree in ~10 %).

## Loop flow — what no free EU tool publishes

Physical minus scheduled, where both grains exist. On DE_LU–FR in June: **physically 970 MW more flowed France→Germany on average than was scheduled**, peaking at 3.0 GW. The note says what it is: transit and loop flow together, **not** a claim about any single interconnector.

Borders with only one grain report `loop_mean_mw: null` **with a reason** — an absent number with an explanation beats an invented one, and a silently blank field reads as a bug rather than as coverage.

## Wiring traps avoided (all named in tests)

- **Own namespace** `sched.*`. One namespace holding both grains would make loop flow uncomputable and every existing `flow.*` ambiguous.
- **Cache source** `entsoe_scheduled_exchange` — `entsoe_gen_total_forecast` is already taken by A71+A01, and `_fetch_zone_month` silently defaults any non-A65 doctype to the **GENMIX** cache. Either collision serves back the wrong document and looks like a data bug.
- **Rail-threshold cache keyed by grain** — a scheduled p95 is a different number from a physical one.
- **Backfill iterates borders, so it sits after the zone loop.** Inside it, `--sources scheduled` would walk 37 zones sleeping through the throttle to do the same 63 borders 37 times over.

`ruff` clean · **882 passed** (15 new) · eslint clean · vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)