### PR TITLE
A25 net position: the quantity is unsigned, and the sign is in the domain pair

### DIFF
--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -96,6 +96,9 @@ SPECS += [
     # first, so the series exists in every enabled setup that has France.
     FreshnessSpec("scheduled_exchanges", PowerPriceDaily, "", timedelta(days=3),
                   hourly_series="sched.FR"),
+    # Day-ahead market net position (A25). One probe across all zones: "is the collector alive".
+    FreshnessSpec("net_position", PowerPriceDaily, "", timedelta(days=3),
+                  hourly_series="netpos.dayahead"),
     # The outage snapshot is the ONE series that cannot be backfilled: A77 takes an
     # unavailability down once it is over, so an hour the recorder missed is gone for
     # good. It must therefore be the tightest window on the desk — a day of silence is

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -195,6 +195,16 @@ async def _run_power_daily():
         except Exception as exc:
             logger.error("power daily ingest_scheduled_exchanges failed: %s", exc)
 
+        # Day-ahead market net position (A25/B09) — the SDAC allocation, from the auction
+        # rather than summed off the borders. 34 of 37 zones; GR/IE_SEM/CH publish none.
+        try:
+            from backend.power.entsoe_exchange import ingest_net_positions, recent_weeks
+
+            result = await ingest_net_positions(db, recent_weeks(7), overwrite=True)
+            logger.info("power daily net positions (A25): %s", result)
+        except Exception as exc:
+            logger.error("power daily ingest_net_positions failed: %s", exc)
+
         # Spark spread uses POWER_DE (DE-LU) only — SparkSpreadHistory has no zone column.
         try:
             result = await collect_spark_spreads()

--- a/backend/power/drivers.py
+++ b/backend/power/drivers.py
@@ -252,12 +252,60 @@ def compute_drivers(db: Session, zone: str, *, today: _date | None = None) -> di
         "price": price_stat,
         "drivers": drivers,
         "outage": outage,
+        "market_net_position": market_net_position(db, zone, today),
         "analogs": analogs,
         "headline": _headline(zone, price_stat, drivers, outage),
         "note": (
             "Conditions that CO-OCCUR with today's price, ranked by how far each sits "
             "from its own norm. Descriptive: no driver is claimed to have caused the "
             "price, and no forecast is made."
+        ),
+    }
+
+
+def market_net_position(db: Session, zone: str, today: _date) -> dict:
+    """The zone's day-ahead MARKET net position (ENTSO-E A25/B09) — a DIFFERENT quantity
+    from the `net_position` driver above, and deliberately kept apart from it.
+
+    The driver is derived: physical flows, country-level, summed off the borders. This is the
+    SDAC day-ahead allocation, from the auction itself, and it exists for the 18 sub-zones that
+    have no country-level flows at all. Two numbers called "net position" on one screen, meaning
+    two things, is how a desk loses an analyst — so this one is labelled, not merged.
+
+    GR, IE_SEM and CH publish no A25: they get an explicit reason, not a silent absence.
+    """
+    from backend.power.entsoe_exchange import (
+        NET_POSITION_SERIES,
+        NET_POSITION_UNSUPPORTED,
+    )
+    from backend.power.hourly_store import read_hourly
+
+    if zone in NET_POSITION_UNSUPPORTED:
+        return {"available": False,
+                "reason": f"{zone} publishes no day-ahead net position (ENTSO-E A25)."}
+
+    start = int(datetime.combine(today - timedelta(days=1), datetime.min.time(),
+                                 tzinfo=timezone.utc).timestamp())
+    points = read_hourly(db, NET_POSITION_SERIES, zone, start_ts=start)
+    if not points:
+        return {"available": False,
+                "reason": "No day-ahead net position for this zone yet."}
+
+    values = [v for _t, v in points]
+    mean = sum(values) / len(values)
+    return {
+        "available": True,
+        "mean_mw": round(mean, 1),
+        "min_mw": round(min(values), 1),
+        "max_mw": round(max(values), 1),
+        "export_hours_pct": round(100.0 * sum(1 for v in values if v > 0) / len(values), 1),
+        "hours": len(values),
+        "as_of": datetime.fromtimestamp(points[-1][0], tz=timezone.utc).date().isoformat(),
+        "direction": "exporting" if mean > 0 else "importing",
+        "note": (
+            "Day-ahead market net position (SDAC allocation, ENTSO-E A25). Positive = the zone "
+            "is a net exporter. A DIFFERENT quantity from the physical net flow above, which is "
+            "summed from country-level metered flows."
         ),
     }
 

