### PR TITLE
Three more "same number, two ways" divergences the owner's clicking exposed

### DIFF
--- a/backend/power/products.py
+++ b/backend/power/products.py
@@ -107,7 +107,10 @@ def day_products(hours: dict[int, float], weekday: int) -> dict:
         ),
         "peak_hours": len(peak_values),
         "hours": len(values),
-        "negative_hours": sum(1 for p in values if p < 0),
+        # negative_hours deliberately NOT reported here: the canonical count is
+        # PowerPriceDaily.negative_hours (resolution-weighted, UTC day), shown on
+        # the day-ahead panel + hero. A whole-hour count on the CET day here gave
+        # a different number for the same day (FR 7 vs 5) — one quantity, one place.
         "min": round(min(values), 2),
         "max": round(max(values), 2),
         "evening_ramp": (lambda r: round(r, 2) if r is not None else None)(_ramp(hours)),

--- a/backend/routes/api_v1.py
+++ b/backend/routes/api_v1.py
@@ -18,8 +18,7 @@ from backend.api_guard import cached_coverage, heavy_query_guard
 from backend.auth.ratelimit import allow, client_ip
 from backend.collectors.freshness import evaluate_freshness
 from backend.database import get_db
-from backend.models.energy import InstalledCapacity, PowerHourly, SeriesDim, ZoneDim
-from backend.power.entsoe_grid import PSR_LABELS
+from backend.models.energy import InstalledCapacity, PowerGenMix, PowerHourly, SeriesDim, ZoneDim
 from backend.power.hourly_store import RowCapExceeded, read_hourly
 from backend.power.zones import DEFAULT_ZONE, POWER_ZONES, ZONE_REGISTRY
 
