### PR TITLE
A day is 24 hours, and a mean divides by the day

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -100,6 +100,14 @@ def run_migrations() -> None:
             "ON power_outage (zone, mrid, revision)"
         ))
 
+    # 2026-07-14: how much of the day each daily mean stands on. Existing rows stay NULL until the
+    # re-derivation (backend/scripts/rederive_daily.py) fills them from the hourly store — and a
+    # NULL means "unknown", so no claim that needs a complete day is made off one.
+    if _add_column_if_missing("power_grid", "load_hours", "INTEGER"):
+        applied.append("power_grid.load_hours")
+    if _add_column_if_missing("power_grid", "gen_hours", "INTEGER"):
+        applied.append("power_grid.gen_hours")
+
     # 2026-07-14: name the fuels that had no name. B03/B07/B08/B13 were missing from PSR_LABELS,
     # so the ingest stored the RAW code as psr_type and the mix legend read "gen.B03". Adding the
     # labels fixes new rows; without this, the record would carry the same fuel under two names

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -105,6 +105,12 @@ class PowerGrid(Base):
     wind_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)   # daily mean MW (B18+B19)
     solar_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # daily mean MW (B16)
     residual_mw: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # load − wind − solar (MW)
+    # How much of the day each mean stands on (backend/power/daily.py). A claim about a renewable
+    # share needs both at 24: the load mean must be a day's, and every hour of the day must have
+    # SOME generation in it — that is what tells "PT omits solar at night" (wind and gas still
+    # report) apart from "the feed fell over for six hours" (nothing does).
+    load_hours: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)   # 0-24
+    gen_hours: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)    # 0-24, any fuel
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     __table_args__ = (UniqueConstraint("date", "zone", name="uq_power_grid_date_zone"),)

