### PR TITLE
Info buttons that explain what the desk is actually showing

### DIFF
--- a/frontend/src/components/PowerMap.jsx
+++ b/frontend/src/components/PowerMap.jsx
@@ -282,7 +282,7 @@ export default function PowerMap() {
       <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-2.5 border-b border-border">
         <div className="flex items-center gap-2 min-w-0">
           <span className="font-mono text-[12px] font-semibold text-neutral-300">Europe · power map</span>
-          <InfoPopover text="Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by the day-ahead price on a fixed scale across the shown week — violet = negative prices, brighter cyan = more expensive — or by grid state. Dark shapes = neighbouring countries, no data by design. Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast." />
+          <InfoPopover text="Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by the day-ahead price — or by grid state. IMPORTANT: it shades ONE HOUR at a time (the hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the all-zones table shows a positive daily mean. Drag the slider to move through the hours. Fixed colour scale across the shown week: violet = negative prices (a distinct state, not just cheap), brighter cyan = more expensive. Dark shapes = neighbouring countries, no data by design. Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast." />
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex items-center gap-1">

--- a/frontend/src/components/PowerOverviewMatrix.jsx
+++ b/frontend/src/components/PowerOverviewMatrix.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { InfoPopover } from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { POLL_FAST_MS } from '../utils/poll'
 
@@ -26,6 +27,17 @@ const COLUMNS = [
   { key: 'residual', label: 'Residual', align: 'right', get: (z) => z.residual_gw },
   { key: 'renewables', label: 'Renewables', align: 'right', get: (z) => (z.renewable_reliable === false ? null : z.renewable_share) },
 ]
+
+// One legend for the whole table (per-column popovers would be clipped by the
+// scroll container). Spells out what each column is — and, crucially, that
+// Day-ahead here is the DAILY MEAN, while the map shades a single hour.
+const TABLE_INFO = (
+  'What each column means. '
+  + 'State: how far this zone sits from its own 30-day norm — CALM / ELEVATED (amber) / STRESSED (red); a deviation vs history, not a forecast. '
+  + 'Day-ahead: the auction price (€/MWh), cleared the day before for this delivery day — a settled market price, NOT a forecast. It is the DAILY MEAN across the day’s hours; the map shades one hour at a time (its slider), so the map’s number differs from this average. '
+  + 'Residual: demand − wind − solar (GW), the gap conventional plants must fill — what actually sets the price. '
+  + 'Renewables: wind + solar as a share of load, left blank when the feed is too incomplete to trust the share.'
+)
 
 export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
   const { data, loading, error } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
@@ -77,6 +89,7 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
     <div className="border border-border bg-surface rounded overflow-hidden shadow-sm">
       <div className="px-4 py-2.5 border-b border-border/60 flex items-center gap-2">
         <span className="font-mono text-[12px] font-semibold text-neutral-300">European power · all zones</span>
+        <InfoPopover text={TABLE_INFO} />
         <span className="font-mono text-[9px] text-neutral-700 ml-auto">sort ↕ · click a zone for detail →</span>
       </div>
       <div className="overflow-x-auto max-h-[520px] overflow-y-auto">


### PR DESCRIPTION
The owner (and by extension a first-time HN visitor) was unsure what "Day-ahead"
means and why the table's €62 and the map's €0 differed for the same zone. Both
are answered now:

- The all-zones table gets an (i) by its title (per-column popovers would be
  clipped by the scroll container) spelling out each column — and, crucially,
  that Day-ahead here is a settled auction price (not a forecast) and the DAILY
  MEAN, while the map shades a single hour.
- The map's existing (i) now leads with the point that bit: it shades ONE HOUR
  at a time (the slider), so a zone can read €0 at 08:00 while the table shows a
  positive daily mean. Violet = negative prices as before.

Reuses the existing InfoPopover from Panel.jsx. No new eslint issues.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
