### PR TITLE
Switching zones kept showing the old zone, and nothing said so

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "eslint-plugin-security": "^4.0.0",
         "globals": "^16.5.0",
+        "playwright-core": "^1.61.1",
         "vite": "^7.3.1"
       }
     },
@@ -6786,6 +6787,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/png-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "eslint-plugin-security": "^4.0.0",
     "globals": "^16.5.0",
+    "playwright-core": "^1.61.1",
     "vite": "^7.3.1"
   }
 }

--- a/frontend/scripts/verify-zone-coherence.mjs
+++ b/frontend/scripts/verify-zone-coherence.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Zone-coherence sweep — the regression guard for the 2026-07-18 bug where
+// switching zones kept every panel silently showing the PREVIOUS zone
+// (useFetchWithError served the old url's payload with no loading state).
+//
+// For each hop in the sweep it clicks the zone in the desk nav and asserts:
+//   1. the POWER SITUATION chip never shows the previous zone after the click
+//      (a short 400 ms grace covers the same-frame race), and
+//   2. the chip shows the NEW zone's label within 5 s.
+// It also reports the observed switch latency per hop.
+//
+// Usage:
+//   node scripts/verify-zone-coherence.mjs [base-url]
+//   (default base http://localhost:5199 — start `npx vite` with an /api proxy,
+//    or pass https://obsyd.dev to sweep production)
+// Needs playwright-core resolvable (npx -y playwright-core is NOT enough — run
+// from a dir with it installed, or set CHROMIUM_PATH to a Chrome/Chromium
+// binary and install playwright-core once: npm i --no-save playwright-core).
+
+import { exit } from 'process'
+
+const BASE = process.argv[2] || 'http://localhost:5199'
+// key = pill/dropdown value in the desk nav, label = what panels display.
+const SWEEP = [
+  { key: 'DE-LU', label: 'DE-LU' },
+  { key: 'NL', label: 'NL' },
+  { key: 'FR', label: 'FR' },
+  { key: 'IT-Sicilia', label: 'IT-Sicilia' },
+  { key: 'SE2', label: 'SE2' },
+  { key: 'DE-LU', label: 'DE-LU' },
+]
+
+let chromium
+try {
+  ({ chromium } = await import('playwright-core'))
+} catch {
+  console.error('playwright-core not resolvable — npm i --no-save playwright-core')
+  exit(2)
+}
+
+const browser = await chromium.launch(
+  process.env.CHROMIUM_PATH ? { executablePath: process.env.CHROMIUM_PATH } : {},
+)
+const page = await browser.newPage({ viewport: { width: 1500, height: 1000 } })
+
+const situationChip = () =>
+  page.evaluate(() => {
+    const el = [...document.querySelectorAll('*')].find(
+      (e) => e.childElementCount === 0 && e.textContent.includes('POWER SITUATION'),
+    )
+    return el?.closest('div[class*="border"]')?.innerText.split('\n')[1]?.trim() || null
+  })
+
+const pickZone = async (key) => {
+  const pill = page.locator('#desk-nav button', { hasText: key })
+  if (await pill.count()) return pill.first().click()
+  return page.locator('#desk-nav select').selectOption({ label: key })
+}
+
+await page.goto(`${BASE}/app?zone=DE_LU#energy`, { timeout: 60000, waitUntil: 'domcontentloaded' })
+await page.waitForSelector('#desk-nav', { timeout: 30000 })
+await page.waitForTimeout(4000)
+
+let failures = 0
+let prev = 'DE-LU'
+for (const { key, label } of SWEEP.slice(1)) {
+  await pickZone(key)
+  const t0 = Date.now()
+  let settled = null
+  let staleSeen = false
+  while (Date.now() - t0 < 5000) {
+    const chip = await situationChip()
+    const dt = Date.now() - t0
+    if (chip === prev && dt > 400) staleSeen = true
+    if (chip === label) { settled = dt; break }
+    await page.waitForTimeout(100)
+  }
+  const ok = settled != null && !staleSeen
+  if (!ok) failures++
+  console.log(
+    `${prev} → ${label}: ${ok ? 'PASS' : 'FAIL'}` +
+    (settled != null ? ` (sichtbar nach ${settled} ms)` : ' (nicht innerhalb 5 s sichtbar)') +
+    (staleSeen ? ' — ALTE ZONE nach >400 ms noch angezeigt' : ''),
+  )
+  prev = label
+  await page.waitForTimeout(1200)
+}
+
+await browser.close()
+console.log(failures === 0 ? 'ZONE COHERENCE: ALL PASS' : `ZONE COHERENCE: ${failures} FAILURES`)
+exit(failures === 0 ? 0 : 1)