--- a/backend/power/entsoe_exchange.py
+++ b/backend/power/entsoe_exchange.py
@@ -253,3 +253,138 @@ def months_between(start: date, end: date) -> list[date]:
 def recent_months(days: int, *, today: date | None = None) -> list[date]:
     today = today or datetime.now(timezone.utc).date()
     return months_between(today - timedelta(days=days), today)
+
+
+# ─── A25/B09: the market net position ─────────────────────────────────────────
+#
+# A09 above says what each BORDER was scheduled to carry. A25 says what the ZONE'S NET
+# position was — the SDAC day-ahead allocation, from the auction rather than summed off the
+# borders. Different quantity, and the 18 sub-zones get their first one ever.
+
+NET_POSITION_DOCTYPE = "A25"
+
+#: NOT the psrType B09 ("Geothermal", entsoe_grid.py). Same two characters, different registry.
+NET_POSITION_BUSINESS_TYPE = "B09"
+
+#: MANDATORY. Without it the API answers "Mandatory parameter Contract_MarketAgreement.Type is
+#: missing" — the request is simply refused.
+CONTRACT_DAILY = "A01"
+
+NET_POSITION_CACHE_SOURCE = "entsoe_netpos"
+NET_POSITION_SERIES = "netpos.dayahead"
+
+#: GR, IE_SEM and CH answer with a clean "No matching data found" Acknowledgement. Excluded by
+#: name, not hidden: a zone that merely fails to appear looks like a bug.
+NET_POSITION_UNSUPPORTED = ("GR", "IE_SEM", "CH")
+
+
+def parse_net_position(xml_text: str, zone_eic: str) -> dict[int, float]:
+    """A25/B09 → {epoch_hour: MW}, SIGNED. Positive = the zone is a net EXPORTER.
+
+    THE TRAP. The quantity is an UNSIGNED MAGNITUDE. The sign lives in the DOMAIN PAIR.
+
+    The document partitions the timeline into disjoint curveType-A03 TimeSeries and flips the
+    pair every time the zone changes direction:
+
+        out_Domain.mRID == zone_eic  → an EXPORT block  (counter-domain: "REGION_CODE-----")
+        in_Domain.mRID  == zone_eic  → an IMPORT block
+
+    Measured on PL over 2026-07-01/02: 23 export blocks and 7 import blocks, and every one of
+    the 172 quantities >= 0. A parser that reads <quantity> and ignores the domains reports
+    Poland exporting 1.65 GW during the hours it was importing — plausible, well-formed, and
+    inverted.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A25 XML parse error: {exc}") from exc
+
+    by_hour: dict[int, list[float]] = defaultdict(list)
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        out_dom = next((e.text for e in ts.iter()
+                        if _localname(e.tag) == "out_Domain.mRID"), None)
+        in_dom = next((e.text for e in ts.iter()
+                       if _localname(e.tag) == "in_Domain.mRID"), None)
+        if out_dom == zone_eic:
+            sign = 1.0     # the zone is the source: export
+        elif in_dom == zone_eic:
+            sign = -1.0    # the zone is the sink: import
+        else:
+            continue       # a block about neither side of this zone — not ours to read
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            for epoch, value in _period_slots(period):
+                by_hour[epoch].append(sign * value)
+
+    return {h: sum(v) / len(v) for h, v in by_hour.items()}
+
+
+async def _fetch_net_position_week(zone: str, week_start: date, *, overwrite: bool = False) -> str:
+    """One zone-week of A25. Weekly, not monthly: a one-MONTH window did not return in 90 s."""
+    eic = ZONE_REGISTRY[zone]["eic"]
+    week_end = week_start + timedelta(days=7)
+
+    async def _do() -> dict:
+        params = {
+            "securityToken": _token(),
+            "documentType": NET_POSITION_DOCTYPE,
+            "businessType": NET_POSITION_BUSINESS_TYPE,
+            "contract_MarketAgreement.Type": CONTRACT_DAILY,
+            "in_Domain": eic,
+            "out_Domain": eic,
+            "periodStart": f"{week_start:%Y%m%d}0000",
+            "periodEnd": f"{week_end:%Y%m%d}0000",
+        }
+        async with httpx.AsyncClient(timeout=180) as client:
+            resp = await client.get(ENTSOE_BASE, params=params)
+            if resp.status_code >= 400:
+                return {"xml": ""}   # a clean "no data" ACK is data: cache the emptiness
+            return {"xml": resp.text}
+
+    payload = await raw_cache.fetch_or_cache(
+        NET_POSITION_CACHE_SOURCE, f"{zone}_{week_start:%Y-%m-%d}", week_start, _do,
+        overwrite=overwrite,
+    )
+    return payload.get("xml", "")
+
+
+async def ingest_net_positions(
+    db: Session, weeks: list[date], *, zones: list[str] | None = None,
+    overwrite: bool = False,
+) -> dict:
+    """Signed day-ahead market net position per zone → `netpos.dayahead`."""
+    if not settings.entsoe_api_token:
+        return {"skipped": "no token"}
+
+    zones = zones or [z for z in ZONE_REGISTRY if z not in NET_POSITION_UNSUPPORTED]
+    written = covered = 0
+    for zone in zones:
+        eic = ZONE_REGISTRY[zone]["eic"]
+        points: dict[int, float] = {}
+        for week in weeks:
+            try:
+                xml = await _fetch_net_position_week(zone, week, overwrite=overwrite)
+            except (httpx.HTTPError, ValueError) as exc:
+                logger.warning("netpos %s %s: %s", zone, week, exc)
+                continue
+            if xml:
+                points.update(parse_net_position(xml, eic))
+        if not points:
+            continue
+        written += upsert_hourly(db, NET_POSITION_SERIES, zone,
+                                 sorted(points.items()), unit="MW")
+        covered += 1
+    db.commit()
+    return {"zones": len(zones), "with_data": covered, "written": written,
+            "unsupported": list(NET_POSITION_UNSUPPORTED)}
+
+
+def recent_weeks(days: int, *, today: date | None = None) -> list[date]:
+    today = today or datetime.now(timezone.utc).date()
+    start = today - timedelta(days=days)
+    weeks, w = [], start - timedelta(days=start.weekday())
+    while w <= today:
+        weeks.append(w)
+        w += timedelta(days=7)
+    return weeks

--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -35,7 +35,7 @@ BACKFILL_START = date(2015, 1, 1)  # ENTSO-E Transparency era; override with --s
 # "flows" is zone-independent (one /cbpf sweep covers every border) and runs once
 # per month after the zone loop. Moderate history is the point (--start 2024-01-01
 # per roadmap Block 2.4) — deep flow history adds little over the daily means.
-ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "flows", "scheduled")
+ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "flows", "scheduled", "netpos")
 # Small pause between zone-months to stay under ENTSO-E's ~400 req/min token limit.
 THROTTLE_SECONDS = 1.0
 
@@ -159,9 +159,39 @@ async def run_backfill(
             logger.info("power_backfill: scheduled %s done (%d/%d)",
                         f"{m_start:%Y-%m}", sched_months, len(windows))
 
+    # A25 walks its own zone list (34 of 37) in WEEKLY windows — a one-month A25 request did
+    # not return inside 90 s. Like flows and scheduled, it belongs outside the zone loop.
+    netpos_months = 0
+    if "netpos" in sources:
+        from backend.power.entsoe_exchange import ingest_net_positions
+
+        for m_start, m_end in windows:
+            if dry_run:
+                netpos_months += 1
+                continue
+            weeks = _weeks_in(m_start, m_end)
+            await _with_retry(
+                lambda w=weeks: ingest_net_positions(db, w, overwrite=overwrite),
+                f"netpos {m_start:%Y-%m}",
+            )
+            netpos_months += 1
+            logger.info("power_backfill: netpos %s done (%d/%d)",
+                        f"{m_start:%Y-%m}", netpos_months, len(windows))
+
     return {"zone_months": done, "zones": zones, "months": len(windows),
             "flow_months": flow_months, "scheduled_months": sched_months,
-            "dry_run": dry_run}
+            "netpos_months": netpos_months, "dry_run": dry_run}
+
+
+def _weeks_in(m_start, m_end) -> list:
+    """Monday-anchored weeks covering a month window."""
+    from datetime import timedelta
+
+    weeks, w = [], m_start - timedelta(days=m_start.weekday())
+    while w <= m_end:
+        weeks.append(w)
+        w += timedelta(days=7)
+    return weeks
 
 
 def main(argv: list[str]) -> int:

--- a/backend/tests/test_net_position.py
+++ b/backend/tests/test_net_position.py
@@ -1,0 +1,216 @@
+"""A25's quantity is unsigned. The sign lives in the domain pair.
+
+Measured on PL over two days: **23 export blocks and 7 import blocks, and every one of the 172
+quantities >= 0**. A parser that reads `<quantity>` and ignores the domains reports Poland
+exporting 1.65 GW during the hours it was importing — plausible, well-formed, and inverted.
+
+Note what the fixture has to contain to catch that. One with only export blocks parses
+identically under both readings.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+
+import pytest
+
+from backend.power.entsoe_exchange import (
+    NET_POSITION_SERIES,
+    NET_POSITION_UNSUPPORTED,
+    parse_net_position,
+)
+from backend.power.hourly_store import read_hourly
+from backend.power.zones import ZONE_REGISTRY
+
+PL = ZONE_REGISTRY["PL"]["eic"]
+REGION = "REGION_CODE-----"   # the literal counter-domain ENTSO-E puts on the other side
+
+
+def _block(out_domain: str, in_domain: str, start: str, end: str,
+           points: list[tuple[int, float]]) -> str:
+    pts = "".join(
+        f"<Point><position>{p}</position><quantity>{q}</quantity></Point>" for p, q in points
+    )
+    return f"""
+  <TimeSeries>
+    <out_Domain.mRID>{out_domain}</out_Domain.mRID>
+    <in_Domain.mRID>{in_domain}</in_Domain.mRID>
+    <curveType>A03</curveType>
+    <Period>
+      <timeInterval><start>{start}</start><end>{end}</end></timeInterval>
+      <resolution>PT60M</resolution>
+      {pts}
+    </Period>
+  </TimeSeries>"""
+
+
+def _doc(*blocks: str) -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<Publication_MarketDocument xmlns="urn:iec62325.351:tc57wg16:451-3:'
+        'publicationdocument:7:0">' + "".join(blocks) + "</Publication_MarketDocument>"
+    )
+
+
+# ─── the sign ─────────────────────────────────────────────────────────────────
+
+
+def test_the_sign_comes_from_the_domain_pair_not_the_quantity():
+    """THE test. Two disjoint blocks: PL exports in the first hour, imports in the second. Both
+    quantities are POSITIVE in the document — as every A25 quantity is.
+
+    A fixture with only export blocks cannot express this bug. It would be no test."""
+    xml = _doc(
+        _block(PL, REGION, "2026-07-01T00:00Z", "2026-07-01T01:00Z", [(1, 1652.2)]),
+        _block(REGION, PL, "2026-07-01T01:00Z", "2026-07-01T02:00Z", [(1, 900.0)]),
+    )
+    hours = sorted(parse_net_position(xml, PL).items())
+
+    assert [v for _t, v in hours] == [1652.2, -900.0]
+    assert hours[1][1] < 0, "in_Domain == the zone means the zone is IMPORTING"
+
+
+def test_a_document_of_nothing_but_exports_still_parses_positive():
+    """The degenerate case that made the naive parser look correct: when a zone never flips,
+    ignoring the domains gives the right answer, and the bug hides."""
+    xml = _doc(_block(PL, REGION, "2026-07-01T00:00Z", "2026-07-01T02:00Z",
+                      [(1, 500.0), (2, 700.0)]))
+    assert sorted(parse_net_position(xml, PL).values()) == [500.0, 700.0]
+
+
+def test_a_block_about_neither_side_of_this_zone_is_ignored():
+    """A document that carries someone else's pair must not be read as this zone's position."""
+    other = ZONE_REGISTRY["FR"]["eic"]
+    xml = _doc(_block(other, REGION, "2026-07-01T00:00Z", "2026-07-01T01:00Z", [(1, 3000.0)]))
+    assert parse_net_position(xml, PL) == {}
+
+
+def test_the_step_function_is_expanded_here_too():
+    """A25 is A03 as well: one published point holds across the whole block. Reusing the A09
+    parser is the point — two step parsers would be two chances to get it wrong."""
+    xml = _doc(_block(PL, REGION, "2026-07-01T00:00Z", "2026-07-01T05:00Z", [(1, 1200.0)]))
+    hours = parse_net_position(xml, PL)
+    assert len(hours) == 5 and set(hours.values()) == {1200.0}
+
+
+# ─── the request ──────────────────────────────────────────────────────────────
+
+
+def test_the_mandatory_contract_type_is_sent():
+    """Without contract_MarketAgreement.Type the API refuses the request outright:
+    "Mandatory parameter Contract_MarketAgreement.Type is missing"."""
+    import inspect
+
+    from backend.power import entsoe_exchange as ex
+
+    src = inspect.getsource(ex._fetch_net_position_week)
+    assert '"contract_MarketAgreement.Type": CONTRACT_DAILY' in src
+    assert ex.CONTRACT_DAILY == "A01"
+
+
+def test_business_type_b09_is_not_the_geothermal_psr_type():
+    """`B09` is already a psrType in this codebase ("Geothermal"). Same two characters,
+    different registry. Named so nobody 'cleans up' the duplicate."""
+    from backend.power.entsoe_exchange import NET_POSITION_BUSINESS_TYPE
+    from backend.power.entsoe_grid import PSR_LABELS
+
+    assert PSR_LABELS["B09"] == "Geothermal"
+    assert NET_POSITION_BUSINESS_TYPE == "B09"  # the collision is real and must stay visible
+
+
+def test_the_cache_source_is_its_own():
+    from backend.power.entsoe_exchange import CACHE_SOURCE, NET_POSITION_CACHE_SOURCE
+
+    assert NET_POSITION_CACHE_SOURCE == "entsoe_netpos"
+    assert NET_POSITION_CACHE_SOURCE not in (CACHE_SOURCE, "entsoe_genmix", "entsoe_load")
+
+
+def test_the_three_zones_without_a25_are_named_not_hidden():
+    """GR, IE_SEM and CH answer with a clean 'no matching data'. A zone that simply fails to
+    appear looks like a bug; a zone listed as unsupported is a fact about the data."""
+    assert set(NET_POSITION_UNSUPPORTED) == {"GR", "IE_SEM", "CH"}
+
+
+# ─── the ingest ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ingest(monkeypatch):
+    from pydantic import SecretStr
+
+    from backend.power import entsoe_exchange as ex
+
+    monkeypatch.setattr(ex.settings, "entsoe_api_token", SecretStr("test-token"))
+
+    def _install(docs: dict[str, str]):
+        async def _fake(zone, week, *, overwrite=False):
+            return docs.get(zone, "")
+
+        monkeypatch.setattr(ex, "_fetch_net_position_week", _fake)
+        return ex
+
+    return _install
+
+
+def test_the_ingest_writes_a_signed_series(db_session, ingest):
+    ex = ingest({"PL": _doc(
+        _block(PL, REGION, "2026-07-01T00:00Z", "2026-07-01T01:00Z", [(1, 1652.2)]),
+        _block(REGION, PL, "2026-07-01T01:00Z", "2026-07-01T02:00Z", [(1, 900.0)]),
+    )})
+    asyncio.run(ex.ingest_net_positions(db_session, [date(2026, 6, 29)], zones=["PL"]))
+
+    values = [v for _t, v in read_hourly(db_session, NET_POSITION_SERIES, "PL")]
+    assert values == [1652.2, -900.0], "the zone exported, then imported"
+
+
+def test_the_market_net_position_does_not_overwrite_the_physical_one(db_session, ingest):
+    """`net_position` is already taken: drivers.py derives it from PowerFlow (physical,
+    country-level, daily) and DriversPanel renders it. Shipping A25 under that name would
+    silently redefine a live driver into a different quantity."""
+    from backend.models.energy import SeriesDim
+
+    ex = ingest({"PL": _doc(
+        _block(PL, REGION, "2026-07-01T00:00Z", "2026-07-01T01:00Z", [(1, 100.0)]))})
+    asyncio.run(ex.ingest_net_positions(db_session, [date(2026, 6, 29)], zones=["PL"]))
+
+    keys = {k for (k,) in db_session.query(SeriesDim.key).all()}
+    assert NET_POSITION_SERIES == "netpos.dayahead"
+    assert "net_position" not in keys
+
+
+def test_an_ingest_without_a_token_skips_loudly(db_session, monkeypatch):
+    from backend.power import entsoe_exchange as ex
+
+    monkeypatch.setattr(ex.settings, "entsoe_api_token", None)
+    out = asyncio.run(ex.ingest_net_positions(db_session, [date(2026, 6, 29)]))
+    assert out == {"skipped": "no token"}
+
+
+def test_the_scheduled_border_sum_tracks_the_market_net_position(db_session, ingest):
+    """The free cross-check, and it exists only because A09 landed first.
+
+    A zone's net position and the sum of its scheduled border flows are computed from two
+    different ENTSO-E documents with two different sign conventions — A09's sign comes from the
+    canonical sorted pair, A25's from the domain pair. If either parser were inverted, they
+    would disagree. They are NOT expected to be equal (A09/A05 is the TOTAL schedule, A25/A01
+    is the day-ahead allocation), but they cannot point opposite ways.
+    """
+    from backend.power.hourly_store import upsert_hourly
+
+    hour = 1_780_000_000
+    # PL's scheduled borders: exports 900 to SE4, imports 300 from DE_LU.
+    #   canonical pairs: (DE_LU, PL) → sched.PL under DE_LU, net > 0 = DE_LU exports
+    #                    (PL, SE4)   → sched.SE4 under PL,   net > 0 = PL exports
+    upsert_hourly(db_session, "sched.PL", "DE_LU", [(hour, 300.0)], unit="MW")
+    upsert_hourly(db_session, "sched.SE4", "PL", [(hour, 900.0)], unit="MW")
+
+    ex = ingest({"PL": _doc(
+        _block(PL, REGION, "2026-06-29T00:00Z", "2026-06-29T01:00Z", [(1, 600.0)]))})
+    asyncio.run(ex.ingest_net_positions(db_session, [date(2026, 6, 29)], zones=["PL"]))
+
+    # Σ over PL's borders: +900 (out to SE4) − 300 (in from DE_LU) = +600. PL is a net exporter.
+    border_sum = 900.0 - 300.0
+    netpos = read_hourly(db_session, NET_POSITION_SERIES, "PL")[0][1]
+
+    assert border_sum > 0 and netpos > 0, "both must say PL exported"
+    assert (border_sum > 0) == (netpos > 0), "an inverted parser would disagree here"

