### PR TITLE
A backfill measured in hours must not be killed by an hourly cron job

### DIFF
--- a/backend/scripts/gas_backfill.py
+++ b/backend/scripts/gas_backfill.py
@@ -35,14 +35,20 @@ ALL_SOURCES = ("entsog", "agsi", "alsi", "entsoe", "weather", "demand", "balance
 
 
 async def _with_retry(coro_factory, label: str, attempts: int = 3, base: float = 1.0):
-    """Retry a network step with exponential backoff (cached days are skipped
-    on retry, so this resumes cheaply rather than re-fetching everything)."""
+    """Retry a step with exponential backoff (cached days are skipped on retry, so this resumes
+    cheaply rather than re-fetching everything).
+
+    OperationalError is caught for the same reason power_backfill catches it: "database is
+    locked" is a transient failure, SQLite takes one writer, and a backfill measured in hours
+    must not be killed by an hourly cron job.
+    """
     import httpx
+    from sqlalchemy.exc import OperationalError
 
     for i in range(attempts):
         try:
             return await coro_factory()
-        except (httpx.HTTPError, OSError) as exc:
+        except (httpx.HTTPError, OSError, OperationalError) as exc:
             if i == attempts - 1:
                 logger.error("%s failed after %d attempts: %s", label, attempts, exc)
                 raise

--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -41,14 +41,22 @@ THROTTLE_SECONDS = 1.0
 
 
 async def _with_retry(coro_factory, label: str, attempts: int = 4, base: float = 2.0):
-    """Retry a network step with exponential backoff. Cached months are skipped on
-    retry (raw_cache), so this resumes cheaply rather than re-fetching everything."""
+    """Retry a step with exponential backoff. Cached months are skipped on retry (raw_cache),
+    so this resumes cheaply rather than re-fetching everything.
+
+    OperationalError is in the catch set because "database is locked" is exactly the kind of
+    transient failure a retry exists for — and it is not hypothetical: the A09 backfill died on
+    one after writing 432,774 points, because the app was writing at the same time (SQLite takes
+    one writer, and the 30 s busy_timeout is not a guarantee). Without it, a backfill measured in
+    hours can be killed by an hourly cron job.
+    """
     import httpx
+    from sqlalchemy.exc import OperationalError
 
     for i in range(attempts):
         try:
             return await coro_factory()
-        except (httpx.HTTPError, OSError) as exc:
+        except (httpx.HTTPError, OSError, OperationalError) as exc:
             if i == attempts - 1:
                 logger.error("%s failed after %d attempts: %s", label, attempts, exc)
                 raise

--- a/backend/tests/test_backfill_retry.py
+++ b/backend/tests/test_backfill_retry.py
@@ -1,0 +1,51 @@
+"""A backfill measured in hours must not be killed by an hourly cron job.
+
+The A09 backfill died after writing 432,774 points with `sqlite3.OperationalError: database is
+locked`. It had run for 40 minutes. SQLite takes exactly one writer, the app writes on its own
+schedule (the hourly outage snapshot, the daily ingests), and the 30 s busy_timeout is a hope,
+not a guarantee.
+
+`_with_retry` existed and caught network errors. A lock is exactly the kind of transient failure
+a retry exists for — it just was not in the set.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from backend.scripts.gas_backfill import _with_retry as gas_retry
+from backend.scripts.power_backfill import _with_retry as power_retry
+
+
+@pytest.mark.parametrize("retry", [power_retry, gas_retry], ids=["power", "gas"])
+def test_a_database_lock_is_retried_not_fatal(retry, monkeypatch):
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    calls = {"n": 0}
+
+    async def _flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OperationalError("INSERT …", {}, Exception("database is locked"))
+        return "written"
+
+    assert asyncio.run(retry(_flaky, "test")) == "written"
+    assert calls["n"] == 2, "the lock was survived, not swallowed"
+
+
+@pytest.mark.parametrize("retry", [power_retry, gas_retry], ids=["power", "gas"])
+def test_a_lock_that_never_clears_still_fails_loudly(retry, monkeypatch):
+    """Retrying forever would hide a real problem — a held lock that never releases is a bug in
+    something else, and the backfill must say so rather than spin."""
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    async def _always_locked():
+        raise OperationalError("INSERT …", {}, Exception("database is locked"))
+
+    with pytest.raises(OperationalError):
+        asyncio.run(retry(_always_locked, "test"))
+
+
+async def _no_sleep(_seconds):
+    return None


### PR DESCRIPTION
The A09 backfill died on prod after 40 minutes and **432,774 written points**:

```
sqlite3.OperationalError: database is locked
```

SQLite takes exactly **one writer**. The app writes on its own schedule — the hourly outage snapshot, the daily ingests — and the engine's 30 s `busy_timeout` is a hope, not a guarantee.

*(It did not help that I was also running `ingest_production_units` and a detector sweep on prod at the same time. That is its own lesson about batch jobs on a live single-writer database.)*

## The fix

`_with_retry` already existed, and already caught network errors. **A lock is exactly the kind of transient failure a retry exists for** — it simply was not in the set. Now it is, in both backfills. The retry is cheap: the raw cache means a retried month re-fetches nothing.

A lock that **never** clears still fails loudly — retrying forever would hide a real problem in something else. Both properties are pinned by tests.

`ruff` clean · 930 passed (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)