### PR TITLE
After A09, "DE_LU-DK is uncoverable" is a lie

### DIFF
--- a/backend/power/borders.py
+++ b/backend/power/borders.py
@@ -294,6 +294,20 @@ def _price_rows(db: Session, zones: set[str], start_ts: int) -> dict[str, dict[i
     return out
 
 
+def _resolvable(code: str) -> bool:
+    """Is this side of a border something the desk can actually resolve to bidding zones?
+
+    A zone key resolves to itself. A country aggregate (`DK`, `NO`, `SE`, `IT`) resolves if we
+    carry its sub-zones — which, since A09, we do, with real borders between them. `GB` and `LU`
+    resolve to nothing: we carry no zone for either.
+    """
+    if code in POWER_ZONES:
+        return True
+    return any(z == code or z.startswith(f"{code}_") or
+               (z[: len(code)] == code and z[len(code):].isdigit())
+               for z in POWER_ZONES)
+
+
 def loop_flow(physical: dict[int, float], scheduled: dict[int, float]) -> dict | None:
     """physical − scheduled, over the hours BOTH grains cover. Pure.
 
@@ -340,7 +354,21 @@ def compute_borders(db: Session, days: int = 30, *, now: datetime | None = None)
     priced = set(POWER_ZONES)
     all_borders = set(physical) | set(scheduled)
     joinable = {b for b in all_borders if b[0] in priced and b[1] in priced}
-    uncoverable = sorted(f"{a}-{b}" for a, b in all_borders if (a, b) not in joinable)
+
+    # The leftovers are not all the same thing, and after A09 saying so matters.
+    #
+    # `flow.DK` is a COUNTRY aggregate from Energy-Charts — Denmark, not DK1 and DK2. Before the
+    # scheduled grain existed, a DE_LU-DK row was a genuine hole: no price on the other side, no
+    # way to resolve it. It is not a hole any more. DE-LU↔DK1 and DE-LU↔DK2 are both covered now,
+    # properly, at bidding-zone level. Listing DE_LU-DK as "uncoverable" would report a gap the
+    # desk no longer has.
+    #
+    # GB and LU are different: they are not zones we carry at all (GB left ENTSO-E's day-ahead
+    # publication after Brexit), and no grain will resolve them. Those stay named.
+    superseded, uncoverable = [], []
+    for a, b in sorted(all_borders - joinable):
+        label = f"{a}-{b}"
+        (superseded if _resolvable(a) and _resolvable(b) else uncoverable).append(label)
 
     prices = _price_rows(db, {z for b in joinable for z in b}, window_start)
 
@@ -391,6 +419,9 @@ def compute_borders(db: Session, days: int = 30, *, now: datetime | None = None)
         "rail_computed_at": rails_at.isoformat(),
         "borders": out,
         "uncoverable_borders": uncoverable,
+        # Country-aggregate physical series whose real bidding-zone borders ARE covered, by the
+        # scheduled grain. Reported so the absence is legible, not as a gap.
+        "superseded_aggregate_flows": superseded,
         "note": (
             "Convergence = share of hours the two zones cleared within "
             f"{COUPLED_EPS_EUR} EUR/MWh. 'At the rail' = flow at or above this border's own "

--- a/backend/tests/test_borders.py
+++ b/backend/tests/test_borders.py
@@ -328,3 +328,27 @@ def test_the_two_grains_never_share_a_rail_threshold(db_session):
 
     assert phys[("DE_LU", "FR")] == 1_000.0
     assert sched[("DE_LU", "FR")] == 300.0
+
+
+def test_a_country_aggregate_is_SUPERSEDED_not_uncoverable(db_session, sub_zones):
+    """After A09, "DE_LU-DK is uncoverable" is a lie.
+
+    `flow.DK` is Energy-Charts' aggregate for Denmark — not DK1, not DK2 — and before the
+    scheduled grain it was a genuine hole: no price on the other side, nothing to join. It is not
+    a hole any more. DE-LU↔DK1 and DE-LU↔DK2 are both covered now, at bidding-zone level, and
+    reporting the aggregate as a gap would claim a blindness the desk no longer has.
+
+    GB is different, and stays named: we carry no zone for it at all (it left ENTSO-E's day-ahead
+    publication after Brexit), and no grain will ever resolve it."""
+    _seed_scheduled(db_session, "DK1", "DK2")
+    ts = _hours(24)
+    upsert_hourly(db_session, "flow.DK", "DE_LU", [(t, 500.0) for t in ts], unit="MW")
+    upsert_hourly(db_session, "flow.GB", "FR", [(t, 900.0) for t in ts], unit="MW")
+
+    out = compute_borders(db_session, days=7, now=_NOW)
+
+    assert "DE_LU-DK" in out["superseded_aggregate_flows"]
+    assert "DE_LU-DK" not in out["uncoverable_borders"], "the desk sees DK1 and DK2 now"
+
+    assert "FR-GB" in out["uncoverable_borders"]
+    assert "FR-GB" not in out["superseded_aggregate_flows"], "GB is not a zone we carry"

--- a/frontend/src/components/BordersPanel.jsx
+++ b/frontend/src/components/BordersPanel.jsx
@@ -97,6 +97,7 @@ export default function BordersPanel() {
 
   const borders = data?.borders ?? []
   const uncoverable = data?.uncoverable_borders ?? []
+  const superseded = data?.superseded_aggregate_flows ?? []
 
   return (
     <Panel
@@ -180,12 +181,27 @@ export default function BordersPanel() {
 
           {open && <SpreadChart a={open.split('|')[0]} b={open.split('|')[1]} />}
 
-          {uncoverable.length > 0 && (
-            <div className="px-4 py-2 border-t border-border/40 font-mono text-[9px] text-neutral-700 leading-relaxed">
-              No price on both sides, so no metrics ({uncoverable.length}): {uncoverable.join(', ')}.
-              Energy-Charts publishes flows at country level, so a border touching a sub-zoned market
-              (Italian zones, DK1/DK2, Nordic zones) or an unpriced neighbour (GB, LU) cannot be joined
-              to a single price.
+          {(uncoverable.length > 0 || superseded.length > 0) && (
+            <div className="px-4 py-2 border-t border-border/40 font-mono text-[9px] text-neutral-700 leading-relaxed space-y-1">
+              {uncoverable.length > 0 && (
+                <div>
+                  <span className="text-neutral-600">Not coverable ({uncoverable.length}):</span>{' '}
+                  {uncoverable.join(', ')} — we carry no bidding zone for these neighbours (GB left
+                  ENTSO-E&apos;s day-ahead publication after Brexit), so no grain will resolve them.
+                </div>
+              )}
+              {superseded.length > 0 && (
+                /* Not a gap. These are Energy-Charts' COUNTRY aggregates — Denmark, not DK1 and
+                   DK2 — and the real bidding-zone borders behind them are all covered above, by
+                   the scheduled grain. Saying "uncoverable" here would claim a blindness the
+                   desk no longer has. */
+                <div>
+                  <span className="text-neutral-600">Superseded ({superseded.length}):</span>{' '}
+                  {superseded.join(', ')} — country-level aggregates from Energy-Charts. The
+                  bidding-zone borders behind them are covered above (scheduled exchanges), which
+                  is why they are listed rather than shown.
+                </div>
+              )}
             </div>
           )}
         </>


### PR DESCRIPTION
The A09 backfill finished: **63 borders where there were 26**, and **all 18 sub-zones covered**. Which turned one of the desk's own honesty features into a false statement.

## The lie

`flow.DK` is Energy-Charts' aggregate for **Denmark** — not DK1, not DK2. Before the scheduled grain existed, a `DE_LU-DK` row was a *genuine* hole: a country aggregate with no single price on the other side and nothing to join it to. The panel said so, and that was right.

**It is not a hole any more.** DE-LU↔DK1 and DE-LU↔DK2 are both covered now, properly, at bidding-zone level. Continuing to list `DE_LU-DK` as *"uncoverable"* claims a blindness the desk no longer has.

## The split

| field | contents | meaning |
|---|---|---|
| `superseded_aggregate_flows` | DE_LU-DK, AT-IT, FI-SE, NL-NO, PL-SE, … | Country aggregates whose **real bidding-zone borders are shown above**. Listed, not hidden — the series still exists in the store, and its absence from the table should be legible rather than mysterious. |
| `uncoverable_borders` | GB- and LU-touching only | We carry **no bidding zone** for either (GB left ENTSO-E's day-ahead publication after Brexit). No grain will ever resolve them. These stay named. |

## What the backfill also showed

Borders that no country-level feed could ever have represented — because they are **inside a single country**:

| border | price-coupled | mean spread |
|---|---:|---:|
| DK1↔DK2 | 25.7 % | €5.13 |
| **NO1↔NO2** | **5.6 %** | **€22.82** |
| SE3↔SE4 | 20.3 % | €31.89 |
| IT-Centro-Nord↔IT-Nord | 98.6 % | €0.08 |

Those are real congestion boundaries, and until today they did not exist on this desk — not as gaps, but as borders it was **structurally unable to represent**.

Loop flow now computes on the 26 borders that have both grains: CH↔FR carries **+1.19 GW** more physically than scheduled, DE-LU↔FR **−1.15 GW**.

`ruff` clean · 944 passed (1 new) · eslint clean · vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)