--- a/backend/power/daily.py
+++ b/backend/power/daily.py
@@ -1,0 +1,117 @@
+"""The daily tables, derived from the canonical hourly store — one source, one answer.
+
+WHY THIS MODULE EXISTS
+----------------------
+`power_grid` and `power_gen_mix` used to be built by a SECOND parse of the ENTSO-E XML, next to
+the one that fills `power_hourly`. Two parses of one document is two answers to one question, and
+all three of the following came out of that gap:
+
+1. **The current day was stored as a day.** The daily mean was `sum(points) / len(points)` over
+   whatever had been published so far — at 10:31 UTC, a mean of nine night-and-morning hours. The
+   radar read the newest row and announced "PT: Dunkelflaute — renewables 11% of load"; six hours
+   later PT sat at 22%, because the sun had come up. Nothing had happened. The day had.
+
+2. **Missing zeros became a higher mean.** Several zones do not publish solar at night — PT sends
+   18 points. Dividing by 18 gives the mean of the DAYLIGHT hours and calls it the day: PT's solar
+   for 2026-07-13 was stored as 1619 MW where the day's mean is 1147, a third too high, on a
+   SETTLED day, for as long as the record goes back. That lifts the renewable share, sinks the
+   residual load, and feeds both into the Dunkelflaute predicate and the z-scores.
+
+3. **Revised points were counted twice.** The daily parse appended every Point in the document,
+   including those an overlapping, revised period restates. The hourly parse averaged per hour. So
+   the daily table and the hourly store disagreed about the same day (DE-LU solar: 19,988 vs
+   19,364 MW) — and the desk quoted whichever one you happened to ask.
+
+THE RULES
+---------
+* **Generation is averaged over the DAY** (24 UTC hours): an hour with no point is a zero the
+  publisher did not send, because a solar farm at 03:00 produces zero and everyone knows it.
+* **Load is averaged over the hours it HAS**: load is never zero, so an absent hour is a hole, not
+  a zero, and averaging it in as one would invent a demand collapse. The row carries `load_hours`
+  so a reader can see how much of the day that mean stands on.
+* **`gen_hours` counts the hours in which ANY fuel was published.** That is what separates "PT
+  omits solar at night" (wind, gas and hydro still report — the day is covered) from "the feed
+  fell over for six hours" (nothing reports — the day is not).
+* **Only finished days become rows.** A day that is not over is not a day: `days_to_derive` stops
+  at yesterday, so the newest row in `power_grid` is a settled day BY CONSTRUCTION, and every
+  consumer of "the latest row" — radar, hero, matrix, /grid, episodes, alert rules — is right
+  without having to know any of this.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+#: A day is 24 UTC hours. Days are keyed in UTC, so this holds across DST.
+HOURS_PER_DAY = 24
+
+#: The psrTypes the grid table lifts out of the mix by name.
+PSR_SOLAR = "B16"
+PSR_WIND_OFFSHORE = "B18"
+PSR_WIND_ONSHORE = "B19"
+
+
+def daily_from_hours(
+    load_hours: dict[int, float],
+    gen_hours: dict[str, dict[int, float]],
+) -> dict:
+    """One day's daily-mean row from its hour maps. Pure — no DB, no clock.
+
+    `load_hours`  {hour_utc: MW}
+    `gen_hours`   {psrType: {hour_utc: MW}} — GENERATION only (consumption series are a separate
+                  key in the store and must never be summed into the mix; see CONSUMPTION_SUFFIX).
+
+    Returns {load_mw, wind_mw, solar_mw, residual_mw, load_hours, gen_hours, mix}.
+    """
+    load_mw = sum(load_hours.values()) / len(load_hours) if load_hours else None
+
+    mix = {
+        psr: sum(hours.values()) / HOURS_PER_DAY
+        for psr, hours in gen_hours.items()
+        if hours
+    }
+    covered: set[int] = set()
+    for hours in gen_hours.values():
+        covered |= set(hours)
+
+    wind_mw = mix.get(PSR_WIND_OFFSHORE, 0.0) + mix.get(PSR_WIND_ONSHORE, 0.0)
+    solar_mw = mix.get(PSR_SOLAR, 0.0)
+
+    # No load → no demand → no residual (IE-SEM has published none since 2025-10-23). No
+    # generation at all → wind/solar are not zero, they are unknown, so neither is the residual.
+    residual_mw = load_mw - wind_mw - solar_mw if load_mw is not None and mix else None
+
+    return {
+        "load_mw": load_mw,
+        "wind_mw": wind_mw if mix else None,
+        "solar_mw": solar_mw if mix else None,
+        "residual_mw": residual_mw,
+        "load_hours": len(load_hours),
+        "gen_hours": len(covered),
+        "mix": mix,
+    }
+
+
+def share_is_claimable(load_hours: int | None, gen_hours: int | None) -> bool:
+    """Can this day carry a statement about the renewable SHARE of load?
+
+    Only with a full day on both legs: a load mean standing on 24 hours, and generation reported
+    in every hour of the day. The second is what tells "PT omits solar at night" (wind and gas
+    still report — nothing is missing) from "the feed fell over for six hours" (nothing reports —
+    and calling those hours zero would manufacture a Dunkelflaute out of an outage).
+
+    NULL means unknown — a row written before the hour counts existed — and unknown is not a yes.
+    """
+    return load_hours == HOURS_PER_DAY and gen_hours == HOURS_PER_DAY
+
+
+def days_to_derive(days: Iterable[str], *, now: datetime | None = None) -> list[str]:
+    """The subset of `days` that are OVER in UTC — the only ones that can be a daily mean.
+
+    Everything downstream reads "the latest row" and treats it as a day. Keeping the current day
+    out of the table is what makes that true, at the source, for all of them at once.
+    """
+    now = now or datetime.now(UTC)
+    today = now.strftime("%Y-%m-%d")
+    return sorted(d for d in days if d < today)

--- a/backend/power/entsoe_grid.py
+++ b/backend/power/entsoe_grid.py
@@ -31,6 +31,7 @@ from backend.config import settings
 from backend.gas import raw_cache
 from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
 from backend.models.energy import PowerGenMix, PowerGrid
+from backend.power.daily import daily_from_hours, days_to_derive
 from backend.power.hourly_store import upsert_day_hours
 
 logger = logging.getLogger(__name__)
@@ -451,9 +452,6 @@ async def ingest_load_forecast(
             logger.warning("entsoe_grid: A65/A01 %s fetch failed: %s", month_start, exc)
             xml = ""
         if xml:
-            for day, mean_mw in parse_load(xml).items():
-                if day in wanted:
-                    load_by_day[day] = mean_mw
             for day, hours in parse_load_hourly(xml).items():
                 if day in wanted:
                     load_hourly_by_day[day] = hours
@@ -469,13 +467,22 @@ async def ingest_load_forecast(
             logger.warning("entsoe_grid: A69/A01 %s fetch failed: %s", month_start, exc)
             gxml = ""
         if gxml:
-            for day, by_psr in parse_generation_by_type(gxml).items():
-                if day in wanted:
-                    wind_by_day[day] = (by_psr.get(PSR_WIND_OFFSHORE, 0.0) or 0.0) + (by_psr.get(PSR_WIND_ONSHORE, 0.0) or 0.0)
-                    solar_by_day[day] = by_psr.get(PSR_SOLAR, 0.0) or 0.0
             for day, by_psr in parse_generation_hourly(gxml).items():
                 if day in wanted:
                     gen_hourly_by_day[day] = by_psr
+
+    # The daily forecast means come from the hourly forecast shape, by the same rule as the
+    # actuals (power/daily.py): a forecast for solar is published for the daylight hours in some
+    # zones, and dividing by those hours forecasts a sun that shines all night. The day filter of
+    # the actuals does NOT apply — a forecast is for a day that has not happened yet, which is
+    # the whole point of it.
+    for day in sorted(set(load_hourly_by_day) | set(gen_hourly_by_day)):
+        derived = daily_from_hours(load_hourly_by_day.get(day, {}), gen_hourly_by_day.get(day, {}))
+        if derived["load_mw"] is not None:
+            load_by_day[day] = derived["load_mw"]
+        if derived["mix"]:
+            wind_by_day[day] = derived["wind_mw"]
+            solar_by_day[day] = derived["solar_mw"]
 
     written = 0
     for day in sorted(set(load_by_day) | set(wind_by_day) | set(solar_by_day)):
@@ -668,27 +675,28 @@ async def ingest_grid(
                 if day in wanted:
                     gen_hourly_by_day[day] = by_psr
 
-    # ── Upsert PowerGrid ───────────────────────────────────────────────────
-    all_days = wanted & (load_by_day.keys() | gen_by_day.keys())
+    # ── Upsert the daily tables — DERIVED FROM THE HOURLY SHAPE ────────────
+    #
+    # Not from `parse_load` / `parse_generation_by_type` (the daily-mean parses) any more. Those
+    # divided by the number of PUBLISHED points, which stored the current day's nine morning hours
+    # as a day, made a zone that omits solar at night (PT: 18 points) a third sunnier than it is,
+    # and counted revised, overlapping points twice. The hour maps below are the same ones that go
+    # into the canonical store, deduped per hour — one parse, one answer. See power/daily.py.
+    #
+    # Only days that are OVER become rows: a day that is not finished is not a day, and everything
+    # downstream reads "the latest row" as one.
+    all_days = wanted & (load_hourly_by_day.keys() | gen_hourly_by_day.keys())
     written = 0
-    for day in sorted(all_days):
-        psr_map = gen_by_day.get(day, {})
-        wind_mw = psr_map.get(PSR_WIND_OFFSHORE, 0.0) + psr_map.get(PSR_WIND_ONSHORE, 0.0)
-        solar_mw = psr_map.get(PSR_SOLAR, 0.0)
-        load_mw = load_by_day.get(day)
-
-        # Residual = dispatchable demand (load − renewables). Only when generation
-        # was actually fetched for this day — otherwise wind/solar default to 0 and
-        # we'd store load−0−0 (inflated), clobbering a previously-correct residual.
-        residual_mw: float | None = None
-        if load_mw is not None and day in gen_by_day:
-            residual_mw = load_mw - wind_mw - solar_mw
-
-        _upsert_grid(db, day, zone, load_mw, wind_mw or None, solar_mw or None, residual_mw)
+    for day in days_to_derive(all_days):
+        gen_of_day = {
+            base_psr(psr): hours
+            for psr, hours in gen_hourly_by_day.get(day, {}).items()
+            if not is_consumption_key(psr)   # pumping is not generation
+        }
+        row = daily_from_hours(load_hourly_by_day.get(day, {}), gen_of_day)
+        _upsert_grid(db, day, zone, row)
+        _upsert_generation_mix(db, day, zone, row["mix"])
         written += 1
-
-    # ── Upsert PowerGenMix (full A75 breakdown) ────────────────────────────
-    _upsert_generation_mix(db, gen_by_day, zone)
 
     db.commit()
 
@@ -732,81 +740,57 @@ async def ingest_grid(
 
 def _upsert_generation_mix(
     db: Session,
-    gen_by_day: dict[str, dict[str, float]],
-    zone: str,
-) -> None:
-    """Upsert the full generation mix (all psrTypes) from a parsed A75 result.
-
-    `gen_by_day` maps {date_str: {psrType_code: mean_mw}}.  Each (date, zone,
-    label) triple is upserted idempotently — existing rows are updated in-place,
-    new rows are inserted. Readable labels from PSR_LABELS are used; unknown
-    codes fall back to the raw code string.
-
-    CONSUMPTION series (pumped-storage pumping) are EXCLUDED: the mix is what the
-    zone generated, and counting pumping as generation inflated both the mix and
-    the generation total that backend/power/coverage.py divides by load.
-
-    Note: does NOT call db.commit() — the caller (ingest_grid) commits once
-    after both _upsert_grid and _upsert_generation_mix complete.
-    """
-    for day, psr_map in gen_by_day.items():
-        for code, mean_mw in psr_map.items():
-            if is_consumption_key(code):
-                continue
-            label = PSR_LABELS.get(code, code)
-            existing = (
-                db.query(PowerGenMix)
-                .filter(
-                    PowerGenMix.date == day,
-                    PowerGenMix.zone == zone,
-                    PowerGenMix.psr_type == label,
-                )
-                .first()
-            )
-            if existing:
-                existing.gen_mw = mean_mw
-            else:
-                db.add(
-                    PowerGenMix(
-                        date=day,
-                        zone=zone,
-                        psr_type=label,
-                        gen_mw=mean_mw,
-                    )
-                )
-
-
-def _upsert_grid(
-    db: Session,
     day: str,
     zone: str,
-    load_mw: float | None,
-    wind_mw: float | None,
-    solar_mw: float | None,
-    residual_mw: float | None = None,
+    mix: dict[str, float],
 ) -> None:
+    """Upsert one day's generation mix (psrType → daily-mean MW, already day-averaged).
+
+    `mix` comes from power/daily.py, so every fuel is averaged over the 24 hours of the day —
+    the hours a zone does not publish are the zeros it does not send, not points to divide by.
+
+    CONSUMPTION series (pumped-storage pumping) never reach here: the mix is what the zone
+    GENERATED, and counting pumping as generation inflated both the mix and the generation total
+    that backend/power/coverage.py divides by load.
+
+    Note: does NOT call db.commit() — the caller commits once per zone-month.
+    """
+    for code, mean_mw in mix.items():
+        label = PSR_LABELS.get(code, code)
+        existing = (
+            db.query(PowerGenMix)
+            .filter(
+                PowerGenMix.date == day,
+                PowerGenMix.zone == zone,
+                PowerGenMix.psr_type == label,
+            )
+            .first()
+        )
+        if existing:
+            existing.gen_mw = mean_mw
+        else:
+            db.add(PowerGenMix(date=day, zone=zone, psr_type=label, gen_mw=mean_mw))
+
+
+def _upsert_grid(db: Session, day: str, zone: str, row: dict) -> None:
+    """Upsert one day's PowerGrid row from a power/daily.py `daily_from_hours` result.
+
+    Writes the hour counts as well: they are what lets a reader — and the Dunkelflaute predicate —
+    see how much of the day a mean stands on. Unlike the old upsert, a None is WRITTEN rather than
+    skipped: this row is the whole truth about the day as the store knows it, and silently keeping
+    a previous value would resurrect the number the re-derivation is here to correct.
+    """
     existing = (
         db.query(PowerGrid)
         .filter(PowerGrid.date == day, PowerGrid.zone == zone)
         .first()
     )
-    if existing:
-        if load_mw is not None:
-            existing.load_mw = load_mw
-        if wind_mw is not None:
-            existing.wind_mw = wind_mw
-        if solar_mw is not None:
-            existing.solar_mw = solar_mw
-        if residual_mw is not None:
-            existing.residual_mw = residual_mw
-    else:
-        db.add(
-            PowerGrid(
-                date=day,
-                zone=zone,
-                load_mw=load_mw,
-                wind_mw=wind_mw,
-                solar_mw=solar_mw,
-                residual_mw=residual_mw,
-            )
-        )
+    target = existing or PowerGrid(date=day, zone=zone)
+    target.load_mw = row["load_mw"]
+    target.wind_mw = row["wind_mw"]
+    target.solar_mw = row["solar_mw"]
+    target.residual_mw = row["residual_mw"]
+    target.load_hours = row["load_hours"]
+    target.gen_hours = row["gen_hours"]
+    if existing is None:
+        db.add(target)

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -47,6 +47,7 @@ from backend.models.energy import (
 )
 from backend.power.baseline import BASELINE_DAYS
 from backend.power.coverage import renewable_share_reliable
+from backend.power.daily import share_is_claimable
 from backend.power.dunkelflaute import ABSOLUTE_THRESHOLD, TAIL_PERCENTILE
 from backend.power.energy_charts_flows import ATTRIBUTION
 from backend.power.entsoe_grid import PSR_LABELS
@@ -402,7 +403,12 @@ async def get_spark_spread(
 
 
 def _grid_row_values(
-    date: str, load_mw: float | None, wind_mw: float | None, solar_mw: float | None
+    date: str,
+    load_mw: float | None,
+    wind_mw: float | None,
+    solar_mw: float | None,
+    load_hours: int | None = None,
+    gen_hours: int | None = None,
 ) -> dict:
     """Derive residual_mw and renewable_share for one row.
 
