### PR TITLE
Obsyd sends no product emails, and the landing stops promising them

### DIFF
--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -13,7 +13,7 @@ Schedule (UTC):
   - EU gas balance: daily 10:00; gas registry: weekly Mon 03:30
   - Signals (radar): every 5 min; scorecards: weekly Mon 05:00
   - Live prices: every 4h; user alert rules: every 30 min
-  - Daily email: Mon-Fri 07:00 (pre-refresh 06:45)
+  - Daily email: PAUSED 2026-07-18 (no product emails; see registration site below)
   - Retention: daily 04:00; collector watchdog: daily 09:00
 """
 
@@ -29,7 +29,6 @@ from backend.collectors.spark_spreads import collect_spark_spreads
 from backend.database import SessionLocal
 from backend.notifications.alert_runner import process_alert_rules
 from backend.notifications.collector_watchdog import check_collectors
-from backend.notifications.daily_email import send_daily_email
 from backend.providers.price_provider import get_live_prices as refresh_live_prices
 from backend.signals.evaluator import evaluate_signals
 
@@ -478,19 +477,10 @@ def start_scheduler():
     # User-defined alert rules: every 30 min (6h cooldown per rule inside the runner).
     scheduler.add_job(process_alert_rules, CronTrigger(minute="15,45"), id="user_alert_rules_30min", **JOB_DEFAULTS)
 
-    # Daily briefing email: Mon-Fri 07:00 UTC (pre-refresh prices at 06:45).
-    scheduler.add_job(
-        refresh_live_prices,
-        CronTrigger(day_of_week="mon-fri", hour=6, minute=45),
-        id="pre_email_price_refresh",
-        **JOB_DEFAULTS,
-    )
-    scheduler.add_job(
-        send_daily_email,
-        CronTrigger(day_of_week="mon-fri", hour=7, minute=0),
-        id="daily_email",
-        **JOB_DEFAULTS,
-    )
+    # Daily briefing email: PAUSED (owner decision 2026-07-18) — Obsyd sends no
+    # product emails. The pipeline (notifications/daily_email.py) stays intact;
+    # re-enable by re-registering send_daily_email (Mon-Fri 07:00 UTC, with a
+    # refresh_live_prices pre-run at 06:45) and reopening POST /api/email/subscribe.
 
     # Retention: daily 04:00 UTC. Collector watchdog: daily 09:00 UTC.
     scheduler.add_job(run_retention, CronTrigger(hour=4, minute=0), id="retention_daily", **JOB_DEFAULTS)

--- a/backend/notifications/alert_runner.py
+++ b/backend/notifications/alert_runner.py
@@ -27,7 +27,6 @@ from typing import Callable
 import httpx
 from sqlalchemy.orm import Session
 
-from backend.config import settings
 from backend.database import SessionLocal
 from backend.models.alert_rules import AlertRule, UserAlertEvent
 from backend.signals.user_alert_rules import EvaluatorResult, evaluator_for
@@ -39,10 +38,14 @@ MAX_TRIGGERS_PER_RUN = 100
 
 
 def _resend_api_key() -> str | None:
-    key = settings.resend_api_key
-    if not key:
-        return None
-    return key.get_secret_value() if hasattr(key, "get_secret_value") else key
+    # PAUSED (owner decision 2026-07-18): Obsyd sends no product emails. Rules
+    # still evaluate and their UserAlertEvent rows land in the ALERTS feed —
+    # only the Resend leg is off. Re-enable by restoring the key lookup:
+    #   key = settings.resend_api_key
+    #   if not key:
+    #       return None
+    #   return key.get_secret_value() if hasattr(key, "get_secret_value") else key
+    return None
 
 
 def _send_alert_email(api_key: str, email: str, title: str, detail: str) -> bool:

--- a/backend/routes/email.py
+++ b/backend/routes/email.py
@@ -6,7 +6,7 @@ import logging
 import secrets
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
 from backend.auth.dependencies import require_auth, require_pro
@@ -96,32 +96,15 @@ async def email_stats(_user=Depends(require_auth)):
 
 @router.post("/subscribe")
 async def subscribe(user=Depends(require_auth)):
-    """Opt the logged-in user into the free daily brief (Weg B).
-
-    Writes/reactivates an EmailSubscriber(tier="free"); the daily send loop mails
-    every active subscriber regardless of tier. Unsubscribe uses the existing
-    GET /api/email/unsubscribe?token= flow.
-    """
-    email = user["email"]
-    db = SessionLocal()
-    try:
-        sub = db.query(EmailSubscriber).filter(EmailSubscriber.email == email).first()
-        if sub is None:
-            sub = EmailSubscriber(
-                email=email,
-                tier="free",
-                unsubscribe_token=secrets.token_urlsafe(32),
-                active=True,
-            )
-            db.add(sub)
-        else:
-            sub.active = True
-            sub.unsubscribed_at = None
-        db.commit()
-        logger.info("Email subscribe (free): %s", email)
-        return {"status": "ok", "subscribed": email}
-    finally:
-        db.close()
+    """PAUSED (owner decision 2026-07-18): the daily brief sends no emails and
+    takes no new signups. 410 keeps the contract honest for any cached client;
+    GET /unsubscribe stays live so links in already-sent mails keep working.
+    The former opt-in body is in git history — restore it together with the
+    daily_email scheduler job to re-enable."""
+    raise HTTPException(
+        status_code=410,
+        detail="The daily brief is paused — Obsyd currently sends no emails.",
+    )
 
 
 @router.get("/subscription")

--- a/backend/tests/test_distribution.py
+++ b/backend/tests/test_distribution.py
@@ -56,33 +56,32 @@ def test_alerts_rss_filters_by_vertical(client, db_session):
     assert "POWER ITEM" in body and "OIL ITEM" not in body
 
 
-# ─── Free daily-brief opt-in ─────────────────────────────────────────────────
+# ─── Free daily-brief opt-in — PAUSED 2026-07-18 (no product emails) ─────────
 
 
-def test_subscribe_creates_free_subscriber(client, db_session):
+def test_subscribe_is_gone_and_writes_nothing(client, db_session):
     app.dependency_overrides[require_auth] = lambda: {"email": "free@user.com"}
     resp = client.post("/api/email/subscribe")
-    assert resp.status_code == 200
-    assert resp.json()["subscribed"] == "free@user.com"
+    assert resp.status_code == 410
     sub = db_session.query(EmailSubscriber).filter(EmailSubscriber.email == "free@user.com").first()
-    assert sub is not None and sub.active is True and sub.tier == "free"
+    assert sub is None
 
 
-def test_subscribe_reactivates_unsubscribed(client, db_session):
+def test_subscribe_does_not_reactivate_unsubscribed(client, db_session):
     db_session.add(EmailSubscriber(email="back@user.com", tier="free",
                                    unsubscribe_token="tok", active=False))
     db_session.commit()
     app.dependency_overrides[require_auth] = lambda: {"email": "back@user.com"}
-    client.post("/api/email/subscribe")
+    assert client.post("/api/email/subscribe").status_code == 410
     sub = db_session.query(EmailSubscriber).filter(EmailSubscriber.email == "back@user.com").first()
-    assert sub.active is True
+    assert sub.active is False
 
 
-def test_subscription_status_reflects_state(client, db_session):
+def test_subscription_status_stays_false_after_paused_subscribe(client, db_session):
     app.dependency_overrides[require_auth] = lambda: {"email": "who@user.com"}
     assert client.get("/api/email/subscription").json()["subscribed"] is False
     client.post("/api/email/subscribe")
-    assert client.get("/api/email/subscription").json()["subscribed"] is True
+    assert client.get("/api/email/subscription").json()["subscribed"] is False
 
 
 # ─── Power block in the brief ────────────────────────────────────────────────

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -41,7 +41,6 @@ import ProductsPanel from './components/ProductsPanel'
 import PowerOverviewMatrix from './components/PowerOverviewMatrix'
 import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
-import BriefSubscribe from './components/BriefSubscribe'
 import CommandPalette from './components/CommandPalette'
 import { useAuth } from './context/AuthContext'
 import { ViewStateProvider, useViewState } from './context/ViewStateContext'
@@ -763,9 +762,6 @@ function Dashboard() {
           <div className="space-y-3">
             <ErrorBoundary name="radar">
               <AlertsPanel weatherAlerts={weatherAlerts} />
-            </ErrorBoundary>
-            <ErrorBoundary name="brief-subscribe">
-              <BriefSubscribe />
             </ErrorBoundary>
             <ErrorBoundary name="alert-rules">
               <AlertRulesPanel />

--- a/frontend/src/components/AlertRulesPanel.jsx
+++ b/frontend/src/components/AlertRulesPanel.jsx
@@ -60,8 +60,8 @@ export default function AlertRulesPanel() {
       <div className="border border-border bg-surface rounded p-6 text-center font-mono">
         <div className="text-[10px] tracking-wider text-cyan-glow mb-2">ALERT RULES</div>
         <div className="text-[12px] text-neutral-400 mb-3 max-w-md mx-auto leading-relaxed">
-          Custom supply-disruption alerts via email — free. Log in to set up your rules and get
-          notified when something deviates.
+          Custom supply-disruption alerts — free. Log in to set up your rules; every firing
+          lands in your on-site alert inbox when something deviates.
         </div>
         <div className="text-[11px] text-neutral-500">
           Use <span className="text-cyan-glow">LOG IN</span> in the sidebar (a magic link, no password).

--- a/frontend/src/components/Landing.jsx
+++ b/frontend/src/components/Landing.jsx
@@ -217,10 +217,10 @@ export default function Landing() {
           </div>
           <div className="bg-[#0a0a12] p-6">
             <div className="text-cyan-glow text-[11px] tracking-widest mb-3">03</div>
-            <div className="text-neutral-100 text-base mb-3 leading-snug">You get the email</div>
+            <div className="text-neutral-100 text-base mb-3 leading-snug">You see it in the feed</div>
             <div className="text-[12px] text-neutral-500 leading-relaxed">
-              The trigger, the evidence, and a link straight to the chart — plus a Mon–Fri daily
-              brief so your morning starts with the energy situation.
+              The trigger, the evidence, and a link straight to the chart — every firing lands
+              in the ALERTS feed on the desk, ranked by severity.
             </div>
           </div>
         </div>
@@ -230,7 +230,7 @@ export default function Landing() {
             href="/app"
             className="px-6 py-3 text-[11px] tracking-wider bg-cyan-glow text-[#0a0a12] hover:bg-cyan-glow/90 transition-colors font-semibold text-center"
           >
-            Get the free daily brief →
+            Set up your alerts →
           </a>
           <span className="text-[11px] text-neutral-600">Log in with a magic link — no card, no spam.</span>
         </div>
@@ -251,7 +251,7 @@ export default function Landing() {
             <ul className="text-[11px] text-neutral-400 space-y-1.5">
               <li>· Full power desk + anomaly radar</li>
               <li>· Day-ahead, residual load, generation mix, cross-border flows, forecasts</li>
-              <li>· Watchlist, custom alerts, daily brief</li>
+              <li>· Watchlist, custom alerts</li>
               <li>· Everything unlocked, no limits</li>
             </ul>
           </div>


### PR DESCRIPTION
Owner decision 2026-07-18: no product emails, no newsletter signup.

- **Daily brief:** scheduler jobs `daily_email` + `pre_email_price_refresh` unregistered (pipeline intact, re-enable = re-register + reopen subscribe).
- **Alert-rule emails:** Resend leg off via `_resend_api_key() → None`; rules keep evaluating, events keep landing in the on-site ALERTS inbox.
- **Signup closed:** `POST /api/email/subscribe` → 410, writes nothing, does not reactivate unsubscribed rows. `GET /unsubscribe` stays live for links in already-sent mails.
- **Frontend:** BriefSubscribe unmounted; landing card 03 / CTA / pricing list no longer promise emails; AlertRulesPanel copy now says on-site inbox.
- **Untouched:** magic-link login mail (transactional — login would be impossible without it), owner-side collector-watchdog notifications.

Tests: subscribe tests rewritten to the 410 contract; affected suites green (42+27). Full suite: 22 pre-existing date-dependent failures, identical count on clean main — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)