### PR TITLE
Production units (A71/A33): names for the EICs, and a denominator for the 18 zones without one

### DIFF
--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -297,6 +297,18 @@ async def _run_capacity_monthly():
                 await ingest_installed_capacity(db, year, eic=cfg["eic"], zone=zone_key, overwrite=True)
             except Exception as exc:
                 logger.error("capacity monthly [%s] failed: %s", zone_key, exc)
+
+        # Production units (A71/A33) ride the same monthly cadence — the registry changes about
+        # as often as the fleet does. It is NOT a second source for installed capacity: it lists
+        # only units above ~100 MW (DE-LU: 52 GW vs A68's 295 GW). It is what gives the outage
+        # board names instead of EICs, and a denominator to the 18 zones that have no A68.
+        try:
+            from backend.power.entsoe_units import ingest_production_units
+
+            result = await ingest_production_units(db, year, overwrite=True)
+            logger.info("production units (A71/A33): %s", result)
+        except Exception as exc:
+            logger.error("production units monthly failed: %s", exc)
     except Exception as exc:
         logger.error("_run_capacity_monthly outer failed: %s", exc)
     finally:

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -261,6 +261,55 @@ class InstalledCapacity(Base):
     )
 
 
+class ProductionUnit(Base):
+    """ENTSO-E production units (A71 / processType A33) — the plants behind the EICs.
+
+    PowerOutage has carried `unit_eic` since it was written and has never READ it: a dangling
+    join key waiting for exactly this table. With it, the outage board says "CATTENOM 3" where
+    it used to say `17W100P100P0001A`.
+
+    THIS IS NOT THE INSTALLED FLEET, AND MUST NEVER BE USED AS ONE.
+    A71/A33 lists only production UNITS above ENTSO-E's ~100 MW publication threshold. Measured:
+
+        DE-LU   A71/A33:  133 units,  65,193 MW      FR   A71/A33:  174 units,  93,903 MW
+                A68    :             294,941 MW           A68    :             163,611 MW
+                                     ──────────                                ──────────
+                                      factor 4.5                                factor 1.7
+
+    And the ratio is not even CONSTANT (NL: 2.7), so no correction factor could turn one into
+    the other.
+
+    A different population, not a smaller sample of the same one. Firing forced_outage_severity's
+    A68-calibrated 3%/8% thresholds against a several-times-too-small denominator would fire far more often
+    — and the 19 A68 zones and the 18 A71 zones would then be measuring different populations
+    under one threshold, which is precisely the cross-zone incomparability outage_history.py
+    already forbids. What it IS good for: A71/A33 is the same population the A77 outages are
+    drawn from, so "% of the zone's published >=100 MW units" is an honest number with its own
+    label — and it exists for all 37 zones, including the 18 that have no A68 at all.
+
+    psr_type stores the RAW B-CODE, deliberately. This table exists to join PowerOutage.unit_eic,
+    and PowerOutage.psr_type is a raw code (labelled at read time), while InstalledCapacity and
+    PowerGenMix store the readable LABEL. Choosing the label here would mean joining a labelled
+    table to a coded one — and PSR_LABELS has real gaps (A71/A33 returns B03; the store already
+    holds gen.B25), so PSR_LABELS.get(code, code) is not injective in the way a join needs.
+    """
+
+    __tablename__ = "production_unit"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    unit_eic: Mapped[str] = mapped_column(String, nullable=False, index=True)  # joins PowerOutage
+    zone: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    year: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
+    psr_type: Mapped[str | None] = mapped_column(String, nullable=True)  # RAW B-code, see above
+    nominal_mw: Mapped[float | None] = mapped_column(Float, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("unit_eic", "year", name="uq_production_unit_eic_year"),
+    )
+
+
 class PowerOutage(Base):
     """ENTSO-E unavailability of generation/production units (A77/A78/A80).
 

--- a/backend/power/drivers.py
+++ b/backend/power/drivers.py
@@ -217,10 +217,15 @@ def compute_drivers(db: Session, zone: str, *, today: _date | None = None) -> di
     # Forced outages are a LEVEL, not a deviation — there is no hourly outage
     # history in the store yet (that is the outage-time-series work), so this
     # carries no z and says so by omitting one.
-    from backend.signals.detectors.power import forced_outage_mw_now, installed_capacity_mw
+    from backend.signals.detectors.power import (
+        forced_outage_mw_now,
+        installed_capacity_mw,
+        published_unit_capacity_mw,
+    )
 
     forced_mw, _rows = forced_outage_mw_now(db, zone)
     installed = installed_capacity_mw(db, zone)
+    published = published_unit_capacity_mw(db, zone)
     outage = None
     if forced_mw > 0:
         outage = {
@@ -230,6 +235,15 @@ def compute_drivers(db: Session, zone: str, *, today: _date | None = None) -> di
             "unit": "MW",
             "z": None,
             "fleet_pct": round(100.0 * forced_mw / installed, 1) if installed else None,
+            # A SECOND denominator, with its own name — never merged into fleet_pct. A71/A33
+            # publishes only units above ~100 MW (DE-LU: 52 GW vs A68's 295 GW), so it is a
+            # different population, not a smaller sample. But it is the SAME population the
+            # outages themselves come from, and it exists for all 37 zones — including the 18
+            # that have no A68 and therefore no fleet_pct at all.
+            "published_fleet_pct": (
+                round(100.0 * forced_mw / published, 1) if published else None
+            ),
+            "published_fleet_mw": round(published, 1) if published else None,
             "notable": True,
         }
 

--- a/backend/power/entsoe_units.py
+++ b/backend/power/entsoe_units.py
@@ -1,0 +1,170 @@
+"""ENTSO-E production units (A71 / processType A33) — names for the EICs on the outage board.
+
+`PowerOutage.unit_eic` has been written since the outage ingest was built and read by nothing.
+This is the table it was waiting for: the outage board can now say "CATTENOM 3" where it said
+`17W100P100P0001A`, and every one of the 37 zones answers — including the 18 that have no A68
+installed-capacity data at all.
+
+WHAT IT IS NOT
+--------------
+It is NOT the installed fleet, and the temptation to use it as one is the whole risk of this
+module. Measured against prod:
+
+    DE-LU   A71/A33:  133 units,  65,193 MW      FR   A71/A33:  174 units,  93,903 MW
+            A68    :             294,941 MW           A68    :             163,611 MW
+                                 ──────────                                ──────────
+                                  factor 4.5                                factor 1.7
+
+And the ratio is not even CONSTANT (NL: 2.7), so no correction factor could turn one into the
+other.
+
+A71/A33 lists only production UNITS above ENTSO-E's ~100 MW publication threshold. It is a
+different population, not a smaller sample of the same one. See ProductionUnit's docstring and
+`published_unit_capacity_mw` for what it may honestly be used for, and
+docs/findings/2026-07-13-entsoe-a09-a25-a71.md for the measurement.
+
+CACHE
+-----
+`entsoe_units`, and it MUST be its own. `entsoe_gen_total_forecast` is already taken by A71 +
+processType **A01** (the day-ahead generation forecast). Same document type, different process
+type, completely different document — sharing the cache would serve back the wrong one, and it
+would look like a data bug rather than a wiring bug.
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from datetime import date
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.gas import raw_cache
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _token
+from backend.models.energy import ProductionUnit
+from backend.power.zones import ZONE_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+UNIT_REGISTRY_DOCTYPE = "A71"
+UNIT_REGISTRY_PROCESS_TYPE = "A33"
+CACHE_SOURCE = "entsoe_units"  # NOT entsoe_gen_total_forecast — see module docstring
+
+
+def parse_production_units(xml_text: str) -> list[dict]:
+    """A71/A33 → [{unit_eic, name, psr_type, nominal_mw}]. Pure.
+
+    One TimeSeries per unit.
+
+    The nominal power arrives under TWO different tag names in the SAME document —
+    `nominalIP_PowerSystemResources.nominalP` on most units and a bare `nominalP` on others (NL
+    2026: 51 of one, 56 of the other). Matching only one and falling through to the Period's
+    quantity for the rest is how a parser looks like it works: the quantity carries the same
+    figure, so nothing errors and half the units are read by accident. Both are matched.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A71 XML parse error: {exc}") from exc
+
+    units: list[dict] = []
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        eic = next((e.text for e in ts.iter()
+                    if _localname(e.tag) == "registeredResource.mRID"), None)
+        if not eic:
+            continue
+        # The nominal power comes under TWO different tag names in the SAME document —
+        # `nominalIP_PowerSystemResources.nominalP` on most units and a bare `nominalP` on
+        # others. Matching one of them and silently falling through to the Period's quantity
+        # for the rest is how a parser looks like it works: the quantity happens to carry the
+        # same figure, so nothing breaks and half the units are read by accident.
+        nominal = next(
+            (e.text for e in ts.iter() if _localname(e.tag).endswith("nominalP")), None
+        )
+        if nominal is None:
+            nominal = next((e.text for e in ts.iter() if _localname(e.tag) == "quantity"), None)
+        units.append({
+            "unit_eic": eic,
+            "name": next((e.text for e in ts.iter()
+                          if _localname(e.tag) == "registeredResource.name"), None),
+            # RAW code. B03 is real and is NOT in PSR_LABELS — label at read time, never here.
+            "psr_type": next((e.text for e in ts.iter()
+                              if _localname(e.tag) == "psrType"), None),
+            "nominal_mw": _float(nominal),
+        })
+    return units
+
+
+def _float(value: str | None) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+async def _fetch_units_year(zone: str, year: int, *, overwrite: bool = False) -> str:
+    eic = ZONE_REGISTRY[zone]["eic"]
+
+    async def _do() -> dict:
+        params = {
+            "securityToken": _token(),
+            "documentType": UNIT_REGISTRY_DOCTYPE,
+            "processType": UNIT_REGISTRY_PROCESS_TYPE,
+            "in_Domain": eic,
+            "periodStart": f"{year}01010000",
+            "periodEnd": f"{year}01020000",
+        }
+        async with httpx.AsyncClient(timeout=180) as client:  # up to ~9 s per zone
+            resp = await client.get(ENTSOE_BASE, params=params)
+            if resp.status_code >= 400:
+                return {"xml": ""}
+            return {"xml": resp.text}
+
+    payload = await raw_cache.fetch_or_cache(
+        CACHE_SOURCE, f"{zone}_{year}", date(year, 1, 1), _do, overwrite=overwrite,
+    )
+    return payload.get("xml", "")
+
+
+async def ingest_production_units(
+    db: Session, year: int, *, zones: list[str] | None = None, overwrite: bool = False,
+) -> dict:
+    """Refresh the production-unit registry for `year`."""
+    if not settings.entsoe_api_token:
+        return {"skipped": "no token"}
+
+    zones = zones or list(ZONE_REGISTRY)
+    written = covered = 0
+    for zone in zones:
+        try:
+            xml = await _fetch_units_year(zone, year, overwrite=overwrite)
+        except httpx.HTTPError as exc:
+            logger.warning("units %s %s: %s", zone, year, exc)
+            continue
+        if not xml:
+            continue
+        units = parse_production_units(xml)
+        if not units:
+            continue
+        for u in units:
+            existing = (
+                db.query(ProductionUnit)
+                .filter(ProductionUnit.unit_eic == u["unit_eic"], ProductionUnit.year == year)
+                .one_or_none()
+            )
+            if existing:
+                existing.zone = zone
+                existing.name = u["name"]
+                existing.psr_type = u["psr_type"]
+                existing.nominal_mw = u["nominal_mw"]
+            else:
+                db.add(ProductionUnit(zone=zone, year=year, **u))
+            written += 1
+        db.flush()  # Session.get/query cannot see pending rows; a re-run would duplicate
+        covered += 1
+    db.commit()
+    return {"year": year, "zones": len(zones), "with_data": covered, "units": written}

--- a/backend/routes/api_v1.py
+++ b/backend/routes/api_v1.py
@@ -283,6 +283,60 @@ async def capacity(
     }
 
 
+@router.get("/units")
+def get_production_units(
+    zone: str = Query(..., description="Bidding zone key"),
+    db: Session = Depends(get_db),
+):
+    """The zone's published production units (ENTSO-E A71/A33) — reference data.
+
+    NOT the installed fleet. A71/A33 lists only units above ENTSO-E's ~100 MW publication
+    threshold: DE-LU reports 52 GW here against 295 GW of A68 installed capacity. It is a
+    different population, not a smaller sample — but it IS the population the A77 outages are
+    drawn from, and unlike A68 it exists for all 37 zones.
+    """
+    from backend.models.energy import ProductionUnit
+    from backend.power.entsoe_grid import PSR_LABELS
+
+    year = (
+        db.query(func.max(ProductionUnit.year))
+        .filter(ProductionUnit.zone == zone).scalar()
+    )
+    if year is None:
+        return {"available": False, "zone": zone,
+                "reason": f"No production-unit registry for {zone} yet."}
+
+    rows = (
+        db.query(ProductionUnit)
+        .filter(ProductionUnit.zone == zone, ProductionUnit.year == year)
+        .order_by(ProductionUnit.nominal_mw.desc().nullslast())
+        .all()
+    )
+    total = sum(r.nominal_mw or 0.0 for r in rows)
+    return {
+        "available": True,
+        "zone": zone,
+        "year": year,
+        "units": [
+            {
+                "unit_eic": r.unit_eic,
+                "name": r.name,
+                "psr_type": r.psr_type,
+                "fuel": PSR_LABELS.get(r.psr_type, r.psr_type),
+                "nominal_mw": r.nominal_mw,
+            }
+            for r in rows
+        ],
+        "count": len(rows),
+        "published_capacity_mw": round(total, 1),
+        "note": (
+            "Published production units (ENTSO-E A71/A33) — only units above the ~100 MW "
+            "publication threshold, so this is NOT the installed fleet (see /api/v1/capacity, "
+            "A68). It is the population the outage messages are drawn from."
+        ),
+    }
+
+
 @router.get("/series/catalog")
 async def catalog(db: Session = Depends(get_db)):
     """What's queryable: every series (key+unit), enabled zones, and the overall

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1623,6 +1623,25 @@ async def get_records(
 _OUTAGE_KIND = {"A53": "planned", "A54": "forced"}
 
 
+def _unit_names_for(db: Session, eics: list[str]) -> dict[str, str]:
+    """{unit_eic: name} for the EICs on this board, in one query.
+
+    The registry keeps a row per (unit_eic, year); the newest year wins, because a plant that
+    was renamed should show its current name against an outage filed last month.
+    """
+    from backend.models.energy import ProductionUnit
+
+    if not eics:
+        return {}
+    rows = (
+        db.query(ProductionUnit.unit_eic, ProductionUnit.name, ProductionUnit.year)
+        .filter(ProductionUnit.unit_eic.in_(set(eics)), ProductionUnit.name.isnot(None))
+        .order_by(ProductionUnit.year.asc())
+        .all()
+    )
+    return {eic: name for eic, name, _year in rows}   # later years overwrite earlier ones
+
+
 @router.get("/outages")
 async def get_outages(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
@@ -1661,6 +1680,12 @@ async def get_outages(
     outages: list[dict] = []
     total_offline = 0.0
     forced_offline = 0.0
+    # Names for the EICs, in ONE query. PowerOutage.unit_eic has been written since the outage
+    # ingest was built and read by nothing; the unit registry (A71/A33) is what it was waiting
+    # for. Hydrating per row would repeat the 0.25 s / 8.5k-entity mistake the outage board has
+    # already made once.
+    unit_names = _unit_names_for(db, [r.unit_eic for r in latest_rows if r.unit_eic])
+
     for r in latest_rows:
         if r.status != "active":
             continue
@@ -1677,7 +1702,10 @@ async def get_outages(
                 forced_offline += offline
         outages.append({
             "mrid": r.mrid,
-            "unit_name": r.unit_name,
+            # The message's own name if it carries one, else the registry's. Many A77 messages
+            # carry no name at all — which is why the board used to print raw EICs.
+            "unit_name": r.unit_name or unit_names.get(r.unit_eic),
+            "unit_eic": r.unit_eic,
             "location": r.location,
             "fuel": PSR_LABELS.get(r.psr_type, r.psr_type),
             "kind": _OUTAGE_KIND.get(r.business_type, r.business_type),

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -139,6 +139,50 @@ def installed_capacity_mw(db, zone: str) -> float | None:
     return float(total) if total else None
 
 
+def published_unit_capacity_mw(db, zone: str) -> float | None:
+    """Total nominal MW of the zone's PUBLISHED production units (ENTSO-E A71/A33).
+
+    A SEPARATE metric from installed_capacity_mw, and deliberately NOT a fallback for it.
+    Measured on prod:
+
+        DE-LU   A71/A33:  133 units,  65,193 MW      FR   A71/A33:  174 units,  93,903 MW
+                A68    :             294,941 MW           A68    :             163,611 MW
+                                     ──────────                                ──────────
+                                      factor 4.5                                factor 1.7
+
+    And the ratio is not even CONSTANT (NL: 2.7), so no correction factor could turn one into
+    the other.
+
+    A71/A33 lists only units above ENTSO-E's ~100 MW publication threshold — a different
+    population, not a smaller sample of the same one. Wiring it in behind installed_capacity_mw
+    would fire the A68-calibrated 3%/8% thresholds against a denominator several times too
+    small, and the 19 A68 zones and the 18 A71 zones would then be measuring different
+    populations under one threshold. That is exactly the cross-zone incomparability
+    outage_history.py forbids in its own docstring.
+
+    What it IS: the same population the A77 outages are drawn from. So "X GW of the zone's Y GW
+    of published >=100 MW units is offline" is an honest sentence — with its own label — and it
+    exists for all 37 zones, including the 18 that have no A68 at all.
+    """
+    from sqlalchemy import func
+
+    from backend.models.energy import ProductionUnit
+
+    year = (
+        db.query(func.max(ProductionUnit.year))
+        .filter(ProductionUnit.zone == zone)
+        .scalar()
+    )
+    if year is None:
+        return None
+    total = (
+        db.query(func.sum(ProductionUnit.nominal_mw))
+        .filter(ProductionUnit.zone == zone, ProductionUnit.year == year)
+        .scalar()
+    )
+    return float(total) if total else None
+
+
 def forced_outage_severity(total_mw: float, installed_mw: float | None) -> str | None:
     """None / "warning" / "critical" for `total_mw` forced offline. Pure — shared
     by the radar detector and the situation-hero flag so they cannot drift."""

--- a/backend/tests/test_production_units.py
+++ b/backend/tests/test_production_units.py
@@ -1,0 +1,272 @@
+"""A71/A33 is not the installed fleet, and the whole risk of this table is that it looks like it.
+
+    DE-LU   A71/A33:  133 units,  65,193 MW      FR   A71/A33:  174 units,  93,903 MW
+            A68    :             294,941 MW           A68    :             163,611 MW
+                                 ──────────                                ──────────
+                                  factor 4.5                                factor 1.7
+
+It lists only units above ENTSO-E's ~100 MW publication threshold: a different population, not a
+smaller sample of the same one — and the ratio is not even constant (NL: 2.7), so no correction
+factor could turn one into the other. Wiring it in as a denominator for the A68-calibrated outage
+thresholds would fire far more often, with the 19 A68 zones and the 18 A71 zones measuring
+different populations under one threshold.
+
+What it IS good for is the reason it was ingested: names for the EICs, and a denominator for the
+18 zones that have none.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.models.energy import InstalledCapacity, PowerOutage, ProductionUnit
+from backend.power.entsoe_units import parse_production_units
+from backend.signals.detectors.power import (
+    forced_outage_severity,
+    installed_capacity_mw,
+    published_unit_capacity_mw,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db):
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _unit(eic: str, name: str, psr: str, mw: float, *, bare_nominal: bool = False) -> str:
+    """One TimeSeries in the REAL document shape.
+
+    `bare_nominal` switches to the OTHER tag name the same document uses. Both are real: NL
+    2026 carries 51 `nominalIP_PowerSystemResources.nominalP` and 56 bare `nominalP`. A parser
+    that matches only one still "works" — the Period's quantity carries the same figure, so it
+    falls through silently and reads half the units by accident. A fixture with only one tag
+    form cannot express that.
+    """
+    tag = "nominalP" if bare_nominal else "nominalIP_PowerSystemResources.nominalP"
+    return f"""
+  <TimeSeries>
+    <registeredResource.mRID codingScheme="A01">{eic}</registeredResource.mRID>
+    <registeredResource.name>{name}</registeredResource.name>
+    <MktPSRType>
+      <psrType>{psr}</psrType>
+      <{tag} unit="MAW">{mw}</{tag}>
+    </MktPSRType>
+  </TimeSeries>"""
+
+
+def _unit_xml(*units: tuple[str, str, str, float]) -> str:
+    blocks = "".join(_unit(eic, name, psr, mw) for eic, name, psr, mw in units)
+    return (
+        '<?xml version="1.0"?><GL_MarketDocument xmlns="urn:x">' + blocks + "</GL_MarketDocument>"
+    )
+
+
+def test_both_nominal_power_tag_names_in_one_document_are_read():
+    """The real A71/A33 document uses TWO tag names for the same field. Matching one of them
+    and letting the rest fall through to the Period's quantity is how a parser looks correct
+    while reading half its units by accident — the quantity carries the same number."""
+    xml = ('<?xml version="1.0"?><GL_MarketDocument xmlns="urn:x">'
+           + _unit("E1", "Long tag", "B19", 120.3)
+           + _unit("E2", "Bare tag", "B04", 480.0, bare_nominal=True)
+           + "</GL_MarketDocument>")
+
+    units = {u["unit_eic"]: u["nominal_mw"] for u in parse_production_units(xml)}
+    assert units == {"E1": 120.3, "E2": 480.0}
+
+
+# ─── the parser ───────────────────────────────────────────────────────────────
+
+
+def test_units_carry_the_eic_the_outage_table_has_been_writing_all_along():
+    units = parse_production_units(
+        _unit_xml(("17W100P100P0001A", "CATTENOM 3", "B14", 1300.0)))
+
+    assert units == [{
+        "unit_eic": "17W100P100P0001A",
+        "name": "CATTENOM 3",
+        "psr_type": "B14",
+        "nominal_mw": 1300.0,
+    }]
+
+
+def test_an_unknown_psr_code_survives_instead_of_raising():
+    """A71/A33 returns B03, which is not in PSR_LABELS — nor is B25, which is already in the
+    store as gen.B25. A KeyError here would take out the whole registry for a zone."""
+    from backend.power.entsoe_grid import PSR_LABELS
+
+    assert "B03" not in PSR_LABELS
+    units = parse_production_units(_unit_xml(("X1", "Mystery Plant", "B03", 200.0)))
+    assert units[0]["psr_type"] == "B03"
+    assert PSR_LABELS.get("B03", "B03") == "B03", "labelled at read time, degrading gracefully"
+
+
+def test_the_psr_type_is_the_RAW_code_not_the_label():
+    """This table exists to join PowerOutage.unit_eic, and PowerOutage.psr_type is a raw code.
+    InstalledCapacity and PowerGenMix store the LABEL. Storing a label here would mean joining a
+    labelled table to a coded one — and PSR_LABELS has gaps, so the mapping is not injective."""
+    units = parse_production_units(_unit_xml(("X1", "Some Plant", "B14", 900.0)))
+    assert units[0]["psr_type"] == "B14"
+    assert units[0]["psr_type"] != "Nuclear"
+
+
+# ─── the denominator: the decision this PR is really about ────────────────────
+
+
+def test_the_published_fleet_is_not_the_installed_fleet(db_session):
+    """THE test. Both denominators seeded at the REAL measured DE-LU figures, and the severity
+    call must still receive the A68 one. A 'simplification' that unified them would fire far
+    more often, against a population the thresholds were never calibrated on."""
+    db_session.add(InstalledCapacity(zone="DE_LU", year=2026, psr_type="Nuclear",
+                                     capacity_mw=294_941.0))   # A68, measured
+    db_session.add(ProductionUnit(zone="DE_LU", year=2026, unit_eic="X1", name="A",
+                                  psr_type="B14", nominal_mw=65_193.0))   # A71/A33, measured
+    db_session.commit()
+
+    installed = installed_capacity_mw(db_session, "DE_LU")
+    published = published_unit_capacity_mw(db_session, "DE_LU")
+
+    assert installed == 294_941.0
+    assert published == 65_193.0
+    assert published < installed / 4, "a different population, not a smaller sample"
+
+    # 10 GW offline: 3.4% of the real fleet (warning), but 15% of the published units (critical).
+    assert forced_outage_severity(10_000.0, installed) != "critical"
+    assert forced_outage_severity(10_000.0, published) == "critical", (
+        "which is exactly why the published fleet must never be passed here"
+    )
+
+
+def test_the_driver_card_keeps_the_two_denominators_apart(db_session):
+    """fleet_pct (A68) and published_fleet_pct (A71) are different numbers with different
+    meanings and are never merged into one."""
+    from datetime import date, timedelta
+
+    from backend.models.energy import PowerGrid, PowerPriceDaily
+    from backend.power.drivers import compute_drivers
+
+    today = date(2026, 7, 1)
+    for i in range(40):
+        d = (today - timedelta(days=i)).isoformat()
+        db_session.add(PowerPriceDaily(date=d, zone="DE_LU", mean_price=90.0, min_price=10.0,
+                                       max_price=150.0, negative_hours=0))
+        db_session.add(PowerGrid(date=d, zone="DE_LU", load_mw=50_000.0 + i * 100,
+                                 wind_mw=10_000.0, solar_mw=5_000.0,
+                                 residual_mw=35_000.0 + i * 100))
+    db_session.add(InstalledCapacity(zone="DE_LU", year=2026, psr_type="Nuclear",
+                                     capacity_mw=200_000.0))
+    db_session.add(ProductionUnit(zone="DE_LU", year=2026, unit_eic="X1", name="A",
+                                  psr_type="B14", nominal_mw=50_000.0))
+    db_session.add(PowerOutage(
+        mrid="M1", revision=1, doc_type="A77", zone="DE_LU", status="active",
+        business_type="A54", nominal_mw=5_000.0, available_mw=0.0,
+        start_utc="2026-06-01T00:00Z", end_utc="2027-01-01T00:00Z",
+    ))
+    db_session.commit()
+
+    out = compute_drivers(db_session, "DE_LU", today=today)
+    outage = out["outage"]
+
+    assert outage["fleet_pct"] == 2.5, "5 GW of a 200 GW installed fleet"
+    assert outage["published_fleet_pct"] == 10.0, "5 GW of a 50 GW published fleet"
+    assert outage["fleet_pct"] != outage["published_fleet_pct"]
+
+
+def test_a_zone_without_a68_still_gets_a_published_denominator(db_session):
+    """The 18 zones with no A68 (all IT sub-zones, SK, CH, all Nordic sub-zones) have had NO
+    relative outage figure at all. A71 answers for all 37."""
+    db_session.add(ProductionUnit(zone="IT_NORD", year=2026, unit_eic="I1", name="X",
+                                  psr_type="B04", nominal_mw=8_000.0))
+    db_session.commit()
+
+    assert installed_capacity_mw(db_session, "IT_NORD") is None
+    assert published_unit_capacity_mw(db_session, "IT_NORD") == 8_000.0
+
+
+# ─── the join: what the whole thing was for ───────────────────────────────────
+
+
+def test_the_outage_board_shows_the_unit_name_from_the_registry(db_session):
+    """PowerOutage.unit_eic has been written since the outage ingest was built and read by
+    NOTHING. The fixture MUST have unit_name=None — with a name on the message, the join is
+    never exercised and the test proves nothing."""
+    db_session.add(PowerOutage(
+        mrid="M1", revision=1, doc_type="A77", zone="DE_LU", status="active",
+        business_type="A54", psr_type="B14",
+        unit_name=None, unit_eic="17W100P100P0001A",
+        nominal_mw=1_300.0, available_mw=0.0,
+        start_utc="2026-06-01T00:00Z", end_utc="2027-01-01T00:00Z",
+    ))
+    db_session.add(ProductionUnit(zone="DE_LU", year=2026, unit_eic="17W100P100P0001A",
+                                  name="CATTENOM 3", psr_type="B14", nominal_mw=1_300.0))
+    db_session.commit()
+
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    row = body["outages"][0]
+
+    assert row["unit_name"] == "CATTENOM 3", "the board used to print the raw EIC here"
+    assert row["unit_eic"] == "17W100P100P0001A"
+
+
+def test_a_name_on_the_message_itself_wins_over_the_registry(db_session):
+    db_session.add(PowerOutage(
+        mrid="M1", revision=1, doc_type="A77", zone="DE_LU", status="active",
+        business_type="A54", unit_name="As filed", unit_eic="E1",
+        nominal_mw=100.0, available_mw=0.0,
+        start_utc="2026-06-01T00:00Z", end_utc="2027-01-01T00:00Z",
+    ))
+    db_session.add(ProductionUnit(zone="DE_LU", year=2026, unit_eic="E1", name="From registry",
+                                  psr_type="B14", nominal_mw=100.0))
+    db_session.commit()
+
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["outages"][0]["unit_name"] == "As filed"
+
+
+# ─── wiring ───────────────────────────────────────────────────────────────────
+
+
+def test_the_cache_source_is_not_the_generation_forecast_cache():
+    """`entsoe_gen_total_forecast` is A71 + processType A01 — same document type, different
+    process type, completely different document. Sharing the cache would serve back the wrong
+    one, and it would look like a data bug rather than a wiring bug."""
+    from backend.power.entsoe_units import CACHE_SOURCE
+
+    assert CACHE_SOURCE == "entsoe_units"
+    assert CACHE_SOURCE != "entsoe_gen_total_forecast"
+
+
+def test_an_ingest_without_a_token_skips_loudly(db_session, monkeypatch):
+    from backend.power import entsoe_units as eu
+
+    monkeypatch.setattr(eu.settings, "entsoe_api_token", None)
+    assert asyncio.run(eu.ingest_production_units(db_session, 2026)) == {"skipped": "no token"}
+
+
+def test_reingesting_a_year_updates_instead_of_duplicating(db_session, monkeypatch):
+    from pydantic import SecretStr
+
+    from backend.power import entsoe_units as eu
+
+    monkeypatch.setattr(eu.settings, "entsoe_api_token", SecretStr("t"))
+
+    async def _fake(zone, year, *, overwrite=False):
+        return _unit_xml(("X1", "Plant A", "B14", 900.0)) if zone == "DE_LU" else ""
+
+    monkeypatch.setattr(eu, "_fetch_units_year", _fake)
+    for _ in range(2):
+        asyncio.run(eu.ingest_production_units(db_session, 2026, zones=["DE_LU"]))
+
+    assert db_session.query(ProductionUnit).count() == 1

--- a/docs/findings/2026-07-13-entsoe-a09-a25-a71.md
+++ b/docs/findings/2026-07-13-entsoe-a09-a25-a71.md
@@ -118,27 +118,39 @@ Every zone answers, and per unit the document carries `registeredResource.mRID` 
 ### ⚠️⚠️ It is NOT the installed fleet, and must never be used as one
 
 ```
-DE-LU  A71/A33 :  161 units,   51,973 MW
-DE-LU  A68     :              294,941 MW   (prod, year 2026)
-                              ────────────
-                              factor 5.7
+        A71/A33                    A68 (prod, 2026)      ratio
+DE-LU   133 units,  65,193 MW      294,941 MW            4.5
+FR      174 units,  93,903 MW      163,611 MW            1.7
+NL       51 units,  23,801 MW       65,343 MW            2.7
 ```
 
 A71/A33 lists only production **units above ENTSO-E's ~100 MW publication threshold**. It is a
-different population, not a smaller sample of the same one.
+different population, not a smaller sample of the same one — **and the ratio is not even
+constant**, so no correction factor could turn one into the other.
 
-Firing `forced_outage_severity`'s A68-calibrated 3 %/8 % thresholds against a denominator 5.7×
-too small would fire roughly five times as often — and the 19 A68 zones and the 18 A71 zones
-would then be measuring **different populations under one threshold**. That is precisely the
-cross-zone incomparability `outage_history.py` already forbids in its own docstring ("Czechia
-has published 6,633 events and Germany 94").
+Firing `forced_outage_severity`'s A68-calibrated 3 %/8 % thresholds against a several-times-too-
+small denominator would fire far more often — and the 19 A68 zones and the 18 A71 zones would
+then be measuring **different populations under one threshold**. That is precisely the cross-zone
+incomparability `outage_history.py` already forbids in its own docstring ("Czechia has published
+6,633 events and Germany 94").
+
+> **Correction (same day).** The first version of this section reported *161 units / 51,973 MW*
+> for DE-LU. That was wrong, and wrong in an instructive way: the probe counted occurrences of a
+> `nominalP` tag rather than TimeSeries. The document uses **two different tag names for the same
+> field** — `nominalIP_PowerSystemResources.nominalP` on most units and a bare `nominalP` on
+> others (NL 2026: 51 of one, 56 of the other). A parser matching only one of them still appears
+> to work, because the Period's `quantity` carries the same figure and it falls through silently.
+> The corrected figures are above; the argument they support only got stronger.
 
 **The honest use:** A71/A33 is the same population the A77 outages are drawn from. So report
 `% of the zone's published ≥100 MW units` as its **own** number with its **own** label, and
 leave the A68 denominator alone. Re-calibrating the radar's thresholds is a separate,
 backtestable decision (`backend/scripts/backtest_radar.py` exists for exactly that).
 
-### Side finding
+### Side findings
+
+**Two tag names for the nominal power, in the same document** — see the correction above. Match
+both, or read half the units by accident.
 
 A71/A33 returns `psrType=B03`, which is **not in `PSR_LABELS`** — nor is `B25`, which already
 exists in the store as `gen.B25` / `consumption.B25`. `PSR_LABELS.get(code, code)` degrades

--- a/frontend/src/components/OutagePanel.jsx
+++ b/frontend/src/components/OutagePanel.jsx
@@ -81,8 +81,12 @@ export default function OutagePanel({ zone = 'DE_LU' }) {
               <tbody>
                 {running.slice(0, 12).map((o) => (
                   <tr key={o.mrid} className="border-t border-border/30">
-                    <td className="px-2 py-1.5 text-neutral-300 max-w-[180px] truncate" title={o.unit_name}>
-                      {o.unit_name || o.mrid}
+                    {/* The name comes from the message where it has one, else from the A71/A33
+                        unit registry via unit_eic — a key the outage table had been writing and
+                        nothing had ever read. Falling back to the mRID means we know neither. */}
+                    <td className="px-2 py-1.5 text-neutral-300 max-w-[180px] truncate"
+                        title={o.unit_name ? `${o.unit_name}${o.unit_eic ? ` · ${o.unit_eic}` : ''}` : o.unit_eic || o.mrid}>
+                      {o.unit_name || o.unit_eic || o.mrid}
                     </td>
                     <td className="px-2 py-1.5 text-neutral-500">{o.fuel || '—'}</td>
                     <td className="px-2 py-1.5 text-right font-bold text-neutral-200">{fmtGw(o.offline_mw)}</td>


### PR DESCRIPTION
Tier 2, PR 5.

`PowerOutage.unit_eic` has been written since the outage ingest was built and **read by nothing** — a dangling join key waiting for exactly this table. The outage board now says **"CATTENOM 3"** where it printed `17W100P100P0001A`, and **all 37 zones answer**, including the 18 that have no A68 installed-capacity data at all.

## This is not the installed fleet, and the whole risk of the table is that it looks like one

| | A71/A33 | A68 (prod, 2026) | ratio |
|---|---|---|---:|
| DE-LU | 133 units, **65,193 MW** | 294,941 MW | **4.5** |
| FR | 174 units, 93,903 MW | 163,611 MW | **1.7** |
| NL | 51 units, 23,801 MW | 65,343 MW | **2.7** |

A71/A33 lists only units above ENTSO-E's ~100 MW publication threshold: **a different population, not a smaller sample** — and **the ratio is not even constant**, so no correction factor could turn one into the other.

Passing it to `forced_outage_severity`'s A68-calibrated 3 %/8 % thresholds would fire far more often, and the 19 A68 zones and the 18 A71 zones would then be measuring *different populations under one threshold* — precisely the cross-zone incomparability `outage_history.py` forbids in its own docstring.

So `published_unit_capacity_mw` lives **next to** `installed_capacity_mw`, never behind it, and the driver card carries `fleet_pct` (A68) and `published_fleet_pct` (A71) as **two labelled numbers that are never merged**. A test seeds both at the real measured figures and asserts the severity call still receives the A68 one.

## Two corrections I owe the record

**1. These are not the figures I put in the spike finding this morning.** That said *"161 units, 51,973 MW"* for DE-LU. It was wrong: the probe counted occurrences of a `nominalP` tag rather than TimeSeries.

**2. And it was wrong for an instructive reason.** The document uses **two different tag names for the same field** — `nominalIP_PowerSystemResources.nominalP` on most units and a bare `nominalP` on others (NL 2026: **51 of one, 56 of the other**). A parser matching only one *still appears to work*, because the Period's `quantity` carries the same number and it falls through silently — **reading half its units by accident.** Both are matched now, the fixture contains both forms, and the finding doc carries the correction rather than quietly swapping the numbers.

The corrected figures make the argument **stronger**: there is no constant relationship between the two populations at all.

## Smaller decisions, stated

- `psr_type` stores the **raw B-code**. This table joins `PowerOutage.unit_eic`, and `PowerOutage.psr_type` is a raw code (labelled at read time) while `InstalledCapacity`/`PowerGenMix` store the *label*. `PSR_LABELS` has real gaps — A71/A33 returns `B03`; the store already holds `gen.B25` — so it is not injective in the way a join needs.
- Cache source `entsoe_units`: `entsoe_gen_total_forecast` is already **A71 + processType A01**, a completely different document under the same doctype.
- Names are joined in **one query**, not hydrated per row — the outage board has already made the 0.25 s / 8.5k-entity mistake once.

`ruff` clean · **916 passed** (12 new) · eslint clean · vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)