### PR TITLE
The desk showed +€25, in green, and called it the CCGT margin. It was not.

### DIFF
--- a/backend/power/spark.py
+++ b/backend/power/spark.py
@@ -1,0 +1,98 @@
+"""The spark spread on this desk is DIRTY, and it was labelled "CCGT margin".
+
+WHAT WAS WRONG
+--------------
+The situation hero showed, in green, for Germany:
+
+    Spark spread   +€25   ·   CCGT margin
+
+A gas plant does not keep that. It has to buy carbon. At an EUA price of €78/t — where the EU
+ETS traded on 2026-07-10 — a CCGT at this desk's own heat rate emits ~0.40 tCO2 per MWh of
+electricity, which costs about €32/MWh. The actual day-ahead margin was NEGATIVE.
+
+Measured across the desk on the same day:
+
+    zone        dirty spark      break-even EUA        margin at ~EUR 78/t
+    DE-LU          +25.5             63 EUR/t              negative
+    FR             +21.6             53                    negative
+    ES             +19.0             47                    negative
+    IT-NORD        +50.9            126                    still positive
+
+So the desk was telling a power analyst that gas generation is profitable in Germany, France and
+Spain, when it is not. This is the class of error that gets a tab closed: it takes ten seconds to
+check and it is wrong in the direction that flatters us.
+
+WHAT THIS MODULE DOES INSTEAD, WITHOUT NEEDING A CARBON PRICE
+------------------------------------------------------------
+It cannot compute the clean spark: there is no confirmed free, redistributable daily EUA series
+(see docs/findings/2026-06-24-eua-coal-data-source.md — the EEX auction reports parse, but their
+licence is unverified, and nothing goes into the free core until it is).
+
+But it does not need one to stop lying. Two things fix the claim:
+
+1. Call it what it is: a DIRTY spark spread. That is the industry's own word for the spread
+   before carbon, and it is not a hedge — it is the correct name.
+
+2. Publish the BREAK-EVEN CARBON PRICE: `dirty_spark / co2_intensity`. The EUA price at which
+   this margin reaches zero. It is arithmetic on our own numbers plus a published technical
+   constant — no carbon price, no licence, no model — and it is more useful than the clean spread
+   would be, because it says exactly how much carbon this zone's gas fleet can absorb before it
+   is under water.
+
+THE GAS LEG, HONESTLY
+---------------------
+TTF via yfinance is Yahoo's copy of the ICE Endex front-month — licensed exchange data, which
+this project does not redistribute (CLAUDE.md). The raw close is therefore no longer served in
+the API response; only the derived spread is.
+
+That is a MITIGATION, not a cure, and saying so is the point: the heat rate is published and the
+power price is public, so anyone can invert the spread back to the gas leg. The real fix is a
+free redistributable European gas benchmark, and one has not been found (EEX EGSI is gated). The
+provenance is labelled so nobody mistakes the mitigation for a solution.
+"""
+
+from __future__ import annotations
+
+#: Emission factor of natural gas, per MWh of THERMAL input. 56.1 kg CO2/GJ (IPCC 2006 default
+#: for natural gas, used by the EEA and in EU ETS monitoring) = 0.202 t/MWh_th.
+NATURAL_GAS_CO2_T_PER_MWH_TH = 0.202
+
+#: Wording, so the desk never says "margin" about a number that is not one.
+DIRTY_SPARK_LABEL = "Dirty spark"
+
+
+def co2_intensity(heat_rate: float) -> float:
+    """tCO2 per MWh of ELECTRICITY for a gas plant at this heat rate.
+
+    heat_rate = MWh_gas per MWh_el = 1 / efficiency. So a 50%-efficient CCGT burns 2 MWh of gas
+    per MWh of power and emits 2 × 0.202 = 0.404 tCO2/MWh_el.
+    """
+    return NATURAL_GAS_CO2_T_PER_MWH_TH * heat_rate
+
+
+def breakeven_eua(dirty_spark: float, heat_rate: float) -> float | None:
+    """The carbon price at which this dirty spread becomes a zero margin. EUR/tCO2.
+
+    Above it, the plant loses money on the day-ahead; below it, it earns. Pure arithmetic on the
+    published record and a published emission factor — no EUA price is needed to state it, which
+    is exactly why it can be published while the licence question is open.
+
+    None when the spread is already negative: a plant that is under water before carbon has no
+    carbon price that saves it, and quoting a negative break-even would invite the reader to read
+    it as one.
+    """
+    intensity = co2_intensity(heat_rate)
+    if intensity <= 0 or dirty_spark <= 0:
+        return None
+    return round(dirty_spark / intensity, 1)
+
+
+def clean_spark(dirty_spark: float, heat_rate: float, eua_price: float | None) -> float | None:
+    """dirty − CO2 cost. None without a carbon price — and there is not one yet.
+
+    Kept here, unused by the API, so that the day the EUA licence clears the arithmetic is
+    already written down and already tested, rather than reinvented under time pressure.
+    """
+    if eua_price is None:
+        return None
+    return round(dirty_spark - co2_intensity(heat_rate) * eua_price, 4)

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -311,13 +311,22 @@ async def get_spark_spread(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL, …"),
     db: Session = Depends(get_db),
 ):
