### PR TITLE
The hero said +2.1σ, the radar said +2.6σ, for the same price

### DIFF
--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -7,6 +7,7 @@ hour count is persisted per (date, zone) in ``PowerPriceDaily.negative_hours``.
 from __future__ import annotations
 
 from backend.models.energy import PowerGrid, PowerPriceDaily
+from backend.power.baseline import BASELINE_DAYS
 from backend.power.coverage import renewable_share_reliable
 from backend.power.daily import HOURS_PER_DAY
 from backend.power.dunkelflaute import ABSOLUTE_THRESHOLD
@@ -484,7 +485,12 @@ def detect_imbalance_extremes(db) -> list[DetectorResult]:
 # keeps "3σ above a flat 60±2 €" from paging anyone. Named price_spike — a
 # user-rule template `dayahead_spike` (absolute threshold breach) already
 # exists in the OTHER alert subsystem; distinct names keep the two apart.
-SPIKE_WINDOW_DAYS = 45
+# Same window as the hero/overview/driver price z-score (backend/power/baseline.py):
+# they all label a day-ahead price "+Nσ vs its own norm", and two surfaces showing
+# a different σ for the same price is exactly the incoherence to avoid. The radar's
+# HIGHER firing threshold (SPIKE_WARN_Z below) stays — a curated feed warns less
+# eagerly than the hero's ELEVATED band — but the σ they compute is now the same.
+SPIKE_WINDOW_DAYS = BASELINE_DAYS
 SPIKE_WARN_Z = 2.5
 SPIKE_CRIT_Z = 3.5
 SPIKE_MIN_DELTA_EUR = 25.0
@@ -524,7 +530,7 @@ def detect_price_spikes(db) -> list[DetectorResult]:
                 title=f"{zone}: day-ahead unusually {direction} — {current:.0f} €/MWh ({z:+.1f}σ)",
                 detail=(
                     f"Daily mean {current:.0f} €/MWh on {rows[0].date} vs ~{mean:.0f} €/MWh "
-                    f"45d norm (z {z:+.2f}). Descriptive deviation vs the zone's own "
+                    f"{BASELINE_DAYS}d norm (z {z:+.2f}). Descriptive deviation vs the zone's own "
                     f"history, not a forecast."
                 ),
                 as_of=rows[0].date,

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -708,6 +708,15 @@ def test_imbalance_extreme_needs_baseline(db_session):
 # ─── price_spike ──────────────────────────────────────────────────────────────
 
 
+def test_price_spike_window_equals_the_hero_baseline():
+    """The radar's price σ and the hero's price σ describe the SAME day-ahead
+    price on two surfaces — they must use the same window, or they disagree
+    (radar 45d gave +2.6σ while the hero's 30d gave +2.1σ for one price)."""
+    from backend.power.baseline import BASELINE_DAYS
+    from backend.signals.detectors.power import SPIKE_WINDOW_DAYS
+    assert SPIKE_WINDOW_DAYS == BASELINE_DAYS
+
+
 def _seed_prices(db, zone="DE_LU", days=40, base=60.0, last=None):
     from datetime import date, timedelta
 


### PR DESCRIPTION
The price-spike detector measured a zone's day-ahead σ over 45 days while the
hero, overview and driver card all measure it over 30 (BASELINE_DAYS) and label
it "vs its 30d norm". Same price, two σ on the two most prominent surfaces.
The detector now uses BASELINE_DAYS too, so the σ agree. Its higher FIRING
threshold (2.5σ vs the hero's 2.0 ELEVATED band) is deliberate and stays — a
curated radar warns less eagerly than the hero's state — but the number they
compute for the same price is now one number. A test pins the two windows
equal. (The imbalance/negative detectors keep 45d: different quantities, no
hero σ to contradict.)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
