### PR TITLE
Night residuals dropped, and two panels called different things "supply"

### DIFF
--- a/backend/power/entsoe_grid.py
+++ b/backend/power/entsoe_grid.py
@@ -330,8 +330,11 @@ def build_hourly_forecast(
 ) -> list[dict]:
     """Combine hourly load + wind + solar forecasts into a 24-point residual series.
 
-    residual = load − (wind_offshore + wind_onshore) − solar, per hour. wind/solar
-    (and thus residual) are None for an hour with no renewable forecast. Returns
+    residual = load − (wind_offshore + wind_onshore) − solar, per hour. An absent
+    leg is 0, not unknown: there is no solar at night, so requiring BOTH legs
+    dropped every night hour in zones that omit solar (ES/IT/PT/GR) and made the
+    residual.actual daily mean disagree with PowerGrid.residual_mw (÷24). Residual
+    is None only when NEITHER renewable leg is present (a whole feed down). Returns
     [{hour, load_mw, wind_mw, solar_mw, residual_mw}] ordered by hour.
     """
     off = gen_by_hour.get(PSR_WIND_OFFSHORE, {})
@@ -344,7 +347,8 @@ def build_hourly_forecast(
         if hour in off or hour in on:
             wind = (off.get(hour) or 0.0) + (on.get(hour) or 0.0)
         s = solar.get(hour)
-        resid = round(load - wind - s, 2) if wind is not None and s is not None else None
+        has_gen = wind is not None or s is not None
+        resid = round(load - (wind or 0.0) - (s or 0.0), 2) if has_gen else None
         out.append({
             "hour": hour,
             "load_mw": round(load, 2),

--- a/backend/scripts/rebuild_residual_actual.py
+++ b/backend/scripts/rebuild_residual_actual.py
@@ -1,0 +1,87 @@
+"""Backfill: rebuild the residual.actual hourly series from load + wind + solar in
+the canonical hourly store — DB-only, no ENTSO-E refetch.
+
+Before the fix, build_hourly_forecast nulled a residual hour whenever wind OR
+solar was absent, dropping every NIGHT hour in zones that omit solar (ES/IT/PT/
+GR). Those dropped high-residual night hours made the residual.actual daily mean
+disagree with PowerGrid.residual_mw (÷24) — ES 12303 vs 12822. This recomputes
+every hour with the fixed rule (absent leg = 0; residual None only when NEITHER
+leg is present) and upserts the now-complete series.
+
+Usage (on the VPS, as the obsyd user):
+    python -m backend.scripts.rebuild_residual_actual --dry-run
+    python -m backend.scripts.rebuild_residual_actual
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+from collections import defaultdict
+from datetime import UTC, datetime
+
+from backend.database import SessionLocal
+from backend.power.entsoe_grid import (
+    PSR_SOLAR,
+    PSR_WIND_OFFSHORE,
+    PSR_WIND_ONSHORE,
+    build_hourly_forecast,
+)
+from backend.power.hourly_store import read_hourly, upsert_day_hours
+from backend.power.zones import POWER_ZONES
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("rebuild_residual_actual")
+
+# The legs build_hourly_forecast reads (its keys are the raw psr codes).
+_GEN_SERIES = {PSR_WIND_OFFSHORE, PSR_WIND_ONSHORE, PSR_SOLAR}
+
+
+def _by_day_hour(rows: list[tuple[int, float]]) -> dict[str, dict[int, float]]:
+    out: dict[str, dict[int, float]] = defaultdict(dict)
+    for ts, v in rows:
+        dt = datetime.fromtimestamp(ts, UTC)
+        out[dt.strftime("%Y-%m-%d")][dt.hour] = v
+    return out
+
+
+def rebuild(*, dry_run: bool) -> dict:
+    db = SessionLocal()
+    zones_done = 0
+    hours_written = 0
+    try:
+        for zone in POWER_ZONES:
+            load_by_day = _by_day_hour(read_hourly(db, "load.actual", zone))
+            if not load_by_day:
+                continue
+            gen_by_day: dict[str, dict[str, dict[int, float]]] = defaultdict(dict)
+            for psr in _GEN_SERIES:
+                for day, hours in _by_day_hour(read_hourly(db, f"gen.{psr}", zone)).items():
+                    gen_by_day[day][psr] = hours
+
+            resid_by_day: dict[str, dict[int, float]] = {}
+            for day, load_hours in load_by_day.items():
+                rr = {
+                    p["hour"]: p["residual_mw"]
+                    for p in build_hourly_forecast(load_hours, gen_by_day.get(day, {}))
+                    if p["residual_mw"] is not None
+                }
+                if rr:
+                    resid_by_day[day] = rr
+            n = sum(len(v) for v in resid_by_day.values())
+            if resid_by_day and not dry_run:
+                upsert_day_hours(db, "residual.actual", zone, resid_by_day, unit="MW")
+            hours_written += n
+            zones_done += 1
+            logger.info("  %s: %d residual hours across %d days", zone, n, len(resid_by_day))
+    finally:
+        db.close()
+    result = {"zones": zones_done, "residual_hours": hours_written, "dry_run": dry_run}
+    logger.info("rebuild_residual_actual: %s", result)
+    return result
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", help="Compute without writing")
+    args = ap.parse_args()
+    rebuild(dry_run=args.dry_run)

--- a/backend/tests/test_borders.py
+++ b/backend/tests/test_borders.py
@@ -20,7 +20,7 @@ from backend.power.borders import (
 )
 from backend.power.hourly_store import upsert_hourly
 
-_NOW = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+_NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)  # now-relative: the db-backed route tests filter on a window ending "now"
 
 
 def _client(db):

--- a/backend/tests/test_power_forecast_hourly.py
+++ b/backend/tests/test_power_forecast_hourly.py
@@ -89,6 +89,27 @@ def test_build_hourly_forecast_residual_none_without_renewables():
     assert series[0]["load_mw"] == 60_000.0
 
 
+def test_night_hours_keep_a_residual_when_only_solar_is_absent():
+    """A solar-only-at-daytime zone (ES/IT/PT) must keep its NIGHT residuals:
+    an absent solar leg is 0 (there is no sun at night), not unknown. Dropping
+    them made the residual.actual daily mean disagree with PowerGrid.residual_mw."""
+    load = {h: 40_000.0 for h in range(24)}
+    gen = {
+        "B19": {h: 8_000.0 for h in range(24)},          # wind onshore, all day
+        "B16": {h: 12_000.0 for h in range(8, 17)},      # solar, daytime only
+    }
+    series = build_hourly_forecast(load, gen)
+    # Every one of the 24 hours has a residual now — night included.
+    assert all(p["residual_mw"] is not None for p in series)
+    # Night hour: 40000 − 8000 wind − 0 solar = 32000.
+    night = next(p for p in series if p["hour"] == 3)
+    assert night["residual_mw"] == 32_000.0
+    assert night["solar_mw"] is None  # still reported as absent, just not fatal
+    # Day hour: 40000 − 8000 − 12000 = 20000.
+    day = next(p for p in series if p["hour"] == 12)
+    assert day["residual_mw"] == 20_000.0
+
+
 # ── ingest persists the hourly series (JSON-in-Text) ──────────────────────────
 
 

--- a/frontend/src/components/GasBalancePanel.jsx
+++ b/frontend/src/components/GasBalancePanel.jsx
@@ -86,7 +86,7 @@ export default function GasBalancePanel() {
               </span>
             </div>
             <div className="font-mono text-[10px] text-neutral-600 mt-1">
-              {flaggedCount} flagged days / 120 · supply {latest.supply_gwh == null ? '—' : Math.round(latest.supply_gwh).toLocaleString()} − demand {latest.demand_gwh == null ? '—' : Math.round(latest.demand_gwh).toLocaleString()} GWh
+              {flaggedCount} flagged days / 120 · supply {latest.supply_gwh == null ? '—' : Math.round(latest.supply_gwh).toLocaleString()} (imports + EU production) − demand {latest.demand_gwh == null ? '—' : Math.round(latest.demand_gwh).toLocaleString()} (incl. power burn) GWh
             </div>
           </div>
 

--- a/frontend/src/components/GasSupplyPanel.jsx
+++ b/frontend/src/components/GasSupplyPanel.jsx
@@ -37,8 +37,8 @@ export default function GasSupplyPanel() {
     <Panel
       id="gas-supply"
       freshness={data}
-      title="EU GAS SUPPLY · ENTSOG"
-      info="Daily EU gas supply (GWh/d) from ENTSOG physical flows: pipeline imports + LNG send-out + net UK interconnector. Free, official data."
+      title="EU GAS IMPORTS · ENTSOG"
+      info="Daily EU gas imports (GWh/d) from ENTSOG physical flows: pipeline imports + LNG send-out + net UK interconnector. This is the IMPORT side only — the balance panel's 'supply' adds EU domestic production on top, so its number is higher. Free, official data."
       collapsible
       headerRight={latest && <span className="font-mono text-[10px] text-cyan-glow font-bold">{Math.round(latest.supply_gwh).toLocaleString()}</span>}
     >
@@ -50,7 +50,7 @@ export default function GasSupplyPanel() {
           <div className="px-4 py-3 border-b border-border/30">
             <div className="flex items-baseline gap-2 mb-2">
               <span className="font-mono text-3xl font-bold text-cyan-glow">{Math.round(latest.supply_gwh).toLocaleString()}</span>
-              <span className="font-mono text-[10px] text-neutral-600">GWh/d total</span>
+              <span className="font-mono text-[10px] text-neutral-600">GWh/d imports</span>
             </div>
             <div className="space-y-1">
               <Stat label="pipeline" value={latest.pipeline_gwh} />


### PR DESCRIPTION
Round 3 of the cross-view pass over every panel found three more:

C (real bug) — the residual.actual hourly series nulled a residual whenever
wind OR solar was absent, so build_hourly_forecast dropped every NIGHT hour in
zones that omit solar (ES/IT/PT/GR). Those high-residual night hours missing
made the residual.actual daily mean disagree with PowerGrid.residual_mw (÷24):
ES 12303 vs 12822, IT-Nord 16086 vs 16681 (DE, which reports every hour, was
fine). An absent leg is 0 (no sun at night), not unknown — residual is None only
when NEITHER leg is present. Affects the duration curve, merit-order scatter,
trends and the hourly compare chart. Regression test + DB-only backfill
(rebuild_residual_actual.py).

A (label ambiguity) — /gas/supply (pipeline+LNG+UK imports, no domestic
production) and /gas/balance supply_gwh (with production) both showed as
"supply", 8931 vs 9522. The supply panel now reads "EU GAS IMPORTS … imports"
and the balance spells out "supply (imports + EU production) − demand (incl.
power burn)". No number changed — both definitions are needed.

B — checked, NOT a UI bug: GasDemandPanel already merges power burn into its
total (power+heat+industrial), so it matches /gas/balance demand_gwh. Only the
raw /gas/demand endpoint returns the components without power; no panel shows
that in isolation.

Also fixed a pre-existing date-flake: test_borders seeded around a fixed
2026-07-12 that fell outside the route's "last 7 days" window today. Now
now-relative. Full suite 983 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