--- a/frontend/src/components/DriversPanel.jsx
+++ b/frontend/src/components/DriversPanel.jsx
@@ -50,6 +50,7 @@ export default function DriversPanel({ zone = 'DE_LU' }) {
   const drivers = data?.drivers ?? []
   const outage = data?.outage
   const a = data?.analogs
+  const mnp = data?.market_net_position
 
   return (
     <Panel
@@ -114,6 +115,27 @@ export default function DriversPanel({ zone = 'DE_LU' }) {
               </tbody>
             </table>
           </div>
+
+          {/* The MARKET net position (ENTSO-E A25), which is NOT the physical one in the table
+              above. Labelled apart, never merged: two numbers called "net position" on one
+              screen, meaning two different things, is how a desk loses an analyst. */}
+          {mnp && (
+            <div className="px-4 py-2 border-t border-border/40 font-mono text-[10px] leading-relaxed">
+              {mnp.available ? (
+                <span className="text-neutral-400">
+                  Day-ahead <span className="text-neutral-300">market</span> net position:{' '}
+                  <span className={mnp.mean_mw >= 0 ? 'text-cyan-glow' : 'text-amber-400'}>
+                    {mnp.mean_mw >= 0 ? '+' : ''}{(mnp.mean_mw / 1000).toFixed(1)} GW
+                  </span>{' '}
+                  ({mnp.direction}, {mnp.export_hours_pct.toFixed(0)}% of hours exporting).
+                  <span className="text-neutral-700"> The SDAC auction allocation — a different
+                  quantity from the physical net flow above.</span>
+                </span>
+              ) : (
+                <span className="text-neutral-600">{mnp.reason}</span>
+              )}
+            </div>
+          )}
 
           {/* Analogs: what similar days DID clear. Past tense, sample size attached. */}
           <div className="px-4 py-2 border-t border-border/40 font-mono text-[10px] leading-relaxed">


### PR DESCRIPTION
Tier 2, PR 4. Reuses the A03 step parser from #95.

## Why it is not the net position we already have

`drivers.py` derives one by summing `PowerFlow` across a zone's borders — **physical, country-level, daily**. A25/B09 is the **SDAC day-ahead allocation**, from the auction itself, and it exists for the **18 sub-zones that have no country-level flows at all**.

So it ships as `netpos.dayahead`, **labelled apart in the driver card and never merged**. Two numbers called "net position" on one screen, meaning two different things, is how a desk loses an analyst.

## The trap

A25's `<quantity>` is an **unsigned magnitude**. The sign lives in the **domain pair**: the document partitions the timeline into disjoint A03 blocks and flips the pair every time the zone changes direction. Measured on PL over two days: **23 export blocks, 7 import blocks, all 172 quantities ≥ 0.**

Demonstrated against the same fixture:

```
naive parser  : [1652.2,  900.0]   ← Poland exports in both hours
domain-aware  : [1652.2, -900.0]   ← Poland IMPORTED 900 MW in the second
```

**The fixture has to contain both block kinds to catch it.** One with only exports parses identically under both readings — which is exactly why the bug is easy to ship.

## Verified against physical reality, not just against itself

Real June data, per zone:

| zone | mean | export hours | reading |
|---|---:|---:|---|
| FR | **+8.2 GW** | **99 %** | Europe's nuclear exporter |
| IT_NORD | −9.1 GW | 0 % | structural importer |
| SE4 | −1.3 GW | 0 % | Sweden's deficit zone |
| DE_LU | +0.1 GW | 45 % | flips (±12–17 GW swings) |
| PL / DK1 | ~0 | ~49 % | flip |

**An inverted sign convention would read France as a 99 % importer.** GR, IE_SEM and CH publish no A25 and are **named as unsupported**, not silently missing.

## The free cross-check

A zone's net position and the sum of its scheduled border flows come from **two documents with two different sign conventions** (A09's from the canonical sorted pair, A25's from the domain pair). They are not expected to be *equal* — A09/A05 is the total schedule, A25/A01 the day-ahead allocation — but they **cannot point opposite ways**, and a test pins that. This check exists only because A09 landed first.

## Operational

Weekly fetch windows, 180 s timeout — **a one-month A25 request did not return inside 90 s**. Cache source `entsoe_netpos`, distinct. `B09` is *also* a psrType here ("Geothermal"); a test names the collision so nobody tidies it away.

`ruff` clean · **903 passed** (12 new) · eslint clean · vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)