@@ -437,12 +443,16 @@ def _grid_row_values(
         "solar_mw": solar_mw,
         "residual_mw": residual_mw,
         "renewable_share": renewable_share,
+        # How much of the day these means stand on (power/daily.py). Shipped, not hidden: a share
+        # is only a share when the day is whole, and a reader is entitled to check that.
+        "load_hours": load_hours,
+        "gen_hours": gen_hours,
         "dunkelflaute": False,
     }
 
 
 def _compute_grid_row(r: PowerGrid) -> dict:
-    return _grid_row_values(r.date, r.load_mw, r.wind_mw, r.solar_mw)
+    return _grid_row_values(r.date, r.load_mw, r.wind_mw, r.solar_mw, r.load_hours, r.gen_hours)
 
 
 def _flag_dunkelflaute(db: Session, zone: str, rows: list[dict]) -> None:
@@ -458,7 +468,14 @@ def _flag_dunkelflaute(db: Session, zone: str, rows: list[dict]) -> None:
             db, zone=zone, date_from=rows[0]["date"], date_to=rows[-1]["date"]
         )
     }
-    verdicts = flag_days(db, zone, {r["date"]: r["renewable_share"] for r in rows}, reliable)
+    # A share is a claim about a whole day: a day of load, and generation reported in every hour
+    # of it. A day with a hole in its feed reads as zeros, and zeros make a Dunkelflaute out of an
+    # outage — so days that cannot carry the claim never reach the predicate.
+    shares = {
+        r["date"]: (r["renewable_share"] if share_is_claimable(r["load_hours"], r["gen_hours"]) else None)
+        for r in rows
+    }
+    verdicts = flag_days(db, zone, shares, reliable)
     for r in rows:
         r["dunkelflaute"] = verdicts.get(r["date"], False)
 
@@ -1075,15 +1092,16 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
     #    ORM entities — hydrating ~4.5k PowerGrid objects cost 0.17s on prod.
     grid_by_zone: dict[str, list[dict]] = {z: [] for z in POWER_ZONES}
     latest_grid: dict[str, tuple[str, float | None]] = {}  # zone -> (date, load_mw)
