### PR TITLE
The radar was standing at 27 Dunkelflaute alerts, and NO5 has no wind

### DIFF
--- a/backend/power/dunkelflaute.py
+++ b/backend/power/dunkelflaute.py
@@ -1,0 +1,156 @@
+"""What counts as a Dunkelflaute, and in which zones the word means anything at all.
+
+THE BUG THIS EXISTS TO FIX
+--------------------------
+The detector asked one question of all 37 zones: is wind+solar below 15% of load? On prod that
+had the radar standing at **27 simultaneous Dunkelflaute alerts — 77% of its entire output** —
+led by:
+
+    "NO5: Dunkelflaute — renewables 0% of load"
+
+NO5 is hydro. It has essentially no wind and no solar, and it never has. It is not in a
+Dunkelflaute; the sentence is a description of its fleet, dressed as an event. Measured across
+the full history:
+
+    NO1, NO5, SK :  100.0% of all days below the threshold
+    SI           :   93.2%
+    CZ           :   80.7%
+    CH           :   77.5%
+    IT_NORD      :   76.0%
+
+A flat physical threshold is not wrong in Germany. It is wrong as a threshold for EUROPE,
+because it silently assumes every zone has a wind and solar fleet worth talking about.
+
+TWO GATES
+---------
+1. **Does the concept apply?** A zone whose renewables are a marginal part of supply cannot have
+   a Dunkelflaute — it has a hydro fleet, or a nuclear one. If the zone's MEDIAN renewable share
+   over its own history is below MIN_FLEET_SHARE, the detector says so and stays silent. Seven
+   zones fall here (CH, CZ, IT_NORD, NO1, NO5, SI, SK); thirty remain.
+
+2. **Is today actually unusual, for this zone, in this month?** The share must fall in the bottom
+   TAIL_PERCENTILE of that zone's OWN history for the SAME calendar month — a January in DE-LU is
+   not a July — AND still be below the absolute threshold, so a zone whose bad days are 30%
+   renewable never gets told it is dark.
+
+CALIBRATION (measured, 30 eligible zones, ~5.5 years)
+-----------------------------------------------------
+    predicate                       zone-days firing     alerts/day across Europe
+    flat 15% (what shipped)              ~40%                    27 standing
+    own-month p2 AND < 15%                1.41%                   0.4
+
+    DE-LU: 36 Dunkelflaute days in 5.5 years — about six a winter, which is what a German
+    Dunkelflaute actually is. DK1 (median renewable share 71%): 16 days.
+
+The threshold constant stays 15%: it is a real grid condition and it belongs in the conjunction.
+What was missing was everything else.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+#: A defined grid condition: wind+solar carry less than this share of load. Kept — but as one
+#: leg of a conjunction, never as the whole test.
+ABSOLUTE_THRESHOLD = 0.15
+
+#: Below this MEDIAN renewable share, a zone has no wind/solar fleet to speak of and the concept
+#: does not apply. Chosen from the data: the seven zones under it (CH, CZ, IT_NORD, NO1, NO5, SI,
+#: SK) sit at medians of 0.0%–9.8% and were firing on 76–100% of all days.
+MIN_FLEET_SHARE = 0.10
+
+#: Today must be in the bottom 2% of the zone's own same-month record. A decile fires 10% of days
+#: BY CONSTRUCTION — with 37 zones that is ~3 alerts every single day, which is a feed, not a
+#: radar. At 2% it is 0.4/day across Europe.
+TAIL_PERCENTILE = 0.02
+
+#: Below this many same-month observations there is no tail to speak of, so no claim is made.
+MIN_MONTH_HISTORY = 60
+
+
+#: One query for every zone's two thresholds. Called per detector run, so it must not be 37
+#: queries plus a percentile in Python — power_grid is small, but the "aggregate in SQL" rule is
+#: not a size rule, it is a habit. The percentile expression is borders.py's, verbatim, and a
+#: test pins this SQL against borders.percentile() on real-shaped data.
+_THRESHOLD_SQL = """
+WITH d AS (
+    SELECT zone,
+           substr(date, 6, 2) AS mon,
+           (COALESCE(wind_mw, 0) + COALESCE(solar_mw, 0)) / load_mw AS share
+      FROM power_grid
+     WHERE load_mw > 0
+),
+ranked_all AS (
+    SELECT zone, share,
+           ROW_NUMBER() OVER (PARTITION BY zone ORDER BY share) AS rn,
+           COUNT(*)     OVER (PARTITION BY zone)                AS cnt
+      FROM d
+),
+med AS (
+    SELECT zone, share AS median_share, cnt AS n_all
+      FROM ranked_all
+     WHERE rn = (cnt + 1) / 2
+),
+ranked_month AS (
+    SELECT zone, share,
+           ROW_NUMBER() OVER (PARTITION BY zone ORDER BY share) AS rn,
+           COUNT(*)     OVER (PARTITION BY zone)                AS cnt
+      FROM d
+     WHERE mon = :mon
+),
+tail AS (
+    -- The SAME nearest-rank expression borders.py uses, character for character. A second
+    -- percentile convention in one codebase is a second answer to the same question.
+    SELECT zone, share AS tail_share, cnt AS n_month
+      FROM ranked_month
+     WHERE rn = CAST(ROUND(:q * (cnt - 1)) AS INTEGER) + 1
+)
+SELECT m.zone, m.median_share, m.n_all, t.tail_share, t.n_month
+  FROM med m LEFT JOIN tail t ON t.zone = m.zone
+"""
+
+
+def zone_thresholds(db: Session, month: str) -> dict[str, dict]:
+    """{zone: {median_share, tail_share, n_month, eligible, reason}} for one calendar month."""
+    rows = db.execute(
+        text(_THRESHOLD_SQL), {"mon": month, "q": TAIL_PERCENTILE}
+    ).all()
+
+    out: dict[str, dict] = {}
+    for zone, median_share, _n_all, tail_share, n_month in rows:
+        if median_share is None or median_share < MIN_FLEET_SHARE:
+            out[zone] = {
+                "eligible": False,
+                "median_share": median_share,
+                "reason": (
+                    f"{zone} has no material wind/solar fleet "
+                    f"({(median_share or 0) * 100:.0f}% of load on a median day) — a "
+                    "Dunkelflaute is not a condition this zone can be in."
+                ),
+            }
+            continue
+        if tail_share is None or (n_month or 0) < MIN_MONTH_HISTORY:
+            out[zone] = {
+                "eligible": False,
+                "median_share": median_share,
+                "reason": (
+                    f"Only {n_month or 0} days of {zone} history for this month — not enough "
+                    "to say what is unusual in it."
+                ),
+            }
+            continue
+        out[zone] = {
+            "eligible": True,
+            "median_share": float(median_share),
+            "tail_share": float(tail_share),
+            "n_month": int(n_month),
+        }
+    return out
+
+
+def is_dunkelflaute(share: float, threshold: dict) -> bool:
+    """Both legs. Unusually dark FOR THIS ZONE IN THIS MONTH, and dark in absolute terms."""
+    if not threshold.get("eligible"):
+        return False
+    return share < threshold["tail_share"] and share < ABSOLUTE_THRESHOLD

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -66,9 +66,26 @@ def detect_negative_prices(db) -> list[DetectorResult]:
 
 
 def detect_dunkelflaute(db) -> list[DetectorResult]:
-    """Latest day where wind+solar cover an unusually small share of load, per zone."""
+    """A day when wind+solar deliver unusually little FOR THIS ZONE, IN THIS MONTH.
+
+    The old test was a flat 15% of load, asked of all 37 zones. On prod that left the radar
+    standing at 27 simultaneous Dunkelflaute alerts — 77% of its entire output — led by
+    "NO5: Dunkelflaute — renewables 0% of load". NO5 is hydro: it has no wind and no solar, and
+    that sentence describes its fleet, not an event. NO1, NO5 and SK were below the threshold on
+    100% of all days in the record.
+
+    Now: the zone must HAVE a wind/solar fleet worth the word, and today must be in the bottom
+    2% of that zone's own same-month history AND below the absolute threshold. Calibrated on the
+    full record: 1.41% of zone-days, ~0.4 alerts a day across Europe, and 36 Dunkelflaute days
+    for DE-LU in 5.5 years — about six a winter, which is what a German Dunkelflaute is.
+    See backend/power/dunkelflaute.py.
+    """
+    from backend.power.dunkelflaute import is_dunkelflaute, zone_thresholds
+
     zones = [z for (z,) in db.query(PowerGrid.zone).distinct().all()]
     results: list[DetectorResult] = []
+    thresholds_by_month: dict[str, dict] = {}
+
     for zone in zones:
         row = (
             db.query(PowerGrid)
@@ -79,13 +96,20 @@ def detect_dunkelflaute(db) -> list[DetectorResult]:
         if row is None or not row.load_mw or row.load_mw <= 0:
             continue
         share = ((row.wind_mw or 0.0) + (row.solar_mw or 0.0)) / row.load_mw
-        if share >= DUNKELFLAUTE_THRESHOLD:
+
+        month = row.date[5:7]
+        if month not in thresholds_by_month:      # one query per month, not per zone
+            thresholds_by_month[month] = zone_thresholds(db, month)
+        threshold = thresholds_by_month[month].get(zone, {})
+        if not is_dunkelflaute(share, threshold):
             continue
+
         # Coverage guard: only trust a low renewable share when the zone's reported
         # generation plausibly covers its load. ENTSO-E A75 is incomplete for some
         # zones (NL), which fakes a near-zero share — suppress rather than cry wolf.
         if not renewable_share_reliable(db, row.date, zone, row.load_mw):
             continue
+
         results.append(
             DetectorResult(
                 rule="dunkelflaute",
@@ -94,8 +118,10 @@ def detect_dunkelflaute(db) -> list[DetectorResult]:
                 severity="warning",
                 title=f"{zone}: Dunkelflaute — renewables {share * 100:.0f}% of load",
                 detail=(
-                    f"Wind+solar only {share * 100:.1f}% of load on {row.date} (<15% threshold); "
-                    f"residual load carried by conventional generation."
+                    f"Wind+solar carried only {share * 100:.1f}% of load on {row.date} — the "
+                    f"bottom 2% of {zone}'s own record for this month "
+                    f"(n={threshold['n_month']}; a normal day is {threshold['median_share'] * 100:.0f}%). "
+                    f"Residual load carried by conventional generation."
                 ),
                 as_of=row.date,
             )

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -319,7 +319,29 @@ def test_flow_anomaly_insufficient_history_no_fire(db_session):
 # ─── Phase B: dunkelflaute / rerouting / chokepoint ───────────────────────────
 
 
+def _seed_dunkelflaute_history(db, zone="DE_LU", *, normal_share=0.40, years=3):
+    """A zone with a REAL wind/solar fleet and a history to be unusual against.
+
+    Both are load-bearing. The old detector needed neither — it asked one flat question of every
+    zone — which is how the radar ended up standing at 27 simultaneous Dunkelflaute alerts, led
+    by "NO5: renewables 0% of load" for a zone that is pure hydro.
+    """
+    from datetime import date, timedelta
+
+    day = date(2026, 6, 24)
+    for i in range(1, years * 365):
+        d = day - timedelta(days=i)
+        if d.month != 6:               # same-month history is what the tail is measured against
+            continue
+        wind = 60_000 * normal_share * 0.6
+        solar = 60_000 * normal_share * 0.4
+        db.add(PowerGrid(date=d.isoformat(), zone=zone, load_mw=60_000,
+                         wind_mw=wind, solar_mw=solar))
+
+
 def test_dunkelflaute_warns(db_session):
+    """The real thing: a zone with a 40% normal renewable share dropping to 8%."""
+    _seed_dunkelflaute_history(db_session)
     db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000, wind_mw=3000, solar_mw=2000))  # ~8%
     # Complete generation coverage (~60 GW ≈ load) → the low renewable share is real.
     db_session.add(PowerGenMix(date="2026-06-24", zone="DE_LU", psr_type="Fossil Gas", gen_mw=40000))
@@ -329,10 +351,42 @@ def test_dunkelflaute_warns(db_session):
     db_session.commit()
     r = detect_dunkelflaute(db_session)[0]
     assert r.vertical == "power" and r.rule == "dunkelflaute" and r.severity == "warning"
+    assert "bottom 2%" in r.detail, "the claim is relative to the zone's own record"
 
 
 def test_dunkelflaute_high_renewables_suppressed(db_session):
+    _seed_dunkelflaute_history(db_session)
     db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000, wind_mw=30000, solar_mw=15000))  # 75%
+    db_session.commit()
+    assert detect_dunkelflaute(db_session) == []
+
+
+def test_a_hydro_zone_is_never_in_a_dunkelflaute(db_session):
+    """THE bug, as it stood on prod: "NO5: Dunkelflaute — renewables 0% of load", every single
+    day. NO5 is hydro — it has no wind and no solar, and never has. The sentence describes its
+    fleet, not an event. NO1, NO5 and SK were below the flat threshold on 100% of ALL days.
+
+    A fixture with a wind fleet cannot express this bug; the zone must have none."""
+    from datetime import date, timedelta
+
+    day = date(2026, 6, 24)
+    for i in range(1, 3 * 365):
+        d = day - timedelta(days=i)
+        if d.month != 6:
+            continue
+        # Pure hydro: a 2% renewable share, every day, forever. Nothing here is an event.
+        db_session.add(PowerGrid(date=d.isoformat(), zone="NO5", load_mw=10_000,
+                                 wind_mw=200, solar_mw=0))
+    db_session.add(PowerGrid(date="2026-06-24", zone="NO5", load_mw=10_000, wind_mw=0, solar_mw=0))
+    db_session.commit()
+
+    assert detect_dunkelflaute(db_session) == [], "0% of load is NO5's normal, not its emergency"
+
+
+def test_a_zone_with_no_history_for_this_month_makes_no_claim(db_session):
+    """Without a same-month record there is no tail to be in, so there is nothing to say."""
+    db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000,
+                             wind_mw=3000, solar_mw=2000))
     db_session.commit()
     assert detect_dunkelflaute(db_session) == []
 

--- a/backend/tests/test_dunkelflaute.py
+++ b/backend/tests/test_dunkelflaute.py
@@ -1,0 +1,132 @@
+"""A Dunkelflaute in a hydro zone is not an event. It is a description of the fleet.
+
+The detector asked one flat question of all 37 zones — is wind+solar under 15% of load — and on
+prod that left the radar standing at 27 simultaneous Dunkelflaute alerts, 77% of its entire
+output, led by "NO5: Dunkelflaute — renewables 0% of load".
+
+Measured across the whole record: NO1, NO5 and SK were under the threshold on 100% of all days.
+SI 93%, CZ 81%, CH 78%, IT_NORD 76%. A flat threshold is not wrong in Germany. It is wrong as a
+threshold for EUROPE.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from backend.models.energy import PowerGrid
+from backend.power.borders import percentile
+from backend.power.dunkelflaute import (
+    ABSOLUTE_THRESHOLD,
+    MIN_FLEET_SHARE,
+    TAIL_PERCENTILE,
+    is_dunkelflaute,
+    zone_thresholds,
+)
+
+TODAY = date(2026, 6, 24)
+
+
+def _seed(db, zone: str, shares: list[float], *, load: float = 60_000.0, month: int = 6):
+    """One PowerGrid day per share, all in the same calendar month."""
+    d = date(2026, month, 1)
+    for i, share in enumerate(shares):
+        day = d + timedelta(days=i)
+        # Keep them inside the month by wrapping the year rather than the month.
+        day = date(2026 - (i // 28), month, (i % 28) + 1)
+        db.add(PowerGrid(date=day.isoformat(), zone=zone, load_mw=load,
+                         wind_mw=load * share * 0.6, solar_mw=load * share * 0.4))
+    db.commit()
+
+
+# ─── gate 1: does the concept even apply? ─────────────────────────────────────
+
+
+def test_a_zone_with_no_wind_or_solar_fleet_is_ineligible_with_a_reason(db_session):
+    """NO5's median renewable share is 0.0%. "Renewables are 0% of load" is true every day of
+    its life. The detector must say so and stay silent — not fire, and not vanish silently."""
+    _seed(db_session, "NO5", [0.00] * 80)
+
+    t = zone_thresholds(db_session, "06")["NO5"]
+
+    assert t["eligible"] is False
+    assert "no material wind/solar fleet" in t["reason"]
+    assert is_dunkelflaute(0.0, t) is False, "its normal is not its emergency"
+
+
+def test_a_zone_with_a_real_fleet_is_eligible(db_session):
+    _seed(db_session, "DE_LU", [0.40] * 80)
+    assert zone_thresholds(db_session, "06")["DE_LU"]["eligible"] is True
+
+
+def test_the_fleet_gate_is_the_MEDIAN_not_todays_share(db_session):
+    """A German winter day at 5% renewables must still be eligible — the gate asks what the zone
+    NORMALLY has, not what it has today. Asking about today would gate away exactly the event."""
+    _seed(db_session, "DE_LU", [0.40] * 79 + [0.05])
+    t = zone_thresholds(db_session, "06")["DE_LU"]
+    assert t["eligible"] is True
+    assert t["median_share"] >= MIN_FLEET_SHARE
+
+
+# ─── gate 2: is today unusual, for this zone, in this month? ──────────────────
+
+
+def test_both_legs_are_required(db_session):
+    """Unusually low FOR THIS ZONE, and low in absolute terms. Either alone is not enough."""
+    threshold = {"eligible": True, "tail_share": 0.10, "median_share": 0.40, "n_month": 200}
+
+    assert is_dunkelflaute(0.08, threshold) is True          # below both
+    assert is_dunkelflaute(0.12, threshold) is False         # unusual? no — above the tail
+    assert is_dunkelflaute(0.05, {**threshold, "tail_share": 0.30}) is True
+
+    # A zone whose bad days are 30% renewable never gets told it is dark, however rare the day.
+    assert is_dunkelflaute(0.25, {**threshold, "tail_share": 0.30}) is False
+    assert ABSOLUTE_THRESHOLD == 0.15
+
+
+def test_a_thin_month_makes_no_claim(db_session):
+    """Below a real same-month record there is no tail to be in, so there is nothing to say —
+    and 'no claim' must be visible, not an empty result that reads like 'all clear'."""
+    _seed(db_session, "DE_LU", [0.40] * 10)
+    t = zone_thresholds(db_session, "06")["DE_LU"]
+
+    assert t["eligible"] is False
+    assert "not enough" in t["reason"]
+
+
+def test_the_tail_is_measured_per_MONTH(db_session):
+    """A January in DE-LU is not a July. Pooling them would judge a normal winter day against
+    summer sunshine, and every winter would look like an emergency."""
+    _seed(db_session, "DE_LU", [0.15] * 80, month=1)   # dark winter: normal is 15%
+    _seed(db_session, "DE_LU", [0.55] * 80, month=7)   # bright summer
+
+    jan = zone_thresholds(db_session, "01")["DE_LU"]
+    jul = zone_thresholds(db_session, "07")["DE_LU"]
+
+    assert jan["tail_share"] < jul["tail_share"], "each month is judged against itself"
+
+
+# ─── the arithmetic: one percentile convention for the whole codebase ─────────
+
+
+def test_the_sql_percentile_matches_the_python_one(db_session):
+    """This SQL computes a percentile; borders.percentile() computes a percentile. Two
+    conventions in one codebase are two answers to the same question — and an off-by-one in the
+    rank is exactly the drift that produced during development."""
+    shares = [round(0.02 * i, 4) for i in range(1, 81)]   # 0.02 … 1.60, deliberately uneven
+    _seed(db_session, "DE_LU", shares)
+
+    t = zone_thresholds(db_session, "06")["DE_LU"]
+    expected = percentile(shares, TAIL_PERCENTILE)
+
+    assert t["tail_share"] == pytest.approx(expected, abs=1e-9)
+
+
+def test_calibration_constants_are_what_the_measurement_said():
+    """These are not taste. A decile fires 10% of days BY CONSTRUCTION — across 37 zones that is
+    ~3 alerts every single day, which is a feed, not a radar. At 2% the measured rate on the full
+    record is 1.41% of zone-days, ~0.4 alerts/day, and 36 Dunkelflaute days for DE-LU in 5.5
+    years: about six a winter, which is what a German Dunkelflaute actually is."""
+    assert TAIL_PERCENTILE == 0.02
+    assert MIN_FLEET_SHARE == 0.10
+    assert ABSOLUTE_THRESHOLD == 0.15


### PR DESCRIPTION
Found while measuring the predicate *before* building the episode archive on it. **It is a live production bug**, not a hypothetical.

**27 of the radar's 35 standing alerts — 77 % of its entire output — were Dunkelflaute**, led by:

> **"NO5: Dunkelflaute — renewables 0 % of load"**

**NO5 is hydro.** It has essentially no wind and no solar and never has. That sentence is a description of its fleet wearing the costume of an event.

Across the full record:

| zone | days below the 15 % threshold |
|---|---:|
| NO1, NO5, SK | **100.0 %** of *all* days |
| SI | 93.2 % |
| CZ | 80.7 % |
| CH | 77.5 % |
| IT_NORD | 76.0 % |

A flat 15 % threshold is not wrong in Germany. **It is wrong as a threshold for Europe**, because it silently assumes every zone has a wind and solar fleet worth the word.

## Two gates, both measured

1. **Does the concept apply?** If a zone's **median** renewable share over its own history is below 10 %, it has a hydro fleet or a nuclear one — not a renewable one — and a Dunkelflaute is not a condition it can be in. Seven zones (CH, CZ, IT_NORD, NO1, NO5, SI, SK) now get an **explicit reason** instead of a daily false alarm. Thirty remain.

2. **Is today unusual *for this zone, in this month*?** The share must fall in the bottom 2 % of that zone's own **same-calendar-month** record **and** still be under the absolute threshold — so a zone whose dark days are 30 % renewable is never told it is dark. *A January in DE-LU is not a July.*

## Calibration, not taste

| predicate | zone-days firing | alerts/day across Europe |
|---|---:|---:|
| flat 15 % (what shipped) | ~40 % | **27 standing** |
| own-month p2 **and** < 15 % | **1.41 %** | **0.4** |

**A decile fires 10 % of days by construction** — across 37 zones that is ~3 alerts every single day, which is a feed, not a radar. At 2 %: **DE-LU gets 36 Dunkelflaute days in 5.5 years** — about six a winter, which is what a German Dunkelflaute actually is. DK1, whose median renewable share is 71 %, gets 16.

**On today's real data the old predicate fires 6 alerts and the new one fires none** — correctly: it is mid-July, and NO2's 1.8 % is *above* its own July threshold of 0.9 %. A normal Nordic summer.

The **15 % constant stays**: it is a real grid condition and belongs in the conjunction. What was missing was everything around it.

## One percentile convention

The thresholds are **one SQL query per month**, using `borders.py`'s nearest-rank percentile expression *character for character*. A second percentile convention in one codebase is a second answer to the same question — and an **off-by-one in the rank is exactly the drift that showed up while writing this**. A test pins the SQL against `borders.percentile()`.

`ruff` clean · **927 passed** (12 new/rewritten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)