### PR TITLE
The tests told local time, and the desk runs on UTC

### DIFF
--- a/backend/tests/test_dunkelflaute_parity.py
+++ b/backend/tests/test_dunkelflaute_parity.py
@@ -11,7 +11,7 @@ One predicate. These tests pin the desk to the radar's, and vice versa.
 """
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -19,7 +19,9 @@ from sqlalchemy.orm import Session
 
 from backend.models.energy import PowerGenMix, PowerGrid
 
-TODAY = date.today()
+# UTC, not local — the episode/radar code buckets on datetime.utcnow().date()
+# (same fix as test_power_situation.py).
+TODAY = datetime.now(timezone.utc).date()
 
 # The predicate is data-driven, not name-driven: a zone is "hydro" to it because its record says
 # so, not because it is called NO5. The test env enables DE_LU/FR/NL, so the fleets are seeded

--- a/backend/tests/test_gas_panel_freshness.py
+++ b/backend/tests/test_gas_panel_freshness.py
@@ -3,7 +3,7 @@ power panels (as_of/age_days/stale), same freshness derivation."""
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -11,7 +11,10 @@ from sqlalchemy.orm import Session
 
 from backend.models.gas import GasBalance, GasDemandModel, GasLng, GasPowerBurn, GasStorage
 
-_TODAY = date.today()
+# UTC, not local: the routes bucket on datetime.utcnow().date(). With a local
+# date.today() these tests fail for the two hours between local and UTC midnight
+# (same fix as test_power_situation.py).
+_TODAY = datetime.now(timezone.utc).date()
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_power_panel_freshness.py
+++ b/backend/tests/test_power_panel_freshness.py
@@ -8,7 +8,7 @@ captions and /api/health/collectors can never disagree.
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -23,7 +23,10 @@ from backend.models.energy import (
     PowerPriceDaily,
 )
 
-_TODAY = date.today()
+# UTC, not local: the routes bucket on datetime.utcnow().date(). With a local
+# date.today() these tests fail for the two hours between local and UTC midnight
+# (same fix as test_power_situation.py).
+_TODAY = datetime.now(timezone.utc).date()
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_power_situation.py
+++ b/backend/tests/test_power_situation.py
@@ -222,7 +222,7 @@ def test_component_freshness_fields_on_fresh_data():
     price = _price_series([50.0, 51.0, 52.0])
     grid = _flat_grid([45_000.0, 46_000.0, 47_000.0])
     spark = {"spark_spread": 5.0, "power_price": 52.0, "gas_price": 30.0,
-             "date": date.today().isoformat()}
+             "date": _TODAY.isoformat()}
     s = build_power_situation("DE_LU", price, grid, spark, today=_TODAY)
 
     for comp in ("price", "grid", "spark"):


### PR DESCRIPTION
22 tests failed every night between 00:00 and 02:00 local (CEST): they seeded
and asserted against date.today() — the LOCAL date — while every route buckets
on datetime.utcnow().date(). For two hours a day the two disagree by one day,
so "fresh" data was a day old and 10-day-old data was 9.

test_power_situation.py had already been fixed for exactly this (the comment
is still there) but kept one stray date.today() at line 225; the other three
files never got the fix. All four now read the same clock as the code.

The remaining date.today() uses in tests are deliberate no-ops for this bug:
they pass today= explicitly into the function under test or never compare
against the routes' clock — all of them passed repeatedly inside tonight's
divergence window.

Verified at 01:00 CEST, inside the failing window: 972 passed, 0 failed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