-    for zone_key, d, load, wind, solar in (
+    for zone_key, d, load, wind, solar, lh, gh in (
         db.query(PowerGrid.zone, PowerGrid.date, PowerGrid.load_mw,
-                 PowerGrid.wind_mw, PowerGrid.solar_mw)
+                 PowerGrid.wind_mw, PowerGrid.solar_mw,
+                 PowerGrid.load_hours, PowerGrid.gen_hours)
         .filter(PowerGrid.date >= date_from, PowerGrid.date <= date_to)
         .order_by(PowerGrid.date.asc())
         .all()
     ):
         if zone_key in grid_by_zone:
-            grid_by_zone[zone_key].append(_grid_row_values(d, load, wind, solar))
+            grid_by_zone[zone_key].append(_grid_row_values(d, load, wind, solar, lh, gh))
             latest_grid[zone_key] = (d, load)
 
     # 3. Coverage guard for each zone's LATEST grid day. Query by the small set
@@ -1126,8 +1144,13 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
             continue
         last = series[-1]
         reliable = {last["date"]} if _coverage_ok(zone_key) else set()
+        share = (
+            last["renewable_share"]
+            if share_is_claimable(last["load_hours"], last["gen_hours"])
+            else None
+        )
         last["dunkelflaute"] = flag_days(
-            db, zone_key, {last["date"]: last["renewable_share"]}, reliable
+            db, zone_key, {last["date"]: share}, reliable
         )[last["date"]]
 
     # 4. Spark legs: every zone's power symbol + TTF. Query by DATE RANGE only —

