### PR TITLE
Four fuel-color maps disagreed, and the fallback cycled through orange

### DIFF
--- a/frontend/src/components/CapturePanel.jsx
+++ b/frontend/src/components/CapturePanel.jsx
@@ -5,19 +5,9 @@ import {
   ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine, Legend,
 } from 'recharts'
 import { CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fuelColor } from '../utils/fuels'
 
 const API = '/api'
-
-/** One colour per technology, held across the table and the chart. */
-const FUEL_COLOR = {
-  B16: '#fbbf24',  // solar
-  B19: '#22d3ee',  // wind onshore
-  B18: '#38bdf8',  // wind offshore
-  B11: '#2dd4bf',  // hydro run-of-river
-  B12: '#4ade80',  // hydro reservoir
-  B14: '#a78bfa',  // nuclear
-  B04: '#f87171',  // fossil gas
-}
 
 /**
  * Capture rate — what a MWh of each technology actually earned.
@@ -106,7 +96,7 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
                 {fuels.map((f) => {
                   const L = f.latest
                   const vf = L.value_factor
-                  const color = FUEL_COLOR[f.psr] || '#94a3b8'
+                  const color = fuelColor(f.psr)
                   return (
                     <tr key={f.psr} className="border-t border-border/30">
                       <td className="px-2 py-1.5 text-neutral-300">
@@ -168,7 +158,7 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
                   <Legend wrapperStyle={{ fontSize: 9, color: '#737373' }} iconSize={6} />
                   {fuels.map((f) => (
                     <Line key={f.psr} type="monotone" dataKey={f.psr} name={f.label}
-                      stroke={FUEL_COLOR[f.psr] || '#94a3b8'} strokeWidth={1.4}
+                      stroke={fuelColor(f.psr)} strokeWidth={1.4}
                       dot={false} connectNulls isAnimationActive={false} />
                   ))}
                 </LineChart>

--- a/frontend/src/components/DurationCurvePanel.jsx
+++ b/frontend/src/components/DurationCurvePanel.jsx
@@ -7,7 +7,7 @@ import PanelTakeaway from './PanelTakeaway'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS } from '../utils/chart'
 
 const API = '/api'
 const MAX_POINTS = 2000
@@ -78,7 +78,7 @@ export default function DurationCurvePanel({ zone = 'DE_LU' }) {
               <XAxis dataKey="pct" tick={{ fontSize: 8, fill: '#737373' }} unit="%" type="number" domain={[0, 100]} />
               <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={40} />
               {metric === 'price' && <ReferenceLine y={0} stroke="#444" />}
-              <Tooltip {...CHART_TOOLTIP_STYLE}
+              <Tooltip {...CHART_TOOLTIP_PROPS}
                 labelFormatter={(p) => `${p}% of hours`}
                 formatter={(v) => [`${Number(v).toFixed(1)} ${m.unit}`, m.label]} />
               <Area type="monotone" dataKey="v" stroke={m.color} fill={m.color} fillOpacity={0.08} strokeWidth={1.5} dot={false} />

--- a/frontend/src/components/GenMixHistoryPanel.jsx
+++ b/frontend/src/components/GenMixHistoryPanel.jsx
@@ -6,19 +6,10 @@ import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fuelColor, sortFuels } from '../utils/fuels'
 
 const API = '/api'
-
-// Readable ENTSO-E fuel label → colour; anything unmapped falls back to the cycle.
-const FUEL_COLORS = {
-  Solar: '#facc15', 'Wind Onshore': '#22d3ee', 'Wind Offshore': '#0ea5e9',
-  'Fossil Gas': '#f97316', 'Hard Coal': '#78716c', 'Fossil Brown coal/Lignite': '#92400e',
-  Nuclear: '#a855f7', 'Hydro Water Reservoir': '#3b82f6', 'Hydro Run-of-river and poundage': '#60a5fa',
-  'Hydro Pumped Storage': '#2563eb', Biomass: '#84cc16', 'Fossil Oil': '#525252',
-  Waste: '#a3a3a3', Geothermal: '#ef4444', Other: '#9ca3af', 'Other renewable': '#4ade80',
-}
-const CYCLE = ['#f472b6', '#fb923c', '#34d399', '#818cf8', '#e879f9', '#fbbf24']
 
 export default function GenMixHistoryPanel({ zone = 'DE_LU' }) {
   const { range } = useViewState()
@@ -28,7 +19,6 @@ export default function GenMixHistoryPanel({ zone = 'DE_LU' }) {
   const url = `${API}/v1/genmix?zone=${zone}&start=${start}&resolution=monthly`
   const { data: resp, loading } = useFetchWithError(url, { deps: [zone, start] })
 
-  const colorFor = (fuel, i) => FUEL_COLORS[fuel] || CYCLE[i % CYCLE.length]
   // Convert MW → GW for readability without mutating source rows.
   const { chart, fuels } = useMemo(() => {
     const f = resp?.fuels || []
@@ -37,7 +27,7 @@ export default function GenMixHistoryPanel({ zone = 'DE_LU' }) {
       for (const fuel of f) if (row[fuel] != null) o[fuel] = Math.round((row[fuel] / 1000) * 10) / 10
       return o
     })
-    return { chart, fuels: f }
+    return { chart, fuels: sortFuels(f) }
   }, [resp])
 
   if (!loading && (!resp?.available || fuels.length === 0)) return null
@@ -59,11 +49,11 @@ export default function GenMixHistoryPanel({ zone = 'DE_LU' }) {
               <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
               <XAxis dataKey="t" tick={{ fontSize: 8, fill: '#737373' }} minTickGap={30} />
               <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={34} unit="" />
-              <Tooltip {...CHART_TOOLTIP_STYLE} formatter={(v, n) => [`${Number(v).toFixed(1)} GW`, n]} />
+              <Tooltip {...CHART_TOOLTIP_PROPS} formatter={(v, n) => [`${Number(v).toFixed(1)} GW`, n]} />
               <Legend wrapperStyle={{ fontSize: 8, fontFamily: 'monospace' }} iconSize={7} />
-              {fuels.map((f, i) => (
-                <Area key={f} type="monotone" dataKey={f} stackId="1" stroke={colorFor(f, i)}
-                  fill={colorFor(f, i)} fillOpacity={0.65} strokeWidth={0.5} />
+              {fuels.map((f) => (
+                <Area key={f} type="monotone" dataKey={f} stackId="1" stroke={fuelColor(f)}
+                  fill={fuelColor(f)} fillOpacity={0.65} strokeWidth={0.5} />
               ))}
             </AreaChart>
           </ResponsiveContainer>

--- a/frontend/src/components/GenerationMixPanel.jsx
+++ b/frontend/src/components/GenerationMixPanel.jsx
@@ -6,31 +6,10 @@ import { rangeDays, rangeStart } from '../utils/ranges'
 import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fuelColor, sortFuels } from '../utils/fuels'
 
 const API = '/api'
-
-// Color palette: darker for firm/dispatchable; brighter for renewables/hydro
-const TYPE_COLORS = {
-  'Nuclear':             '#c084fc', // violet
-  'Lignite':             '#78716c', // stone (dark)
-  'Hard Coal':           '#57534e', // stone (darker)
-  'Fossil Gas':          '#6b7280', // gray
-  'Oil':                 '#44403c', // very dark
-  'Biomass':             '#4ade80', // green
-  'Geothermal':          '#fb923c', // orange
-  'Hydro Pumped Storage':'#38bdf8', // sky
-  'Hydro Run-of-river':  '#0ea5e9', // sky darker
-  'Hydro Reservoir':     '#0284c7', // blue
-  'Other Renewable':     '#a3e635', // lime
-  'Solar':               '#fbbf24', // amber
-  'Waste':               '#a8a29e', // stone light
-  'Wind Offshore':       '#22d3ee', // cyan
-  'Wind Onshore':        '#67e8f9', // cyan lighter
-  'Other':               '#374151', // gray dark
-}
-
-const DEFAULT_COLOR = '#64748b'
 
 export default function GenerationMixPanel({ zone = 'DE_LU' }) {
   const { range } = useViewState()
@@ -55,7 +34,7 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
 
   const rows = data?.data ?? []
   const latest = data?.latest
-  const types = data?.types ?? []
+  const types = sortFuels(data?.types ?? [])
 
   // Top type by generation in latest snapshot
   const topType = latest
@@ -105,7 +84,7 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
               {topType && (
                 <span
                   className="font-mono text-[10px] font-semibold"
-                  style={{ color: TYPE_COLORS[topType] ?? DEFAULT_COLOR }}
+                  style={{ color: fuelColor(topType) }}
                 >
                   top: {topType} ({((latest[topType] / latest.total_mw) * 100).toFixed(1)}%)
                 </span>
@@ -135,7 +114,7 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
                     tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
                   />
                   <Tooltip
-                    contentStyle={CHART_TOOLTIP_STYLE}
+                    {...CHART_TOOLTIP_PROPS}
                     formatter={(v, name) => [`${Math.round(v).toLocaleString()} MW`, name]}
                     labelFormatter={fmtDate}
                   />
@@ -146,8 +125,8 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
                       dataKey={type}
                       name={type}
                       stackId="mix"
-                      stroke={TYPE_COLORS[type] ?? DEFAULT_COLOR}
-                      fill={TYPE_COLORS[type] ?? DEFAULT_COLOR}
+                      stroke={fuelColor(type)}
+                      fill={fuelColor(type)}
                       fillOpacity={0.18}
                       strokeWidth={1}
                       dot={false}
@@ -160,7 +139,7 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
               {/* Legend — two rows max, 8 per row */}
               <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 mt-1 font-mono text-[8px] text-neutral-600">
                 {types.map((type) => (
-                  <span key={type} style={{ color: TYPE_COLORS[type] ?? DEFAULT_COLOR }}>
+                  <span key={type} style={{ color: fuelColor(type) }}>
                     ▬ {type}
                   </span>
                 ))}