@@ -151,29 +150,31 @@ def genmix(
     z = zone if zone in POWER_ZONES else DEFAULT_ZONE
     end_dt = _parse_ts(end, datetime.now(UTC))
     start_dt = _parse_ts(start, end_dt - timedelta(days=365))
-    zid = db.query(ZoneDim.id).filter(ZoneDim.key == z).scalar()
-    gen = db.query(SeriesDim.id, SeriesDim.key).filter(SeriesDim.key.like("gen.%")).all()
-    if zid is None or not gen:
-        return {"available": False, "zone": z, "reason": "No generation-mix data yet."}
-    sid_label = {sid: PSR_LABELS.get(key.split(".", 1)[1], key) for sid, key in gen}
+    # Read the CANONICAL daily generation table (PowerGenMix, daily-mean ÷24 per
+    # daily.py — a fuel absent at night counts as 0). This is the SAME source the
+    # /api/power/generation-mix panel uses, so the public API and the desk can't
+    # disagree. Averaging power_hourly over PUBLISHED hours (the old path) divided
+    # solar by ~18 daylight hours, overstating it (IT-Nord ~29%). Settled days only.
     rows = (
-        db.query(PowerHourly.series_id, PowerHourly.ts_utc, PowerHourly.value)
+        db.query(PowerGenMix.date, PowerGenMix.psr_type, PowerGenMix.gen_mw)
         .filter(
-            PowerHourly.zone_id == zid,
-            PowerHourly.series_id.in_(list(sid_label)),
-            PowerHourly.ts_utc >= int(start_dt.timestamp()),
-            PowerHourly.ts_utc < int(end_dt.timestamp()),
+            PowerGenMix.zone == z,
+            PowerGenMix.date >= start_dt.strftime("%Y-%m-%d"),
+            PowerGenMix.date <= end_dt.strftime("%Y-%m-%d"),
         )
         .all()
     )
-    fmt = "%Y-%m-%d" if resolution == "daily" else "%Y-%m"
+    if not rows:
+        return {"available": False, "zone": z, "reason": "No generation-mix data yet."}
+    monthly = resolution == "monthly"
     buckets: dict[str, dict[str, list[float]]] = {}
-    for sid, ts, v in rows:
-        pk = datetime.fromtimestamp(ts, UTC).strftime(fmt)
-        buckets.setdefault(pk, {}).setdefault(sid_label[sid], []).append(v)
+    for date, psr, mw in rows:
+        pk = date[:7] if monthly else date
+        buckets.setdefault(pk, {}).setdefault(psr, []).append(mw)
     data = []
     for pk in sorted(buckets):
         row: dict = {"t": pk}
+        # daily: one value per fuel already; monthly: mean of the daily means.
         for label, vals in buckets[pk].items():
             row[label] = round(sum(vals) / len(vals), 1)
         data.append(row)

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -432,9 +432,15 @@ def _grid_row_values(
     wind = wind_mw or 0.0
     solar = solar_mw or 0.0
     has_load = load_mw is not None and load_mw > 0
+    # A whole-day A75 blackout leaves wind AND solar None (unknown) with gen_hours 0.
+    # Reading those as 0 would invent residual = full load and a 0% renewable share
+    # (the mirror of the missing-load bug). So generation counts as present only if
+    # a renewable leg exists OR gen_hours says the feed ran — an all-thermal day
+    # (no wind/solar, gen_hours > 0) is a REAL 0% share, not a blackout.
+    has_gen = wind_mw is not None or solar_mw is not None or (gen_hours is not None and gen_hours > 0)
 
-    residual_mw = round(load_mw - wind - solar, 2) if has_load else None
-    renewable_share = round((wind + solar) / load_mw, 4) if has_load else None
+    residual_mw = round(load_mw - wind - solar, 2) if has_load and has_gen else None
+    renewable_share = round((wind + solar) / load_mw, 4) if has_load and has_gen else None
 
     return {
         "date": date,

--- a/backend/tests/test_api_v1.py
+++ b/backend/tests/test_api_v1.py
@@ -135,10 +135,19 @@ def test_status_reports_coverage(db_session):
     assert body["total"] >= 6  # 3 zones × (dayahead+grid) + flows/gas/ttf
 
 
+def _seed_genmix(db, date, zone, **fuels):
+    """Seed the canonical PowerGenMix daily table (the source /api/v1/genmix reads,
+    same as the desk panel) rather than power_hourly — so the API and the desk
+    can't disagree on the ÷24 daily mean."""
+    from backend.models.energy import PowerGenMix
+    for label, mw in fuels.items():
+        db.add(PowerGenMix(date=date, zone=zone, psr_type=label, gen_mw=mw))
+    db.commit()
+
+
 def test_genmix_wide_by_fuel(db_session):
-    # 24h of solar (B16) + wind onshore (B19) on one UTC day → one daily row, readable fuels.
-    upsert_hourly(db_session, "gen.B16", "DE_LU", [(_BASE + i * _H, 5_000.0) for i in range(24)], unit="MW")
-    upsert_hourly(db_session, "gen.B19", "DE_LU", [(_BASE + i * _H, 10_000.0) for i in range(24)], unit="MW")
+    # PowerGenMix holds the daily-mean MW per fuel (÷24) — genmix serves it verbatim.
+    _seed_genmix(db_session, "2026-06-01", "DE_LU", Solar=5_000.0, **{"Wind Onshore": 10_000.0})
     body = _client(db_session).get(
         "/api/v1/genmix?zone=DE_LU&start=2026-06-01&end=2026-06-02&resolution=daily"
     ).json()
@@ -150,10 +159,22 @@ def test_genmix_wide_by_fuel(db_session):
     assert row["Wind Onshore"] == 10_000.0
 
 
+def test_genmix_serves_the_canonical_div24_value_not_the_published_hours_mean(db_session):
+    """The bug this closes: solar published only in daylight hours must NOT be
+    divided by its published-hours count. PowerGenMix already stores the ÷24
+    daily mean; genmix serves it, so it matches the desk panel exactly."""
+    # A day where solar's true daily mean (÷24) is 3000 — genmix must return 3000,
+    # not some hourly-store recomputation over daylight hours only.
+    _seed_genmix(db_session, "2026-06-01", "DE_LU", Solar=3_000.0)
+    body = _client(db_session).get(
+        "/api/v1/genmix?zone=DE_LU&start=2026-06-01&end=2026-06-02&resolution=daily"
+    ).json()
+    assert body["data"][0]["Solar"] == 3_000.0
+
+
 def test_genmix_csv_streams_wide_download(db_session):
     # Same wide shape as the JSON view, streamed as a CSV download: header = t + sorted fuels.
-    upsert_hourly(db_session, "gen.B16", "DE_LU", [(_BASE + i * _H, 5_000.0) for i in range(24)], unit="MW")
-    upsert_hourly(db_session, "gen.B19", "DE_LU", [(_BASE + i * _H, 10_000.0) for i in range(24)], unit="MW")
+    _seed_genmix(db_session, "2026-06-01", "DE_LU", Solar=5_000.0, **{"Wind Onshore": 10_000.0})
     resp = _client(db_session).get(
         "/api/v1/genmix?zone=DE_LU&start=2026-06-01&end=2026-06-02&resolution=daily&format=csv"
     )

--- a/backend/tests/test_power_grid_route.py
+++ b/backend/tests/test_power_grid_route.py
@@ -62,6 +62,25 @@ def test_compute_renewable_share():
     assert d["renewable_share"] == pytest.approx(0.2)
 
 
+def test_whole_day_generation_blackout_gives_no_residual_not_full_load():
+    """gen_hours=0 (A75 feed down all day) leaves wind/solar None because UNKNOWN.
+    Reading them as 0 would invent residual = full load and a 0% renewable share.
+    Load is present, generation is not → residual/share must be None."""
+    row = _make_row(load_mw=45_000.0, wind_mw=None, solar_mw=None, gen_hours=0)
+    d = _compute_grid_row(row)
+    assert d["residual_mw"] is None
+    assert d["renewable_share"] is None
+
+
+def test_zone_with_no_wind_or_solar_but_generation_present_still_computes():
+    """gen_hours>0 with no wind/solar (e.g. an all-thermal day) is a REAL 0% share
+    and residual == load — must not be suppressed."""
+    row = _make_row(load_mw=30_000.0, wind_mw=None, solar_mw=None, gen_hours=24)
+    d = _compute_grid_row(row)
+    assert d["residual_mw"] == pytest.approx(30_000.0)
+    assert d["renewable_share"] == pytest.approx(0.0)
+
+
 def test_a_single_row_makes_no_dunkelflaute_claim():
     """A Dunkelflaute is a judgment against the zone's own history — a lone row cannot make it.
 

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -103,10 +103,13 @@ def test_evening_ramp_is_the_steepest_three_hour_rise():
     assert p["evening_ramp"] == pytest.approx(hours[20] - hours[17])
 
 
-def test_negative_hours_are_counted_on_the_delivery_day():
+def test_negative_hours_not_reported_here():
+    # The canonical negative-hour count is PowerPriceDaily.negative_hours (UTC,
+    # resolution-weighted), shown on the day-ahead panel — products must not
+    # publish a second, CET-day whole-hour count that disagrees with it.
     hours = {h: (-5.0 if h < 6 else 50.0) for h in range(24)}
     p = day_products(hours, weekday=1)
-    assert p["negative_hours"] == 6
+    assert "negative_hours" not in p
 
 
 # ─── DB-backed ────────────────────────────────────────────────────────────────

--- a/frontend/src/components/ProductsPanel.jsx
+++ b/frontend/src/components/ProductsPanel.jsx
@@ -102,7 +102,6 @@ export default function ProductsPanel({ zone = 'DE_LU' }) {
                   <th className="text-right px-2 py-1">Off-peak</th>
                   <th className="text-right px-2 py-1" title="Peak ÷ Base. Below 1.0 = the peak product is cheaper than off-peak.">Premium</th>
                   <th className="text-right px-2 py-1" title="Steepest 3-hour rise of the day">Ramp</th>
-                  <th className="text-right px-2 py-1">Neg h</th>
                 </tr>
               </thead>
               <tbody>
@@ -125,9 +124,6 @@ export default function ProductsPanel({ zone = 'DE_LU' }) {
                     </td>
                     <td className="px-2 py-1.5 text-right text-neutral-500">
                       {r.evening_ramp != null ? `€${r.evening_ramp.toFixed(0)}` : '—'}
-                    </td>
-                    <td className={`px-2 py-1.5 text-right ${r.negative_hours > 0 ? 'text-orange-400' : 'text-neutral-700'}`}>
-                      {r.negative_hours || '—'}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
After the FR price bug, a systematic cross-view consistency pass (not just "does
it 200") found three more instances of the same class — verified LIVE, not
assumed:

1. Generation mix: /api/v1/genmix averaged power_hourly over PUBLISHED hours,
   while the desk panel (/api/power/generation-mix) reads PowerGenMix's ÷24
   daily mean. Solar (absent at night) and every gap-fuel disagreed — IT-Nord
   solar 2353 (desk) vs 3322 (public API/client), a 29% gap the Python client
   inherited. Fix: v1/genmix reads the SAME PowerGenMix table. One source.

2. Negative hours: /api/power/products recomputed them as a whole-hour integer
   count on the CET day, disagreeing with the canonical resolution-weighted UTC
   count on the day-ahead panel/hero (FR 7 vs 5). Removed the redundant field
   (products has no QH data to match the canonical method); negative hours now
   live in one place. Frontend column + test updated.

3. Residual/renewable share: a whole-day A75 blackout leaves wind AND solar None
   (unknown); the read path coerced them to 0, inventing residual = full load and
   0% renewables (mirror of the missing-load bug). Now suppressed to None unless
   a renewable leg exists or gen_hours > 0 — an all-thermal day is still a real
   0% share.

Checked and found single-sourced (no fix needed): residual on normal days,
state, spark, units, percentages, timezone. Regression tests pin all three;
full suite 981 green. No backfill needed — all compute-on-read / source swap.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
