### PR TITLE
The ENTSO-E API key was in the logs. All of them.

### DIFF
--- a/backend/ingest_main.py
+++ b/backend/ingest_main.py
@@ -17,8 +17,10 @@ import signal
 from backend.collectors.scheduler import _run_power_daily, start_scheduler, stop_scheduler
 from backend.database import init_db
 from backend.migrations import run_migrations
+from backend.observability import install_log_redaction
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+install_log_redaction()  # ENTSO-E puts its key in the query string; httpx logs the URL
 logger = logging.getLogger("obsyd.ingest")
 
 

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import uuid
 from contextvars import ContextVar
 from typing import Awaitable, Callable
@@ -119,6 +120,39 @@ _LOG_RECORD_BUILTIN_ATTRS = {
 }
 
 
+#: Credentials that ENTSO-E and friends want in the QUERY STRING, where every HTTP client
+#: library in the world will happily log them.
+#:
+#: httpx logs `HTTP Request: GET <full url>` at INFO. ENTSO-E takes its API key as
+#: `?securityToken=…`. So every single ENTSO-E call — and there are thousands a day across 37
+#: zones — wrote the token, in plaintext, into journald. Measured on prod before this filter:
+#: **10,959 occurrences in three days.** journald persists and rotates into archives, so the
+#: credential outlives any one process, and anyone who can read the logs has the key.
+#:
+#: Silencing httpx would fix the symptom. This redacts the VALUE instead, on every handler, so
+#: a token that falls out of an exception message or a debug line is caught too — the leak was
+#: never really about httpx.
+_SECRET_QUERY_PARAMS = ("securityToken", "api_key", "apikey", "token", "x-key")
+
+_SECRET_RE = re.compile(
+    r"(?i)\b(" + "|".join(re.escape(p) for p in _SECRET_QUERY_PARAMS) + r")=([^&\s\"']+)"
+)
+
+
+class _SecretRedactingFilter(logging.Filter):
+    """Strip credential values from every record before it reaches a handler."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:  # a broken format string is not this filter's problem
+            return True
+        if "=" in msg and _SECRET_RE.search(msg):
+            record.msg = _SECRET_RE.sub(r"\1=<redacted>", msg)
+            record.args = ()
+        return True
+
+
 def setup_logging() -> None:
     """Configure root logging. Call before any logger.X() in main.py.
 
@@ -148,3 +182,18 @@ def setup_logging() -> None:
         )
     root.addHandler(handler)
     root.setLevel(logging.INFO)
+    install_log_redaction()
+
+
+def install_log_redaction() -> None:
+    """Attach the redaction filter to every handler on the root logger.
+
+    Separate from setup_logging because the batch scripts (power_backfill, gas_backfill,
+    repair_storage_series, …) configure logging with `logging.basicConfig` and never call
+    setup_logging — and they are precisely the processes that make thousands of ENTSO-E calls
+    in a row. A redaction that only protects the web app protects the smaller half.
+    """
+    root = logging.getLogger()
+    for h in root.handlers:
+        if not any(isinstance(f, _SecretRedactingFilter) for f in h.filters):
+            h.addFilter(_SecretRedactingFilter())

--- a/backend/scripts/backfill_gie_countries.py
+++ b/backend/scripts/backfill_gie_countries.py
@@ -27,6 +27,7 @@ from sqlalchemy import text
 from backend.database import SessionLocal, init_db
 from backend.gas import raw_cache
 from backend.gas.gie import upsert_lng_countries, upsert_storage_countries
+from backend.observability import install_log_redaction
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,7 @@ def run(db, start: date, end: date, *, dry_run: bool = False) -> dict:
 def main(argv: list[str]) -> int:
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    install_log_redaction()  # ENTSO-E puts its key in the query string; httpx logs the URL
     p = argparse.ArgumentParser(description="Re-read cached AGSI/ALSI payloads into the country tables")
     p.add_argument("--start", default="2023-01-01")
     p.add_argument("--end", default=date.today().isoformat())

--- a/backend/scripts/compress_raw_cache.py
+++ b/backend/scripts/compress_raw_cache.py
@@ -26,6 +26,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from backend.observability import install_log_redaction
+
 logger = logging.getLogger(__name__)
 
 
@@ -129,6 +131,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    install_log_redaction()  # ENTSO-E puts its key in the query string; httpx logs the URL
 
     if not args.root.is_dir():
         logger.error("no such directory: %s", args.root)

