### PR TITLE
Fifteen async endpoints that never await, one worker, one event loop

### DIFF
--- a/backend/routes/alert_rules.py
+++ b/backend/routes/alert_rules.py
@@ -119,7 +119,7 @@ ACTIVE_TEMPLATE_VERTICALS = {"power", "gas"}
 
 
 @router.get("/templates")
-async def list_templates():
+def list_templates():
     """Schema discovery for the frontend rule-builder. Not behind require_pro
     — even Free users may want to see what they'd get on Pro."""
     return {
@@ -137,7 +137,7 @@ async def list_templates():
 
 
 @router.get("/rules")
-async def list_rules(user: dict = Depends(require_auth)):
+def list_rules(user: dict = Depends(require_auth)):
     db = SessionLocal()
     try:
         rules = (
@@ -156,7 +156,7 @@ async def list_rules(user: dict = Depends(require_auth)):
 
 
 @router.post("/rules")
-async def create_rule(body: CreateRuleBody, user: dict = Depends(require_auth)):
+def create_rule(body: CreateRuleBody, user: dict = Depends(require_auth)):
     ok, err = validate_params(body.rule_type, body.params)
     if not ok:
         raise HTTPException(status_code=422, detail=err)
@@ -196,7 +196,7 @@ async def create_rule(body: CreateRuleBody, user: dict = Depends(require_auth)):
 
 
 @router.patch("/rules/{rule_id}")
-async def patch_rule(rule_id: int, body: PatchRuleBody, user: dict = Depends(require_auth)):
+def patch_rule(rule_id: int, body: PatchRuleBody, user: dict = Depends(require_auth)):
     db = SessionLocal()
     try:
         rule = (
@@ -218,7 +218,7 @@ async def patch_rule(rule_id: int, body: PatchRuleBody, user: dict = Depends(req
 
 
 @router.delete("/rules/{rule_id}")
-async def delete_rule(rule_id: int, user: dict = Depends(require_auth)):
+def delete_rule(rule_id: int, user: dict = Depends(require_auth)):
     db = SessionLocal()
     try:
         rule = (
@@ -239,7 +239,7 @@ async def delete_rule(rule_id: int, user: dict = Depends(require_auth)):
 
 
 @router.get("/notifications")
-async def list_notifications(limit: int = 50, user: dict = Depends(require_auth)):
+def list_notifications(limit: int = 50, user: dict = Depends(require_auth)):
     limit = max(1, min(limit, 200))
     db = SessionLocal()
     try:
@@ -260,7 +260,7 @@ async def list_notifications(limit: int = 50, user: dict = Depends(require_auth)
 
 
 @router.post("/notifications/{event_id}/seen")
-async def mark_seen(event_id: int, user: dict = Depends(require_auth)):
+def mark_seen(event_id: int, user: dict = Depends(require_auth)):
     db = SessionLocal()
     try:
         evt = (

--- a/backend/routes/alerts.py
+++ b/backend/routes/alerts.py
@@ -66,7 +66,7 @@ def _attach_context(db, items: list[dict]) -> None:
 
 
 @router.get("")
-async def get_alerts(
+def get_alerts(
     rule: str = Query(None, description="Filter by rule name"),
     zone: str = Query(None, description="Filter by zone"),
     vertical: str = Query(None, description="Filter by vertical (oil/gas/power/metals/sentiment)"),
@@ -104,7 +104,7 @@ async def get_alerts(
 
 
 @router.get("/rss")
-async def alerts_rss(
+def alerts_rss(
     vertical: str = Query(None, description="Filter by vertical (oil/gas/power/metals/sentiment)"),
     max_age_hours: int = Query(48, ge=1, le=720),
     limit: int = Query(50, ge=1, le=500),
@@ -139,7 +139,7 @@ async def alerts_rss(
 
 
 @router.get("/portwatch")
-async def get_portwatch_alerts():
+def get_portwatch_alerts():
     """Get current PortWatch chokepoint anomaly alerts (computed live from SQLite)."""
     alerts = check_chokepoint_anomalies()
     return {

--- a/backend/routes/api_v1.py
+++ b/backend/routes/api_v1.py
@@ -72,7 +72,7 @@ def _to_daily(points: list[tuple[int, float]]) -> list[tuple[str, float, int]]:
 
 
 @router.get("/meta")
-async def meta(db: Session = Depends(get_db)):
+def meta(db: Session = Depends(get_db)):
     """Sources, licenses, enabled zones and available series — the API's front matter."""
     series = [{"key": k, "unit": u} for k, u in db.query(SeriesDim.key, SeriesDim.unit).order_by(SeriesDim.key).all()]
     return {
@@ -88,7 +88,7 @@ async def meta(db: Session = Depends(get_db)):
 
 
 @router.get("/status")
-async def status(db: Session = Depends(get_db)):
+def status(db: Session = Depends(get_db)):
     """Honest data-coverage view: per-source + per-zone freshness for the power/gas
     desk (from the shared freshness spec). `healthy` is true when every product-critical
     source is within its window. The transparency answer to a black-box feed — 'here is
@@ -111,7 +111,7 @@ async def status(db: Session = Depends(get_db)):
 
 
 @router.get("/zones")
-async def zones():
+def zones():
     """Every bidding zone in the registry with its enablement + flow-mapping flags —
     the single source of truth for zone selectors/navigation across the frontend."""
     enabled = set(POWER_ZONES)
@@ -132,7 +132,7 @@ async def zones():
 
 
 @router.get("/genmix")
-async def genmix(
+def genmix(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     start: str | None = Query(None, description="YYYY-MM-DD / ISO 8601 (default: 1 year ago)"),
     end: str | None = Query(None, description="default: now"),
@@ -208,7 +208,7 @@ async def genmix(
 
 
 @router.get("/snapshot")
-async def snapshot(
+def snapshot(
     series: str = Query("price.dayahead", description="Series key to snapshot"),
     hours: int = Query(168, ge=1, le=744, description="Lookback window (default 7 days)"),
     start: str | None = Query(None, description="Override window start (ISO / YYYY-MM-DD)"),
@@ -259,7 +259,7 @@ async def snapshot(
 
 
 @router.get("/capacity")
-async def capacity(
+def capacity(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     year: int | None = Query(None, description="Year (default: latest available)"),
     db: Session = Depends(get_db),
@@ -343,7 +343,7 @@ def get_production_units(
 
 
 @router.get("/series/catalog")
-async def catalog(db: Session = Depends(get_db)):
+def catalog(db: Session = Depends(get_db)):
     """What's queryable: every series (key+unit), enabled zones, and the overall
     hourly coverage window."""
     series = [{"key": k, "unit": u} for k, u in db.query(SeriesDim.key, SeriesDim.unit).order_by(SeriesDim.key).all()]
@@ -361,7 +361,7 @@ async def catalog(db: Session = Depends(get_db)):
 
 
 @router.get("/series")
-async def series(
+def series(
     request: Request,
     series: str = Query(..., description="Series key, e.g. price.dayahead, load.actual, gen.B16"),
     zone: str = Query(..., description="Bidding zone key, e.g. DE_LU, FR, ES"),

--- a/backend/routes/crypto.py
+++ b/backend/routes/crypto.py
@@ -23,7 +23,7 @@ _SYMBOLS = {sym for _gid, sym, _name in CRYPTO_ASSETS}
 
 
 @router.get("/prices")
-async def get_crypto_prices(db: Session = Depends(get_db)):
+def get_crypto_prices(db: Session = Depends(get_db)):
     """Latest quote per asset (most recent stored date), sorted by market cap desc."""
     latest_date = db.query(func.max(CryptoPrice.date)).scalar()
     if not latest_date:
@@ -48,7 +48,7 @@ async def get_crypto_prices(db: Session = Depends(get_db)):
 
 
 @router.get("/history")
-async def get_crypto_history(
+def get_crypto_history(
     symbol: str = Query(..., description="Ticker, e.g. BTC"),
     days: int = Query(90, ge=1, le=1500),
     db: Session = Depends(get_db),

--- a/backend/routes/gas.py
+++ b/backend/routes/gas.py
@@ -52,7 +52,7 @@ def _panel_freshness(rows) -> dict:
 
 
 @router.get("/supply")
-async def get_supply(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
+def get_supply(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
     """Daily supply (GWh/d) decomposed into pipeline imports, LNG, net UK."""
     date_from, date_to = _window(days)
     rows = validation.compute_daily_supply(db, date_from, date_to)
@@ -134,7 +134,7 @@ def get_storage_countries(
 
 
 @router.get("/storage")
-async def get_storage(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
+def get_storage(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
     date_from, date_to = _window(days)
     rows = (
         db.query(GasStorage)
@@ -155,7 +155,7 @@ async def get_storage(days: int = Query(90, ge=1, le=1500), db: Session = Depend
 
 
 @router.get("/lng")
-async def get_lng(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
+def get_lng(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
     date_from, date_to = _window(days)
     rows = (
         db.query(GasLng)
@@ -169,7 +169,7 @@ async def get_lng(days: int = Query(90, ge=1, le=1500), db: Session = Depends(ge
 
 
 @router.get("/power-burn")
-async def get_power_burn(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
+def get_power_burn(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
     """Gas-fired power generation (measured) + implied gas demand (Phase 2)."""
     date_from, date_to = _window(days)
     rows = (
@@ -192,7 +192,7 @@ async def get_power_burn(days: int = Query(90, ge=1, le=1500), db: Session = Dep
 
 
 @router.get("/demand")
-async def get_demand(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
+def get_demand(days: int = Query(90, ge=1, le=1500), db: Session = Depends(get_db)):
     """Modeled gas demand: HDD-driven heating + flat industrial baseline (Phase 3)."""
     date_from, date_to = _window(days)
     rows = (
@@ -222,7 +222,7 @@ async def get_demand(days: int = Query(90, ge=1, le=1500), db: Session = Depends
 
 
 @router.get("/balance")
-async def get_balance(days: int = Query(120, ge=1, le=1500), db: Session = Depends(get_db)):
+def get_balance(days: int = Query(120, ge=1, le=1500), db: Session = Depends(get_db)):
     """The residual signal (Phase 4): implied vs actual ΔStorage, 7d-smoothed,
     z-scored, flagged. The residual is the product — persistent deviation =
     demand destruction / unexpected flows the market hasn't priced."""
@@ -270,7 +270,7 @@ async def get_balance(days: int = Query(120, ge=1, le=1500), db: Session = Depen
 
 
 @router.get("/validation")
-async def get_validation(
+def get_validation(
     date_from: str = Query(None, description="YYYY-MM-DD; defaults to the Bruegel CSV's span"),
     date_to: str = Query(None),
     db: Session = Depends(get_db),

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -9,7 +9,7 @@ router = APIRouter()
 
 
 @router.get("/health")
-async def health_check(db: Session = Depends(get_db)):
+def health_check(db: Session = Depends(get_db)):
     """Liveness + DB readiness. Returns 503 if the DB is unreachable,
     so the health-check cron restarts the service."""
     try:
@@ -20,7 +20,7 @@ async def health_check(db: Session = Depends(get_db)):
 
 
 @router.get("/api/health/collectors")
-async def collector_status(db: Session = Depends(get_db)):
+def collector_status(db: Session = Depends(get_db)):
     """Which data collectors are fresh (not just ever-written).
 
     Product-critical sources (ENTSO-E day-ahead/grid, Energy-Charts flows, gas

--- a/backend/routes/metals.py
+++ b/backend/routes/metals.py
@@ -27,7 +27,7 @@ _UNIT = "metric tons"
 
 
 @router.get("/copper")
-async def get_copper_supply(
+def get_copper_supply(
     months: int = Query(36, ge=1, le=120),
     db: Session = Depends(get_db),
 ):

--- a/backend/routes/news.py
+++ b/backend/routes/news.py
@@ -14,12 +14,12 @@ router = APIRouter(prefix="/api/news", tags=["news"])
 
 
 @router.get("/topics")
-async def topics():
+def topics():
     return {"topics": [{"key": k, "label": label} for k, label, _q in TOPICS]}
 
 
 @router.get("/feed")
-async def feed(
+def feed(
     topic: str = Query(None, description="Curated topic key (see /topics)"),
     q: str = Query(None, description="Free-text query (overrides topic)"),
 ):

--- a/backend/routes/ports.py
+++ b/backend/routes/ports.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/api/ports", tags=["ports"])
 
 
 @router.get("/activity")
-async def get_port_activity(
+def get_port_activity(
     kind: str = Query(None, description="Filter by 'port' or 'chokepoint'"),
     port_id: str = Query(None, description="Filter by port/chokepoint ID"),
     days: int = Query(7, ge=1, le=90),
@@ -53,7 +53,7 @@ async def get_port_activity(
 
 
 @router.get("/summary")
-async def get_port_summary(
+def get_port_summary(
     db: Session = Depends(get_db),
 ):
     """Get latest-day summary per port and chokepoint for dashboard display."""

--- a/backend/routes/portwatch.py
+++ b/backend/routes/portwatch.py
@@ -65,7 +65,7 @@ def _ensure_data(days: int = 30):
 
 
 @router.get("/chokepoints")
-async def get_chokepoints():
+def get_chokepoints():
     """Current daily values for all chokepoints."""
     data = _ensure_data(days=7)
 
@@ -83,7 +83,7 @@ async def get_chokepoints():
 
 
 @router.get("/chokepoints/{name}/history")
-async def get_chokepoint_history(
+def get_chokepoint_history(
     name: str = Path(
         description="Chokepoint name (e.g. 'hormuz', 'suez', 'malacca', 'panama', 'cape')", pattern=r"^[a-z_]+$"
     ),
@@ -163,7 +163,7 @@ def _query_ais_daily(zone_name: str, after_date: str) -> list[dict]:
 
 
 @router.get("/disruptions")
-async def get_disruptions():
+def get_disruptions():
     """Active disruption events."""
     data = fetch_disruptions(days=365)
     store_disruptions(data)
@@ -178,7 +178,7 @@ async def get_disruptions():
 
 
 @router.get("/summary")
-async def get_summary():
+def get_summary():
     """Dashboard overview: current values + anomaly vs 30-day average.
 
     Includes weighted tanker counts from AIS geofence data where available.

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -97,7 +97,7 @@ def _window(days: int) -> tuple[str, str]:
 
 
 @router.get("/day-ahead")
-async def get_day_ahead(
+def get_day_ahead(
     days: int = Query(120, ge=1, le=1500),
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     db: Session = Depends(get_db),
@@ -258,7 +258,7 @@ def _day_ahead_qh(db: Session, zone: str, date: str | None) -> dict:
 
 
 @router.get("/day-ahead/hourly")
-async def get_day_ahead_hourly(
+def get_day_ahead_hourly(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     date: str = Query(None, description="YYYY-MM-DD; default = latest day with hourly data"),
     resolution: str = Query("hourly", pattern="^(hourly|qh)$",
@@ -308,7 +308,7 @@ async def get_day_ahead_hourly(
 
 
 @router.get("/spark-spread")
-async def get_spark_spread(
+def get_spark_spread(
     days: int = Query(120, ge=7, le=1500),
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL, …"),
     db: Session = Depends(get_db),
@@ -481,7 +481,7 @@ def _flag_dunkelflaute(db: Session, zone: str, rows: list[dict]) -> None:
 
 
 @router.get("/grid")
-async def get_grid(
+def get_grid(
     days: int = Query(120, ge=1, le=1500),
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     db: Session = Depends(get_db),
@@ -540,7 +540,7 @@ async def get_grid(
 
 
 @router.get("/load-forecast")
-async def get_load_forecast(
+def get_load_forecast(
     days: int = Query(30, ge=1, le=365),
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     db: Session = Depends(get_db),
@@ -612,7 +612,7 @@ async def get_load_forecast(
 
 
 @router.get("/load-forecast/hourly")
-async def get_load_forecast_hourly(
+def get_load_forecast_hourly(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     date: str = Query(None, description="YYYY-MM-DD; default = latest forecast day (tomorrow)"),
     db: Session = Depends(get_db),
@@ -1224,7 +1224,7 @@ def load_power_situations_bulk(db: Session) -> dict[str, dict]:
 
 
 @router.get("/situation")
-async def get_situation(
+def get_situation(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     db: Session = Depends(get_db),
 ):
@@ -1270,7 +1270,7 @@ def _flow_direction(from_zone: str, to_zone: str, net_mw: float) -> str:
 
 
 @router.get("/flows")
-async def get_flows(
+def get_flows(
     days: int = Query(30, ge=1, le=1500),
     db: Session = Depends(get_db),
 ):
@@ -1382,7 +1382,7 @@ _FORECAST_PAIRS: dict[str, tuple[str, list[str]]] = {
 
 
 @router.get("/forecast-error")
-async def get_forecast_error(
+def get_forecast_error(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     series: str = Query("load", pattern="^(load|residual|wind|solar)$"),
     days: int = Query(7, ge=1, le=90),
@@ -1435,7 +1435,7 @@ async def get_forecast_error(
 
 
 @router.get("/flows/hourly")
-async def get_flows_hourly(
+def get_flows_hourly(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     hours: int = Query(72, ge=6, le=720, description="Lookback window in hours"),
     db: Session = Depends(get_db),
@@ -1647,7 +1647,7 @@ def get_spread(
 
 
 @router.get("/imbalance")
-async def get_imbalance(
+def get_imbalance(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     days: int = Query(7, ge=1, le=90),
     resolution: str = Query("hourly", pattern="^(hourly|qh)$"),
@@ -1706,7 +1706,7 @@ RECORD_FRESH_DAYS = 7
 
 
 @router.get("/records")
-async def get_records(
+def get_records(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     db: Session = Depends(get_db),
 ):
@@ -1770,7 +1770,7 @@ def _unit_names_for(db: Session, eics: list[str]) -> dict[str, str]:
 
 
 @router.get("/outages")
-async def get_outages(
+def get_outages(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     horizon_days: int = Query(30, ge=1, le=400,
                               description="Include outages starting up to this many days out"),
@@ -1878,7 +1878,7 @@ HYDRO_STALE_DAYS = 16
 
 
 @router.get("/hydro")
-async def get_hydro(db: Session = Depends(get_db)):
+def get_hydro(db: Session = Depends(get_db)):
     """Weekly reservoir filling (ENTSO-E A72, MWh → TWh) for the hydro zones —
     Nordics, Alps, Iberia, France — each compared against the same ISO week in
     its own prior years. Descriptive: a filling level vs its seasonal norm,
@@ -1925,7 +1925,7 @@ async def get_hydro(db: Session = Depends(get_db)):
 
 
 @router.get("/generation-mix")
-async def get_generation_mix(
+def get_generation_mix(
     days: int = Query(30, ge=1, le=1500),
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL"),
     db: Session = Depends(get_db),

--- a/backend/routes/rates.py
+++ b/backend/routes/rates.py
@@ -45,7 +45,7 @@ def _latest(db: Session, series_id: str):
 
 
 @router.get("/curve")
-async def get_curve(db: Session = Depends(get_db)):
+def get_curve(db: Session = Depends(get_db)):
     """Latest yield per tenor (ascending by maturity) + the 10Y-2Y inversion spread."""
     points = []
     as_of = None
@@ -72,7 +72,7 @@ async def get_curve(db: Session = Depends(get_db)):
 
 
 @router.get("/history")
-async def get_history(
+def get_history(
     series: str = Query(..., description="FRED tenor series, e.g. DGS10"),
     days: int = Query(365, ge=1, le=3650),
     db: Session = Depends(get_db),

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -17,13 +17,13 @@ class ProviderUpdate(BaseModel):
 
 
 @router.get("")
-async def get_settings():
+def get_settings():
     """Get current provider configuration."""
     return price_provider.get_settings()
 
 
 @router.post("/provider")
-async def set_provider(body: ProviderUpdate, _user: dict = Depends(require_auth)):
+def set_provider(body: ProviderUpdate, _user: dict = Depends(require_auth)):
     """Change the active price provider (auth required)."""
     try:
         price_provider.set_providers(body.primary, body.fallback)
@@ -33,7 +33,7 @@ async def set_provider(body: ProviderUpdate, _user: dict = Depends(require_auth)
 
 
 @router.get("/credits")
-async def get_credits():
+def get_credits():
     """Get Twelve Data credit usage for today."""
     from backend.providers.twelvedata_provider import get_credits_used
 

--- a/backend/routes/situation.py
+++ b/backend/routes/situation.py
@@ -14,5 +14,5 @@ router = APIRouter(prefix="/api", tags=["situation"])
 
 
 @router.get("/situation")
-async def get_physical_situation(db: Session = Depends(get_db)):
+def get_physical_situation(db: Session = Depends(get_db)):
     return build_physical_situation(db)

--- a/backend/routes/validation.py
+++ b/backend/routes/validation.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/api/validation", tags=["validation"])
 
 
 @router.get("/scorecards")
-async def get_scorecards(db: Session = Depends(get_db)):
+def get_scorecards(db: Session = Depends(get_db)):
     """Latest per-signal track record (one set per signal × horizon).
 
     Public, but deliberately honest: each card carries `n` and `confident`
@@ -57,7 +57,7 @@ async def get_scorecards(db: Session = Depends(get_db)):
 
 
 @router.get("/disruption-weights")
-async def get_disruption_weights(
+def get_disruption_weights(
     horizon: int = Query(7, ge=1, le=60),
     db: Session = Depends(get_db),
 ):

--- a/backend/routes/vessels.py
+++ b/backend/routes/vessels.py
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/api/vessels", tags=["vessels"])
 
 
 @router.get("/positions")
-async def get_vessel_positions(
+def get_vessel_positions(
     zone: str = Query(None, description="Filter by geofence zone name"),
     limit: int = Query(500, ge=1, le=2000),
     db: Session = Depends(get_db),
@@ -69,7 +69,7 @@ async def get_vessel_positions(
 
 
 @router.get("/global")
-async def get_global_vessels(
+def get_global_vessels(
     limit: int = Query(5000, ge=1, le=10000),
     db: Session = Depends(get_db),
 ):
@@ -92,7 +92,7 @@ async def get_global_vessels(
 
 
 @router.get("/geofence-events")
-async def get_geofence_events(
+def get_geofence_events(
     zone: str = Query(None, description="Filter by geofence zone name"),
     limit: int = Query(30, ge=1, le=365),
     db: Session = Depends(get_db),
@@ -115,7 +115,7 @@ async def get_geofence_events(
 
 
 @router.get("/zones")
-async def list_zones():
+def list_zones():
     """List all configured geofence zones, including STS hotspots."""
     main = [
         {
@@ -156,7 +156,7 @@ async def list_zones():
 
 
 @router.get("/weighted")
-async def get_weighted_vessels(
+def get_weighted_vessels(
     zone: str = Query(..., description="Geofence zone name (e.g. 'hormuz', 'suez')"),
     db: Session = Depends(get_db),
 ):
@@ -212,7 +212,7 @@ async def get_weighted_vessels(
 
 
 @router.get("/sts")
-async def get_sts_intelligence(
+def get_sts_intelligence(
     db: Session = Depends(get_db),
 ):
     """STS transfer detection + dark activity tracking.
@@ -280,7 +280,7 @@ async def get_sts_intelligence(
 
 
 @router.get("/floating-storage")
-async def get_floating_storage(
+def get_floating_storage(
     db: Session = Depends(get_db),
 ):
     """Tankers stationary for 7+ days — potential floating storage.
@@ -329,7 +329,7 @@ async def get_floating_storage(
 
 
 @router.get("/zone-history")
-async def get_zone_history(
+def get_zone_history(
     zone: str = Query(None, description="Zone name (e.g. 'hormuz'). Omit for all zones."),
     days: int = Query(90, ge=7, le=365),
     db: Session = Depends(get_db),
@@ -360,7 +360,7 @@ async def get_zone_history(
 
 
 @router.get("/registry")
-async def get_vessel_registry(
+def get_vessel_registry(
     mmsi: str = Query(..., description="Vessel MMSI"),
     db: Session = Depends(get_db),
 ):

--- a/backend/routes/voyages.py
+++ b/backend/routes/voyages.py
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/api/voyages", tags=["voyages"])
 
 
 @router.get("/recent")
-async def get_recent_voyages(
+def get_recent_voyages(
     days: int = Query(30, ge=1, le=365),
     limit: int = Query(50, ge=1, le=500),
     db: Session = Depends(get_db),
@@ -56,7 +56,7 @@ async def get_recent_voyages(
 
 
 @router.get("/flow-matrix")
-async def get_flow_matrix(
+def get_flow_matrix(
     days: int = Query(30, ge=1, le=365),
     db: Session = Depends(get_db),
 ):

--- a/backend/routes/waitlist.py
+++ b/backend/routes/waitlist.py
@@ -48,7 +48,7 @@ class WaitlistSignup(BaseModel):
 
 
 @router.post("")
-async def signup(body: WaitlistSignup, db: Session = Depends(get_db)):
+def signup(body: WaitlistSignup, db: Session = Depends(get_db)):
     existing = db.query(Waitlist).filter(Waitlist.email == body.email).first()
     if existing:
         return {"status": "ok", "message": "already registered"}
@@ -65,13 +65,13 @@ async def signup(body: WaitlistSignup, db: Session = Depends(get_db)):
 
 
 @router.get("/count")
-async def count(db: Session = Depends(get_db)):
+def count(db: Session = Depends(get_db)):
     total = db.query(Waitlist).count()
     return {"count": total}
 
 
 @router.get("/unsubscribe")
-async def unsubscribe(email: str, token: str, db: Session = Depends(get_db)):
+def unsubscribe(email: str, token: str, db: Session = Depends(get_db)):
     expected = _make_unsubscribe_token(email)
     if not hmac.compare_digest(token, expected):
         return {"status": "error", "message": "Invalid token"}

--- a/backend/routes/watchlist.py
+++ b/backend/routes/watchlist.py
@@ -58,7 +58,7 @@ class CreateItemBody(BaseModel):
 
 
 @router.get("/catalog")
-async def watchlist_catalog():
+def watchlist_catalog():
     """Everything a user can watch, grouped by kind (material/zone/symbol). Ungated."""
     return {
         kind: [{"key": k, "label": v} for k, v in items.items()]
@@ -67,7 +67,7 @@ async def watchlist_catalog():
 
 
 @router.get("")
-async def list_watchlist(user: dict = Depends(require_auth)):
+def list_watchlist(user: dict = Depends(require_auth)):
     db = SessionLocal()
     try:
         items = (
@@ -82,7 +82,7 @@ async def list_watchlist(user: dict = Depends(require_auth)):
 
 
 @router.post("")
-async def add_watchlist(body: CreateItemBody, user: dict = Depends(require_auth)):
+def add_watchlist(body: CreateItemBody, user: dict = Depends(require_auth)):
     if body.kind not in VALID_KEYS:
         raise HTTPException(status_code=422, detail=f"unknown kind: {body.kind}")
     if body.key not in VALID_KEYS[body.kind]:
@@ -122,7 +122,7 @@ async def add_watchlist(body: CreateItemBody, user: dict = Depends(require_auth)
 
 
 @router.delete("/{item_id}")
-async def delete_watchlist(item_id: int, user: dict = Depends(require_auth)):
+def delete_watchlist(item_id: int, user: dict = Depends(require_auth)):
     db = SessionLocal()
     try:
         item = (


### PR DESCRIPTION
Every read endpoint on the desk was `async def` with a fully synchronous
body (sync SQLAlchemy, zero awaits) — so uvicorn's single worker ran ALL of
them strictly serialized on the event loop. A zone switch fires ~18 panel
requests; three switches queue ~50 heavy analytics queries, and the next
situation call waits 14 s behind them (client aborts don't cancel server
work). The desk felt broken exactly when someone explored it.

Declaring them `def` moves them to Starlette's threadpool: parallel readers,
which SQLite WAL handles natively (check_same_thread=False was already set).
Only routers with zero awaits were converted; genuinely async routers
(briefing, prices, signals, …) are untouched. The single-writer doctrine is
unaffected — ingest still owns all writes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