--- a/backend/scripts/rederive_daily.py
+++ b/backend/scripts/rederive_daily.py
@@ -1,0 +1,189 @@
+"""Re-derive power_grid + power_gen_mix from the canonical hourly store. No API calls.
+
+WHY
+---
+The daily tables were built by a second parse of the ENTSO-E XML, with `sum(points)/len(points)`
+as the daily mean. That stored the current day's morning hours as a day, made every zone that
+omits solar at night (PT sends 18 points, not 24) a third sunnier than it is, and counted revised
+overlapping points twice — so the daily table and the hourly store disagreed about the same day.
+backend/power/daily.py now owns the rule; this script applies it to the history that was written
+under the old one.
+
+Verified before writing this: `power_hourly` covers the daily history exactly — same first day,
+same day count, for all 37 zones — so nothing is lost by deriving the days from it.
+
+WHAT IT DOES, per zone-month:
+  * rebuilds every finished day's PowerGrid row (means, and the hour counts behind them)
+  * rebuilds its PowerGenMix rows from the same hour maps
+  * deletes rows for days that are NOT OVER — a running total is not a daily mean
+
+OPS
+---
+The last full grid backfill drove this VPS's disk from 70% to 90% with a 439 MB WAL, because the
+API process holds long-lived readers and SQLite therefore cannot checkpoint. This writes far less
+(it only rewrites existing rows), but it checkpoints every CHECKPOINT_EVERY zone-months anyway and
+prints the WAL size as it goes. Run it with an eye on `df -h`.
+
+    python -m backend.scripts.rederive_daily              # every zone, whole history
+    python -m backend.scripts.rederive_daily --zones PT   # one zone
+    python -m backend.scripts.rederive_daily --dry-run    # report the deltas, write nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+from sqlalchemy import text
+
+from backend.database import SessionLocal
+from backend.models.energy import PowerGenMix, PowerGrid
+from backend.power.daily import daily_from_hours, days_to_derive
+from backend.power.entsoe_grid import PSR_LABELS
+from backend.power.zones import POWER_ZONES
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger("rederive_daily")
+
+CHECKPOINT_EVERY = 20  # zone-months
+
+
+def _wal_mb() -> float:
+    from backend.config import settings
+
+    url = settings.database_url
+    if not url.startswith("sqlite"):
+        return 0.0
+    wal = Path(url.split("///")[-1] + "-wal")
+    return wal.stat().st_size / 1e6 if wal.exists() else 0.0
+
+
+def _hours_by_day(db, zone: str, month: str) -> tuple[dict, dict]:
+    """{day: {hour: mw}} for load, and {day: {psr: {hour: mw}}} for generation — one query."""
+    rows = db.execute(text("""
+        SELECT s.key,
+               strftime('%Y-%m-%d', h.ts_utc, 'unixepoch') AS day,
+               CAST(strftime('%H', h.ts_utc, 'unixepoch') AS INTEGER) AS hour,
+               h.value
+          FROM power_hourly h
+          JOIN series_dim s ON s.id = h.series_id
+          JOIN zone_dim  z ON z.id = h.zone_id
+         WHERE z.key = :zone
+           AND (s.key = 'load.actual' OR s.key LIKE 'gen.%')
+           AND strftime('%Y-%m', h.ts_utc, 'unixepoch') = :month
+    """), {"zone": zone, "month": month}).all()
+
+    load: dict[str, dict[int, float]] = defaultdict(dict)
+    gen: dict[str, dict[str, dict[int, float]]] = defaultdict(lambda: defaultdict(dict))
+    for key, day, hour, value in rows:
+        if key == "load.actual":
+            load[day][hour] = value
+        else:
+            gen[day][key.split(".", 1)[1]][hour] = value   # gen.B16 → B16
+    return load, gen
+
+
+def _months(db, zone: str) -> list[str]:
+    return [
+        m for (m,) in db.execute(text("""
+            SELECT DISTINCT strftime('%Y-%m', h.ts_utc, 'unixepoch') AS m
+              FROM power_hourly h JOIN zone_dim z ON z.id = h.zone_id
+             WHERE z.key = :zone ORDER BY m
+        """), {"zone": zone}).all()
+    ]
+
+
+def rederive(zones: list[str], *, dry_run: bool = False) -> None:
+    from backend.migrations import run_migrations
+
+    run_migrations()   # idempotent; the hour columns are what this script fills
+    db = SessionLocal()
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    worst: list[tuple[float, str, str, float, float]] = []
+    n_days = n_deleted = n_months = 0
+
+    try:
+        for zone in zones:
+            for month in _months(db, zone):
+                load_by_day, gen_by_day = _hours_by_day(db, zone, month)
+                days = set(load_by_day) | set(gen_by_day)
+
+                # A day that is not over is not a day — and the old code wrote one.
+                for unfinished in sorted(d for d in days if d >= today):
+                    if not dry_run:
+                        db.query(PowerGrid).filter_by(zone=zone, date=unfinished).delete()
+                        db.query(PowerGenMix).filter_by(zone=zone, date=unfinished).delete()
+                    n_deleted += 1
+
+                for day in days_to_derive(days):
+                    row = daily_from_hours(load_by_day.get(day, {}), gen_by_day.get(day, {}))
+                    existing = db.query(PowerGrid).filter_by(zone=zone, date=day).first()
+
+                    # Track the biggest corrections so the run can be judged, not just trusted.
+                    if existing and existing.solar_mw and row["solar_mw"]:
+                        drift = abs(existing.solar_mw - row["solar_mw"]) / existing.solar_mw
+                        worst.append((drift, zone, day, existing.solar_mw, row["solar_mw"]))
+
+                    if not dry_run:
+                        target = existing or PowerGrid(date=day, zone=zone)
+                        target.load_mw = row["load_mw"]
+                        target.wind_mw = row["wind_mw"]
+                        target.solar_mw = row["solar_mw"]
+                        target.residual_mw = row["residual_mw"]
+                        target.load_hours = row["load_hours"]
+                        target.gen_hours = row["gen_hours"]
+                        if existing is None:
+                            db.add(target)
+
+                        for code, mean_mw in row["mix"].items():
+                            label = PSR_LABELS.get(code, code)
+                            mix_row = (
+                                db.query(PowerGenMix)
+                                .filter_by(zone=zone, date=day, psr_type=label)
+                                .first()
+                            )
+                            if mix_row:
+                                mix_row.gen_mw = mean_mw
+                            else:
+                                db.add(PowerGenMix(date=day, zone=zone,
+                                                   psr_type=label, gen_mw=mean_mw))
+                    n_days += 1
+
+                if not dry_run:
+                    db.commit()
+                n_months += 1
+                if n_months % CHECKPOINT_EVERY == 0:
+                    if not dry_run:
+                        db.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
+                        db.commit()
+                    logger.info("… %s %s · %d days · WAL %.0f MB", zone, month, n_days, _wal_mb())
+
+        if not dry_run:
+            db.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
+            db.commit()
+    finally:
+        db.close()
+
+    worst.sort(reverse=True)
+    logger.info("%s: %d days re-derived, %d unfinished days dropped",
+                "DRY RUN" if dry_run else "done", n_days, n_deleted)
+    logger.info("Biggest solar corrections (old → new daily mean):")
+    seen: set[str] = set()
+    for drift, zone, day, old, new in worst:
+        if zone in seen:
+            continue
+        seen.add(zone)
+        logger.info("   %-16s %s  %8.0f → %8.0f MW  (%.0f%%)", zone, day, old, new, drift * 100)
+        if len(seen) >= 10:
+            break
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--zones", nargs="*", default=list(POWER_ZONES))
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    rederive(args.zones, dry_run=args.dry_run)

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from backend.models.energy import PowerGrid, PowerPriceDaily
 from backend.power.coverage import renewable_share_reliable
+from backend.power.daily import HOURS_PER_DAY
 from backend.power.dunkelflaute import ABSOLUTE_THRESHOLD
 from backend.power.entsoe_grid import PSR_LABELS
 from backend.signals.detectors.base import DetectorResult, trailing_zscore
@@ -89,9 +90,17 @@ def detect_dunkelflaute(db) -> list[DetectorResult]:
     thresholds_by_month: dict[str, dict] = {}
 
     for zone in zones:
+        # The newest day the zone can actually be judged on: a full day of load, and generation
+        # reported in every hour of it. power_grid holds only finished days now (power/daily.py),
+        # but a finished day can still have a hole in its feed — and a hole read as zeros is a
+        # Dunkelflaute made of nothing.
         row = (
             db.query(PowerGrid)
-            .filter(PowerGrid.zone == zone)
+            .filter(
+                PowerGrid.zone == zone,
+                PowerGrid.load_hours == HOURS_PER_DAY,
+                PowerGrid.gen_hours == HOURS_PER_DAY,
+            )
             .order_by(PowerGrid.date.desc())
             .first()
         )

--- a/backend/signals/user_alert_rules.py
+++ b/backend/signals/user_alert_rules.py
@@ -28,6 +28,7 @@ from backend.models.energy import PowerGrid, PowerPriceDaily, SparkSpreadHistory
 from backend.models.gas import GasBalance
 from backend.models.vessels import FloatingStorageEvent, GeofenceEvent
 from backend.power.coverage import renewable_share_reliable
+from backend.power.daily import HOURS_PER_DAY
 from backend.power.zones import POWER_ZONES
 from backend.signals.detectors.base import trailing_zscore
 from backend.signals.detectors.power import (
@@ -357,9 +358,15 @@ def evaluate_dunkelflaute(
     except (TypeError, ValueError):
         threshold = DUNKELFLAUTE_THRESHOLD
 
+    # The newest day this can be asked of: a full day of load, generation in every hour of it
+    # (see power/daily.py). A rule that fires on a half-published day fires on the clock.
     row = (
         db.query(PowerGrid)
-        .filter(PowerGrid.zone == zone)
+        .filter(
+            PowerGrid.zone == zone,
+            PowerGrid.load_hours == HOURS_PER_DAY,
+            PowerGrid.gen_hours == HOURS_PER_DAY,
+        )
         .order_by(PowerGrid.date.desc())
         .first()
     )

--- a/backend/tests/test_alert_rules.py
+++ b/backend/tests/test_alert_rules.py
@@ -208,7 +208,7 @@ def test_crack_spread_breach_no_trigger_within_band(db_session):
 
 def test_dunkelflaute_triggers_with_full_coverage(db_session):
     d = "2026-05-20"
-    db_session.add(PowerGrid(date=d, zone="DE_LU", load_mw=60000, wind_mw=3000, solar_mw=2000))  # ~8%
+    db_session.add(PowerGrid(date=d, zone="DE_LU", load_mw=60000, wind_mw=3000, solar_mw=2000, load_hours=24, gen_hours=24))  # ~8%
     # Reported generation ≈ load → coverage OK → the low share is real.
     db_session.add(PowerGenMix(date=d, zone="DE_LU", psr_type="Fossil Gas", gen_mw=40000))
     db_session.add(PowerGenMix(date=d, zone="DE_LU", psr_type="Nuclear", gen_mw=15000))
@@ -223,7 +223,7 @@ def test_dunkelflaute_triggers_with_full_coverage(db_session):
 
 def test_dunkelflaute_suppressed_on_incomplete_coverage(db_session):
     d = "2026-05-20"
-    db_session.add(PowerGrid(date=d, zone="NL", load_mw=10000, wind_mw=70, solar_mw=60))  # ~1.3%
+    db_session.add(PowerGrid(date=d, zone="NL", load_mw=10000, wind_mw=70, solar_mw=60, load_hours=24, gen_hours=24))  # ~1.3%
     db_session.add(PowerGenMix(date=d, zone="NL", psr_type="Fossil Gas", gen_mw=3400))  # total < 60% of load
     db_session.commit()
     res = user_alert_rules.evaluate_dunkelflaute(db_session, {"zone": "NL"}, now=NOW)

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -343,7 +343,7 @@ def _seed_dunkelflaute_history(db, zone="DE_LU", *, normal_share=0.40, years=3):
 def test_dunkelflaute_warns(db_session):
     """The real thing: a zone with a 40% normal renewable share dropping to 8%."""
     _seed_dunkelflaute_history(db_session)
-    db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000, wind_mw=3000, solar_mw=2000))  # ~8%
+    db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000, wind_mw=3000, solar_mw=2000, load_hours=24, gen_hours=24))  # ~8%
     # Complete generation coverage (~60 GW ≈ load) → the low renewable share is real.
     db_session.add(PowerGenMix(date="2026-06-24", zone="DE_LU", psr_type="Fossil Gas", gen_mw=40000))
     db_session.add(PowerGenMix(date="2026-06-24", zone="DE_LU", psr_type="Nuclear", gen_mw=15000))
@@ -357,7 +357,7 @@ def test_dunkelflaute_warns(db_session):
 
 def test_dunkelflaute_high_renewables_suppressed(db_session):
     _seed_dunkelflaute_history(db_session)
-    db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000, wind_mw=30000, solar_mw=15000))  # 75%
+    db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000, wind_mw=30000, solar_mw=15000, load_hours=24, gen_hours=24))  # 75%
     db_session.commit()
     assert detect_dunkelflaute(db_session) == []
 
@@ -378,7 +378,7 @@ def test_a_hydro_zone_is_never_in_a_dunkelflaute(db_session):
         # Pure hydro: a 2% renewable share, every day, forever. Nothing here is an event.
         db_session.add(PowerGrid(date=d.isoformat(), zone="NO5", load_mw=10_000,
                                  wind_mw=200, solar_mw=0))
-    db_session.add(PowerGrid(date="2026-06-24", zone="NO5", load_mw=10_000, wind_mw=0, solar_mw=0))
+    db_session.add(PowerGrid(date="2026-06-24", zone="NO5", load_mw=10_000, wind_mw=0, solar_mw=0, load_hours=24, gen_hours=24))
     db_session.commit()
 
     assert detect_dunkelflaute(db_session) == [], "0% of load is NO5's normal, not its emergency"
@@ -387,7 +387,7 @@ def test_a_hydro_zone_is_never_in_a_dunkelflaute(db_session):
 def test_a_zone_with_no_history_for_this_month_makes_no_claim(db_session):
     """Without a same-month record there is no tail to be in, so there is nothing to say."""
     db_session.add(PowerGrid(date="2026-06-24", zone="DE_LU", load_mw=60000,
-                             wind_mw=3000, solar_mw=2000))
+                             wind_mw=3000, solar_mw=2000, load_hours=24, gen_hours=24))
     db_session.commit()
     assert detect_dunkelflaute(db_session) == []
 
@@ -526,7 +526,7 @@ def test_dunkelflaute_suppressed_on_incomplete_coverage(db_session):
     d = date.today().isoformat()
     # Load 10 GW, wind+solar ~1% → would flag. But the generation mix only reports
     # ~4.8 GW total (<60% of load) → coverage too low to trust the share → suppress.
-    db_session.add(PowerGrid(date=d, zone="NL", load_mw=10000, wind_mw=70, solar_mw=60))
+    db_session.add(PowerGrid(date=d, zone="NL", load_mw=10000, wind_mw=70, solar_mw=60, load_hours=24, gen_hours=24))
     db_session.add(PowerGenMix(date=d, zone="NL", psr_type="Fossil Gas", gen_mw=3400))
     db_session.add(PowerGenMix(date=d, zone="NL", psr_type="Hard Coal", gen_mw=1360))
     db_session.commit()
@@ -536,7 +536,7 @@ def test_dunkelflaute_suppressed_on_incomplete_coverage(db_session):
 def test_dunkelflaute_suppressed_when_no_generation_mix(db_session):
     # Grid present but no generation-mix rows at all → cannot validate coverage → suppress.
     d = date.today().isoformat()
-    db_session.add(PowerGrid(date=d, zone="NL", load_mw=10000, wind_mw=70, solar_mw=60))
+    db_session.add(PowerGrid(date=d, zone="NL", load_mw=10000, wind_mw=70, solar_mw=60, load_hours=24, gen_hours=24))
     db_session.commit()
     assert detect_dunkelflaute(db_session) == []
 

--- a/backend/tests/test_daily_from_hours.py
+++ b/backend/tests/test_daily_from_hours.py
@@ -1,0 +1,114 @@
+"""A day is 24 hours, and a mean divides by the day — not by the points that happened to arrive.
+
+`parse_load` and `parse_generation_by_type` built the daily tables with `sum(vals) / len(vals)`:
+the mean over the points ENTSO-E PUBLISHED. That is three bugs wearing one coat.
+
+1. THE CURRENT DAY. At 10:31 UTC the record holds nine hours, and their mean was stored as the
+   day. The radar read it and announced "PT: Dunkelflaute — renewables 11% of load"; by the
+   afternoon PT was at 22%, because the sun had come up. The alert was an artifact of a half-full
+   day, not an event.
+
+2. THE MISSING ZEROS. Several zones do not publish solar at night — PT sends 18 points, not 24.
+   Dividing by 18 states the mean of the DAYLIGHT hours and calls it the day: PT's 2026-07-13
+   solar was stored as 1619 MW when the day's true mean is 1147. A third too high, on a settled
+   day, throughout the history — which lifts the renewable share, sinks the residual load, and
+   feeds both into the Dunkelflaute predicate and every z-score on the desk.
+
+3. THE DOUBLE COUNT. The daily parse appended every Point in the document, including the ones a
+   revised, overlapping period restates; the hourly parse averaged per hour. So the daily table
+   and the canonical hourly store disagreed about the same day (DE-LU solar: 19,988 vs 19,364).
+
+All three come from the same decision: the daily tables were built by a SECOND parse of the XML
+instead of being derived from the hourly store. They are derived from it now, and this is the rule.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.power.daily import HOURS_PER_DAY, daily_from_hours
+
+# PT, 2026-07-13, as it actually sits in the store: solar published 05:00-22:00 UTC only.
+PT_SOLAR = {h: v for h, v in zip(range(5, 23), [
+    120, 700, 1600, 2600, 3300, 3700, 3800, 3700, 3400, 2900, 2300, 1700, 1100, 500, 90, 5, 0, 0,
+], strict=True)}
+
+
+def test_a_fuel_that_is_dark_at_night_is_averaged_over_the_whole_day():
+    """The 18 published points are the daylight ones. The other six are not missing data — they
+    are the nights ENTSO-E does not bother to send, and a solar farm at 03:00 produces zero."""
+    row = daily_from_hours(load_hours={h: 6000.0 for h in range(24)},
+                           gen_hours={"B16": PT_SOLAR})
+
+    published_mean = sum(PT_SOLAR.values()) / len(PT_SOLAR)
+    day_mean = sum(PT_SOLAR.values()) / HOURS_PER_DAY
+
+    assert row["solar_mw"] == pytest.approx(day_mean, abs=0.5)
+    assert row["solar_mw"] < published_mean * 0.8, "the old rule was a third too high"
+
+
+def test_load_is_averaged_over_the_hours_it_has():
+    """Load is never zero, so an absent hour is a HOLE, not a zero — averaging it in as one would
+    invent a demand collapse. Its mean is the mean of what was published; the hour count says how
+    much that was."""
+    row = daily_from_hours(load_hours={h: 6000.0 for h in range(20)}, gen_hours={})
+
+    assert row["load_mw"] == pytest.approx(6000.0)
+    assert row["load_hours"] == 20
+
+
+def test_the_row_carries_the_hours_behind_it():
+    """Completeness is data, not a guess: the desk and the radar refuse to judge a day whose
+    generation feed has holes, and this is what they read."""
+    row = daily_from_hours(
+        load_hours={h: 6000.0 for h in range(24)},
+        gen_hours={"B16": PT_SOLAR, "B19": {h: 500.0 for h in range(24)}},
+    )
+
+    assert row["load_hours"] == 24
+    # Wind publishes through the night, so every hour of the day has generation in it: the solar
+    # gaps are the unsent zeros, not a feed that fell over.
+    assert row["gen_hours"] == 24
+
+
+def test_a_generation_feed_with_a_real_hole_is_visible_as_one():
+    """If NOTHING is published for an hour, that hour is unaccounted for — and the row says so."""
+    row = daily_from_hours(
+        load_hours={h: 6000.0 for h in range(24)},
+        gen_hours={"B16": {h: 100.0 for h in range(12)}, "B19": {h: 500.0 for h in range(12)}},
+    )
+
+    assert row["gen_hours"] == 12
+
+
+def test_residual_is_load_minus_the_day_means():
+    row = daily_from_hours(
+        load_hours={h: 10_000.0 for h in range(24)},
+        gen_hours={"B16": {h: 2_400.0 for h in range(24)},           # 2400 MW day mean
+                   "B18": {h: 600.0 for h in range(24)},             # wind offshore
+                   "B19": {h: 1_000.0 for h in range(24)}},          # wind onshore
+    )
+
+    assert row["wind_mw"] == pytest.approx(1_600.0)
+    assert row["solar_mw"] == pytest.approx(2_400.0)
+    assert row["residual_mw"] == pytest.approx(6_000.0)
+
+
+def test_a_zone_that_publishes_no_load_makes_no_residual():
+    """IE-SEM has published no A65 load since 2025-10-23. Its generation is still real; its
+    residual is not a number anyone has."""
+    row = daily_from_hours(load_hours={}, gen_hours={"B19": {h: 900.0 for h in range(24)}})
+
+    assert row["load_mw"] is None
+    assert row["residual_mw"] is None
+    assert row["load_hours"] == 0
+    assert row["wind_mw"] == pytest.approx(900.0)
+
+
+def test_the_mix_carries_every_fuel_by_the_same_rule():
+    row = daily_from_hours(
+        load_hours={h: 5_000.0 for h in range(24)},
+        gen_hours={"B16": PT_SOLAR, "B04": {h: 1_200.0 for h in range(24)}},
+    )
+
+    assert row["mix"]["B04"] == pytest.approx(1_200.0)
+    assert row["mix"]["B16"] == pytest.approx(sum(PT_SOLAR.values()) / HOURS_PER_DAY, abs=0.5)