--- a/frontend/src/components/CoveragePanel.jsx
+++ b/frontend/src/components/CoveragePanel.jsx
@@ -16,7 +16,7 @@ function label(key) {
 }
 
 export default function CoveragePanel() {
-  const { data, loading } = useFetchWithError(`${API}/v1/status`)
+  const { data, loading, error } = useFetchWithError(`${API}/v1/status`)
   const sources = data?.sources || []
 
   return (
@@ -35,6 +35,9 @@ export default function CoveragePanel() {
 
       {loading && (
         <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">Checking coverage…</div>
+      )}
+      {!loading && error && sources.length === 0 && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-red-400">Fetch error — retrying on next refresh.</div>
       )}
       {!loading && sources.length > 0 && (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1 px-4 py-3">

--- a/frontend/src/components/DurationCurvePanel.jsx
+++ b/frontend/src/components/DurationCurvePanel.jsx
@@ -24,7 +24,7 @@ export default function DurationCurvePanel({ zone = 'DE_LU' }) {
   const start = rangeStart(range)
 
   const url = `${API}/v1/series?series=${m.key}&zone=${zone}&start=${start}&resolution=hourly`
-  const { data: resp, loading } = useFetchWithError(url, { deps: [m.key, zone, start] })
+  const { data: resp, loading, error } = useFetchWithError(url, { deps: [m.key, zone, start] })
 
   const { curve, stats } = useMemo(() => {
     const vals = (resp?.data || []).map((p) => p.value * m.scale).filter((v) => v != null && !Number.isNaN(v))
@@ -39,6 +39,13 @@ export default function DurationCurvePanel({ zone = 'DE_LU' }) {
     return { curve, stats: { n, max: vals[0], min: vals[n - 1], median, negHours } }
   }, [resp, m.scale, metric])
 
+  if (error && !resp) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">DURATION CURVE // FETCH ERROR</div>
+      </div>
+    )
+  }
   if (!loading && (!resp?.available || !stats)) return null
 
   return (

--- a/frontend/src/components/GenMixHistoryPanel.jsx
+++ b/frontend/src/components/GenMixHistoryPanel.jsx
@@ -17,7 +17,7 @@ export default function GenMixHistoryPanel({ zone = 'DE_LU' }) {
   const start = rangeStart(range, 365)
 
   const url = `${API}/v1/genmix?zone=${zone}&start=${start}&resolution=monthly`
-  const { data: resp, loading } = useFetchWithError(url, { deps: [zone, start] })
+  const { data: resp, loading, error } = useFetchWithError(url, { deps: [zone, start] })
 
   // Convert MW → GW for readability without mutating source rows.
   const { chart, fuels } = useMemo(() => {
@@ -30,6 +30,13 @@ export default function GenMixHistoryPanel({ zone = 'DE_LU' }) {
     return { chart, fuels: sortFuels(f) }
   }, [resp])
 
+  if (error && !resp) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">GENERATION MIX HISTORY // FETCH ERROR</div>
+      </div>
+    )
+  }
   if (!loading && (!resp?.available || fuels.length === 0)) return null
 
   return (

--- a/frontend/src/components/MeritOrderScatter.jsx
+++ b/frontend/src/components/MeritOrderScatter.jsx
@@ -18,8 +18,8 @@ export default function MeritOrderScatter({ zone = 'DE_LU' }) {
 
   const priceUrl = `${API}/v1/series?series=price.dayahead&zone=${zone}&start=${start}&resolution=hourly`
   const resUrl = `${API}/v1/series?series=residual.actual&zone=${zone}&start=${start}&resolution=hourly`
-  const { data: priceResp, loading: l1 } = useFetchWithError(priceUrl, { deps: [zone, start] })
-  const { data: resResp, loading: l2 } = useFetchWithError(resUrl, { deps: [zone, start] })
+  const { data: priceResp, loading: l1, error: e1 } = useFetchWithError(priceUrl, { deps: [zone, start] })
+  const { data: resResp, loading: l2, error: e2 } = useFetchWithError(resUrl, { deps: [zone, start] })
   const loading = l1 || l2
 
   const { points, corr } = useMemo(() => {
@@ -42,6 +42,13 @@ export default function MeritOrderScatter({ zone = 'DE_LU' }) {
     return { points, corr }
   }, [priceResp, resResp])
 
+  if ((e1 || e2) && points.length === 0) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">PRICE VS RESIDUAL // FETCH ERROR</div>
+      </div>
+    )
+  }
   if (!loading && points.length === 0) return null
 
   return (

--- a/frontend/src/components/MiniMixCard.jsx
+++ b/frontend/src/components/MiniMixCard.jsx
@@ -14,7 +14,7 @@ export default function MiniMixCard({ title, zone, height = 120 }) {
   const { range } = useViewState()
   const start = rangeStart(range, 90)
   const url = `${API}/v1/genmix?zone=${zone}&start=${start}&resolution=daily`
-  const { data: resp, loading } = useFetchWithError(url, { deps: [zone, start] })
+  const { data: resp, loading, error } = useFetchWithError(url, { deps: [zone, start] })
 
   const { chart, fuels } = useMemo(() => {
     const f = resp?.fuels || []
@@ -55,7 +55,9 @@ export default function MiniMixCard({ title, zone, height = 120 }) {
         </div>
       )}
       {!loading && chart.length === 0 && (
-        <div className="px-3 py-8 text-center font-mono text-[10px] text-neutral-600">No data for this zone.</div>
+        <div className={`px-3 py-8 text-center font-mono text-[10px] ${error ? 'text-red-400' : 'text-neutral-600'}`}>
+          {error ? 'Fetch error — retrying on next refresh.' : 'No data for this zone.'}
+        </div>
       )}
     </div>
   )

--- a/frontend/src/components/OutagePanel.jsx
+++ b/frontend/src/components/OutagePanel.jsx
@@ -24,7 +24,15 @@ function fmtEnd(iso) {
  * that — most raw messages are withdrawn revisions).
  */
 export default function OutagePanel({ zone = 'DE_LU' }) {
-  const { data, loading } = useFetchWithError(`${API}/power/outages?zone=${zone}`, { deps: [zone], pollMs: POLL_SLOW_MS })
+  const { data, loading, error } = useFetchWithError(`${API}/power/outages?zone=${zone}`, { deps: [zone], pollMs: POLL_SLOW_MS })
+
+  if (error && !data) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">OUTAGES // FETCH ERROR</div>
+      </div>
+    )
+  }
 
   if (!data?.available && !loading) {
     return (

--- a/frontend/src/components/PowerSituationHeader.jsx
+++ b/frontend/src/components/PowerSituationHeader.jsx
@@ -64,7 +64,17 @@ function Metric({ label, value, sub, color, band, comp }) {
  * drill-down evidence). Always-on hero across every tab.
  */
 export default function PowerSituationHeader({ zone = 'DE_LU' }) {
-  const { data, loading } = useFetchWithError(`${API}/power/situation?zone=${zone}`, { deps: [zone], pollMs: POLL_FAST_MS })
+  const { data, loading, error } = useFetchWithError(`${API}/power/situation?zone=${zone}`, { deps: [zone], pollMs: POLL_FAST_MS })
+
+  // A failed fetch must say so — silently keeping the previous zone's numbers
+  // is exactly the lie this desk exists to avoid.
+  if (error && !data) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">POWER SITUATION // FETCH ERROR</div>
+      </div>
+    )
+  }
 
   if (loading && !data) {
     return (

--- a/frontend/src/components/SeriesExplorer.jsx
+++ b/frontend/src/components/SeriesExplorer.jsx
@@ -88,7 +88,7 @@ export default function SeriesExplorer() {
 
   const enc = encodeURIComponent(series)
   const url = `${API}/v1/series?series=${enc}&zone=${zone}&start=${start}&resolution=${resolution}`
-  const { data: resp, loading } = useFetchWithError(url, { deps: [series, zone, start, resolution] })
+  const { data: resp, loading, error } = useFetchWithError(url, { deps: [series, zone, start, resolution] })
 
   const comparing = !!compareZone && compareZone !== zone
   const cmpZoneEff = compareZone || zone  // when off, same URL as primary → served from SWR cache (no extra fetch)
@@ -174,6 +174,9 @@ export default function SeriesExplorer() {
 
       <div className="px-2 pt-3 pb-1" style={{ minHeight: 240 }}>
         {loading && <div className="px-4 py-10 text-center font-mono text-[10px] text-neutral-600 animate-pulse">Loading…</div>}
+        {!loading && error && !resp && (
+          <div className="px-4 py-10 text-center font-mono text-[10px] text-red-400">Fetch error — retrying on next refresh.</div>
+        )}
         {!loading && resp && resp.available === false && (
           <div className="px-4 py-10 text-center font-mono text-[10px] text-neutral-600">
             {resp.reason || 'No data for this selection.'}

--- a/frontend/src/components/TrendsPanel.jsx
+++ b/frontend/src/components/TrendsPanel.jsx
@@ -20,9 +20,9 @@ export default function TrendsPanel({ zone = 'DE_LU' }) {
   const priceUrl = `${API}/v1/series?series=price.dayahead&zone=${zone}&start=${start}&resolution=hourly`
   const loadUrl = `${API}/v1/series?series=load.actual&zone=${zone}&start=${start}&resolution=daily`
   const resUrl = `${API}/v1/series?series=residual.actual&zone=${zone}&start=${start}&resolution=daily`
-  const { data: price, loading: l1 } = useFetchWithError(priceUrl, { deps: [zone, start] })
-  const { data: load, loading: l2 } = useFetchWithError(loadUrl, { deps: [zone, start] })
-  const { data: res, loading: l3 } = useFetchWithError(resUrl, { deps: [zone, start] })
+  const { data: price, loading: l1, error: e1 } = useFetchWithError(priceUrl, { deps: [zone, start] })
+  const { data: load, loading: l2, error: e2 } = useFetchWithError(loadUrl, { deps: [zone, start] })
+  const { data: res, loading: l3, error: e3 } = useFetchWithError(resUrl, { deps: [zone, start] })
   const loading = l1 || l2 || l3
 
   const { rows, totalNeg } = useMemo(() => {
@@ -60,6 +60,13 @@ export default function TrendsPanel({ zone = 'DE_LU' }) {
     return { rows, totalNeg }
   }, [price, load, res])
 
+  if ((e1 || e2 || e3) && rows.length === 0) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">TRENDS // FETCH ERROR</div>
+      </div>
+    )
+  }
   if (!loading && rows.length === 0) return null
 
   return (

--- a/frontend/src/components/ZoneCompareChart.jsx
+++ b/frontend/src/components/ZoneCompareChart.jsx
@@ -57,6 +57,7 @@ export default function ZoneCompareChart({ title, series, zone, compare = [], un
   }, [r0.data, r1.data, r2.data, r3.data, zones.join(','), scale])
 
   const loading = responses.slice(0, zones.length).some((r) => r.loading)
+  const failedZones = zones.filter((z, i) => responses[i].error && !responses[i].data)
   const colorOf = (z, i) => (i === 0 ? color : COMPARE_COLORS[(i - 1) % COMPARE_COLORS.length])
   const label = (z) => (labelFor ? labelFor(z) : z)
 
@@ -72,6 +73,12 @@ export default function ZoneCompareChart({ title, series, zone, compare = [], un
           ↓ CSV
         </a>
       </div>
+
+      {failedZones.length > 0 && (
+        <div className="px-3 pt-2 font-mono text-[10px] text-red-400">
+          Fetch error for {failedZones.map(label).join(', ')} — retrying on next refresh.
+        </div>
+      )}
 
       {/* Legend: the zones on the chart, each with its latest value — and, when the last day is
           still filling in, the hours that mean actually averaged. */}

--- a/frontend/src/hooks/useFetchWithError.js
+++ b/frontend/src/hooks/useFetchWithError.js
@@ -36,12 +36,16 @@ export default function useFetchWithError(url, opts = {}) {
   const run = useCallback(
     async (controller) => {
       const myReq = ++reqRef.current
-      // Serve stale data immediately while revalidating; only show the
-      // loading state when we have nothing cached for this URL yet.
+      // Serve stale data immediately while revalidating — but ONLY data that
+      // belongs to THIS url. When the url changes (zone/range switch) and the
+      // new url has no cache yet, `data` must drop to null: keeping the old
+      // url's payload made every panel silently show zone A labeled as
+      // current while zone B was loading (or forever, if the fetch failed).
       if (swrCache.has(url)) {
         setData(swrCache.get(url))
         setLoading(false)
       } else {
+        setData(null)
         setLoading(true)
       }
       setError(null)


### PR DESCRIPTION
The stale-while-revalidate in useFetchWithError kept the PREVIOUS url's
payload in state when the url changed: switch DE-LU → NL and every panel
silently rendered DE-LU (labeled DE-LU, next to a selector saying NL) until
the NL response landed — measured at ~2.5 s locally, longer in prod, and
FOREVER when the fetch failed, because ten panels never looked at `error`.
For a desk whose one promise is "never pretend", that is the worst bug class.

Two changes:
- The hook drops `data` to null on a cache-miss url change. Data on screen now
  always belongs to the current url; a cached zone still returns instantly.
- Every rendered panel that ignored `error` now shows a FETCH ERROR state when
  it has nothing valid to show (error && !data) — stale-while-error for the
  SAME url stays, the panels carry freshness stamps for that.

scripts/verify-zone-coherence.mjs is the regression guard: sweeps
DE-LU → NL → FR → IT-Sicilia → SE2 → DE-LU and fails if the situation panel
ever shows the previous zone after 400 ms or misses the new one within 5 s.
Post-fix: ALL PASS, new zone visible in 320-620 ms, cached return in 1 ms.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
