### PR TITLE
Grid stress is an episode, and the radar only ever saw today

### DIFF
--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -20,6 +20,7 @@ from sqlalchemy import func
 
 from backend.models.energy import (
     EnergyPrice,
+    PowerEpisode,
     PowerFlow,
     PowerGrid,
     PowerHourly,
@@ -99,6 +100,9 @@ SPECS += [
     # Day-ahead market net position (A25). One probe across all zones: "is the collector alive".
     FreshnessSpec("net_position", PowerPriceDaily, "", timedelta(days=3),
                   hourly_series="netpos.dayahead"),
+    # Episodes are DERIVED, not ingested — so the probe asks whether the nightly recompute ran,
+    # not whether a feed arrived. A silent episode engine looks exactly like a quiet Europe.
+    FreshnessSpec("episodes", PowerEpisode, "updated_at", timedelta(days=2)),
     # The outage snapshot is the ONE series that cannot be backfilled: A77 takes an
     # unavailability down once it is over, so an hour the recorder missed is gone for
     # good. It must therefore be the tightest window on the desk — a day of silence is

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -347,6 +347,25 @@ async def _run_outages():
         db.close()
 
 
+async def _run_episodes_nightly():
+    """Re-derive every grid-stress episode from the canonical series.
+
+    A full recompute, like the records job: no incremental state means no state to corrupt, and
+    a rerun is always correct. It also RETRACTS — an episode a later revision of the data no
+    longer supports disappears, rather than sitting in the archive forever.
+    """
+    from backend.power.episodes import compute_episodes
+
+    db = SessionLocal()
+    try:
+        result = compute_episodes(db)
+        logger.info("episodes nightly: %s", result)
+    except Exception as exc:
+        logger.error("_run_episodes_nightly failed: %s", exc)
+    finally:
+        db.close()
+
+
 async def _run_outage_snapshot():
     """Write down how much capacity is offline RIGHT NOW, every hour.
 
@@ -421,6 +440,9 @@ def start_scheduler():
     scheduler.add_job(_run_outage_snapshot, CronTrigger(minute=45), id="outage_snapshot_hourly", **JOB_DEFAULTS)
     # All-time records: nightly at 23:45, after the 22:30 power ingest.
     scheduler.add_job(_run_records_nightly, CronTrigger(hour=23, minute=45), id="records_nightly", **JOB_DEFAULTS)
+    # Episodes: 23:50, right after the records — same doctrine (full recompute from the canonical
+    # store, no incremental state), and it wants the same freshly-ingested day underneath it.
+    scheduler.add_job(_run_episodes_nightly, CronTrigger(hour=23, minute=50), id="episodes_nightly", **JOB_DEFAULTS)
 
     # Energy prices (TTF for the spark spread, + power ticker): daily 22:15 UTC.
     scheduler.add_job(collect_energy_prices, CronTrigger(hour=22, minute=15), id="energy_prices_daily", **JOB_DEFAULTS)

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -373,3 +373,42 @@ class PowerRecord(Base):
     __table_args__ = (
         UniqueConstraint("series_key", "zone", "kind", name="uq_power_record_series_zone_kind"),
     )
+
+
+class PowerEpisode(Base):
+    """A stretch of grid stress as an OBJECT, not a daily flag.
+
+    Grid stress is an episode: a Dunkelflaute runs for days, a negative-price weekend for a
+    weekend. The radar only ever saw today. Worse, it could not have been taught otherwise from
+    what it stored — `_upsert_alert` mutates the existing Alert row in place, slides created_at
+    forward and DELETES older duplicates, so a five-day run collapses into one row that claims
+    nothing about duration. The history was never written.
+
+    So episodes are RE-DERIVED from the canonical series, nightly, in full — exactly the
+    doctrine PowerRecord already follows. No incremental state means no state to corrupt.
+
+    `depth_date` is the evidence pointer (records.py's discipline): the day the episode was at
+    its worst, so a reader can go and look.
+
+    Day grain, deliberately: the predicates live on PowerGrid and PowerPriceDaily, both daily.
+    An hour-grained duration would be a precision we do not have.
+    """
+
+    __tablename__ = "power_episode"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    kind: Mapped[str] = mapped_column(String, nullable=False, index=True)   # see episodes.KINDS
+    zone: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    start_date: Mapped[str] = mapped_column(String, nullable=False)         # YYYY-MM-DD
+    end_date: Mapped[str] = mapped_column(String, nullable=False)
+    duration_days: Mapped[int] = mapped_column(Integer, nullable=False)
+    depth: Mapped[float] = mapped_column(Float, nullable=False)             # the worst value
+    depth_date: Mapped[str] = mapped_column(String, nullable=False)         # …and when
+    mean_value: Mapped[float] = mapped_column(Float, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)             # active | resolved
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow,
+                                                 onupdate=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("kind", "zone", "start_date", name="uq_power_episode_kind_zone_start"),
+    )

--- a/backend/power/coverage.py
+++ b/backend/power/coverage.py
@@ -1,15 +1,26 @@
 """Generation-data coverage guard for renewable-share metrics.
 
-ENTSO-E A75 (actual generation per production type) is materially incomplete for
-some bidding zones — notably NL, where reported generation covers only ~half of
-load and wind+solar look artificially tiny. Renewable share = (wind+solar)/load
-is then meaningless, and a naive Dunkelflaute check (share < 15%) cries wolf.
+Renewable share = (wind+solar)/load is meaningless when the reported generation is materially
+incomplete: the numerator shrinks, the denominator does not, and a naive Dunkelflaute check
+cries wolf. So the share is trusted only when the reported generation TOTAL is a plausible
+fraction of load — and when it cannot be proven, it is not trusted (fail safe).
 
-The share is only trustworthy when the reported generation *total* is a plausible
-fraction of load. We treat it as unreliable when reported generation covers less
-than ``COVERAGE_MIN_RATIO`` of load for that day, or when there is no generation-mix
-data at all to validate against (fail safe: if we cannot prove coverage, we do not
-trust the share). This is data-driven, so it auto-heals if ENTSO-E backfills a zone.
+WHICH ZONES THIS ACTUALLY CATCHES — measured 2026-07-13, and NOT what it used to be:
+
+    SE4             gen/load 0.36    IT_CENTRO_SUD  0.69    SE3   0.74
+    NO1             0.60             IE_SEM         0.72    DK2   0.78
+
+NL used to be the headline example here (~0.49). **It is now 1.01**: the A75 parser was
+splitting inBiddingZone (generation) from outBiddingZone (consumption) incorrectly, and fixing
+that healed the coverage. The guard is data-driven, so it healed with it — which is the whole
+argument for making it data-driven.
+
+A KNOWN LIMITATION, stated rather than hidden: this guard cannot tell an INCOMPLETE FEED from a
+genuine NET IMPORTER. SE4 imports most of its power; its domestic generation really is about a
+third of its load, and its renewable share is perfectly meaningful. The guard suppresses it
+anyway. That is a false negative — the safe direction, and the one this codebase already chose —
+but it IS a false negative, and with A09/A25 now ingested (generation + net import ≈ load) there
+is a better guard available to whoever wants to write it.
 """
 
 from __future__ import annotations
@@ -57,3 +68,30 @@ def renewable_share_reliable(db: Session, date: str, zone: str, load_mw: float |
     if total is None:
         return False
     return total >= coverage_min_ratio(zone) * load_mw
+
+
+def reliable_days(db: Session) -> set[tuple[str, str]]:
+    """{(date, zone)} whose renewable share is trustworthy — the whole record, ONE query.
+
+    `renewable_share_reliable` above answers for a single day, which is right for a detector
+    looking at today. An episode engine walks five years of 37 zones, and calling it in a loop
+    would be ~67,000 round trips: the "aggregate in SQL, not in Python" trap in its purest form.
+
+    Same rule, same constants, one grouped query. A day with no generation mix at all is absent
+    from the set (fail safe: if we cannot prove coverage, we do not trust the share).
+    """
+    from sqlalchemy import text
+
+    rows = db.execute(text("""
+        SELECT g.date, g.zone, SUM(m.gen_mw) AS gen, g.load_mw
+          FROM power_grid g
+          JOIN power_gen_mix m ON m.date = g.date AND m.zone = g.zone
+         WHERE g.load_mw > 0
+         GROUP BY g.date, g.zone
+    """)).all()
+
+    return {
+        (date, zone)
+        for date, zone, gen, load in rows
+        if gen is not None and gen >= coverage_min_ratio(zone) * load
+    }

--- a/backend/power/episodes.py
+++ b/backend/power/episodes.py
@@ -1,0 +1,389 @@
+"""Grid stress is an episode, and the radar only ever saw today.
+
+A Dunkelflaute runs for days. A negative-price stretch runs for a weekend. The desk could say
+"DE-LU is in a Dunkelflaute" and never "this is the fourth-longest one in our record" — which is
+the sentence an analyst actually wants, because it is the one that says whether to care.
+
+WHY THIS CANNOT BE MINED FROM THE ALERTS
+----------------------------------------
+It looks like the history is already there: the radar has been writing Alert rows for months.
+It is not. `_upsert_alert` (signals/rules.py, DEDUP_HOURS=24) MUTATES the existing row in place,
+slides `created_at` forward and DELETES older duplicates — so a five-day Dunkelflaute collapses
+into a single row whose timestamp keeps moving and which claims nothing about duration. The
+radar is stateless by construction, and re-firing actively destroys the record an episode would
+be built from.
+
+So episodes are RE-DERIVED from the canonical series, nightly, in full. That is exactly the
+doctrine records.py already follows: no incremental state means no state to corrupt, and a
+recompute is always correct.
+
+THE GUARD IS THE PART THAT DECIDES WHETHER THIS SHIPS OR EMBARRASSES
+--------------------------------------------------------------------
+records.py's `_bounds` exists because a 0 MW ENTSO-E gap once produced a bogus all-time low for
+SI "that the radar dutifully celebrated". An episode grouper has the same failure mode,
+amplified: if a zone's A75 feed drops for two days, wind reads 0 and solar reads 0, the renewable
+share reads 0 — and out comes a two-day Dunkelflaute that never happened. A run of them would be
+worse: the engine would find its longest episode ever in an outage of our own collector.
+
+Hence: an hour the coverage guard rejects is a HOLE, not an episode day, and a hole longer than
+the gap tolerance ENDS the episode rather than bridging it.
+
+A PROPERTY WORTH KNOWING BEFORE SOMEONE REPORTS IT AS A BUG
+-----------------------------------------------------------
+The predicates are relative — "the bottom 2% of this zone's own record for this month" — and an
+episode's own days are PART of that record. So a run that is very long relative to the record it
+is judged against is reported TRUNCATED to its darkest days: with 230 January days on file, the
+cutoff is the 6th-darkest, and a hypothetical ten-day Dunkelflaute would surface as its five
+worst days rather than all ten. That is exactly what "the bottom 2%" means, and it is the honest
+reading — but it is not obvious, and it is the reason the tests seed six years of history rather
+than two.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from backend.models.energy import PowerEpisode, PowerGrid, PowerPriceDaily
+from backend.power.coverage import reliable_days
+from backend.power.dunkelflaute import is_dunkelflaute, zone_thresholds
+
+logger = logging.getLogger(__name__)
+
+#: A single missing day must not split a five-day run — feeds have holes. A three-day hole is
+#: not a gap in an episode, it is two episodes with a gap between them.
+MAX_GAP_DAYS = 1
+
+#: One qualifying day is a day, not an episode. Two consecutive is the shortest thing worth
+#: calling a run.
+MIN_DURATION_DAYS = 2
+
+#: A window less than this fraction populated is not an episode, it is a coverage hole with a
+#: few readings in it.
+MIN_POPULATED = 0.8
+
+#: Below a year of history for a zone, a rank is a statement about our coverage, not about the
+#: grid. records.py's RECORD_MIN_COVERAGE_DAYS, and the same argument.
+MIN_HISTORY_DAYS = 365
+
+#: A negative-price day: the existing detector's own floor, so the desk has one definition.
+NEGATIVE_HOURS_MIN = 3
+
+
+@dataclass(frozen=True)
+class Run:
+    """A maximal stretch of qualifying days. Pure — no DB, no dates beyond what it was given."""
+
+    start: str
+    end: str
+    days: int
+    depth: float
+    depth_date: str
+    mean: float
+    populated: float
+
+
+def group_runs(
+    points: list[tuple[str, float]],
+    predicate,
+    *,
+    holes: set[str] | None = None,
+    deeper,
+    min_days: int = MIN_DURATION_DAYS,
+    max_gap_days: int = MAX_GAP_DAYS,
+) -> list[Run]:
+    """Consecutive qualifying days → runs. Pure.
+
+    `points` is an ascending [(YYYY-MM-DD, value)] list. `holes` are days we do not trust (the
+    coverage guard rejected them, or they are simply absent). A hole does NOT qualify and does
+    not extend a run — but a run survives up to `max_gap_days` of them, because a feed with a
+    one-day hole in it is still one episode, and a feed with a three-day hole is two.
+
+    `deeper(a, b) -> bool` says which of two values is the worse one, so the same grouper serves
+    a minimum (Dunkelflaute) and a maximum (a price spike) without knowing which it is.
+    """
+    by_date = dict(points)
+    if not by_date:
+        return []
+    holes = holes or set()
+
+    all_days = _day_range(min(by_date), max(by_date))
+    runs: list[Run] = []
+    current: list[str] = []
+    gap = 0
+
+    for day in all_days:
+        value = by_date.get(day)
+        qualifies = day not in holes and value is not None and predicate(day, value)
+
+        if qualifies:
+            current.append(day)
+            gap = 0
+            continue
+        if not current:
+            continue
+        gap += 1
+        if gap > max_gap_days:
+            runs.append(_close(current, by_date, deeper))
+            current, gap = [], 0
+
+    if current:
+        runs.append(_close(current, by_date, deeper))
+
+    return [r for r in runs if r.days >= min_days and r.populated >= MIN_POPULATED]
+
+
+def _close(days: list[str], by_date: dict[str, float], deeper) -> Run:
+    span = _day_range(days[0], days[-1])
+    values = [by_date[d] for d in days]
+    depth_date = days[0]
+    for d in days:
+        if deeper(by_date[d], by_date[depth_date]):
+            depth_date = d
+    return Run(
+        start=days[0],
+        end=days[-1],
+        days=len(span),                      # the SPAN, so a bridged hole is counted honestly
+        depth=by_date[depth_date],
+        depth_date=depth_date,
+        mean=sum(values) / len(values),
+        populated=len(days) / len(span),
+    )
+
+
+def _day_range(start: str, end: str) -> list[str]:
+    a, b = date.fromisoformat(start), date.fromisoformat(end)
+    return [(a + timedelta(days=i)).isoformat() for i in range((b - a).days + 1)]
+
+
+# ─── the kinds ────────────────────────────────────────────────────────────────
+
+KINDS = ("dunkelflaute", "negative_prices", "price_spike")
+
+#: A price spike is judged the way a Dunkelflaute is: against the zone's OWN record for the SAME
+#: calendar month. A flat EUR threshold would call every 2022 day a spike and no 2020 day one.
+SPIKE_TAIL = 0.02
+
+
+def compute_episodes(db: Session, *, today: date | None = None) -> dict:
+    """Full recompute of every episode, every zone. Idempotent. Returns a counter."""
+    today = today or datetime.now(timezone.utc).date()
+    reliable = reliable_days(db)          # ONE query for the whole coverage guard
+
+    counts = {k: 0 for k in KINDS}
+    seen: set[tuple[str, str, str]] = set()
+
+    for kind in KINDS:
+        for zone, runs in _runs_for_kind(db, kind, reliable, today).items():
+            for run in runs:
+                _upsert(db, kind, zone, run, today)
+                seen.add((kind, zone, run.start))
+                counts[kind] += 1
+
+    # A full recompute must also RETRACT: a run that a later revision of the data no longer
+    # supports has to disappear, or the archive slowly fills with episodes that never happened.
+    removed = 0
+    for row in db.query(PowerEpisode).all():
+        if (row.kind, row.zone, row.start_date) not in seen:
+            db.delete(row)
+            removed += 1
+
+    db.commit()
+    return {**counts, "removed": removed}
+
+
+def _runs_for_kind(db: Session, kind: str, reliable: set, today: date) -> dict[str, list[Run]]:
+    if kind == "dunkelflaute":
+        return _dunkelflaute_runs(db, reliable)
+    if kind == "negative_prices":
+        return _price_runs(db, "negative_hours")
+    if kind == "price_spike":
+        return _price_runs(db, "mean_price")
+    raise ValueError(f"unknown episode kind {kind}")
+
+
+def _dunkelflaute_runs(db: Session, reliable: set) -> dict[str, list[Run]]:
+    """Runs of days the calibrated Dunkelflaute predicate fires on (see dunkelflaute.py)."""
+    rows = (
+        db.query(PowerGrid.zone, PowerGrid.date, PowerGrid.load_mw,
+                 PowerGrid.wind_mw, PowerGrid.solar_mw)
+        .order_by(PowerGrid.zone, PowerGrid.date)
+        .all()
+    )
+    by_zone: dict[str, list[tuple[str, float]]] = {}
+    holes: dict[str, set[str]] = {}
+    for zone, day, load, wind, solar in rows:
+        if not load or load <= 0:
+            holes.setdefault(zone, set()).add(day)
+            continue
+        share = ((wind or 0.0) + (solar or 0.0)) / load
+        by_zone.setdefault(zone, []).append((day, share))
+        # THE guard. A zone whose A75 feed dropped reads wind=0, solar=0, share=0 — and without
+        # this every collector outage becomes the longest Dunkelflaute in the record.
+        if (day, zone) not in reliable:
+            holes.setdefault(zone, set()).add(day)
+
+    thresholds: dict[str, dict] = {}
+    out: dict[str, list[Run]] = {}
+    for zone, points in by_zone.items():
+        def _predicate(day: str, share: float, _zone=zone) -> bool:
+            month = day[5:7]
+            if month not in thresholds:
+                thresholds[month] = zone_thresholds(db, month)
+            return is_dunkelflaute(share, thresholds[month].get(_zone, {}))
+
+        runs = group_runs(points, _predicate, holes=holes.get(zone), deeper=lambda a, b: a < b)
+        if runs:
+            out[zone] = runs
+    return out
+
+
+def _price_runs(db: Session, column: str) -> dict[str, list[Run]]:
+    rows = (
+        db.query(PowerPriceDaily.zone, PowerPriceDaily.date,
+                 PowerPriceDaily.negative_hours, PowerPriceDaily.mean_price)
+        .order_by(PowerPriceDaily.zone, PowerPriceDaily.date)
+        .all()
+    )
+    by_zone: dict[str, list[tuple[str, float]]] = {}
+    for zone, day, neg, mean in rows:
+        value = neg if column == "negative_hours" else mean
+        if value is None:
+            continue
+        by_zone.setdefault(zone, []).append((day, float(value)))
+
+    out: dict[str, list[Run]] = {}
+    for zone, points in by_zone.items():
+        if column == "negative_hours":
+            runs = group_runs(
+                points,
+                lambda _d, v: v >= NEGATIVE_HOURS_MIN,
+                deeper=lambda a, b: a > b,     # the deepest day is the one with the MOST hours
+            )
+        else:
+            # Same discipline as the Dunkelflaute: unusual FOR THIS ZONE, IN THIS MONTH. A flat
+            # EUR threshold would make every day of 2022 a spike and no day of 2020 one.
+            cutoffs = _monthly_cutoffs(points, SPIKE_TAIL)
+            if not cutoffs:
+                continue
+            runs = group_runs(
+                points,
+                lambda d, v: d[5:7] in cutoffs and v >= cutoffs[d[5:7]],
+                deeper=lambda a, b: a > b,
+            )
+        if runs:
+            out[zone] = runs
+    return out
+
+
+def _monthly_cutoffs(points: list[tuple[str, float]], tail: float) -> dict[str, float]:
+    """{month: value at the (1 - tail) percentile of that month's own record}."""
+    from backend.power.borders import percentile
+    from backend.power.dunkelflaute import MIN_MONTH_HISTORY
+
+    by_month: dict[str, list[float]] = {}
+    for day, value in points:
+        by_month.setdefault(day[5:7], []).append(value)
+    return {
+        month: percentile(values, 1.0 - tail)
+        for month, values in by_month.items()
+        if len(values) >= MIN_MONTH_HISTORY
+    }
+
+
+def _upsert(db: Session, kind: str, zone: str, run: Run, today: date) -> None:
+    # "Active" means the run reaches the newest day we have. It is not a claim that it continues
+    # tomorrow — only that it has not been seen to end.
+    status = "active" if run.end >= (today - timedelta(days=1)).isoformat() else "resolved"
+    existing = (
+        db.query(PowerEpisode)
+        .filter(PowerEpisode.kind == kind, PowerEpisode.zone == zone,
+                PowerEpisode.start_date == run.start)
+        .one_or_none()
+    )
+    values = {
+        "end_date": run.end,
+        "duration_days": run.days,
+        "depth": round(run.depth, 4),
+        "depth_date": run.depth_date,
+        "mean_value": round(run.mean, 4),
+        "status": status,
+    }
+    if existing:
+        for k, v in values.items():
+            setattr(existing, k, v)
+    else:
+        db.add(PowerEpisode(kind=kind, zone=zone, start_date=run.start, **values))
+    db.flush()
+
+
+# ─── reading them back ────────────────────────────────────────────────────────
+
+
+def zone_episodes(db: Session, zone: str, kind: str) -> dict:
+    """Every episode of one kind in one zone, with the running one ranked against the rest."""
+    rows = (
+        db.query(PowerEpisode)
+        .filter(PowerEpisode.kind == kind, PowerEpisode.zone == zone)
+        .order_by(PowerEpisode.start_date.desc())
+        .all()
+    )
+    if not rows:
+        return {"available": False, "zone": zone, "kind": kind,
+                "reason": f"No {kind.replace('_', ' ')} episodes on record for {zone}."}
+
+    history_days = _history_days(db, kind, zone)
+    by_length = sorted(rows, key=lambda r: -r.duration_days)
+    active = next((r for r in rows if r.status == "active"), None)
+
+    rank = None
+    if active is not None:
+        if history_days < MIN_HISTORY_DAYS:
+            rank = {"position": None, "of": len(rows),
+                    "reason": (f"Only {history_days} days of {zone} history — a rank would be a "
+                               "statement about our coverage, not about the grid.")}
+        else:
+            rank = {
+                "position": by_length.index(active) + 1,
+                "of": len(rows),
+                "by": "duration_days",
+                "longest_days": by_length[0].duration_days,
+                "longest_start": by_length[0].start_date,
+            }
+
+    return {
+        "available": True,
+        "zone": zone,
+        "kind": kind,
+        "history_days": history_days,
+        "active": _row(active) if active else None,
+        "rank": rank,
+        "episodes": [_row(r) for r in by_length[:20]],
+        "count": len(rows),
+        "note": (
+            "An episode is a run of consecutive qualifying days, re-derived nightly from the "
+            "published record — not an alert log. Ranked by duration against this zone's own "
+            "history. Descriptive: what has happened, never what happens next."
+        ),
+    }
+
+
+def _row(r: PowerEpisode) -> dict:
+    return {
+        "start_date": r.start_date, "end_date": r.end_date,
+        "duration_days": r.duration_days,
+        "depth": r.depth, "depth_date": r.depth_date,
+        "mean_value": r.mean_value, "status": r.status,
+    }
+
+
+def _history_days(db: Session, kind: str, zone: str) -> int:
+    from sqlalchemy import func
+
+    model = PowerGrid if kind == "dunkelflaute" else PowerPriceDaily
+    return int(
+        db.query(func.count(model.date)).filter(model.zone == zone).scalar() or 0
+    )

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1459,6 +1459,30 @@ def get_capture(
     return compute_capture(db, _resolve_zone(zone), months=months)
 
 
+@router.get("/episodes")
+def get_episodes(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    kind: str = Query("dunkelflaute", description="dunkelflaute | negative_prices | price_spike"),
+    db: Session = Depends(get_db),
+):
+    """Grid stress as EPISODES — runs of consecutive days, ranked against the zone's own record.
+
+    The radar only ever saw today: "DE-LU is in a Dunkelflaute". It could not say "and this is
+    the fourth-longest in five years", which is the sentence that decides whether to care. And it
+    could not have learned to — the alert table mutates its rows in place, so the history was
+    never written. Episodes are re-derived nightly from the published record.
+
+    Descriptive (Posture B): what has happened and how it compares to what happened before. An
+    "active" episode is one that reaches the newest day we hold — not a claim that it continues.
+    """
+    from backend.power.episodes import KINDS, zone_episodes
+
+    if kind not in KINDS:
+        return {"available": False, "reason": f"Unknown episode kind {kind}.",
+                "kinds": list(KINDS)}
+    return zone_episodes(db, _resolve_zone(zone), kind)
+
+
 # ─── Drivers: why is this zone expensive today? ───────────────────────────────
 
 

--- a/backend/signals/detectors/__init__.py
+++ b/backend/signals/detectors/__init__.py
@@ -27,6 +27,7 @@ from backend.signals.detectors.base import is_stale
 from backend.signals.detectors.gas import detect_gas_balance
 from backend.signals.detectors.power import (
     detect_dunkelflaute,
+    detect_episode_rank,
     detect_forced_outages,
     detect_hydro_deviations,
     detect_imbalance_extremes,
@@ -53,6 +54,7 @@ DETECTORS = [
     detect_price_spikes,
     detect_hydro_deviations,
     detect_record_breaks,
+    detect_episode_rank,
 ]
 
 

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -642,3 +642,79 @@ def detect_record_breaks(db) -> list[DetectorResult]:
             )
         )
     return results
+
+
+#: An active episode is only worth interrupting an analyst for if it is genuinely unusual for
+#: the zone. Top 3 by duration in its own record — a sentence the radar could not say before,
+#: because it only ever saw today.
+EPISODE_RANK_TOP_N = 3
+
+#: Ranking against a thin record is a statement about our coverage, not about the grid. The same
+#: argument, and the same number, as records.py::RECORD_MIN_COVERAGE_DAYS.
+EPISODE_MIN_HISTORY_DAYS = 365
+
+_EPISODE_LABELS = {
+    "dunkelflaute": "Dunkelflaute",
+    "negative_prices": "negative-price run",
+    "price_spike": "price spike",
+}
+
+
+def detect_episode_rank(db) -> list[DetectorResult]:
+    """An episode that is RUNNING and ranks in the top N of its zone's own record.
+
+    The payoff of the episode archive, and the sentence the radar has never been able to say:
+
+        "DE-LU: Dunkelflaute running 3 days — 2nd-longest in our 5-year record
+         (longest: 4 days, 2021-04-29)."
+
+    Past tense, the zone's own history, a sample size, and no claim about tomorrow. "Running"
+    means the episode reaches the newest day we hold — not that it will continue.
+    """
+    from backend.models.energy import PowerEpisode
+    from backend.power.episodes import KINDS, zone_episodes
+
+    zones = [z for (z,) in db.query(PowerEpisode.zone).distinct().all()]
+    results: list[DetectorResult] = []
+
+    for zone in zones:
+        for kind in KINDS:
+            data = zone_episodes(db, zone, kind)
+            active = data.get("active")
+            rank = data.get("rank") or {}
+            if not active or rank.get("position") is None:
+                continue
+            if data.get("history_days", 0) < EPISODE_MIN_HISTORY_DAYS:
+                continue
+            if rank["position"] > EPISODE_RANK_TOP_N:
+                continue
+
+            label = _EPISODE_LABELS.get(kind, kind)
+            years = data["history_days"] // 365
+            results.append(
+                DetectorResult(
+                    rule="episode_rank",
+                    zone=zone,
+                    vertical="power",
+                    severity="warning" if rank["position"] == 1 else "info",
+                    title=(
+                        f"{zone}: {label} running {active['duration_days']} days — "
+                        f"{_ordinal(rank['position'])}-longest on record"
+                    ),
+                    detail=(
+                        f"{active['start_date']} → {active['end_date']}. "
+                        f"{_ordinal(rank['position'])}-longest of {rank['of']} "
+                        f"{label}s in {years} years of {zone} data "
+                        f"(longest: {rank['longest_days']} days, from {rank['longest_start']})."
+                    ),
+                    as_of=active["end_date"],
+                )
+            )
+    return results
+
+
+def _ordinal(n: int) -> str:
+    if 10 <= n % 100 <= 20:          # 11th, 12th, 13th — not 11st
+        return f"{n}th"
+    suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+    return f"{n}{suffix}"

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -269,7 +269,8 @@ def test_run_all_detectors_isolates_failures(db_session, monkeypatch):
 
 
 def test_detector_registry_count(db_session):
-    assert len(DETECTORS) == 8  # gas/negative_prices/dunkelflaute/forced_outages + imbalance_extreme/price_spike/hydro_deviation/record_break
+    assert len(DETECTORS) == 9  # gas/negative_prices/dunkelflaute/forced_outages
+    # + imbalance_extreme/price_spike/hydro_deviation/record_break/episode_rank
 
 
 # ─── flow_anomaly (legacy maritime check) — baseline + onset cure ─────────────

--- a/backend/tests/test_episodes.py
+++ b/backend/tests/test_episodes.py
@@ -1,0 +1,255 @@
+"""An episode is an object. The radar only ever saw today.
+
+And it could not have been taught otherwise from what it stored: `_upsert_alert` mutates the
+Alert row in place, slides created_at forward and DELETES older duplicates, so a five-day
+Dunkelflaute collapses into one row that claims nothing about duration. The history was never
+written — episodes must be re-derived from the canonical series, exactly as records are.
+
+The tests that matter here are the GUARD tests. An episode grouper's worst failure is not
+missing an event; it is celebrating an outage of our own collector as the longest Dunkelflaute
+in the record.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from backend.models.energy import PowerEpisode, PowerGenMix, PowerGrid, PowerPriceDaily
+from backend.power.episodes import (
+    MAX_GAP_DAYS,
+    MIN_HISTORY_DAYS,
+    compute_episodes,
+    group_runs,
+    zone_episodes,
+)
+
+TODAY = date(2026, 6, 30)
+
+
+def _days(start: str, n: int) -> list[str]:
+    d = date.fromisoformat(start)
+    return [(d + timedelta(days=i)).isoformat() for i in range(n)]
+
+
+def _lower_is_worse(a, b):
+    return a < b
+
+
+# ─── grouping ─────────────────────────────────────────────────────────────────
+
+
+def test_a_five_day_run_is_ONE_episode_not_five_alerts():
+    """The whole point. Today's alert table would show a single mutated row claiming nothing
+    about duration; here it is one object that knows it lasted five days."""
+    points = [(d, 0.05) for d in _days("2026-01-01", 5)]
+    runs = group_runs(points, lambda _d, v: v < 0.15, deeper=_lower_is_worse)
+
+    assert len(runs) == 1
+    assert runs[0].days == 5
+    assert runs[0].start == "2026-01-01" and runs[0].end == "2026-01-05"
+
+
+def test_a_one_day_hole_does_not_split_a_run():
+    """Feeds have holes. A run that a single missing day cuts in half is an artefact of our
+    collection, not of the weather."""
+    points = [(d, 0.05) for d in _days("2026-01-01", 5)]
+    del points[2]                                   # 2026-01-03 simply absent
+
+    runs = group_runs(points, lambda _d, v: v < 0.15, deeper=_lower_is_worse)
+
+    assert len(runs) == 1
+    assert runs[0].days == 5, "the SPAN, counted honestly across the bridged hole"
+    assert runs[0].populated == pytest.approx(4 / 5)
+
+
+def test_a_hole_longer_than_the_tolerance_ends_the_run():
+    """A three-day hole is not a gap in an episode. It is two episodes with a gap between them,
+    and pretending otherwise would manufacture the longest Dunkelflaute in the record."""
+    points = ([(d, 0.05) for d in _days("2026-01-01", 3)]
+              + [(d, 0.05) for d in _days("2026-01-07", 3)])
+
+    runs = group_runs(points, lambda _d, v: v < 0.15, deeper=_lower_is_worse)
+
+    assert len(runs) == 2
+    assert MAX_GAP_DAYS == 1
+
+
+def test_the_depth_points_at_the_day_it_was_worst():
+    """records.py's discipline: an extreme without its evidence is an assertion."""
+    points = list(zip(_days("2026-01-01", 4), [0.10, 0.03, 0.08, 0.12]))
+    run = group_runs(points, lambda _d, v: v < 0.15, deeper=_lower_is_worse)[0]
+
+    assert run.depth == 0.03
+    assert run.depth_date == "2026-01-02"
+
+
+def test_a_single_qualifying_day_is_a_day_not_an_episode():
+    points = [("2026-01-01", 0.05), ("2026-01-02", 0.50)]
+    assert group_runs(points, lambda _d, v: v < 0.15, deeper=_lower_is_worse) == []
+
+
+# ─── the guard: the test this module lives or dies by ─────────────────────────
+
+
+def _seed_grid(db, zone, days, share, *, coverage=1.0, load=60_000.0):
+    """PowerGrid + a matching generation mix. `coverage` scales the reported generation."""
+    for d in days:
+        db.add(PowerGrid(date=d, zone=zone, load_mw=load,
+                         wind_mw=load * share * 0.6, solar_mw=load * share * 0.4))
+        db.add(PowerGenMix(date=d, zone=zone, psr_type="Fossil Gas",
+                           gen_mw=load * coverage))
+
+
+def _january_history(exclude: list[str]) -> list[str]:
+    """Six Januaries of normal days — the same-month record the tail is measured against.
+
+    The LENGTH is load-bearing, and for a reason worth knowing: an episode's own days are part
+    of the record it is judged against. With 79 days of history, the 2nd-percentile rank falls
+    INSIDE a four-day event, and the event cannot be below its own cutoff — it self-suppresses.
+    With six Januaries (186 days) the cutoff lands on a historical day, which is the regime real
+    data is in (DE-LU has 230 January days on record).
+
+    The property is real, not a fixture artefact: a run that is very long RELATIVE TO ITS OWN
+    RECORD is reported truncated to its darkest days. That is what "the bottom 2%" means, and it
+    is the honest reading — but it is worth knowing before someone reports a bug.
+
+    Excluding the event window also matters: seeding a day twice is not a fixture, it is a
+    UNIQUE constraint waiting to fire.
+    """
+    days = [d for year in range(2020, 2026) for d in _days(f"{year}-01-01", 31)]
+    days += _days("2026-01-20", 12)
+    return [d for d in days if d not in exclude]
+
+
+def test_a_collector_outage_is_not_a_dunkelflaute(db_session):
+    """THE guard test. When a zone's A75 feed drops, wind reads 0 and solar reads 0 — and the
+    renewable share reads 0. Without the coverage guard the engine finds its longest Dunkelflaute
+    ever inside an outage of our own collector.
+
+    The fixture MUST seed a coverage failure, not a genuinely dark period. A fixture that seeds
+    real low wind cannot express this bug at all."""
+    outage = _days("2026-01-05", 10)
+    _seed_grid(db_session, "DE_LU", _january_history(outage), 0.40)  # a real fleet, a real record
+
+    # Ten days where generation reporting collapses to a fifth of load: share reads ~0.
+    _seed_grid(db_session, "DE_LU", outage, 0.0, coverage=0.2)
+    db_session.commit()
+
+    compute_episodes(db_session, today=TODAY)
+
+    episodes = db_session.query(PowerEpisode).filter_by(kind="dunkelflaute").all()
+    assert episodes == [], "a broken feed is not weather"
+
+
+def test_a_genuine_dunkelflaute_survives_the_guard(db_session):
+    """The guard must not be a mute button: the same shape, with the generation reporting
+    intact, has to come through."""
+    event = _days("2026-01-05", 4)
+    _seed_grid(db_session, "DE_LU", _january_history(event), 0.40)
+    _seed_grid(db_session, "DE_LU", event, 0.03)   # dark, but fully reported
+    db_session.commit()
+
+    compute_episodes(db_session, today=TODAY)
+
+    episodes = db_session.query(PowerEpisode).filter_by(kind="dunkelflaute").all()
+    assert len(episodes) == 1
+    assert episodes[0].duration_days == 4
+
+
+# ─── the recompute ────────────────────────────────────────────────────────────
+
+
+def test_the_recompute_is_idempotent(db_session):
+    event = _days("2026-01-05", 3)
+    _seed_grid(db_session, "DE_LU", _january_history(event), 0.40)
+    _seed_grid(db_session, "DE_LU", event, 0.03)
+    db_session.commit()
+
+    first = compute_episodes(db_session, today=TODAY)
+    second = compute_episodes(db_session, today=TODAY)
+
+    assert first["dunkelflaute"] == second["dunkelflaute"] == 1
+    assert db_session.query(PowerEpisode).count() == 1
+
+
+def test_an_episode_the_data_no_longer_supports_is_RETRACTED(db_session):
+    """A full recompute must also un-say things. Without the retraction the archive fills up
+    with episodes a later revision of the data no longer supports — and they would be ranked
+    against, forever."""
+    db_session.add(PowerEpisode(
+        kind="dunkelflaute", zone="DE_LU", start_date="2019-01-01", end_date="2019-01-09",
+        duration_days=9, depth=0.01, depth_date="2019-01-04", mean_value=0.02,
+        status="resolved",
+    ))
+    db_session.commit()
+
+    out = compute_episodes(db_session, today=TODAY)
+
+    assert out["removed"] == 1
+    assert db_session.query(PowerEpisode).count() == 0
+
+
+# ─── reading them back ────────────────────────────────────────────────────────
+
+
+def _seed_negative_run(db, zone="DE_LU", *, history_days=800):
+    for d in _days("2024-01-01", history_days):
+        db.add(PowerPriceDaily(date=d, zone=zone, mean_price=60.0, min_price=10.0,
+                               max_price=90.0, negative_hours=0))
+    for d in _days("2026-06-27", 4):        # runs up to TODAY − 1 → active
+        db.add(PowerPriceDaily(date=d, zone=zone, mean_price=5.0, min_price=-20.0,
+                               max_price=30.0, negative_hours=8))
+    db.commit()
+
+
+def test_the_running_episode_is_ranked_against_the_zones_own_record(db_session):
+    """The sentence the radar could never say: not "there is a run", but "and it is the longest
+    one we have"."""
+    _seed_negative_run(db_session)
+    compute_episodes(db_session, today=TODAY)
+
+    out = zone_episodes(db_session, "DE_LU", "negative_prices")
+
+    assert out["available"] is True
+    assert out["active"]["duration_days"] == 4
+    assert out["rank"]["position"] == 1
+    assert out["rank"]["longest_days"] == 4
+
+
+def test_a_rank_is_withheld_below_a_year_of_history(db_session):
+    """A rank over three months of data is a statement about our coverage, not about the grid —
+    records.py's rule, and the same number."""
+    _seed_negative_run(db_session, history_days=100)
+    compute_episodes(db_session, today=TODAY)
+
+    out = zone_episodes(db_session, "DE_LU", "negative_prices")
+
+    assert out["rank"]["position"] is None
+    assert "coverage" in out["rank"]["reason"]
+    assert MIN_HISTORY_DAYS == 365
+
+
+def test_a_zone_with_no_episodes_says_so(db_session):
+    out = zone_episodes(db_session, "FR", "dunkelflaute")
+    assert out["available"] is False
+    assert "No dunkelflaute episodes" in out["reason"]
+
+
+def test_the_detector_names_the_rank_and_never_forecasts(db_session):
+    """Posture B: past tense, the zone's own record, a sample size. "Running" means the episode
+    reaches the newest day we hold — not that it will continue."""
+    from backend.signals.detectors.power import detect_episode_rank
+
+    _seed_negative_run(db_session)
+    compute_episodes(db_session, today=TODAY)
+
+    results = detect_episode_rank(db_session)
+    assert len(results) == 1
+    r = results[0]
+
+    assert r.rule == "episode_rank" and r.vertical == "power"
+    assert "1st-longest" in r.title
+    assert "longest:" in r.detail
+    for forbidden in ("because", "will", "expect", "forecast", "caused"):
+        assert forbidden not in (r.title + r.detail).lower()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ import OutagePanel from './components/OutagePanel'
 import RecordChip from './components/RecordChip'
 import ImbalancePanel from './components/ImbalancePanel'
 import RecordsPanel from './components/RecordsPanel'
+import EpisodeArchivePanel from './components/EpisodeArchivePanel'
 import CapturePanel from './components/CapturePanel'
 import BordersPanel from './components/BordersPanel'
 import DriversPanel from './components/DriversPanel'
@@ -689,6 +690,11 @@ function Dashboard() {
             <div className="mt-3">
               <ErrorBoundary name="power-capture">
                 <CapturePanel zone={energyZone} />
+              </ErrorBoundary>
+            </div>
+            <div className="mt-3">
+              <ErrorBoundary name="power-episodes">
+                <EpisodeArchivePanel zone={energyZone} />
               </ErrorBoundary>
             </div>
             <div className="mt-3">

--- a/frontend/src/components/EpisodeArchivePanel.jsx
+++ b/frontend/src/components/EpisodeArchivePanel.jsx
@@ -1,0 +1,145 @@
+import { useState } from 'react'
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+
+const API = '/api'
+
+const KINDS = [
+  { key: 'dunkelflaute', label: 'DUNKELFLAUTE', unit: 'share' },
+  { key: 'negative_prices', label: 'NEGATIVE PRICES', unit: 'hours' },
+  { key: 'price_spike', label: 'PRICE SPIKES', unit: 'eur' },
+]
+
+function fmtDepth(kind, value) {
+  if (value == null) return '—'
+  if (kind === 'dunkelflaute') return `${(value * 100).toFixed(1)}%`
+  if (kind === 'negative_prices') return `${value.toFixed(0)}h`
+  return `€${value.toFixed(0)}`
+}
+
+/**
+ * Grid stress as episodes — runs of days, ranked against the zone's own record.
+ *
+ * The radar only ever saw today: "DE-LU is in a Dunkelflaute". It could never say "and this is
+ * the second-longest in five years", which is the sentence that decides whether to care.
+ */
+export default function EpisodeArchivePanel({ zone = 'DE_LU' }) {
+  const [kind, setKind] = useState('dunkelflaute')
+  const { data, loading, error } = useFetchWithError(
+    `${API}/power/episodes?zone=${zone}&kind=${kind}`,
+    { deps: [zone, kind], pollMs: POLL_SLOW_MS },
+  )
+
+  if (error) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">EPISODES // FETCH ERROR</div>
+      </div>
+    )
+  }
+
+  const active = data?.active
+  const rank = data?.rank
+  const episodes = data?.episodes ?? []
+  const current = KINDS.find((k) => k.key === kind)
+
+  return (
+    <Panel
+      id="power-episodes"
+      title={`EPISODE ARCHIVE · ${zone}`}
+      info={data?.note || 'Runs of consecutive qualifying days, re-derived nightly from the published record.'}
+      collapsible
+      headerRight={
+        <div className="flex items-center gap-1">
+          {KINDS.map((k) => (
+            <button
+              key={k.key}
+              onClick={() => setKind(k.key)}
+              className={`font-mono text-[9px] px-1.5 py-0.5 rounded border ${
+                kind === k.key
+                  ? 'border-cyan-glow/40 text-cyan-glow'
+                  : 'border-border text-neutral-600 hover:text-neutral-400'
+              }`}
+            >
+              {k.label}
+            </button>
+          ))}
+        </div>
+      }
+    >
+      {loading && !data ? (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">Loading episodes…</div>
+      ) : !data?.available ? (
+        <div className="px-4 py-3 font-mono text-[10px] text-neutral-500">
+          {data?.reason || 'No episodes on record.'}
+        </div>
+      ) : (
+        <>
+          {/* The running episode, with the only thing that makes it worth reading: its rank. */}
+          {active && (
+            <div className="px-4 py-3 border-b border-border/40">
+              <div className="font-mono text-[11px] text-neutral-200">
+                Running {active.duration_days} days
+                <span className="text-neutral-600"> · {active.start_date} → {active.end_date}</span>
+              </div>
+              <div className="font-mono text-[10px] mt-1">
+                {rank?.position != null ? (
+                  <span className={rank.position === 1 ? 'text-amber-400' : 'text-cyan-glow'}>
+                    {rank.position === 1 ? 'Longest' : `${rank.position}${['th', 'st', 'nd', 'rd'][rank.position % 10] || 'th'}-longest`}
+                    {' '}of {rank.of} on record
+                    <span className="text-neutral-600">
+                      {' '}(longest: {rank.longest_days} days, from {rank.longest_start})
+                    </span>
+                  </span>
+                ) : (
+                  <span className="text-neutral-600">{rank?.reason}</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="px-2 py-2 overflow-x-auto">
+            <table className="w-full font-mono text-[11px]">
+              <thead>
+                <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                  <th className="text-left px-2 py-1">Episode</th>
+                  <th className="text-right px-2 py-1">Days</th>
+                  <th className="text-right px-2 py-1" title="The worst value reached, and the day it was reached">Deepest</th>
+                  <th className="text-left px-2 py-1">on</th>
+                </tr>
+              </thead>
+              <tbody>
+                {episodes.map((e) => (
+                  <tr key={e.start_date} className="border-t border-border/30">
+                    <td className="px-2 py-1.5 text-neutral-300">
+                      {e.start_date} → {e.end_date}
+                      {e.status === 'active' && (
+                        <span className="ml-1.5 text-[9px] text-cyan-glow">RUNNING</span>
+                      )}
+                    </td>
+                    <td className="px-2 py-1.5 text-right text-neutral-200">{e.duration_days}</td>
+                    <td className="px-2 py-1.5 text-right text-amber-400">
+                      {fmtDepth(kind, e.depth)}
+                    </td>
+                    {/* The evidence pointer — records.py's discipline: an extreme without a date
+                        to go and look at is an assertion. */}
+                    <td className="px-2 py-1.5 text-neutral-600">{e.depth_date}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="px-4 pb-2 font-mono text-[9px] text-neutral-700 leading-relaxed">
+            {data.count} {current?.label.toLowerCase()} episode{data.count === 1 ? '' : 's'} in{' '}
+            {Math.floor((data.history_days || 0) / 365)} years of {zone} data. An episode is a run
+            of consecutive qualifying days, re-derived nightly from the published record — not an
+            alert log. &ldquo;Running&rdquo; means it reaches the newest day we hold, not that it
+            continues.
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}


### PR DESCRIPTION
Tier 2, PR 6 — the last one.

The desk could say *"DE-LU is in a Dunkelflaute"*. It could not say *"and this is the second-longest in five years"* — which is the sentence that decides whether to care.

**And it could not have been taught to, from what it stored.** It looks like the history is already there — the radar has been writing `Alert` rows for months — but `_upsert_alert` **mutates the row in place**, slides `created_at` forward and **deletes older duplicates**. A five-day Dunkelflaute collapses into one row whose timestamp keeps moving and which claims nothing about duration. The radar is stateless by construction, and **re-firing actively destroys the record an episode would be built from**.

So episodes are **re-derived nightly, in full**, from the canonical series — `records.py`'s doctrine: no incremental state means no state to corrupt.

## What it found, without being told

| zone | episode | depth |
|---|---|---|
| DE-LU | **2024-11-06 → 11-07** | renewables down to **3.1 %** |
| DE-LU | **2024-12-11 → 12-12** | down to 3.4 % |
| DE-LU | 2023-11-30 → 12-02 (3 days) | down to 5.0 % |

Those are **the German Dunkelflauten that made international news**, rediscovered from the published record. Seven for DE-LU in seven years — about the right number for a thing that is meant to be rare.

| DE-LU / BE / BG / CZ | **2022-03-03 → 03-09** | price spike, peak **€538** |
|---|---|---|

The invasion shock, correctly surfaced as a **continental** event across four zones at once, not four coincidences. And ES 2025-04-25 → 06-01: **38 days** of negative prices — the Spanish solar spring.

## The guard is what decides whether this ships or embarrasses

An episode grouper's worst failure is not missing an event. It is **celebrating an outage of our own collector as the longest Dunkelflaute in the record**: when a zone's A75 feed drops, wind reads 0 and solar reads 0, so the renewable share reads 0.

A day the coverage guard rejects is therefore a **hole**, not an episode day, and a hole longer than the gap tolerance **ends** the episode instead of bridging it. The guard runs as **one query** for the whole record — the per-day version in a loop would be ~67,000 round trips.

A **one-day** hole does *not* split a run (feeds have holes; a run that a missing day cuts in half is an artefact of our collection, not of the weather). A **three-day** hole does.

And a full recompute must be able to **un-say** things: an episode a later revision no longer supports is **retracted**, or the archive fills with events that never happened — and they would be ranked against, forever.

## A property worth knowing before someone files it as a bug

The predicates are relative — *"the bottom 2 % of this zone's own record for this month"* — and **an episode's own days are part of that record**. A run that is very long relative to its record is therefore reported **truncated to its darkest days**. That is precisely what "the bottom 2 %" means, but it is not obvious, and it is why the tests seed six years of history rather than two.

## Side finding, corrected in passing

`coverage.py` named **NL** as its headline broken zone (~0.49 of load). **NL is now at 1.01** — the A75 in/out parser fix healed it. The zones it actually catches today are **SE4 (0.36)**, NO1 (0.60), IT_CENTRO_SUD (0.69).

And **SE4 is not a broken feed at all**: it is a genuine net importer whose domestic generation really *is* a third of its load. The guard cannot tell those apart and suppresses it anyway — a false negative, the safe direction, but a false negative. Now that A09/A25 are ingested (generation + net import ≈ load), a better guard is available to whoever wants to write it.

`ruff` clean · **943 passed** (13 new) · eslint clean · vite build green · the engine runs the full 5-year, 37-zone record in **2.3 s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)