### PR TITLE
The table said €62, the chart said €53 — one canonical daily mean

### DIFF
--- a/backend/power/entsoe_prices.py
+++ b/backend/power/entsoe_prices.py
@@ -26,7 +26,7 @@ from backend.config import settings
 from backend.gas import raw_cache
 from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
 from backend.models.energy import EnergyPrice, PowerPriceDaily
-from backend.power.hourly_store import upsert_day_hours, upsert_hourly
+from backend.power.hourly_store import day_hour_ts, read_hourly, upsert_day_hours, upsert_hourly
 
 logger = logging.getLogger(__name__)
 
@@ -305,17 +305,9 @@ async def ingest_day_ahead(
             if datetime.fromtimestamp(t, tz=timezone.utc).strftime("%Y-%m-%d") in wanted
         )
 
-    written = 0
-    for day, stats in stats_by_day.items():
-        mean = stats["mean"]
-        # Keep EnergyPrice(POWER_DE) identical — scorecard + spark-spread use it.
-        _upsert(db, day, symbol, mean)
-        # Upsert the richer per-day stats row.
-        _upsert_daily(db, day, zone, stats)
-        written += 1
-    db.commit()
-
     # ── Hourly day-ahead price → power_hourly (canonical store; roadmap Block 1) ──
+    # Write this FIRST: the daily mean below is derived from it, so the table's
+    # mean_price is the exact number the chart, the v1 API and the client average.
     price_by_day: dict[str, dict[int, float]] = {
         day: {int(p["hour"]): float(p["price"]) for p in stats["hourly"]}
         for day, stats in stats_by_day.items()
@@ -323,6 +315,22 @@ async def ingest_day_ahead(
     }
     if price_by_day:
         upsert_day_hours(db, "price.dayahead", zone, price_by_day, unit="EUR/MWh")
+
+    written = 0
+    for day, stats in stats_by_day.items():
+        # Derive the mean from the canonical hourly store, NOT from stats["mean"]
+        # (a finest-resolution snapshot). On mixed-resolution days those diverge —
+        # stats["mean"] averaged the QH slots (19h) while the chart averages the
+        # accumulated hourly series (22h), so the table and the chart disagreed.
+        mean = _canonical_daily_mean(db, zone, day)
+        if mean is None:
+            mean = stats["mean"]  # no hourly written (shouldn't happen); stay safe
+        # Keep EnergyPrice(POWER_DE) identical — scorecard + spark-spread use it.
+        _upsert(db, day, symbol, mean)
+        # Upsert the richer per-day stats row (mean overridden to the canonical one).
+        _upsert_daily(db, day, zone, {**stats, "mean": mean})
+        written += 1
+    db.commit()
 
     # ── Raw 15-min auction points → price.dayahead.qh (roadmap Block 2) ──
     # Present only for delivery days since the SDAC 15-min switch (2025-10-01);
@@ -337,6 +345,18 @@ async def ingest_day_ahead(
         symbol,
     )
     return {"days": len(days), "written": written}
+
+
+def _canonical_daily_mean(db: Session, zone: str, day: str) -> float | None:
+    """The day's mean EUR/MWh from the canonical hourly store (price.dayahead) — the
+    same series the chart, the v1 API and the python client average. Deriving
+    mean_price/close from here (instead of a separate finest-resolution snapshot)
+    guarantees no two views of the desk ever disagree on a zone's daily price."""
+    start = day_hour_ts(day, 0)
+    rows = read_hourly(db, "price.dayahead", zone, start, start + 86400)
+    if not rows:
+        return None
+    return sum(p for _, p in rows) / len(rows)
 
 
 def _upsert(db: Session, day: str, symbol: str, close: float) -> None:

--- a/backend/scripts/recompute_daily_means.py
+++ b/backend/scripts/recompute_daily_means.py
@@ -1,0 +1,80 @@
+"""Backfill: re-derive PowerPriceDaily.mean_price (and EnergyPrice.close) from the
+canonical price.dayahead hourly store — DB-only, no ENTSO-E refetch.
+
+Before the coherence fix, the daily mean was averaged from a finest-resolution
+snapshot (the QH slots) while the chart/v1-API/client average the accumulated
+hourly series. On mixed-resolution days (ENTSO-E serving some hours as PT60M and
+some as PT15M since the SDAC 15-min switch, 2025-10-01) the two diverged — the
+table said FR €62 while the chart said €53. This recomputes every affected day's
+mean straight from the hourly store, so all views agree.
+
+Usage (on the VPS, as the obsyd user):
+    python -m backend.scripts.recompute_daily_means --dry-run          # count only
+    python -m backend.scripts.recompute_daily_means --since 2025-10-01 # write
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+
+from backend.database import SessionLocal
+from backend.models.energy import EnergyPrice, PowerPriceDaily
+from backend.power.entsoe_prices import _canonical_daily_mean
+from backend.power.zones import ZONE_REGISTRY
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("recompute_daily_means")
+
+# Divergence only exists on days that also have a 15-min series, i.e. since SDAC's
+# quarter-hour switch. Default the floor there; older days were pure-hourly and match.
+DEFAULT_SINCE = "2025-10-01"
+
+_ZONE_SYMBOL = {z: cfg["price_symbol"] for z, cfg in ZONE_REGISTRY.items()}
+
+
+def recompute(since: str, *, dry_run: bool) -> dict:
+    db = SessionLocal()
+    changed = 0
+    checked = 0
+    max_delta = 0.0
+    try:
+        rows = (
+            db.query(PowerPriceDaily)
+            .filter(PowerPriceDaily.date >= since)
+            .order_by(PowerPriceDaily.zone, PowerPriceDaily.date)
+            .all()
+        )
+        for row in rows:
+            checked += 1
+            mean = _canonical_daily_mean(db, row.zone, row.date)
+            if mean is None:
+                continue
+            if row.mean_price is None or abs(row.mean_price - mean) > 0.005:
+                max_delta = max(max_delta, abs((row.mean_price or 0) - mean))
+                if not dry_run:
+                    row.mean_price = mean
+                    symbol = _ZONE_SYMBOL.get(row.zone)
+                    if symbol:
+                        ep = (
+                            db.query(EnergyPrice)
+                            .filter(EnergyPrice.date == row.date, EnergyPrice.symbol == symbol)
+                            .first()
+                        )
+                        if ep is not None:
+                            ep.close = mean
+                changed += 1
+        if not dry_run:
+            db.commit()
+    finally:
+        db.close()
+    result = {"checked": checked, "changed": changed, "max_delta": round(max_delta, 2), "dry_run": dry_run}
+    logger.info("recompute_daily_means: %s", result)
+    return result
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--since", default=DEFAULT_SINCE, help="Earliest delivery day to recompute (YYYY-MM-DD)")
+    ap.add_argument("--dry-run", action="store_true", help="Count what would change without writing")
+    args = ap.parse_args()
+    recompute(args.since, dry_run=args.dry_run)

--- a/backend/tests/test_power_prices.py
+++ b/backend/tests/test_power_prices.py
@@ -322,3 +322,51 @@ async def test_ingest_qh_respects_the_requested_days(db_session, monkeypatch):
     qh = read_hourly(db_session, "price.dayahead.qh", "DE_LU")
     assert len(qh) == 96
     assert all(v == 10.0 for _, v in qh)
+
+
+# ─── coherence regression: table mean must equal the canonical hourly store ────
+
+
+async def test_mean_price_matches_hourly_store_after_resolution_change(db_session, monkeypatch):
+    """The bug FR exposed 2026-07-19: when ENTSO-E republishes a day as 15-min but
+    the QH series covers fewer hours than the accumulated hourly store, the daily
+    mean (table/situation) must still equal the mean of the canonical price.dayahead
+    series — the exact number the chart, the v1 API and the client average — not the
+    QH-slot snapshot. Reproduced via two ingests (hourly, then a QH subset)."""
+    from pydantic import SecretStr
+
+    from backend.models.energy import PowerPriceDaily
+    from backend.power import entsoe_prices
+    from backend.power.hourly_store import day_hour_ts, read_hourly
+
+    day = "2026-05-01"
+    # Ingest 1 — full hourly day: hours 0-19 @ 100, hours 20-23 @ 0 (cheap evening).
+    xml1 = _a44(_ts(f"{day}T00:00Z", "2026-05-02T00:00Z", [100.0] * 20 + [0.0] * 4, res="PT60M"))
+    # Ingest 2 — same day now 15-min, but only the first 20 hours (80 QH) @ 100.
+    xml2 = _a44(_ts(f"{day}T00:00Z", f"{day}T20:00Z", [100.0] * 80, res="PT15M"))
+
+    monkeypatch.setattr(entsoe_prices.settings, "entsoe_api_token", SecretStr("tok"))
+
+    async def fetch1(eic, m, *, overwrite=False):
+        return xml1
+
+    monkeypatch.setattr(entsoe_prices, "_fetch_zone_month", fetch1)
+    await entsoe_prices.ingest_day_ahead(db_session, [day])
+
+    async def fetch2(eic, m, *, overwrite=False):
+        return xml2
+
+    monkeypatch.setattr(entsoe_prices, "_fetch_zone_month", fetch2)
+    await entsoe_prices.ingest_day_ahead(db_session, [day])
+
+    # Canonical store now holds 24h: 0-19 @ 100 (overwritten by QH), 20-23 @ 0 (kept).
+    start = day_hour_ts(day, 0)
+    rows = read_hourly(db_session, "price.dayahead", "DE_LU", start, start + 86400)
+    assert len(rows) == 24
+    hourly_mean = sum(p for _, p in rows) / len(rows)
+    assert hourly_mean == pytest.approx((20 * 100 + 4 * 0) / 24)  # 83.33, NOT the 100 the QH snapshot gave
+
+    daily = db_session.query(PowerPriceDaily).filter_by(date=day, zone="DE_LU").first()
+    close = db_session.query(EnergyPrice).filter_by(date=day, symbol="POWER_DE").first().close
+    assert daily.mean_price == pytest.approx(hourly_mean)
+    assert close == pytest.approx(hourly_mean)


### PR DESCRIPTION
A user comparing the all-zones table (FR €62) with the price chart (FR €53) hit
a real incoherence. Root cause: the daily mean lived twice. The table's
mean_price/close was averaged from a finest-resolution snapshot (since SDAC's
15-min switch, the QH slots — 19h for FR that day), while the chart, the v1 API
and the python client average the canonical price.dayahead hourly series (22h).
On mixed-resolution days — ENTSO-E serving some hours as PT60M, some as PT15M,
and upsert_day_hours accumulating the older PT60M hours a later QH ingest drops
— the two diverge by the value of those cheap dropped hours.

Fix: one source of truth. ingest_day_ahead now writes the hourly store FIRST,
then derives mean_price AND EnergyPrice.close from it (_canonical_daily_mean) —
the exact number every other view averages. The QH sawtooth stays as drill-down;
only the aggregate comes from one place, so the desk can't contradict itself.

Blast radius (spark-spread, radar detectors, scorecard, drivers read close/
mean_price) verified: full suite 978 + targeted spark/scorecard/situation 83
green. Regression test reproduces the bug via two ingests (hourly then a QH
subset) and pins mean_price == the hourly-store mean; it fails on the old code.

Historical rows stay QH-based until backfilled: recompute_daily_means.py
re-derives every day since 2025-10-01 from the hourly store, DB-only (no
ENTSO-E refetch). Run after deploy.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