-    """Spark spread (power − gas × heat_rate, EUR/MWh) for any zone.
+    """DIRTY spark spread (power − gas × heat_rate, EUR/MWh) for any zone — and the carbon
+    price at which it becomes a zero margin.
 
-    Computed live by aligning the zone's day-ahead price (EnergyPrice POWER_<zone>)
-    with the TTF gas front-month on each date. The gas leg is TTF (the European
-    benchmark hub) for every zone — a per-zone gas hub is a later refinement. CO₂/
-    clean-spark stay null until a free EUA source is confirmed. `latest` is the most
-    recent row; `data` is the ascending window for charting.
+    It is DIRTY, and the name is not a hedge: this is the spread BEFORE carbon. A gas plant has
+    to buy EUAs, and at 2026 prices that is around EUR 30/MWh — enough to flip the sign in most
+    of Europe. This endpoint used to call the number a "CCGT margin" and the hero painted it
+    green. It is not a margin. See backend/power/spark.py.
+
+    `breakeven_eua_eur_t` is what the desk publishes instead of a clean spread it cannot compute:
+    the EUA price at which this zone's gas fleet reaches zero. Pure arithmetic on our own record
+    plus a published emission factor — no carbon price needed, so no licence question, and more
+    useful than the clean spread anyway.
+
+    The gas leg is TTF for every zone (a per-zone hub is a later refinement) and its raw close is
+    NOT returned: yfinance's TTF is Yahoo's copy of the ICE Endex front-month, licensed exchange
+    data this project does not redistribute. That is a mitigation, not a cure — see spark.py.
     """
     resolved_zone = _resolve_zone(zone)
     symbol = POWER_ZONES[resolved_zone]["price_symbol"]
@@ -345,26 +354,41 @@ async def get_spark_spread(
             "reason": f"Spark spread isn't available for {POWER_ZONES[resolved_zone]['label']} yet — check back shortly.",
         }
 
-    data = [
-        {
+    from backend.power.spark import breakeven_eua, co2_intensity
+
+    data = []
+    for d in dates:
+        dirty = round(power_by[d] - ttf_by[d] * heat_rate, 4)
+        data.append({
             "date": d,
             "power_price": power_by[d],
-            "gas_price": ttf_by[d],
+            # gas_price (the raw TTF close) is deliberately NOT returned — see the docstring.
             "heat_rate": heat_rate,
-            "spark_spread": round(power_by[d] - ttf_by[d] * heat_rate, 4),
+            "dirty_spark_spread": dirty,
+            "breakeven_eua_eur_t": breakeven_eua(dirty, heat_rate),
             "co2_price": None,
             "clean_spark_spread": None,
-        }
-        for d in dates
-    ]
+        })
     return {
         "available": True,
         "zone": resolved_zone,
         "zones": _ZONE_KEYS,
         "unit": "EUR/MWh",
         "heat_rate_note": "1 / CCGT_efficiency; default efficiency = 0.50",
-        "gas_leg_note": "gas leg = TTF (European benchmark) for all zones; per-zone hub is a later refinement",
-        "co2_note": "co2_price and clean_spark_spread are deferred (EUA ticker TBD)",
+        "co2_intensity_t_per_mwh": round(co2_intensity(heat_rate), 4),
+        "gas_leg_note": (
+            "Gas leg = TTF front-month for every zone (a per-zone hub is a later refinement). Its "
+            "raw close is not returned: yfinance's TTF is Yahoo's copy of the ICE Endex contract, "
+            "licensed exchange data this project does not redistribute."
+        ),
+        "co2_note": (
+            "This spread is DIRTY — it excludes the cost of carbon, which at 2026 EUA prices is "
+            f"around EUR 30/MWh for a CCGT ({round(co2_intensity(heat_rate), 3)} tCO2 per MWh of "
+            "electricity at this heat rate). `breakeven_eua_eur_t` is the carbon price at which "
+            "the margin reaches zero: above it, the plant loses money on the day-ahead. The clean "
+            "spread itself stays null until a free, redistributable daily EUA series is confirmed "
+            "(docs/findings/2026-06-24-eua-coal-data-source.md)."
+        ),
         "latest": data[-1],
         "from": date_from,
         "to": date_to,
@@ -716,7 +740,8 @@ def build_power_situation(
 
     price_series — ascending [{"date","close","negative_hours"}]
     grid_series  — ascending _compute_grid_row dicts (residual_mw/renewable_share/dunkelflaute)
-    spark_latest — latest {"spark_spread","power_price","gas_price"} or None (DE-LU only)
+    spark_latest — latest {"spark_spread","power_price","gas_price"} or None. The DIRTY spread;
+        the block it produces renames it and adds the break-even carbon price (power/spark.py).
     spark_supported — False for zones without a spark series (FR/NL) so the header can signpost.
     grid_coverage_ok — False when ENTSO-E generation coverage is too low to trust the
         renewable share (e.g. NL). The Dunkelflaute flag is then suppressed rather than
@@ -766,16 +791,25 @@ def build_power_situation(
         **_freshness(grid_latest["date"] if grid_latest else None, today),
     }
 
-    # ── spark block (DE-LU only; signpost on FR/NL) ──
+    # ── spark block ──
+    #
+    # DIRTY, and the hero must say so. It used to render this as "CCGT margin", in green when
+    # positive — for a number that excludes the cost of carbon, which is around EUR 30/MWh and
+    # flips the sign in most of Europe. The break-even carbon price goes out with it, because it
+    # is the number that makes the omission legible: above that EUA price, the margin is negative.
+    from backend.power.spark import breakeven_eua
+
     has_spark = spark_supported and spark_latest is not None
+    _heat_rate = round(1.0 / settings.gas_ccgt_efficiency, 4)
+    _dirty = round(spark_latest["spark_spread"], 2) if has_spark else None
     spark = {
         "available": has_spark,
         "supported": spark_supported,
-        "spark_spread": round(spark_latest["spark_spread"], 2) if has_spark else None,
+        "dirty_spark_spread": _dirty,
+        "breakeven_eua_eur_t": breakeven_eua(_dirty, _heat_rate) if _dirty is not None else None,
         "power_price": round(spark_latest["power_price"], 2)
         if has_spark and spark_latest.get("power_price") is not None else None,
-        "gas_price": round(spark_latest["gas_price"], 2)
-        if has_spark and spark_latest.get("gas_price") is not None else None,
+        # The raw TTF close is NOT exposed: licensed exchange data (see power/spark.py).
         # Spark's gas leg is yfinance TTF (~3 trading days + weekends) — judge it
         # by the SAME window as the spark panel caption. With the 1-day default,
         # every weekend flagged EVERY zone's situation stale (worst-of semantics),
@@ -852,7 +886,11 @@ def build_power_situation(
         else:
             parts.append("residual n/a — no published load for this zone")
     if spark["available"]:
-        parts.append(f"spark €{spark['spark_spread']:+.0f}/MWh" + _age_suffix(spark))
+        seg = f"dirty spark €{spark['dirty_spark_spread']:+.0f}/MWh"
+        if spark["breakeven_eua_eur_t"] is not None:
+            # The whole point of the sentence: the spread is only a margin below this carbon price.
+            seg += f" (zero at €{spark['breakeven_eua_eur_t']:.0f}/t CO₂)"
+        parts.append(seg + _age_suffix(spark))
     headline = f"{zone_label} · " + " · ".join(parts) if parts else f"{zone_label} · no power data yet"
 
     return {

--- a/backend/tests/test_power_situation.py
+++ b/backend/tests/test_power_situation.py
@@ -89,7 +89,11 @@ def test_calm_state_no_flags():
     assert s["flags"] == []
     assert abs(s["price"]["z"]) < 2.0
     assert s["spark"]["available"] is True
-    assert s["spark"]["spark_spread"] == pytest.approx(8.0)
+    assert s["spark"]["dirty_spark_spread"] == pytest.approx(8.0)
+    # It is DIRTY, and the hero says so: a positive spread is only a margin below
+    # this carbon price. 8.0 / 0.404 = 19.8 EUR/t.
+    assert s["spark"]["breakeven_eua_eur_t"] == pytest.approx(19.8, abs=0.1)
+    assert "gas_price" not in s["spark"], "licensed exchange data is not republished"
 
 
 def test_dunkelflaute_elevates_and_flags():
@@ -359,12 +363,16 @@ def test_route_fr_spark_matches_the_panel(db_session):
     assert body["available"] is True
     assert body["spark"]["supported"] is True
     assert body["spark"]["available"] is True
-    # heat_rate = 1/0.50 → spark = 100 − 30·2 = 40
-    assert body["spark"]["spark_spread"] == pytest.approx(40.0)
+    # heat_rate = 1/0.50 → dirty spark = 100 − 30·2 = 40
+    assert body["spark"]["dirty_spark_spread"] == pytest.approx(40.0)
     assert body["spark"]["as_of"] == _TODAY.isoformat()
 
     panel = client.get("/api/power/spark-spread?zone=FR&days=7").json()
-    assert panel["latest"]["spark_spread"] == pytest.approx(body["spark"]["spark_spread"])
+    assert panel["latest"]["dirty_spark_spread"] == pytest.approx(body["spark"]["dirty_spark_spread"])
+    # The break-even carbon price must agree too — the hero and the panel computing the same
+    # number two ways is exactly how they came to disagree in the first place.
+    assert panel["latest"]["breakeven_eua_eur_t"] == pytest.approx(
+        body["spark"]["breakeven_eua_eur_t"])
 
 
 def test_route_fr_spark_without_prices_is_signposted_not_pretended(db_session):
@@ -377,7 +385,8 @@ def test_route_fr_spark_without_prices_is_signposted_not_pretended(db_session):
     body = client.get("/api/power/situation?zone=FR").json()
     assert body["spark"]["supported"] is True
     assert body["spark"]["available"] is False
-    assert body["spark"]["spark_spread"] is None
+    assert body["spark"]["dirty_spark_spread"] is None
+    assert body["spark"]["breakeven_eua_eur_t"] is None
 
 
 def test_route_empty_unavailable(db_session):

--- a/backend/tests/test_spark_honesty.py
+++ b/backend/tests/test_spark_honesty.py
@@ -1,0 +1,126 @@
+"""The desk showed +€25, in green, and called it the CCGT margin. It was not.
+
+A gas plant has to buy carbon. At the EUA price the EU ETS was trading at, a CCGT at this desk's
+own heat rate owes about €32/MWh for it — enough to turn Germany's, France's and Spain's
+"margins" negative. The number was wrong in the direction that flatters us, and it takes an
+analyst ten seconds to check.
+
+These tests pin the honest version: the spread is DIRTY, it says so, and it publishes the carbon
+price at which it becomes a zero margin — which needs no EUA data at all, and is therefore
+publishable while the licence question is still open.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.models.energy import EnergyPrice  # registers the table before conftest creates it
+from backend.power.spark import (
+    NATURAL_GAS_CO2_T_PER_MWH_TH,
+    breakeven_eua,
+    clean_spark,
+    co2_intensity,
+)
+
+HEAT_RATE = 2.0  # 1 / 0.50, this desk's default CCGT efficiency
+
+
+def test_the_carbon_a_ccgt_owes_per_mwh_of_electricity():
+    """0.202 tCO2 per MWh of GAS burned (IPCC's default factor for natural gas, the one EU ETS
+    monitoring uses) × 2 MWh of gas per MWh of power = 0.404 tCO2 per MWh of electricity."""
+    assert NATURAL_GAS_CO2_T_PER_MWH_TH == 0.202
+    assert co2_intensity(HEAT_RATE) == pytest.approx(0.404)
+
+
+def test_the_breakeven_carbon_price_is_where_the_margin_hits_zero():
+    """THE number this module exists to publish. Germany on 2026-07-10: a dirty spread of €25.50.
+    Divide by the carbon intensity and you get the EUA price at which the plant earns nothing.
+
+    €63/t. The EU ETS was at €78. The German "margin" was negative, and the desk was showing it
+    in green."""
+    assert breakeven_eua(25.50, HEAT_RATE) == pytest.approx(63.1, abs=0.1)
+
+    # …and the arithmetic is consistent: at exactly that carbon price, the clean spread is zero.
+    assert clean_spark(25.50, HEAT_RATE, 63.1) == pytest.approx(0.0, abs=0.05)
+
+
+def test_the_carbon_price_that_was_actually_trading_flips_the_sign():
+    """Not a rounding error. A sign error."""
+    assert clean_spark(25.50, HEAT_RATE, 78.0) < 0, "DE-LU"
+    assert clean_spark(21.60, HEAT_RATE, 78.0) < 0, "FR"
+    assert clean_spark(19.00, HEAT_RATE, 78.0) < 0, "ES"
+    assert clean_spark(50.90, HEAT_RATE, 78.0) > 0, "IT-Nord — the one that really was in profit"
+
+
+def test_a_spread_that_is_already_negative_has_no_breakeven():
+    """A plant under water BEFORE carbon is not saved by any carbon price. Quoting a negative
+    break-even would invite the reader to take it for one."""
+    assert breakeven_eua(-69.1, HEAT_RATE) is None      # SE1, on real data
+    assert breakeven_eua(0.0, HEAT_RATE) is None
+
+
+def test_the_clean_spread_stays_None_without_a_carbon_price():
+    """It is not computed from a guess. There is no confirmed free, redistributable daily EUA
+    series (docs/findings/2026-06-24-eua-coal-data-source.md), and nothing enters the free core
+    until there is. The arithmetic is written down and tested anyway, so the day the licence
+    clears it is not reinvented under time pressure."""
+    assert clean_spark(25.50, HEAT_RATE, None) is None
+
+
+# ─── what the desk must no longer say ─────────────────────────────────────────
+
+
+def test_the_api_does_not_republish_the_gas_leg(db_session):
+    """yfinance's TTF is Yahoo's copy of the ICE Endex front-month — licensed exchange data,
+    which CLAUDE.md says this project does not redistribute. The raw close is gone from the
+    response; only the derived spread is served.
+
+    A MITIGATION, not a cure, and the docstring says so: the heat rate is published and the power
+    price is public, so the spread can be inverted back to the gas leg by anyone who cares. The
+    real fix is a free redistributable European gas benchmark, and there is not one."""
+    from datetime import date, timedelta
+
+    from fastapi.testclient import TestClient
+
+    from backend.database import get_db
+    from backend.main import app
+
+    d = (date.today() - timedelta(days=3)).isoformat()
+    db_session.add(EnergyPrice(date=d, symbol="POWER_DE", close=122.81))
+    db_session.add(EnergyPrice(date=d, symbol="TTF", close=48.655))
+    db_session.commit()
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    try:
+        body = TestClient(app).get("/api/power/spark-spread?zone=DE_LU&days=30").json()
+        hero = TestClient(app).get("/api/power/situation?zone=DE_LU").json()
+    finally:
+        app.dependency_overrides.clear()
+
+    assert "gas_price" not in body["latest"]
+    assert "gas_price" not in hero["spark"]
+
+    # The real DE-LU numbers of 2026-07-10, end to end.
+    assert body["latest"]["dirty_spark_spread"] == pytest.approx(25.5, abs=0.01)
+    assert body["latest"]["breakeven_eua_eur_t"] == pytest.approx(63.1, abs=0.1)
+
+
+def test_the_headline_never_calls_a_dirty_spread_a_margin(db_session):
+    """The exact words that were wrong: the hero rendered "CCGT margin", in green, for a number
+    that excludes the cost of carbon. It must say what it is, and carry the carbon price that
+    makes the omission legible."""
+    from backend.routes.power import build_power_situation
+
+    price = [{"date": "2026-07-10", "close": 122.81, "negative_hours": 0}]
+    grid = [{"date": "2026-07-10", "residual_mw": 30_000.0, "renewable_share": 0.4,
+             "dunkelflaute": False}]
+    spark_latest = {"spark_spread": 25.5, "power_price": 122.81, "gas_price": 48.655}
+
+    s = build_power_situation("DE_LU", price, grid, spark_latest)
+
+    assert s["spark"]["dirty_spark_spread"] == pytest.approx(25.5)
+    assert s["spark"]["breakeven_eua_eur_t"] == pytest.approx(63.1, abs=0.1)
+
+    headline = s["headline"].lower()
+    assert "dirty spark" in headline
+    assert "margin" not in headline, "it is not a margin until the carbon is paid for"
+    assert "/t co₂" in headline or "/t co2" in headline, "the break-even travels with the number"

