### PR TITLE
The catalog scanned 28M rows on every unthrottled call — DoS-proof the v1 API

### DIFF
--- a/backend/api_guard.py
+++ b/backend/api_guard.py
@@ -1,0 +1,78 @@
+"""Availability guards for the public v1 data API.
+
+The v1 read endpoints run as sync handlers in Starlette's threadpool (one uvicorn
+worker, ~40 threads). A handful of the endpoints scan the 28M-row power_hourly
+store, and one — /series/catalog — did a full min/max scan on every unthrottled
+call. Under a launch spike (or a curl loop) enough concurrent heavy scans occupy
+every threadpool thread and the whole app stalls for everyone.
+
+Two cheap defences, no external dependency:
+
+- `heavy_query_guard`: a bounded semaphore so at most HEAVY_QUERY_SLOTS heavy
+  scans run at once; the overflow gets an immediate 503 instead of queueing and
+  starving the light endpoints (health, situation, meta). It does NOT slow a
+  legitimate single bulk pull — it only caps how many run simultaneously.
+- `cached_coverage`: the catalog's coverage window changes only when the hourly
+  ingest writes (hourly), so a short TTL cache turns a 28s cold scan into one
+  scan per hour. A lock collapses a cold-start thundering herd to one scan.
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Callable
+
+from fastapi import HTTPException
+
+# From ~40 threadpool threads, allow this many concurrent heavy scans; the rest
+# stay free for the cheap endpoints. Env-tunable without a code change.
+HEAVY_QUERY_SLOTS = int(os.environ.get("OBSYD_HEAVY_QUERY_SLOTS", "8"))
+
+_heavy_sem = threading.BoundedSemaphore(HEAVY_QUERY_SLOTS)
+
+
+def heavy_query_guard():
+    """FastAPI dependency: hold one heavy-query slot for the request's duration.
+
+    Non-blocking acquire — if every slot is taken, fail fast with 503 rather than
+    block this threadpool thread waiting (which would make the exhaustion worse).
+    """
+    if not _heavy_sem.acquire(blocking=False):
+        raise HTTPException(
+            status_code=503,
+            detail="The data API is busy (too many concurrent large queries). Retry shortly.",
+        )
+    try:
+        yield
+    finally:
+        _heavy_sem.release()
+
+
+_COVERAGE_TTL = 3600.0
+_coverage: dict[str, object] = {"value": None, "expires": 0.0}
+_coverage_lock = threading.Lock()
+
+
+def cached_coverage(compute: Callable[[], object], *, now: float | None = None) -> object:
+    """Return the cached coverage window, recomputing at most once per TTL.
+
+    `compute` is the expensive min/max scan; it runs under a lock so a cold cache
+    hit by N threads does the scan once, not N times.
+    """
+    t = time.monotonic() if now is None else now
+    if _coverage["value"] is not None and t < _coverage["expires"]:
+        return _coverage["value"]
+    with _coverage_lock:
+        # Re-check inside the lock: another thread may have filled it while we waited.
+        if _coverage["value"] is not None and t < _coverage["expires"]:
+            return _coverage["value"]
+        _coverage["value"] = compute()
+        _coverage["expires"] = t + _COVERAGE_TTL
+        return _coverage["value"]
+
+
+def _reset_coverage_cache() -> None:
+    """Test hook."""
+    _coverage["value"] = None
+    _coverage["expires"] = 0.0

--- a/backend/power/hourly_store.py
+++ b/backend/power/hourly_store.py
@@ -99,16 +99,30 @@ def upsert_day_hours(
     return upsert_hourly(db, series_key, zone_key, points, unit=unit)
 
 
+class RowCapExceeded(Exception):
+    """A read matched more rows than max_rows — the caller should narrow the range."""
+
+    def __init__(self, cap: int):
+        self.cap = cap
+        super().__init__(f"result exceeds {cap} rows")
+
+
 def read_hourly(
     db: Session,
     series_key: str,
     zone_key: str,
     start_ts: int | None = None,
     end_ts: int | None = None,
+    max_rows: int | None = None,
 ) -> list[tuple[int, float]]:
     """Read (ts_utc, value) for one series+zone in [start_ts, end_ts), ordered by time.