--- a/backend/scripts/gas_backfill.py
+++ b/backend/scripts/gas_backfill.py
@@ -24,6 +24,7 @@ from backend.gas.entsoe import ingest_power_burn
 from backend.gas.entsog import ingest_flows, sync_points
 from backend.gas.gie import daterange, ingest_lng, ingest_storage
 from backend.gas.weather import ingest_weather
+from backend.observability import install_log_redaction
 
 logger = logging.getLogger("gas_backfill")
 
@@ -92,6 +93,7 @@ async def run_backfill(db, start: date, end: date, sources: set[str], overwrite:
 
 def main(argv: list[str]) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    install_log_redaction()  # ENTSO-E puts its key in the query string; httpx logs the URL
     p = argparse.ArgumentParser(description="EU gas balance backfill")
     p.add_argument("--start", default=BACKFILL_START.isoformat())
     p.add_argument("--end", default=date.today().isoformat())

--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -22,6 +22,7 @@ import sys
 from datetime import date, datetime, timedelta
 
 from backend.database import SessionLocal
+from backend.observability import install_log_redaction
 from backend.power.energy_charts_flows import ingest_cbpf
 from backend.power.entsoe_grid import ingest_grid, ingest_load_forecast
 from backend.power.entsoe_imbalance import ingest_imbalance
@@ -165,6 +166,7 @@ async def run_backfill(
 
 def main(argv: list[str]) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    install_log_redaction()  # ENTSO-E puts its key in the query string; httpx logs the URL
     p = argparse.ArgumentParser(description="European power desk deep backfill")
     p.add_argument("--start", default=BACKFILL_START.isoformat())
     p.add_argument("--end", default=date.today().isoformat())

--- a/backend/scripts/repair_storage_series.py
+++ b/backend/scripts/repair_storage_series.py
@@ -38,6 +38,7 @@ from sqlalchemy import text
 from backend.database import SessionLocal
 from backend.gas import raw_cache
 from backend.models.energy import PowerGenMix, PowerGrid
+from backend.observability import install_log_redaction
 from backend.power.entsoe_grid import (
     PSR_LABELS,
     PSR_SOLAR,
@@ -226,6 +227,7 @@ def run(db, start: date, end: date, *, dry_run: bool = False) -> dict:
 def main(argv: list[str]) -> int:
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    install_log_redaction()  # ENTSO-E puts its key in the query string; httpx logs the URL
     p = argparse.ArgumentParser(description="Repair pumped-storage series written by the old A75 parser")
     p.add_argument("--start", default="2015-01-01")
     p.add_argument("--end", default=date.today().isoformat())

--- a/backend/tests/test_log_redaction.py
+++ b/backend/tests/test_log_redaction.py
@@ -1,0 +1,96 @@
+"""The ENTSO-E API key was in the logs. All of them. For as long as the project has existed.
+
+httpx logs `HTTP Request: GET <full url>` at INFO, and ENTSO-E takes its key as a query
+parameter — `?securityToken=…`. So every call, across 37 zones, several thousand a day, wrote
+the credential in plaintext into journald. Counted on prod before the fix: **10,959 occurrences
+in three days.** journald persists and rotates into archives, so the key outlived every process
+that used it, and anyone who could read the logs had it.
+
+Nothing about this is specific to A09 — it was simply visible in a backfill log while doing
+something else. These tests are here so it cannot come back.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from backend.observability import install_log_redaction, setup_logging
+
+#: The literal SHAPE httpx emits — with an obviously fake key in it.
+#:
+#: The first version of this file pasted the real token straight out of the prod log, which is
+#: how a leak becomes a worse leak: the fixture would have carried the live credential into a
+#: public repository. The shape is what the test needs; the value must never be a real one.
+FAKE_TOKEN = "00000000-0000-4000-8000-000000000000"  # not a key: a uuid of zeros
+
+HTTPX_LINE = (
+    "HTTP Request: GET https://web-api.tp.entsoe.eu/api"
+    f"?securityToken={FAKE_TOKEN}&documentType=A09"
+    "&out_Domain=10YHU-MAVIR----U \"HTTP/1.1 200 OK\""
+)
+
+
+@pytest.fixture
+def captured(caplog):
+    setup_logging()          # installs the redaction filter on the root handler
+    install_log_redaction()  # idempotent; also what the batch scripts call
+    root = logging.getLogger()
+    handler = root.handlers[0]
+
+    def _emit(msg: str, *args) -> str:
+        record = logging.LogRecord("httpx", logging.INFO, __file__, 1, msg, args, None)
+        for f in handler.filters:
+            f.filter(record)
+        return record.getMessage()
+
+    return _emit
+
+
+def test_the_entsoe_token_never_reaches_a_handler(captured):
+    out = captured(HTTPX_LINE)
+
+    assert FAKE_TOKEN not in out
+    assert "securityToken=<redacted>" in out
+    # …and the rest of the line survives, because a log you cannot read is its own outage.
+    assert "documentType=A09" in out
+    assert "10YHU-MAVIR----U" in out
+
+
+def test_a_token_in_an_exception_message_is_redacted_too(captured):
+    """Silencing httpx would have fixed the symptom. The leak was never really about httpx —
+    a raised URL, a debug line, a retry warning all carry the same query string."""
+    out = captured("ENTSO-E fetch failed for %s", HTTPX_LINE)
+    assert FAKE_TOKEN not in out
+
+
+@pytest.mark.parametrize("param", ["securityToken", "api_key", "apikey", "token", "x-key"])
+def test_every_credential_shaped_parameter_is_covered(captured, param):
+    out = captured(f"GET https://example.test/api?{param}=SUPERSECRET&days=7")
+    assert "SUPERSECRET" not in out
+    assert "days=7" in out, "only the secret goes"
+
+
+def test_an_ordinary_line_is_untouched(captured):
+    """A redactor that mangles normal logs gets turned off, and then it protects nothing."""
+    msg = "power daily grid ingest [DE_LU]: {'days': 7, 'written': 168}"
+    assert captured(msg) == msg
+
+
+def test_every_batch_script_installs_the_redaction():
+    """The web app and the batch scripts configure logging separately, and it is the SCRIPTS
+    that make thousands of ENTSO-E calls in a row. A redaction that only protects the app
+    protects the smaller half."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1]
+    for path in [
+        "scripts/power_backfill.py",
+        "scripts/gas_backfill.py",
+        "scripts/repair_storage_series.py",
+        "scripts/backfill_gie_countries.py",
+        "ingest_main.py",
+    ]:
+        src = (root / path).read_text()
+        assert "logging.basicConfig" in src, f"{path} no longer configures logging — recheck"
+        assert "install_log_redaction()" in src, f"{path} logs unredacted"


### PR DESCRIPTION
Found while reading a backfill log for something else.

## The leak

httpx logs `HTTP Request: GET <full url>` at INFO. ENTSO-E takes its key as a **query parameter** — `?securityToken=…`. So **every ENTSO-E call this project has ever made wrote the credential, in plaintext, into the log.**

```
$ journalctl -u obsyd --since -3days | grep -c securityToken=
10959
```

**10,959 occurrences in three days.** journald persists and rotates into archives, so the key outlives every process that used it, and anyone who can read the logs has it. This is not new and has nothing to do with A09 — it has been true since the first ENTSO-E ingest.

## The fix

Silencing the httpx logger would fix the *symptom*. Instead a filter **redacts the value** on every handler, so a token that falls out of an exception message, a retry warning or a debug line is caught too — **the leak was never really about httpx.** The rest of the line survives; a log you cannot read is its own kind of outage.

```
before:  GET …/api?securityToken=d9668359-466c-45a7-9da8-ff32dac6d5b2&documentType=A09
after:   GET …/api?securityToken=<redacted>&documentType=A09
```

Wired into the **batch scripts** as well as the app. They configure logging separately with `logging.basicConfig` and never call `setup_logging` — and they are precisely the processes that make thousands of ENTSO-E calls in a row. A redaction that only protects the web app protects the smaller half. A test enforces that each of them installs it.

## Verification

Through the **real library**, not a mock: an actual `httpx` request with a planted token now logs `securityToken=<redacted>`, and the token does not appear. The unit fixture uses the **literal line httpx emits** — a test written against an invented message proves nothing about the leak it is supposed to stop.

`ruff` clean · 892 passed (9 new).

## ⚠️ Owner action

**The token has been in the logs for months and should be rotated** (request a new one from `transparency@entsoe.eu`). This fix stops the bleeding; it does not un-write the archives already on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)