--- a/backend/tests/test_dunkelflaute_parity.py
+++ b/backend/tests/test_dunkelflaute_parity.py
@@ -53,6 +53,7 @@ def _seed(
     dates: list[str],
     load: float = 50_000.0,
     coverage: bool = True,
+    gen_hours: int = 24,
 ) -> None:
     """One grid day per share, with matching A75 generation so the coverage guard is satisfied.
 
@@ -61,7 +62,8 @@ def _seed(
     """
     for day, share in zip(dates, shares, strict=True):
         db.add(PowerGrid(date=day, zone=zone, load_mw=load,
-                         wind_mw=load * share * 0.6, solar_mw=load * share * 0.4))
+                         wind_mw=load * share * 0.6, solar_mw=load * share * 0.4,
+                         load_hours=24, gen_hours=gen_hours))
         if coverage:
             # Reported generation ≈ load → coverage ratio 1.0, comfortably over the 0.6 floor.
             db.add(PowerGenMix(date=day, zone=zone, psr_type="Fossil Gas", gen_mw=load))
@@ -165,3 +167,20 @@ def test_the_situation_hero_agrees_with_the_radar(db_session):
 
     assert body["grid"]["dunkelflaute"] is False
     assert [f for f in body["flags"] if f["key"] == "dunkelflaute"] == []