--- a/backend/tests/test_spark_spreads.py
+++ b/backend/tests/test_spark_spreads.py
@@ -191,8 +191,17 @@ def test_spark_route_computes_per_zone(db_session, monkeypatch):
     assert body["available"] is True
     assert body["zone"] == "FR"
     assert set(body["zones"]) == {"DE_LU", "FR", "NL"}
-    assert body["data"][0]["spark_spread"] == 90.0 - 30.0 * 2.0  # 30.0, heat_rate=2.0
-    assert body["latest"]["gas_price"] == 30.0
+    assert body["data"][0]["dirty_spark_spread"] == 90.0 - 30.0 * 2.0  # 30.0, heat_rate=2.0
+
+    # The raw TTF close must NOT be in the response: it is Yahoo's copy of the ICE Endex
+    # front-month, licensed exchange data this project does not redistribute.
+    assert "gas_price" not in body["latest"]
+    assert all("gas_price" not in row for row in body["data"])
+
+    # And the number the desk publishes INSTEAD of a clean spread it cannot compute: the carbon
+    # price at which this margin hits zero. 30.0 / (0.202 × 2.0) = 74.3 EUR/t.
+    assert body["latest"]["breakeven_eua_eur_t"] == pytest.approx(74.3, abs=0.1)
+    assert body["co2_intensity_t_per_mwh"] == pytest.approx(0.404)
 
 
 def test_spark_route_unavailable_without_overlap(db_session):

