### PR TITLE
An hourly toggle on the compare chart — where the intraday shape lives

### DIFF
--- a/frontend/src/components/LiveCharts.jsx
+++ b/frontend/src/components/LiveCharts.jsx
@@ -29,6 +29,7 @@ function readCompare() {
 
 export default function LiveCharts() {
   const [section, setSection] = useState('prices')
+  const [resolution, setResolution] = useState('daily')  // series view: daily trend vs today's hourly shape
   const [compare, setCompare] = useState(readCompare)
   const { zone } = useViewState()
   const { zones } = useZones()
@@ -118,6 +119,25 @@ export default function LiveCharts() {
           </button>
         ))}
         {full && <span className="text-neutral-600">3 is the limit — four lines is a chart, five is a thicket</span>}
+        {/* Daily trend vs the intraday shape — the hourly view is where a zone's
+            morning solar dip (FR to €0) or evening peak actually shows. */}
+        {s.kind === 'series' && (
+          <div className="ml-auto flex items-center gap-0.5 shrink-0">
+            {['daily', 'hourly'].map((r) => (
+              <button
+                key={r}
+                onClick={() => setResolution(r)}
+                className={`px-2 py-0.5 rounded border transition-colors capitalize ${
+                  resolution === r
+                    ? 'border-cyan-glow/50 text-cyan-glow bg-cyan-glow/10'
+                    : 'border-border text-neutral-500 hover:text-neutral-300'
+                }`}
+              >
+                {r === 'hourly' ? 'Hourly · 3d' : 'Daily'}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       {s.kind === 'mix' ? (
@@ -141,6 +161,7 @@ export default function LiveCharts() {
           scale={s.scale}
           color={s.color}
           labelFor={labelFor}
+          resolution={resolution}
         />
       )}
     </div>

--- a/frontend/src/components/ZoneCompareChart.jsx
+++ b/frontend/src/components/ZoneCompareChart.jsx
@@ -17,11 +17,28 @@ const MAX_COMPARE = 3
 // the third indigo. The primary keeps its section's colour.
 const COMPARE_COLORS = ['#f472b6', '#4ade80', '#818cf8']
 
-export default function ZoneCompareChart({ title, series, zone, compare = [], unit, scale = 1, color = '#22d3ee', labelFor }) {
-  const { range } = useViewState()
-  const start = rangeStart(range)
+// Compact UTC axis label for the hourly view ("Jul 19 08h").
+function fmtHourAxis(iso) {
+  const d = new Date(iso)
+  if (isNaN(d)) return String(iso)
+  return d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', hour12: false, timeZone: 'UTC' }).replace(', ', ' ').replace(/:\d\d$/, 'h')
+}
 
-  const urlFor = (z) => `${API}/v1/series?series=${series}&zone=${z}&start=${start}&resolution=daily`
+// Fixed lookback for the hourly view: enough to see the intraday shape across a
+// few days, and — crucially — NOT the global range (5Y × hourly would trip the
+// per-request row cap). One request per zone, well inside the cap.
+const HOURLY_LOOKBACK_DAYS = 3
+
+export default function ZoneCompareChart({ title, series, zone, compare = [], unit, scale = 1, color = '#22d3ee', labelFor, resolution = 'daily' }) {
+  const { range } = useViewState()
+  const hourly = resolution === 'hourly'
+  const start = hourly
+    ? new Date(Date.now() - HOURLY_LOOKBACK_DAYS * 86400_000).toISOString().slice(0, 10)
+    : rangeStart(range)
+  const tkey = hourly ? 'datetime_utc' : 'date'
+  const fmtAxis = hourly ? fmtHourAxis : fmtDate
+
+  const urlFor = (z) => `${API}/v1/series?series=${series}&zone=${z}&start=${start}&resolution=${resolution}`
 
   // Hooks cannot run in a loop, so the compare slots are fixed. An unused slot points at the
   // PRIMARY zone's url — already in the SWR cache, so it costs no request (the SeriesExplorer
@@ -41,8 +58,9 @@ export default function ZoneCompareChart({ title, series, zone, compare = [], un
     zones.forEach((z, i) => {
       const points = responses[i].data?.data || []
       for (const p of points) {
-        if (!byDate.has(p.date)) byDate.set(p.date, { t: p.date })
-        byDate.get(p.date)[z] = p.value == null ? null : p.value * scale
+        const t = p[tkey]
+        if (!byDate.has(t)) byDate.set(t, { t })
+        byDate.get(t)[z] = p.value == null ? null : p.value * scale
       }
       const last = points.at(-1)
       latestByZone[z] = last?.value == null ? null : last.value * scale
@@ -54,7 +72,7 @@ export default function ZoneCompareChart({ title, series, zone, compare = [], un
       hours: hoursByZone,
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [r0.data, r1.data, r2.data, r3.data, zones.join(','), scale])
+  }, [r0.data, r1.data, r2.data, r3.data, zones.join(','), scale, tkey])
 
   const loading = responses.slice(0, zones.length).some((r) => r.loading)
   const failedZones = zones.filter((z, i) => responses[i].error && !responses[i].data)
@@ -94,7 +112,7 @@ export default function ZoneCompareChart({ title, series, zone, compare = [], un
             ) : (
               <span className="text-neutral-600">no data</span>
             )}
-            {hours[z] != null && hours[z] < 24 && (
+            {!hourly && hours[z] != null && hours[z] < 24 && (
               <span
                 className="text-neutral-600"
                 title={`The last day is still filling in: this mean averages ${hours[z]} of 24 hours.`}
@@ -117,11 +135,11 @@ export default function ZoneCompareChart({ title, series, zone, compare = [], un
           <ResponsiveContainer width="100%" height={280}>
             <LineChart data={rows} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-              <XAxis dataKey="t" tickFormatter={fmtDate} tick={{ fontSize: 9, fill: '#737373' }} minTickGap={40} />
+              <XAxis dataKey="t" tickFormatter={fmtAxis} tick={{ fontSize: 9, fill: '#737373' }} minTickGap={hourly ? 60 : 40} />
               <YAxis tick={{ fontSize: 9, fill: '#737373' }} width={40} domain={['auto', 'auto']} />
               <Tooltip
                 {...CHART_TOOLTIP_PROPS}
-                labelFormatter={fmtDate}
+                labelFormatter={fmtAxis}
                 formatter={(v, name) => [v != null ? `${Number(v).toFixed(1)} ${unit}` : '—', label(name)]}
               />
               {zones.map((z, i) => (


### PR DESCRIPTION
The daily compare chart shows the trend across days; it can't show WHY FR reads
€0 on the map at 08:00 while its daily mean is positive. A Daily/Hourly toggle
on the Prices/Load/Residual compare view now draws the last 3 days at hourly
resolution, so the morning solar dip and evening peak — and where one zone
dives below another — are visible. This is the answer to the €0-vs-positive
question in chart form.

The hourly view uses a FIXED 3-day lookback, never the global range: 5Y ×
hourly would trip the per-request row cap. One request per zone. ZoneCompare-
Chart is now resolution-aware (x-axis, aggregation key, and the "x/24h"
stub-day note all switch); the toggle only shows for the series sections.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