+
+
+def test_a_day_with_a_hole_in_its_generation_feed_is_not_judged(db_session):
+    """A settled day can still be a broken one. If a zone's generation feed stops for six hours,
+    those hours are unaccounted for — and a daily mean that reads them as zeros manufactures a
+    dark day out of an outage. Both surfaces must stay silent, not agree on a fiction."""
+    from backend.signals.detectors.power import detect_dunkelflaute
+
+    hist = _same_month_history(70)
+    _seed(db_session, FLEET, [0.40] * len(hist), dates=hist)
+    _seed(db_session, FLEET, [0.05], dates=[_dark_day()], gen_hours=18)
+
+    body = _make_client(db_session).get(f"/api/power/grid?zone={FLEET}&days=120").json()
+
+    assert body["latest"]["dunkelflaute"] is False
+    assert body["latest"]["gen_hours"] == 18, "the hole is visible in the row, not hidden"
+    assert {r.zone for r in detect_dunkelflaute(db_session)} == set(), "the radar keeps quiet too"

--- a/backend/tests/test_power_grid.py
+++ b/backend/tests/test_power_grid.py
@@ -342,3 +342,65 @@ async def test_ingest_keeps_pumping_out_of_the_generation_mix(db_session, monkey
 
     assert read_hourly(db_session, "gen.B10", "DE_LU")[0][1] == 1_253.0
     assert read_hourly(db_session, "consumption.B10", "DE_LU")[0][1] == 1_579.0
+
+
+# ── the daily tables are derived from the hourly shape (power/daily.py) ───────
+
+
+async def test_a_day_that_is_not_over_is_not_a_day(db_session, monkeypatch):
+    """The radar read the newest PowerGrid row and announced "PT: Dunkelflaute — renewables 11%
+    of load" at breakfast; by the afternoon PT was at 22%, because the sun had come up. The row
+    was the mean of the nine hours that had been published. A day that is not finished is not a
+    day, and the ingest no longer writes one — which fixes every consumer of "the latest row" at
+    once, without any of them having to know."""
+    from datetime import UTC, datetime
+
+    from pydantic import SecretStr
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    yesterday_dt = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    yesterday = (yesterday_dt.toordinal() - 1)
+    yesterday = datetime.fromordinal(yesterday).strftime("%Y-%m-%d")
+
+    load_xml = _a65(_load_ts(f"{yesterday}T00:00Z", 50_000.0) + _load_ts(f"{today}T00:00Z", 51_000.0, n=9))
+    gen_xml = _a75_gen(_gen_ts("B16", f"{yesterday}T00:00Z", 5_000.0) + _gen_ts("B16", f"{today}T00:00Z", 1_000.0, n=9))
+
+    async def fake_fetch(eic, month_start, doctype, extra_params, *, overwrite=False):
+        return load_xml if doctype == "A65" else gen_xml if doctype == "A75" else ""
+
+    monkeypatch.setattr(grid_mod, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", SecretStr("test-token"))
+
+    await grid_mod.ingest_grid(db_session, [yesterday, today])
+
+    days = {r.date for r in db_session.query(PowerGrid).filter_by(zone="DE_LU").all()}
+    assert yesterday in days
+    assert today not in days, "the current day is a running total, not a daily mean"
+
+
+async def test_a_fuel_that_is_only_published_by_day_is_averaged_over_the_whole_day(db_session, monkeypatch):
+    """PT publishes solar for 18 hours and nothing at night. The old daily parse divided by 18 and
+    stored the mean of the DAYLIGHT hours as the day's — a third too high, on a settled day, right
+    through the history. The hours it does not send are zeros: the sun is down."""
+    from pydantic import SecretStr
+
+    day = "2026-04-01"
+    # Solar: 3000 MW for 18 hours, nothing published for the other six.
+    gen_xml = _a75_gen(
+        _gen_ts("B16", f"{day}T05:00Z", 3_000.0, n=18)
+        + _gen_ts("B19", f"{day}T00:00Z", 1_000.0)     # wind reports all night → the day IS covered
+    )
+    load_xml = _a65(_load_ts(f"{day}T00:00Z", 6_000.0))
+
+    async def fake_fetch(eic, month_start, doctype, extra_params, *, overwrite=False):
+        return load_xml if doctype == "A65" else gen_xml if doctype == "A75" else ""
+
+    monkeypatch.setattr(grid_mod, "_fetch_zone_month", fake_fetch)
+    monkeypatch.setattr(grid_mod.settings, "entsoe_api_token", SecretStr("test-token"))
+
+    await grid_mod.ingest_grid(db_session, [day])
+
+    row = db_session.query(PowerGrid).filter_by(date=day, zone="DE_LU").first()
+    assert row.solar_mw == 3_000.0 * 18 / 24 == 2_250.0, "divided by the day, not by the points"
+    assert row.load_hours == 24
+    assert row.gen_hours == 24, "wind reports through the night — the day has no hole in it"

--- a/backend/tests/test_power_grid_route.py
+++ b/backend/tests/test_power_grid_route.py
@@ -39,6 +39,9 @@ def _make_row(**kwargs) -> SimpleNamespace:
         load_mw=kwargs.get("load_mw", None),
         wind_mw=kwargs.get("wind_mw", None),
         solar_mw=kwargs.get("solar_mw", None),
+        # A settled day, unless a test says otherwise: 24 hours of load, generation in each of them.
+        load_hours=kwargs.get("load_hours", 24),
+        gen_hours=kwargs.get("gen_hours", 24),
     )
 
 
@@ -126,6 +129,8 @@ def _seed_grid(db: Session, rows: list[dict]) -> None:
                 load_mw=r.get("load_mw"),
                 wind_mw=r.get("wind_mw"),
                 solar_mw=r.get("solar_mw"),
+                load_hours=r.get("load_hours", 24),
+                gen_hours=r.get("gen_hours", 24),
             )
         )
     db.commit()