-    Returns [] if the series/zone is unknown. This is the core range scan the future
-    /api/v1/series export builds on."""
+    Returns [] if the series/zone is unknown. This is the core range scan the
+    /api/v1/series export builds on.
+
+    `max_rows` caps a single read so one request can't materialise an unbounded
+    result into memory (and, for parquet, three copies of it). We fetch one row
+    past the cap and raise RowCapExceeded rather than silently truncate — a
+    truncated series is a wrong series."""
     sid = db.query(SeriesDim.id).filter(SeriesDim.key == series_key).scalar()
     zid = db.query(ZoneDim.id).filter(ZoneDim.key == zone_key).scalar()
     if sid is None or zid is None:
@@ -120,4 +134,10 @@ def read_hourly(
         q = q.filter(PowerHourly.ts_utc >= start_ts)
     if end_ts is not None:
         q = q.filter(PowerHourly.ts_utc < end_ts)
-    return [(int(ts), float(v)) for ts, v in q.order_by(PowerHourly.ts_utc.asc()).all()]
+    q = q.order_by(PowerHourly.ts_utc.asc())
+    if max_rows is not None:
+        q = q.limit(max_rows + 1)
+    rows = [(int(ts), float(v)) for ts, v in q.all()]
+    if max_rows is not None and len(rows) > max_rows:
+        raise RowCapExceeded(max_rows)
+    return rows

--- a/backend/routes/api_v1.py
+++ b/backend/routes/api_v1.py
@@ -14,17 +14,19 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from backend.api_guard import cached_coverage, heavy_query_guard
 from backend.auth.ratelimit import allow, client_ip
 from backend.collectors.freshness import evaluate_freshness
 from backend.database import get_db
 from backend.models.energy import InstalledCapacity, PowerHourly, SeriesDim, ZoneDim
 from backend.power.entsoe_grid import PSR_LABELS
-from backend.power.hourly_store import read_hourly
+from backend.power.hourly_store import RowCapExceeded, read_hourly
 from backend.power.zones import DEFAULT_ZONE, POWER_ZONES, ZONE_REGISTRY
 
 router = APIRouter(prefix="/api/v1", tags=["v1"])
 
 MAX_JSON_POINTS = 100_000  # beyond this, JSON is refused with a "use format=csv" hint
+MAX_SCAN_ROWS = 1_500_000  # per-request row cap on a single-series read (csv/parquet too)
 DEFAULT_WINDOW_DAYS = 30
 RATE_PER_MIN = 120  # per-IP requests/minute for the data API
 
@@ -72,7 +74,7 @@ def _to_daily(points: list[tuple[int, float]]) -> list[tuple[str, float, int]]:
 
 
 @router.get("/meta")
-def meta(db: Session = Depends(get_db)):
+def meta(db: Session = Depends(get_db), _rl: None = Depends(_rate_limit)):
     """Sources, licenses, enabled zones and available series — the API's front matter."""
     series = [{"key": k, "unit": u} for k, u in db.query(SeriesDim.key, SeriesDim.unit).order_by(SeriesDim.key).all()]
     return {
@@ -88,7 +90,7 @@ def meta(db: Session = Depends(get_db)):
 
 
 @router.get("/status")
-def status(db: Session = Depends(get_db)):
+def status(db: Session = Depends(get_db), _rl: None = Depends(_rate_limit), _g: None = Depends(heavy_query_guard)):
     """Honest data-coverage view: per-source + per-zone freshness for the power/gas
     desk (from the shared freshness spec). `healthy` is true when every product-critical
     source is within its window. The transparency answer to a black-box feed — 'here is
@@ -111,7 +113,7 @@ def status(db: Session = Depends(get_db)):
 
 
 @router.get("/zones")
-def zones():
+def zones(_rl: None = Depends(_rate_limit)):
     """Every bidding zone in the registry with its enablement + flow-mapping flags —
     the single source of truth for zone selectors/navigation across the frontend."""
     enabled = set(POWER_ZONES)
@@ -140,6 +142,7 @@ def genmix(
     format: str = Query("json", pattern="^(json|csv)$"),
     db: Session = Depends(get_db),
     _rl: None = Depends(_rate_limit),
+    _g: None = Depends(heavy_query_guard),
 ):
     """Generation mix over time — every fuel (gen.<psr>) for one zone, aggregated to
     daily or monthly mean MW, in a wide shape ({t, <fuel>: mw, ...}) for a stacked area.
@@ -215,12 +218,18 @@ def snapshot(
     end: str | None = Query(None, description="Override window end (default: now)"),
     db: Session = Depends(get_db),
     _rl: None = Depends(_rate_limit),
+    _g: None = Depends(heavy_query_guard),
 ):
     """Per-zone hourly values for one series over a window, aligned to a common
     timestamp grid ({timestamps: [...], zones: {zone: [v, ...]}}). Powers the map
     time-scrubber — one call, then the client slides the index. Descriptive."""
     end_dt = _parse_ts(end, datetime.now(UTC))
     start_dt = _parse_ts(start, end_dt - timedelta(hours=hours))
+    # start/end overrides mustn't defeat the `hours` cap: this scans every zone,
+    # so an unbounded window is a full-table fan-out. Hold the same 744h ceiling.
+    if end_dt - start_dt > timedelta(hours=744):
+        return {"available": False, "series": series,
+                "reason": "Snapshot window exceeds 744h — narrow it, or use /series for long ranges."}
     sid = db.query(SeriesDim.id).filter(SeriesDim.key == series).scalar()
     unit = db.query(SeriesDim.unit).filter(SeriesDim.key == series).scalar()
     if sid is None:
@@ -263,6 +272,7 @@ def capacity(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     year: int | None = Query(None, description="Year (default: latest available)"),
     db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
 ):
     """Installed generation capacity per production type (MW) for a zone-year — ENTSO-E
     A68 annual reference data. Defaults to the latest available year. Pan-EU context
@@ -292,6 +302,7 @@ def capacity(
 def get_production_units(
     zone: str = Query(..., description="Bidding zone key"),
     db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
 ):
     """The zone's published production units (ENTSO-E A71/A33) — reference data.
 
@@ -342,20 +353,30 @@ def get_production_units(
     }
 
 
+def _coverage_window(db: Session) -> dict:
+    """The overall hourly coverage window — a global min/max over power_hourly.
+
+    ts_utc is the 3rd column of the (series_id, zone_id, ts_utc) PK with no
+    standalone index, so this is a full scan (~28s cold on prod). Cached for an
+    hour via cached_coverage: the window only moves when the hourly ingest runs.
+    """
+    lo, hi = db.query(func.min(PowerHourly.ts_utc), func.max(PowerHourly.ts_utc)).first()
+    return {
+        "from": datetime.fromtimestamp(lo, UTC).isoformat() if lo else None,
+        "to": datetime.fromtimestamp(hi, UTC).isoformat() if hi else None,
+    }
+
+
 @router.get("/series/catalog")
-def catalog(db: Session = Depends(get_db)):
+def catalog(db: Session = Depends(get_db), _rl: None = Depends(_rate_limit), _g: None = Depends(heavy_query_guard)):
     """What's queryable: every series (key+unit), enabled zones, and the overall
     hourly coverage window."""
     series = [{"key": k, "unit": u} for k, u in db.query(SeriesDim.key, SeriesDim.unit).order_by(SeriesDim.key).all()]
-    lo, hi = db.query(func.min(PowerHourly.ts_utc), func.max(PowerHourly.ts_utc)).first()
     return {
         "available": bool(series),
         "series": series,
         "zones": [{"key": k, "label": v["label"]} for k, v in POWER_ZONES.items()],
-        "coverage": {
-            "from": datetime.fromtimestamp(lo, UTC).isoformat() if lo else None,
-            "to": datetime.fromtimestamp(hi, UTC).isoformat() if hi else None,
-        },
+        "coverage": cached_coverage(lambda: _coverage_window(db)),
         "series_count": len(series),
     }
 
@@ -371,6 +392,7 @@ def series(
     format: str = Query("json", pattern="^(json|csv|parquet)$"),
     db: Session = Depends(get_db),
     _rl: None = Depends(_rate_limit),
+    _g: None = Depends(heavy_query_guard),
 ):
     """One series for one zone over a time range — the core data endpoint.
 
@@ -391,11 +413,19 @@ def series(
         raise HTTPException(status_code=400, detail="start must be before end.")
 
     unit = db.query(SeriesDim.unit).filter(SeriesDim.key == series).scalar()
-    points = read_hourly(
-        db, series, zone,
-        int(start_dt.timestamp()),
-        int(end_dt.timestamp()) if end_dt is not None else None,
-    )
+    try:
+        points = read_hourly(
+            db, series, zone,
+            int(start_dt.timestamp()),
+            int(end_dt.timestamp()) if end_dt is not None else None,
+            max_rows=MAX_SCAN_ROWS,
+        )
+    except RowCapExceeded:
+        return {
+            "available": False, "series": series, "zone": zone, "resolution": resolution,
+            "reason": (f"Range matches more than {MAX_SCAN_ROWS:,} rows — narrow start/end. "
+                       "This is a per-request cap, not the coverage limit."),
+        }
 
     if resolution == "daily":
         rows = [{"date": d, "value": v, "hours": n} for d, v, n in _to_daily(points)]

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -5,7 +5,7 @@ Settings API — runtime provider configuration.
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from backend.auth.dependencies import require_auth
+from backend.auth.dependencies import require_pro
 from backend.providers import price_provider
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
@@ -23,8 +23,9 @@ def get_settings():
 
 
 @router.post("/provider")
-def set_provider(body: ProviderUpdate, _user: dict = Depends(require_auth)):
-    """Change the active price provider (auth required)."""
+def set_provider(body: ProviderUpdate, _user: dict = Depends(require_pro)):
+    """Change the active price provider — server-wide state, so owner-only
+    (require_pro), not any free login."""
     try:
         price_provider.set_providers(body.primary, body.fallback)
         return {"status": "ok", **price_provider.get_settings()}

--- a/backend/routes/waitlist.py
+++ b/backend/routes/waitlist.py
@@ -3,10 +3,11 @@ import hmac
 import logging
 import re
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, field_validator
 from sqlalchemy.orm import Session
 
+from backend.auth.ratelimit import allow, client_ip
 from backend.config import settings
 from backend.database import get_db
 from backend.models.waitlist import Waitlist
@@ -48,7 +49,11 @@ class WaitlistSignup(BaseModel):
 
 
 @router.post("")
-def signup(body: WaitlistSignup, db: Session = Depends(get_db)):
+def signup(body: WaitlistSignup, request: Request, db: Session = Depends(get_db)):
+    # Unauthenticated public insert — throttle per IP so it can't be used to
+    # bloat the table with arbitrary emails.
+    if not allow([(f"waitlist:{client_ip(request)}", 5, 3600.0)]):
+        raise HTTPException(status_code=429, detail="Too many signups — try again later.")
     existing = db.query(Waitlist).filter(Waitlist.email == body.email).first()
     if existing:
         return {"status": "ok", "message": "already registered"}

--- a/backend/tests/test_api_v1.py
+++ b/backend/tests/test_api_v1.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.api_guard import _reset_coverage_cache
 from backend.auth.ratelimit import reset_limits
 from backend.database import get_db
 from backend.main import app
@@ -19,9 +20,11 @@ _H = 3600
 @pytest.fixture(autouse=True)
 def _isolate():
     reset_limits()
+    _reset_coverage_cache()  # process-global; would leak the coverage window between tests
     yield
     app.dependency_overrides.clear()
     reset_limits()
+    _reset_coverage_cache()
 
 
 def _client(db):
@@ -309,3 +312,74 @@ def test_daily_csv_carries_the_hour_count_too(db_session):
     ).text
     assert text.splitlines()[0] == "date,value,hours"
     assert text.splitlines()[1].endswith(",9")
+
+
+# ── DoS guards (2026-07-18) ──────────────────────────────────────────────────
+
+def test_coverage_is_cached_across_calls(db_session, monkeypatch):
+    """The catalog's coverage window must be computed at most once per TTL —
+    the min/max scan is a 28s full-table hit on prod."""
+    import backend.routes.api_v1 as v1
+
+    _seed(db_session)
+    calls = {"n": 0}
+    real = v1._coverage_window
+
+    def counting(db):
+        calls["n"] += 1
+        return real(db)
+
+    monkeypatch.setattr(v1, "_coverage_window", counting)
+    c = _client(db_session)
+    c.get("/api/v1/series/catalog")
+    c.get("/api/v1/series/catalog")
+    c.get("/api/v1/series/catalog")
+    assert calls["n"] == 1, "coverage scan ran more than once despite the cache"
+
+
+def test_series_row_cap_refuses_instead_of_materialising(db_session, monkeypatch):
+    """A range over the per-request row cap must return available:False, not
+    scan+build the whole result."""
+    import backend.routes.api_v1 as v1
+
+    monkeypatch.setattr(v1, "MAX_SCAN_ROWS", 3)
+    _seed(db_session, n=10)
+    body = _client(db_session).get(
+        "/api/v1/series?series=load.actual&zone=DE_LU&start=2026-06-01&end=2026-07-01"
+    ).json()
+    assert body["available"] is False
+    assert "narrow" in body["reason"].lower()
+
+
+def test_snapshot_rejects_oversized_window(db_session):
+    _seed(db_session)
+    body = _client(db_session).get(
+        "/api/v1/snapshot?series=load.actual&start=2020-01-01&end=2026-01-01"
+    ).json()
+    assert body["available"] is False
+    assert "744" in body["reason"]
+
+
+def test_heavy_query_guard_returns_503_when_full(db_session):
+    """When every heavy slot is taken, the next heavy request fails fast (503)
+    instead of queueing and starving the light endpoints."""
+    import backend.api_guard as guard
+
+    _seed(db_session)
+    c = _client(db_session)
+    # Drain every slot, then the guarded endpoint must 503; a light endpoint still 200s.
+    acquired = [guard._heavy_sem.acquire(blocking=False) for _ in range(guard.HEAVY_QUERY_SLOTS)]
+    try:
+        assert all(acquired)
+        assert c.get("/api/v1/series/catalog").status_code == 503
+        assert c.get("/api/v1/zones").status_code == 200  # light endpoint unaffected
+    finally:
+        for _ in acquired:
+            guard._heavy_sem.release()
+
+
+def test_catalog_is_rate_limited(db_session):
+    _seed(db_session)
+    c = _client(db_session)
+    codes = {c.get("/api/v1/series/catalog").status_code for _ in range(130)}
+    assert 429 in codes, "catalog must be throttled like the other data endpoints"


### PR DESCRIPTION
Before a public launch, the /api/v1 read layer had a cheap denial-of-service:
/series/catalog ran a full min/max scan over the 28M-row power_hourly store
(measured 27.8s cold, 2.5s warm) on EVERY call, with NO rate limit. One curl
loop of ~40 concurrent catalog hits pins every threadpool thread on the single
worker and the whole desk stalls for everyone — indefinitely, since nothing
throttles it. /series, /snapshot and /genmix also accepted unbounded ranges
(a single /series?start=2000 pull measured 74s / 272k rows; parquet
materialises the result three times → OOM against the 2G cap).

backend/api_guard.py adds two dependency-free defences:
- heavy_query_guard: a bounded semaphore (8 slots) so at most N heavy scans run
  at once; the overflow gets an immediate 503 instead of queueing and starving
  the light endpoints. It caps concurrency, not a single legitimate bulk pull.
- cached_coverage: the catalog window changes only on the hourly ingest, so a
  1h TTL cache (lock-collapsed on cold start) turns 28s into one scan per hour.

Plus: rate-limit the six previously-unthrottled v1 endpoints; a per-request
MAX_SCAN_ROWS cap in read_hourly (raise RowCapExceeded, never silently
truncate); a 744h ceiling on /snapshot so start/end can't defeat the hours cap.

Two quick hardenings caught in the same review: POST /api/settings/provider
(server-wide state) moves from require_auth to require_pro — a free login could
flip the global price provider; POST /api/waitlist gets a per-IP throttle so an
unauthenticated insert can't bloat the table.

No SQLi, no committed secrets, no IDOR were found — the auth model is sound;
this is purely abuse/resource-exhaustion hardening. Full suite 977 passed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