--- a/frontend/src/components/MeritOrderScatter.jsx
+++ b/frontend/src/components/MeritOrderScatter.jsx
@@ -7,7 +7,7 @@ import PanelTakeaway from './PanelTakeaway'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS } from '../utils/chart'
 
 const API = '/api'
 const MAX_POINTS = 4000
@@ -69,7 +69,7 @@ export default function MeritOrderScatter({ zone = 'DE_LU' }) {
                 label={{ value: 'Residual load (GW)', position: 'insideBottom', offset: -4, fontSize: 8, fill: '#737373' }} />
               <YAxis type="number" dataKey="y" name="Price" unit=" €" tick={{ fontSize: 8, fill: '#737373' }} width={40} />
               <ReferenceLine y={0} stroke="#444" />
-              <Tooltip {...CHART_TOOLTIP_STYLE} cursor={{ strokeDasharray: '3 3' }}
+              <Tooltip {...CHART_TOOLTIP_PROPS} cursor={{ strokeDasharray: '3 3' }}
                 formatter={(v, n) => [n === 'Price' ? `${Number(v).toFixed(1)} €/MWh` : `${Number(v).toFixed(1)} GW`, n]} />
               <Scatter data={points} fill="#22d3ee" fillOpacity={0.35} />
             </ScatterChart>

--- a/frontend/src/components/MiniMixCard.jsx
+++ b/frontend/src/components/MiniMixCard.jsx
@@ -3,19 +3,10 @@ import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianG
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fuelColor, sortFuels } from '../utils/fuels'
 
 const API = '/api'