### PR DESCRIPTION
Follow-on to #105, found while verifying it in production: the radar announced
**"PT: Dunkelflaute — renewables 11% of load"** at breakfast, and by the afternoon PT sat at 22%,
because the sun had come up. Nothing had happened. The day had.

Chasing that turned up three bugs with one root: `power_grid` and `power_gen_mix` were built by a
**second parse of the ENTSO-E XML**, with `sum(points) / len(points)` as the daily mean — the mean
over the points that happened to have arrived.

| | what it did | evidence (production DB) |
|---|---|---|
| **The current day** | stored as a day, and every consumer of "the latest row" read it as one | 2026-07-14, 10:31 UTC: load had 9 of 24 hours |
| **Missing zeros** | zones that omit solar at night were made sunnier than they are | PT 2026-07-13 solar stored **1619 MW**; the day's mean is **1147** (+33%, on a SETTLED day, throughout the history) |
| **Revised points** | counted twice, so the daily table and the hourly store disagreed about the same day | DE-LU solar 2026-07-13: 19,988 (daily table) vs 19,364 (hourly store) |

The second is the serious one: it lifts the renewable share and sinks the residual load for every
affected zone — the two numbers the Dunkelflaute predicate and the desk's z-scores are built from.

## The rule (`backend/power/daily.py`)

- **Generation is averaged over the DAY** (24 UTC hours). An hour with no point is a zero the
  publisher did not send: a solar farm at 03:00 produces zero and everyone knows it.
- **Load is averaged over the hours it HAS.** Load is never zero, so an absent hour is a hole, not
  a zero, and averaging it in as one would invent a demand collapse.
- **`gen_hours` counts the hours in which ANY fuel reported.** That is what tells "PT omits solar
  at night" (wind and gas still report) from "the feed fell over for six hours" (nothing does).
- **Only finished days become rows.** A day that is not over is not a day — which fixes the radar,
  the hero, the matrix, `/grid`, the episodes and the alert rules at the source, without any of
  them having to know.
- A **share** is claimed only on a day with 24 hours of load AND generation in every one of them.

The forecast ingest had the same denominator (forecasting a sun that shines all night) and now
follows the same rule.

## Repair

`backend/scripts/rederive_daily.py` rebuilds the history from the hourly store — no API calls, WAL
checkpoints every 20 zone-months (the last full backfill took this VPS's disk from 70% to 90%).
Verified first that `power_hourly` covers the daily history exactly: same first day, same day count,
all 37 zones — nothing is lost by deriving the days from it.

**Deploy order matters:** between the deploy and the re-derivation every row has NULL hour counts,
so no share is claimed anywhere — the fail-safe direction, and it lasts only as long as the script
runs.

## Verification

- 972 backend tests pass; the two new ingest tests were confirmed to FAIL on the old code
  (today's row written; solar 3000 where the day's mean is 2250)
- ruff clean
- Every measurement above is from the production database, not from a fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)