--- a/frontend/src/components/PowerSituationHeader.jsx
+++ b/frontend/src/components/PowerSituationHeader.jsx
@@ -93,8 +93,11 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
 
   const priceColor = price.z != null && Math.abs(price.z) >= 2 ? st.text : 'text-neutral-200'
   const residColor = grid.z != null && Math.abs(grid.z) >= 2 ? st.text : 'text-neutral-200'
-  const sparkColor = spark.spark_spread == null ? 'text-neutral-500'
-    : spark.spark_spread >= 0 ? 'text-green-glow' : 'text-orange-400'
+  // NOT green-when-positive. This is the spread BEFORE carbon, and at 2026 EUA prices the cost
+  // of carbon (~€30/MWh for a CCGT) flips the sign across most of Europe. Painting a dirty spread
+  // green told a power analyst that gas generation is profitable in Germany when it is not.
+  // Neutral — the break-even carbon price below it carries the meaning.
+  const sparkColor = spark.dirty_spark_spread == null ? 'text-neutral-500' : 'text-neutral-200'
 
   return (
     <div className={`border ${st.border} bg-surface rounded overflow-hidden`}>
@@ -169,9 +172,17 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
             band={grid.z != null && <ReferenceBand z={grid.z} baselineN={grid.baseline_n} className="mt-1.5" />}
           />
           <Metric
-            label="Spark spread"
-            value={spark.spark_spread != null ? `${spark.spark_spread >= 0 ? '+' : ''}€${spark.spark_spread.toFixed(0)}` : '—'}
-            sub={spark.available ? 'CCGT margin' : 'no data yet'}
+            label="Dirty spark"
+            value={spark.dirty_spark_spread != null ? `${spark.dirty_spark_spread >= 0 ? '+' : ''}€${spark.dirty_spark_spread.toFixed(0)}` : '—'}
+            /* Not "CCGT margin" — it is only a margin BELOW this carbon price. Above it, the
+               plant loses money on the day-ahead, and the desk used to say the opposite. */
+            sub={
+              spark.available
+                ? (spark.breakeven_eua_eur_t != null
+                  ? `zero at €${spark.breakeven_eua_eur_t.toFixed(0)}/t CO₂`
+                  : 'negative before carbon')
+                : 'no data yet'
+            }
             color={sparkColor}
             comp={spark}
           />

--- a/frontend/src/components/SparkSpreadPanel.jsx
+++ b/frontend/src/components/SparkSpreadPanel.jsx
@@ -38,8 +38,11 @@ export default function SparkSpreadPanel({ zone = 'DE_LU' }) {
 
   const rows = data?.data ?? []
   const latest = data?.latest
-  const spread = latest?.spark_spread
-  const spreadColor = spread == null ? '#737373' : spread >= 0 ? '#4ade80' : '#fb923c'
+  const spread = latest?.dirty_spark_spread
+  const breakeven = latest?.breakeven_eua_eur_t
+  // Never green-for-positive: this is the spread BEFORE carbon, and a positive one is not a
+  // profit. The panel used to colour it green and call it a CCGT margin.
+  const spreadColor = spread == null ? '#737373' : '#e5e5e5'
 
   return (
     <Panel
@@ -80,10 +83,13 @@ export default function SparkSpreadPanel({ zone = 'DE_LU' }) {
                   {latest.power_price != null ? `${latest.power_price.toFixed(1)} €/MWh` : '—'}
                 </span>
               </div>
+              {/* The raw TTF close used to sit here. It is Yahoo's copy of the ICE Endex
+                  front-month — licensed exchange data this project does not redistribute — and
+                  the break-even carbon price is the number a reader actually needs. */}
               <div className="font-mono text-[10px] text-neutral-500">
-                <span className="text-neutral-600">GAS</span>{' '}
-                <span className="text-neutral-300">
-                  {latest.gas_price != null ? `${latest.gas_price.toFixed(2)} €/MWh` : '—'}
+                <span className="text-neutral-600">ZERO AT</span>{' '}
+                <span className={breakeven != null ? 'text-amber-400' : 'text-neutral-600'}>
+                  {breakeven != null ? `€${breakeven.toFixed(0)}/t CO₂` : 'already negative'}
                 </span>
               </div>
               <div className="font-mono text-[10px] text-neutral-500">
@@ -124,7 +130,7 @@ export default function SparkSpreadPanel({ zone = 'DE_LU' }) {
                   <ReferenceLine y={0} stroke="#444" />
                   <Area
                     type="monotone"
-                    dataKey="spark_spread"
+                    dataKey="dirty_spark_spread"
                     stroke="#4ade80"
                     fill="#4ade80"
                     fillOpacity={0.06}


### PR DESCRIPTION
A gas plant has to buy carbon.

At an EUA price of **€78/t** — where the EU ETS traded on 2026-07-10 — a CCGT at this desk's own heat rate emits **0.404 tCO₂ per MWh of electricity**, which costs about **€32/MWh**. Measured across the desk on the same day:

| zone | dirty spark | break-even EUA | margin at ~€78/t |
|---|---:|---:|---|
| **DE-LU** | +25.5 | **€63/t** | **NEGATIVE** |
| **FR** | +21.6 | €53 | **NEGATIVE** |
| **ES** | +19.0 | €47 | **NEGATIVE** |
| IT-Nord | +50.9 | €126 | positive |

So the situation hero — **the front door** — was telling a power analyst that gas generation is profitable in Germany, France and Spain. In green. Under the label **"CCGT margin"**.

It is not a margin. It is the spread *before carbon*, and **the sign flips**. This is the class of error that gets a tab closed: ten seconds to check, and wrong in the direction that flatters us.

## Two fixes, neither of which needs a carbon price

**1. Call it what it is: a DIRTY spark spread.** That is the industry's own term, and it is not a hedge — it is the correct name. It is no longer painted green when positive, because *a positive dirty spread is not a profit*.

**2. Publish the break-even carbon price**: `dirty_spark ÷ co2_intensity` — the EUA price at which the margin reaches zero. Arithmetic on our own record plus a published emission factor (0.202 tCO₂/MWh_th, the IPCC default that EU ETS monitoring uses). **No carbon price, no licence, no model.** And it is more useful than the clean spread would be, because it says exactly how much carbon this zone's gas fleet can absorb before it is under water.

A spread that is **already negative** gets no break-even: a plant under water before carbon is not saved by any carbon price, and quoting a negative number would invite the reader to take it for one.

The **clean spread stays null**. There is still no confirmed free, redistributable daily EUA series (`docs/findings/2026-06-24-eua-coal-data-source.md`), and nothing enters the free core until there is. The arithmetic is written and tested anyway, so the day the licence clears it is not reinvented under time pressure.

## And the gas leg, honestly

**The raw TTF close is no longer returned.** yfinance's TTF is Yahoo's copy of the ICE Endex front-month — licensed exchange data, which `CLAUDE.md` says this project does not redistribute — and it was being served in **every row of a public endpoint**.

That is a **mitigation, not a cure**, and the module says so: the heat rate is published and the power price is public, so anyone who cares can invert the spread back to the gas leg. The real fix is a free redistributable European gas benchmark, and **there is not one** (EEX EGSI is gated). Labelled rather than quietly patched, so nobody mistakes the mitigation for a solution.

`ruff` clean · **951 passed** (7 new) · eslint clean · vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)