-
-// Same fuel palette as GenMixHistoryPanel.
-const FUEL_COLORS = {
-  Solar: '#facc15', 'Wind Onshore': '#22d3ee', 'Wind Offshore': '#0ea5e9',
-  'Fossil Gas': '#f97316', 'Hard Coal': '#78716c', 'Fossil Brown coal/Lignite': '#92400e',
-  Nuclear: '#a855f7', 'Hydro Water Reservoir': '#3b82f6', 'Hydro Run-of-river and poundage': '#60a5fa',
-  'Hydro Pumped Storage': '#2563eb', Biomass: '#84cc16', 'Fossil Oil': '#525252',
-  Waste: '#a3a3a3', Geothermal: '#ef4444', Other: '#9ca3af', 'Other renewable': '#4ade80',
-}
-const CYCLE = ['#f472b6', '#fb923c', '#34d399', '#818cf8', '#e879f9', '#fbbf24']
 
 // Compact stacked generation mix per zone for the Live grid (Fuel Mix section).
 // Daily resolution, floored to 90d so the stack has shape; GW.
@@ -32,9 +23,8 @@ export default function MiniMixCard({ title, zone, height = 120 }) {
       for (const fuel of f) if (row[fuel] != null) o[fuel] = Math.round((row[fuel] / 1000) * 10) / 10
       return o
     })
-    return { chart: rows, fuels: f }
+    return { chart: rows, fuels: sortFuels(f) }
   }, [resp])
-  const colorFor = (fuel, i) => FUEL_COLORS[fuel] || CYCLE[i % CYCLE.length]
 
   return (
     <div className="border border-border bg-surface rounded overflow-hidden shadow-sm">
@@ -56,9 +46,9 @@ export default function MiniMixCard({ title, zone, height = 120 }) {
               <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
               <XAxis dataKey="t" tick={{ fontSize: 8, fill: '#737373' }} minTickGap={30} />
               <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={30} />
-              <Tooltip {...CHART_TOOLTIP_STYLE} formatter={(v, n) => [`${Number(v).toFixed(1)} GW`, n]} />
-              {fuels.map((f, i) => (
-                <Area key={f} type="monotone" dataKey={f} stackId="1" stroke={colorFor(f, i)} fill={colorFor(f, i)} fillOpacity={0.6} strokeWidth={0.5} />
+              <Tooltip {...CHART_TOOLTIP_PROPS} formatter={(v, n) => [`${Number(v).toFixed(1)} GW`, n]} />
+              {fuels.map((f) => (
+                <Area key={f} type="monotone" dataKey={f} stackId="1" stroke={fuelColor(f)} fill={fuelColor(f)} fillOpacity={0.6} strokeWidth={0.5} />
               ))}
             </AreaChart>
           </ResponsiveContainer>

--- a/frontend/src/components/PowerLoadForecastPanel.jsx
+++ b/frontend/src/components/PowerLoadForecastPanel.jsx
@@ -5,7 +5,7 @@ import useFetchWithError from '../hooks/useFetchWithError'
 import {
   ResponsiveContainer, LineChart, Line, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
-import { fmtDate, fmtHour, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, fmtHour, CHART_TOOLTIP_PROPS } from '../utils/chart'
 
 const API = '/api'
 
@@ -137,7 +137,7 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
                 <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
                 <XAxis dataKey="hour" tickFormatter={fmtHour} tick={{ fontSize: 8, fill: '#737373' }} interval={2} />
                 <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={34} unit="" />
-                <Tooltip {...CHART_TOOLTIP_STYLE} labelFormatter={(h) => `${fmtHour(h)} UTC`}
+                <Tooltip {...CHART_TOOLTIP_PROPS} labelFormatter={(h) => `${fmtHour(h)} UTC`}
                   formatter={(v, n) => [v != null ? `${Number(v).toFixed(1)} GW` : '—',
                     { residual: 'Residual', load: 'Load', wind: 'Wind', solar: 'Solar' }[n] ?? n]} />
                 <Area type="monotone" dataKey="residual" stroke={COLOR_FORECAST} fill={COLOR_FORECAST}
@@ -154,7 +154,7 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
                 <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
                 <XAxis dataKey="date" tickFormatter={fmtDate} tick={{ fontSize: 9, fill: '#737373' }} minTickGap={24} />
                 <YAxis tick={{ fontSize: 9, fill: '#737373' }} width={34} domain={['auto', 'auto']} unit="" />
-                <Tooltip {...CHART_TOOLTIP_STYLE} labelFormatter={fmtDate}
+                <Tooltip {...CHART_TOOLTIP_PROPS} labelFormatter={fmtDate}
                   formatter={(v, n) => [v != null ? `${v.toFixed(1)} GW` : '—', n === 'forecast' ? 'Forecast' : 'Actual']} />
                 <Line type="monotone" dataKey="forecast" stroke={COLOR_FORECAST} dot={false} strokeWidth={1.5} connectNulls />
                 <Line type="monotone" dataKey="actual" stroke={COLOR_ACTUAL} dot={false} strokeWidth={1.5} connectNulls />

--- a/frontend/src/components/SeriesExplorer.jsx
+++ b/frontend/src/components/SeriesExplorer.jsx
@@ -6,7 +6,7 @@ import { InfoPopover } from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS } from '../utils/chart'
 
 const API = '/api'
 const COLOR_A = '#22d3ee'
@@ -202,7 +202,7 @@ export default function SeriesExplorer() {
                 <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
                 <XAxis dataKey="t" tickFormatter={fmtT} tick={{ fontSize: 8, fill: '#737373' }} minTickGap={40} />
                 <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={44} domain={['auto', 'auto']} />
-                <Tooltip {...CHART_TOOLTIP_STYLE} labelFormatter={fmtT}
+                <Tooltip {...CHART_TOOLTIP_PROPS} labelFormatter={fmtT}
                   formatter={(v, n) => [v != null ? Number(v).toFixed(1) : '—', n === 'd' ? `${zoneLabel(zone)} − ${zoneLabel(compareZone)}` : n === 'a' ? zoneLabel(zone) : zoneLabel(compareZone)]} />
                 {showSpread ? (
                   <>

--- a/frontend/src/components/TrendsPanel.jsx
+++ b/frontend/src/components/TrendsPanel.jsx
@@ -7,7 +7,7 @@ import PanelTakeaway from './PanelTakeaway'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS } from '../utils/chart'
 
 const API = '/api'
 
@@ -85,7 +85,7 @@ export default function TrendsPanel({ zone = 'DE_LU' }) {
               <XAxis dataKey="t" tick={{ fontSize: 8, fill: '#737373' }} minTickGap={30} />
               <YAxis yAxisId="l" tick={{ fontSize: 8, fill: '#737373' }} width={30} />
               <YAxis yAxisId="r" orientation="right" tick={{ fontSize: 8, fill: '#737373' }} width={30} unit="%" domain={[0, 100]} />
-              <Tooltip {...CHART_TOOLTIP_STYLE}
+              <Tooltip {...CHART_TOOLTIP_PROPS}
                 formatter={(v, n) => [n === 'renewShare' ? `${v}%` : v, n === 'negHours' ? 'Neg-price h' : 'Renewables']} />
               <Legend wrapperStyle={{ fontSize: 8, fontFamily: 'monospace' }} iconSize={7} />
               <Bar yAxisId="l" dataKey="negHours" name="Neg-price h" fill="#f87171" fillOpacity={0.7} />

--- a/frontend/src/components/ZoneCompareChart.jsx
+++ b/frontend/src/components/ZoneCompareChart.jsx
@@ -3,7 +3,7 @@ import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianG
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_STYLE, fmtDate } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS, fmtDate } from '../utils/chart'
 
 const API = '/api'
 
@@ -113,7 +113,7 @@ export default function ZoneCompareChart({ title, series, zone, compare = [], un
               <XAxis dataKey="t" tickFormatter={fmtDate} tick={{ fontSize: 9, fill: '#737373' }} minTickGap={40} />
               <YAxis tick={{ fontSize: 9, fill: '#737373' }} width={40} domain={['auto', 'auto']} />
               <Tooltip
-                {...CHART_TOOLTIP_STYLE}
+                {...CHART_TOOLTIP_PROPS}
                 labelFormatter={fmtDate}
                 formatter={(v, name) => [v != null ? `${Number(v).toFixed(1)} ${unit}` : '—', label(name)]}
               />

--- a/frontend/src/utils/chart.js
+++ b/frontend/src/utils/chart.js
@@ -11,6 +11,17 @@ export function fmtDate(d) {
 
 export const CHART_TOOLTIP_STYLE = { background: '#0f1115', border: '1px solid #262a33', fontFamily: 'inherit', fontSize: 12, borderRadius: 8 }
 
+// Spread THESE into a recharts <Tooltip>. Spreading CHART_TOOLTIP_STYLE itself
+// passes `background` etc. as unknown Tooltip props — recharts ignores them and
+// renders its white default box on the dark desk. contentStyle is the real
+// prop; itemStyle/labelStyle keep the text in ink instead of the series color
+// (a bright series hue is unreadable as text — the mark carries identity).
+export const CHART_TOOLTIP_PROPS = {
+  contentStyle: CHART_TOOLTIP_STYLE,
+  itemStyle: { color: '#c9ccd6' },
+  labelStyle: { color: '#8b8fa3' },
+}
+
 // Hour-of-day label for the hourly day-ahead curve (0 → "00h", 13 → "13h").
 export function fmtHour(h) {
   return `${String(h).padStart(2, '0')}h`

--- a/frontend/src/utils/fuels.js
+++ b/frontend/src/utils/fuels.js
@@ -1,0 +1,119 @@
+// Canonical fuel palette — ONE source of truth for every generation-mix chart
+// (GenerationMixPanel, GenMixHistoryPanel, MiniMixCard, CapturePanel).
+//
+// Before this file each chart kept its own map, two of them keyed to raw
+// ENTSO-E names the APIs never emit — those fuels fell into an index cycle and
+// three different fuels came out near-identical orange, differently per zone.
+//
+// Rules:
+// - color follows the FUEL, never its index. No cycling: unknown fuels all get
+//   the one gray, because a made-up hue is a made-up identity.
+// - one hue per family, big lightness steps inside a family: gas=orange (the
+//   only orange), coal-derived gas=red, coal/oil=browns and grays,
+//   nuclear=violet, hydro=blues, wind=cyans, solar=yellow, biomass and other
+//   renewables=greens, geothermal=rose, marine=teal.
+// - validated with CVD simulation over adjacent pairs in STACK_ORDER against
+//   both surfaces (#0f1115 dark, #ffffff light): worst adjacent ΔE 16.5
+//   deutan / 10.7 tritan; every mix chart also names fuels in legend/tooltip,
+//   so identity is never color-alone. Waste/Oil/Other are deliberately
+//   recessive grays.
+
+// Bottom of the stack = firm/dispatchable, top = variable renewables, so the
+// stack reads the same in every zone and family neighbours keep their ΔE.
+export const STACK_ORDER = [
+  'Nuclear',
+  'Lignite',
+  'Hard Coal',
+  'Fossil Coal-derived gas',
+  'Fossil Gas',
+  'Oil',
+  'Oil Shale',
+  'Peat',
+  'Waste',
+  'Other',
+  'Biomass',
+  'Geothermal',
+  'Marine',
+  'Hydro Reservoir',
+  'Hydro Run-of-river',
+  'Hydro Pumped Storage',
+  'Other Renewable',
+  'Wind Offshore',
+  'Wind Onshore',
+  'Solar',
+]
+
+const CANONICAL = {
+  'Nuclear': '#a78bfa',
+  'Lignite': '#b45309',
+  'Hard Coal': '#a8a29e',
+  'Fossil Coal-derived gas': '#dc2626',
+  'Fossil Gas': '#fb923c',
+  'Oil': '#64748b',
+  'Oil Shale': '#78716c',
+  'Peat': '#ca8a04',
+  'Waste': '#a1a1aa',
+  'Other': '#6b7280',
+  'Biomass': '#4ade80',
+  'Geothermal': '#f43f5e',
+  'Marine': '#2dd4bf',
+  'Hydro Reservoir': '#2563eb',
+  'Hydro Run-of-river': '#60a5fa',
+  'Hydro Pumped Storage': '#6366f1',
+  'Other Renewable': '#16a34a',
+  'Wind Offshore': '#0891b2',
+  'Wind Onshore': '#67e8f9',
+  'Solar': '#facc15',
+}
+
+// The APIs emit PSR_LABELS (backend/power/entsoe_grid.py); CapturePanel keys by
+// raw B-code; old rows / other feeds may carry ENTSO-E's long names. All three
+// spellings resolve to the same canonical fuel.
+const ALIASES = {
+  B01: 'Biomass',
+  B02: 'Lignite',
+  B03: 'Fossil Coal-derived gas',
+  B04: 'Fossil Gas',
+  B05: 'Hard Coal',
+  B06: 'Oil',
+  B07: 'Oil Shale',
+  B08: 'Peat',
+  B09: 'Geothermal',
+  B10: 'Hydro Pumped Storage',
+  B11: 'Hydro Run-of-river',
+  B12: 'Hydro Reservoir',
+  B13: 'Marine',
+  B14: 'Nuclear',
+  B15: 'Other Renewable',
+  B16: 'Solar',
+  B17: 'Waste',
+  B18: 'Wind Offshore',
+  B19: 'Wind Onshore',
+  B20: 'Other',
+  'Fossil Brown coal/Lignite': 'Lignite',
+  'Fossil Hard coal': 'Hard Coal',
+  'Fossil Oil': 'Oil',
+  'Fossil Oil shale': 'Oil Shale',
+  'Fossil Peat': 'Peat',
+  'Hydro Water Reservoir': 'Hydro Reservoir',
+  'Hydro Run-of-river and poundage': 'Hydro Run-of-river',
+  'Other renewable': 'Other Renewable',
+}
+
+export const DEFAULT_FUEL_COLOR = '#6b7280'
+
+export function fuelColor(key) {
+  return CANONICAL[key] ?? CANONICAL[ALIASES[key]] ?? DEFAULT_FUEL_COLOR
+}
+
+const ORDER_INDEX = new Map(STACK_ORDER.map((label, i) => [label, i]))
+
+function orderIndex(key) {
+  return ORDER_INDEX.get(key) ?? ORDER_INDEX.get(ALIASES[key]) ?? STACK_ORDER.length
+}
+
+// Stable stack order for any fuel list the API returns (it sends them
+// alphabetically, which puts look-alike families side by side).
+export function sortFuels(fuels) {
+  return [...fuels].sort((a, b) => orderIndex(a) - orderIndex(b) || a.localeCompare(b))
+}


### PR DESCRIPTION
## What

- **One canonical fuel palette** (`frontend/src/utils/fuels.js`) replaces four diverging per-component maps. Two of them were keyed to raw ENTSO-E names the v1 API never emits (`Hydro Water Reservoir`, `Fossil Brown coal/Lignite`, …) — every unmapped fuel fell into an index-based color cycle, so *Fossil Coal-derived gas*, *Hydro Run-of-river* and *Fossil Gas* rendered as near-identical oranges, and the colors changed per zone depending on which fuels exist. Color now follows the fuel, never its index; unknown fuels get one gray.
- **Per-family hues** with big lightness steps inside a family (gas = the only orange, coal-derived gas = red, hydro = blues, wind = cyans, solar = yellow, coal/oil = browns+grays, nuclear = violet). Validated with CVD simulation over adjacent pairs in stack order against both surfaces (`#0f1115` dark, `#ffffff` light): worst adjacent ΔE 16.5 deutan / 10.7 tritan, all 20 ≥ 3:1 contrast on dark. Legend/tooltip always name the fuel, so identity is never color-alone.
- **Canonical stack order** (firm → variable) instead of the API's alphabetical order, so the stack reads the same in every zone.
- **Tooltip fix (9 call sites):** `<Tooltip {...CHART_TOOLTIP_STYLE}>` spread the style object as unknown Tooltip props — recharts ignored them and rendered its **white default tooltip** on the dark desk. New `CHART_TOOLTIP_PROPS` wraps it in `contentStyle` and sets tooltip text to ink instead of the series color (a bright series hue was unreadable as text).

## Verified

- `npm run build` + `eslint` green.
- Screenshotted via headless Chromium against live data (dev proxy): Fuel Mix DE-LU dark + light, tooltip hover, mobile 390×844. Bands clearly distinguishable in all four; mobile has no horizontal body scroll (all-zones matrix scrolls inside its own `overflow-x-auto` wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)