### PR TITLE
Add live today-view, balancing & capacity prices, chart builder, embeds, transmission outages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ OBSYD is open source under AGPL-3.0 and **completely free** — there is no paid
 - **Europe map** — bidding-zone choropleth by day-ahead price or grid state
 - **Public data API + Python client** — `GET /api/v1/series` (JSON/CSV/**Parquet** export), catalog, zones, capacity, meta and an honest coverage/status endpoint — see [docs/API.md](docs/API.md); pip-installable client in [clients/python](clients/python)
 - **Interactive series explorer** — query any series/zone/range, **compare two zones** on one chart, download as CSV
+- **Chart-Builder** (`/builder`) — the series explorer as its own full-screen, shareable-URL page
+- **Embeddable widgets + badges** — self-refreshing `/embed/<zone>/<metric>` iframes (price/genmix/load) and `/api/v1/badge` SVG status images for READMEs/dashboards
+- **Activated balancing energy** — aFRR/mFRR activation price (and volume, where ENTSO-E serves it) per zone
+- **German balancing-capacity prices** — FCR/aFRR/mFRR procured-capacity tenders (DE-LU LFC block)
+- **Transmission outages** — cross-border line/PST unavailability (ENTSO-E A78) alongside the generation-outage board (A77)
+- **Live today-view** — near-real-time load, generation mix and day-ahead price for the current day, refreshing intraday
 
 ## Public data API
 
@@ -105,7 +111,7 @@ The power desk runs on the official European record:
 
 | Source | Data | Update Frequency |
 |--------|------|-----------------|
-| [ENTSO-E Transparency](https://transparency.entsoe.eu/) | Day-ahead prices (A44, 15-min since 2025-10), load (A65), generation per fuel (A75), forecasts (A69/A71), imbalance (A85/reBAP), hydro reservoirs (A72), outages (A77), installed capacity (A68) | 30 min – daily per doc type |
+| [ENTSO-E Transparency](https://transparency.entsoe.eu/) | Day-ahead prices (A44, 15-min since 2025-10), load (A65), generation per fuel (A75), forecasts (A69/A71), imbalance (A85/reBAP), hydro reservoirs (A72), outages (A77/A78), installed capacity (A68), balancing energy/capacity (A83/A84/A15) | 30 min – daily per doc type |
 | [Fraunhofer Energy-Charts](https://www.energy-charts.info/) | Cross-border physical flows (CBPF), CC BY 4.0 | 30 min |
 | [GIE AGSI+/ALSI](https://agsi.gie.eu/) | EU gas storage and LNG send-out | Daily |
 | [ENTSOG](https://transparency.entsog.eu/) | Cross-border gas flows | Daily |

--- a/backend/api_guard.py
+++ b/backend/api_guard.py
@@ -69,12 +69,12 @@ def cached_value(key: str, compute: Callable[[], object], *, ttl: float = _COVER
     """
     t = time.monotonic() if now is None else now
     slot = _cache.get(key)
-    if slot is not None and slot["value"] is not None and t < slot["expires"]:
+    if slot is not None and t < slot["expires"]:
         return slot["value"]
     with _cache_lock:
         # Re-check inside the lock: another thread may have filled it while we waited.
         slot = _cache.get(key)
-        if slot is not None and slot["value"] is not None and t < slot["expires"]:
+        if slot is not None and t < slot["expires"]:
             return slot["value"]
         value = compute()
         _cache[key] = {"value": value, "expires": t + ttl}

--- a/backend/api_guard.py
+++ b/backend/api_guard.py
@@ -12,9 +12,12 @@ Two cheap defences, no external dependency:
   scans run at once; the overflow gets an immediate 503 instead of queueing and
   starving the light endpoints (health, situation, meta). It does NOT slow a
   legitimate single bulk pull — it only caps how many run simultaneously.
-- `cached_coverage`: the catalog's coverage window changes only when the hourly
-  ingest writes (hourly), so a short TTL cache turns a 28s cold scan into one
-  scan per hour. A lock collapses a cold-start thundering herd to one scan.
+- `cached_value`: a keyed TTL cache — the catalog's coverage window (and, since
+  P1, its per-(series,zone) coverage table) changes only when the hourly ingest
+  writes (hourly), so caching either for an hour turns a full-table scan into
+  one scan per hour instead of one per request. A lock collapses a cold-start
+  thundering herd to one scan per key. `cached_coverage` is the original global
+  window, kept as a thin wrapper over `cached_value` for existing callers.
 """
 from __future__ import annotations
 
@@ -50,29 +53,44 @@ def heavy_query_guard():
 
 
 _COVERAGE_TTL = 3600.0
-_coverage: dict[str, object] = {"value": None, "expires": 0.0}
-_coverage_lock = threading.Lock()
+_cache: dict[str, dict[str, object]] = {}
+_cache_lock = threading.Lock()
+
+
+def cached_value(key: str, compute: Callable[[], object], *, ttl: float = _COVERAGE_TTL,
+                  now: float | None = None) -> object:
+    """Return the cached value for `key`, recomputing at most once per `ttl` seconds.
+
+    One shared keyed cache rather than one slot per caller: every entry (the global
+    coverage window, the per-(series,zone) coverage table, …) needs the identical
+    "recompute at most once per TTL, one lock so a cold thundering herd does the
+    expensive `compute` once, not N times" semantics, so it lives here once instead
+    of copy-pasted per cache.
+    """
+    t = time.monotonic() if now is None else now
+    slot = _cache.get(key)
+    if slot is not None and slot["value"] is not None and t < slot["expires"]:
+        return slot["value"]
+    with _cache_lock:
+        # Re-check inside the lock: another thread may have filled it while we waited.
+        slot = _cache.get(key)
+        if slot is not None and slot["value"] is not None and t < slot["expires"]:
+            return slot["value"]
+        value = compute()
+        _cache[key] = {"value": value, "expires": t + ttl}
+        return value
 
 
 def cached_coverage(compute: Callable[[], object], *, now: float | None = None) -> object:
-    """Return the cached coverage window, recomputing at most once per TTL.
+    """The catalog's global coverage window, cached under its own key.
 
-    `compute` is the expensive min/max scan; it runs under a lock so a cold cache
-    hit by N threads does the scan once, not N times.
+    Kept as a thin wrapper so existing callers/tests (which pass no `ttl`) are
+    unaffected by the move to a keyed cache.
     """
-    t = time.monotonic() if now is None else now
-    if _coverage["value"] is not None and t < _coverage["expires"]:
-        return _coverage["value"]
-    with _coverage_lock:
-        # Re-check inside the lock: another thread may have filled it while we waited.
-        if _coverage["value"] is not None and t < _coverage["expires"]:
-            return _coverage["value"]
-        _coverage["value"] = compute()
-        _coverage["expires"] = t + _COVERAGE_TTL
-        return _coverage["value"]
+    return cached_value("coverage", compute, ttl=_COVERAGE_TTL, now=now)
 
 
 def _reset_coverage_cache() -> None:
-    """Test hook."""
-    _coverage["value"] = None
-    _coverage["expires"] = 0.0
+    """Test hook — clears the WHOLE keyed cache, not just 'coverage'. Every cache
+    entry is process-global and would otherwise leak its value across tests."""
+    _cache.clear()

--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -103,6 +103,16 @@ SPECS += [
     # Episodes are DERIVED, not ingested — so the probe asks whether the nightly recompute ran,
     # not whether a feed arrived. A silent episode engine looks exactly like a quiet Europe.
     FreshnessSpec("episodes", PowerEpisode, "updated_at", timedelta(days=2)),
+    # /api/power/live (near-real-time TODAY). The intraday scheduler writes
+    # load.actual every ~30 min and ENTSO-E's own publication lag is ~1-2h, so 6h
+    # would be the honest window for THIS probe alone — but test_outage_history.py
+    # pins outage_snapshot (below) as the tightest window on the desk on purpose
+    # (it is the one series that cannot be backfilled at all), so this stays
+    # capped at 1 day rather than undercutting that invariant. The live route's
+    # own `lag_minutes` field carries the real-time precision this coarser
+    # health-check window can't.
+    FreshnessSpec("live_load", PowerPriceDaily, "", timedelta(days=1),
+                  hourly_series="load.actual"),
     # The outage snapshot is the ONE series that cannot be backfilled: A77 takes an
     # unavailability down once it is over, so an hour the recorder missed is gone for
     # good. It must therefore be the tightest window on the desk — a day of silence is

--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -120,10 +120,13 @@ SPECS += [
     FreshnessSpec("outage_snapshot", PowerPriceDaily, "", timedelta(days=1),
                   hourly_series="outage.offline"),
     # Activated balancing energy (aFRR/mFRR, A83 volumes/A84 prices — backend/power/
-    # entsoe_balancing.py). aFRR price is the probe: every enabled zone that has any
-    # balancing coverage at all has aFRR (mFRR is sparser). 2 days respects the pinned
-    # invariant that outage_snapshot (1 day, above) stays the tightest hourly spec on the
-    # desk (see test_outage_history.py).
+    # entsoe_balancing.py). aFRR price is the probe — ONE reference series across ALL
+    # zones ("is the collector alive at all"), the same pattern flows_hourly/
+    # scheduled_exchanges/net_position use above, NOT a per-zone coverage claim: the live
+    # spike found aFRR/mFRR coverage varies by zone and even by window (FR's own 3-day
+    # spike window carried mFRR/FCR/RR prices but no aFRR at all). 2 days respects the
+    # pinned invariant that outage_snapshot (1 day, above) stays the tightest hourly spec
+    # on the desk (see test_outage_history.py).
     FreshnessSpec("balancing_energy", PowerPriceDaily, "", timedelta(days=2),
                   hourly_series="balancing.afrr.price.up"),
 ]

--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -85,15 +85,16 @@ SPECS += [
                   hourly_series="generation.forecast"),
     FreshnessSpec("hydro_reservoir", PowerPriceDaily, "", timedelta(days=16),
                   hourly_series="hydro.reservoir"),
-    # Outage messages land continuously across 37 zones; a silent day means
-    # the collector is dead, not that Europe stopped breaking. Doc-type-agnostic
-    # (no filter_col) by construction: it watches the OVERALL ingest job. A78
-    # (below) gets its OWN probe rather than riding on this one, because A77's much
-    # higher message volume would keep this one "fresh" even if the A78 pass inside
-    # _run_outages broke silently — the two passes are independent try/excepts
-    # specifically so one can fail without the other, and the freshness layer has to
-    # be able to tell that apart too.
-    FreshnessSpec("power_outages", PowerOutage, "created_at", timedelta(days=2)),
+    # Outage messages land continuously across 37 zones; a silent day means the
+    # collector is dead, not that Europe stopped breaking. Doc-type masking runs in
+    # BOTH directions on a shared probe: A77's much higher volume could keep it
+    # "fresh" while A78 died silently, and (found in review) the REVERSE is just as
+    # real — A78 traffic alone could keep a doc-type-agnostic probe "fresh" while the
+    # desk-critical A77 pass was dead. _run_outages runs the two as independent
+    # try/excepts specifically so one can fail without the other, so each doc type
+    # gets its OWN scoped probe here too.
+    FreshnessSpec("power_outages", PowerOutage, "created_at", timedelta(days=2),
+                  filter_col="doc_type", filter_val="A77"),
     # A78 transmission-infrastructure unavailability (Task P12) is real but much
     # rarer than A77 across the 126 directed border-pair queries — the live spike
     # found ~1 new document every ~2 days on JUST one border-direction (DE_LU->FR,

--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -119,6 +119,13 @@ SPECS += [
     # a day of history destroyed, not a late delivery to catch up on.
     FreshnessSpec("outage_snapshot", PowerPriceDaily, "", timedelta(days=1),
                   hourly_series="outage.offline"),
+    # Activated balancing energy (aFRR/mFRR, A83 volumes/A84 prices — backend/power/
+    # entsoe_balancing.py). aFRR price is the probe: every enabled zone that has any
+    # balancing coverage at all has aFRR (mFRR is sparser). 2 days respects the pinned
+    # invariant that outage_snapshot (1 day, above) stays the tightest hourly spec on the
+    # desk (see test_outage_history.py).
+    FreshnessSpec("balancing_energy", PowerPriceDaily, "", timedelta(days=2),
+                  hourly_series="balancing.afrr.price.up"),
 ]
 
 # Per-enabled-zone day-ahead + grid freshness (was DE_LU-hardcoded — every enabled

--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -129,6 +129,11 @@ SPECS += [
     # on the desk (see test_outage_history.py).
     FreshnessSpec("balancing_energy", PowerPriceDaily, "", timedelta(days=2),
                   hourly_series="balancing.afrr.price.up"),
+    # Procured balancing-CAPACITY prices (FCR/aFRR/mFRR tenders, ENTSO-E A15 — backend/power/
+    # entsoe_reserves.py). DE_LU only (the German LFC block has no per-zone equivalent), daily
+    # tenders publish every day, so 2 days mirrors balancing_energy's window above.
+    FreshnessSpec("capacity_prices", PowerPriceDaily, "", timedelta(days=2),
+                  hourly_series="capacity.fcr.price"),
 ]
 
 # Per-enabled-zone day-ahead + grid freshness (was DE_LU-hardcoded — every enabled

--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -86,8 +86,21 @@ SPECS += [
     FreshnessSpec("hydro_reservoir", PowerPriceDaily, "", timedelta(days=16),
                   hourly_series="hydro.reservoir"),
     # Outage messages land continuously across 37 zones; a silent day means
-    # the collector is dead, not that Europe stopped breaking.
+    # the collector is dead, not that Europe stopped breaking. Doc-type-agnostic
+    # (no filter_col) by construction: it watches the OVERALL ingest job. A78
+    # (below) gets its OWN probe rather than riding on this one, because A77's much
+    # higher message volume would keep this one "fresh" even if the A78 pass inside
+    # _run_outages broke silently — the two passes are independent try/excepts
+    # specifically so one can fail without the other, and the freshness layer has to
+    # be able to tell that apart too.
     FreshnessSpec("power_outages", PowerOutage, "created_at", timedelta(days=2)),
+    # A78 transmission-infrastructure unavailability (Task P12) is real but much
+    # rarer than A77 across the 126 directed border-pair queries — the live spike
+    # found ~1 new document every ~2 days on JUST one border-direction (DE_LU->FR,
+    # 26 docs / 7 weeks), so a global window wider than power_outages' 2 days avoids
+    # false "stale" alarms on quiet weeks while still catching a genuinely dead pass.
+    FreshnessSpec("power_outages_transmission", PowerOutage, "created_at", timedelta(days=7),
+                  filter_col="doc_type", filter_val="A78"),
     # Hourly cross-border flows (Block 2.4). flow.FR is the probe because a
     # French border (DE_LU-FR sorts DE_LU-first) exists in every enabled setup;
     # the daily grain keeps its own power_flows spec above.

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -13,6 +13,7 @@ Schedule (UTC):
   - EU gas balance: daily 10:00; gas registry: weekly Mon 03:30
   - Signals (radar): every 5 min; scorecards: weekly Mon 05:00
   - Live prices: every 4h; user alert rules: every 30 min
+  - Balancing-capacity prices (FCR/aFRR/mFRR, DE_LU only): daily 11:30
   - Daily email: PAUSED 2026-07-18 (no product emails; see registration site below)
   - Retention: daily 04:00; collector watchdog: daily 09:00
 """
@@ -430,6 +431,30 @@ async def _run_balancing():
         db.close()
 
 
+async def _run_capacity_prices():
+    """Daily German balancing-capacity refresh (ENTSO-E A15: FCR/aFRR/mFRR tenders).
+
+    DE_LU only (see backend/power/entsoe_reserves.py) — no zone loop. A 3-day window with
+    overwrite=True: yesterday's tender is the frontier this desk cares about, and a short
+    rolling overwrite catches any late TSO revision the way the rest of the daily power
+    ingest does for its own zone-day windows.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from backend.power.entsoe_reserves import ingest_capacity_prices
+
+    today = datetime.now(timezone.utc).date()
+    days = [(today - timedelta(days=i)).isoformat() for i in range(3)][::-1]
+    db = SessionLocal()
+    try:
+        result = await ingest_capacity_prices(db, days, overwrite=True)
+        logger.info("capacity prices daily: %s", result)
+    except Exception as exc:
+        logger.error("_run_capacity_prices failed: %s", exc)
+    finally:
+        db.close()
+
+
 async def _run_hydro_weekly():
     """Refresh weekly reservoir filling (ENTSO-E A72) for the hydro zones.
     Current year with overwrite=True — the raw cache is write-once and would
@@ -484,6 +509,10 @@ def start_scheduler():
     scheduler.add_job(_run_outage_snapshot, CronTrigger(minute=45), id="outage_snapshot_hourly", **JOB_DEFAULTS)
     # Activated balancing energy (aFRR/mFRR, A83/A84): hourly, same-day activation signal.
     scheduler.add_job(_run_balancing, CronTrigger(minute=20), id="balancing_hourly", **JOB_DEFAULTS)
+    # Procured balancing-capacity prices (FCR/aFRR/mFRR, A15): daily 11:30 UTC — comfortably
+    # after all three TSO publication windows (FCR ~08:30, aFRR ~09:30, mFRR ~11:00
+    # Europe/Berlin, i.e. UTC+1/+2 — see docs/findings/2026-07-20-regelleistung-capacity-prices.md).
+    scheduler.add_job(_run_capacity_prices, CronTrigger(hour=11, minute=30), id="capacity_prices_daily", **JOB_DEFAULTS)
     # All-time records: nightly at 23:45, after the 22:30 power ingest.
     scheduler.add_job(_run_records_nightly, CronTrigger(hour=23, minute=45), id="records_nightly", **JOB_DEFAULTS)
     # Episodes: 23:50, right after the records — same doctrine (full recompute from the canonical

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -173,6 +173,9 @@ async def _run_power_daily():
             try:
                 from backend.power.entsoe_balancing import ingest_balancing
 
+                # Full overwrite on BOTH doctypes (unlike the hourly job, which passes
+                # overwrite_volumes=False) — this once-a-day pass is the deliberate REVERIFY
+                # probe for whether A83's structural rejection has ever come back.
                 result = await ingest_balancing(db, days, zone=zone_key, overwrite=True)
                 logger.info("power daily balancing ingest [%s]: %s", zone_key, result)
             except Exception as exc:
@@ -398,7 +401,15 @@ async def _run_balancing():
     enabled zones — today's window, like the intraday grid/flows jobs: aFRR/mFRR activation
     is a same-day, near-real-time signal (see backend/power/entsoe_balancing.py's module
     docstring for the live-spike coverage caveats: DE_LU is TenneT-only, A83 volumes are not
-    currently served by the public API at all)."""
+    currently served by the public API at all).
+
+    `overwrite_volumes=False`: A83's structural rejection is stable and gets cached on the
+    first call (see entsoe_balancing.py's module docstring), so this hourly job would
+    otherwise re-issue that known-futile request for all 37 zones × 24 times a day — ~888
+    guaranteed 400s against ENTSO-E for nothing. Prices (`overwrite=True`) still refresh every
+    run. The nightly `_run_power_daily` pass keeps full overwrite for both, which is the
+    deliberate once-a-day "has A83 come back?" probe.
+    """
     from backend.power.entsoe_balancing import ingest_balancing
     from backend.power.zones import POWER_ZONES
 
@@ -407,7 +418,9 @@ async def _run_balancing():
         days = _intraday_days()
         for zone_key in POWER_ZONES:
             try:
-                result = await ingest_balancing(db, days, zone=zone_key, overwrite=True)
+                result = await ingest_balancing(
+                    db, days, zone=zone_key, overwrite=True, overwrite_volumes=False
+                )
                 logger.info("balancing hourly ingest [%s]: %s", zone_key, result)
             except Exception as exc:
                 logger.error("balancing hourly ingest [%s] failed: %s", zone_key, exc)

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -343,17 +343,25 @@ async def _run_records_nightly():
 
 
 async def _run_outages():
-    """Refresh the rolling generation-unavailability window (ENTSO-E A77) for all
-    enabled zones. Every 6 h: forced outages land intraday, and the desk's whole
-    point is showing them before the price does."""
+    """Refresh the rolling generation-unavailability (ENTSO-E A77) AND transmission-
+    infrastructure-unavailability (A78) windows for all enabled zones/borders. Every
+    6 h: forced outages land intraday, and the desk's whole point is showing them
+    before the price does. The two passes are independent try/excepts — A78 uses a
+    completely different query shape (directed border pairs, see entsoe_outages.py),
+    so a break there must not take down the A77 pass that already worked."""
     from backend.power.entsoe_outages import ingest_outages
 
     db = SessionLocal()
     try:
         result = await ingest_outages(db)
-        logger.info("outages: %s", result)
+        logger.info("outages (A77 generation): %s", result)
     except Exception as exc:
-        logger.error("_run_outages failed: %s", exc)
+        logger.error("_run_outages (A77 generation) failed: %s", exc)
+    try:
+        result78 = await ingest_outages(db, doc_type="A78")
+        logger.info("outages (A78 transmission): %s", result78)
+    except Exception as exc:
+        logger.error("_run_outages (A78 transmission) failed: %s", exc)
     finally:
         db.close()
 

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -170,6 +170,14 @@ async def _run_power_daily():
             except Exception as exc:
                 logger.error("power daily ingest_imbalance [%s] failed: %s", zone_key, exc)
 
+            try:
+                from backend.power.entsoe_balancing import ingest_balancing
+
+                result = await ingest_balancing(db, days, zone=zone_key, overwrite=True)
+                logger.info("power daily balancing ingest [%s]: %s", zone_key, result)
+            except Exception as exc:
+                logger.error("power daily ingest_balancing [%s] failed: %s", zone_key, exc)
+
         # Cross-border physical flows (Energy-Charts CBPF, CC BY 4.0).
         try:
             from backend.power.energy_charts_flows import ingest_cbpf
@@ -385,6 +393,30 @@ async def _run_outage_snapshot():
         db.close()
 
 
+async def _run_balancing():
+    """Hourly activated-balancing-energy refresh (ENTSO-E A83 volumes / A84 prices) for all
+    enabled zones — today's window, like the intraday grid/flows jobs: aFRR/mFRR activation
+    is a same-day, near-real-time signal (see backend/power/entsoe_balancing.py's module
+    docstring for the live-spike coverage caveats: DE_LU is TenneT-only, A83 volumes are not
+    currently served by the public API at all)."""
+    from backend.power.entsoe_balancing import ingest_balancing
+    from backend.power.zones import POWER_ZONES
+
+    db = SessionLocal()
+    try:
+        days = _intraday_days()
+        for zone_key in POWER_ZONES:
+            try:
+                result = await ingest_balancing(db, days, zone=zone_key, overwrite=True)
+                logger.info("balancing hourly ingest [%s]: %s", zone_key, result)
+            except Exception as exc:
+                logger.error("balancing hourly ingest [%s] failed: %s", zone_key, exc)
+    except Exception as exc:
+        logger.error("_run_balancing outer failed: %s", exc)
+    finally:
+        db.close()
+
+
 async def _run_hydro_weekly():
     """Refresh weekly reservoir filling (ENTSO-E A72) for the hydro zones.
     Current year with overwrite=True — the raw cache is write-once and would
@@ -437,6 +469,8 @@ def start_scheduler():
     # over, so the only history that will ever exist is the one we write ourselves —
     # at :45, after the 6h ingest has landed. Local read + upsert, no network.
     scheduler.add_job(_run_outage_snapshot, CronTrigger(minute=45), id="outage_snapshot_hourly", **JOB_DEFAULTS)
+    # Activated balancing energy (aFRR/mFRR, A83/A84): hourly, same-day activation signal.
+    scheduler.add_job(_run_balancing, CronTrigger(minute=20), id="balancing_hourly", **JOB_DEFAULTS)
     # All-time records: nightly at 23:45, after the 22:30 power ingest.
     scheduler.add_job(_run_records_nightly, CronTrigger(hour=23, minute=45), id="records_nightly", **JOB_DEFAULTS)
     # Episodes: 23:50, right after the records — same doctrine (full recompute from the canonical

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -348,7 +348,12 @@ async def _run_outages():
     6 h: forced outages land intraday, and the desk's whole point is showing them
     before the price does. The two passes are independent try/excepts — A78 uses a
     completely different query shape (directed border pairs, see entsoe_outages.py),
-    so a break there must not take down the A77 pass that already worked."""
+    so a break there must not take down the A77 pass that already worked. They share
+    one Session, so each except calls db.rollback() before moving on: without it, an
+    IntegrityError (or any DB-level error) in the first pass leaves the session in
+    SQLAlchemy's failed-transaction state, and every statement the second pass tries
+    to run raises PendingRollbackError instead of actually attempting anything —
+    which would make the "independent" claim above false exactly when it matters."""
     from backend.power.entsoe_outages import ingest_outages
 
     db = SessionLocal()
@@ -356,11 +361,13 @@ async def _run_outages():
         result = await ingest_outages(db)
         logger.info("outages (A77 generation): %s", result)
     except Exception as exc:
+        db.rollback()
         logger.error("_run_outages (A77 generation) failed: %s", exc)
     try:
         result78 = await ingest_outages(db, doc_type="A78")
         logger.info("outages (A78 transmission): %s", result78)
     except Exception as exc:
+        db.rollback()
         logger.error("_run_outages (A78 transmission) failed: %s", exc)
     finally:
         db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from backend.routes import briefing as briefing_routes
 from backend.routes import crypto as crypto_routes
 from backend.routes import econ as econ_routes
 from backend.routes import email as email_routes
+from backend.routes import embed as embed_routes
 from backend.routes import filings as filings_routes
 from backend.routes import gas as gas_routes
 from backend.routes import jodi as jodi_routes
@@ -191,5 +192,6 @@ app.include_router(metals_routes.router)
 app.include_router(atlas_routes.router)
 app.include_router(power_routes.router)
 app.include_router(api_v1.router)  # public data API v1 (/api/v1/series, catalog, meta)
+app.include_router(embed_routes.router)  # /api/v1/badge/*.svg — embeddable status badges
 app.include_router(situation_routes.router)
 app.include_router(watchlist_routes.router)

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -108,6 +108,12 @@ def run_migrations() -> None:
     if _add_column_if_missing("power_grid", "gen_hours", "INTEGER"):
         applied.append("power_grid.gen_hours")
 
+    # 2026-07-21: A78 transmission-infrastructure unavailability shares power_outage with
+    # A77; the counterparty area (the OTHER end of the interconnector/line) is a concept
+    # A77 never had. NULL for every existing (A77) row, populated going forward for A78.
+    if _add_column_if_missing("power_outage", "counterparty_zone", "VARCHAR"):
+        applied.append("power_outage.counterparty_zone")
+
     # 2026-07-14: name the fuels that had no name. B03/B07/B08/B13 were missing from PSR_LABELS,
     # so the ingest stored the RAW code as psr_type and the mix legend read "gen.B03". Adding the
     # labels fixes new rows; without this, the record would carry the same fuel under two names

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -338,7 +338,11 @@ class PowerOutage(Base):
     available_mw. counterparty_zone is A78-only (null for A77): ENTSO-E requires a
     DIRECTED zone pair for A78 (in_Domain/out_Domain), so ingest stores one row per
     queried direction under zone=in_Domain, counterparty_zone=out_Domain — mapped
-    through ZONE_REGISTRY where possible, kept as a raw EIC when unmapped.
+    through ZONE_REGISTRY where possible, kept as a raw EIC when unmapped. Because a
+    border publishes as two DISJOINT messages (one per direction — see the live
+    spike in entsoe_outages.py), a zone's transmission outages live under BOTH
+    `zone == that zone` AND `counterparty_zone == that zone` rows; the read side
+    (latest_outage_revisions, doc_type="A78") matches either column, not just `zone`.
     """
 
     __tablename__ = "power_outage"

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -317,7 +317,7 @@ class ProductionUnit(Base):
 
 
 class PowerOutage(Base):
-    """ENTSO-E unavailability of generation/production units (A77/A78/A80).
+    """ENTSO-E unavailability of generation units (A77) AND transmission infrastructure (A78).
 
     An EVENT, not a time series: one row per (mRID, revision) of an
     Unavailability_MarketDocument. Revision semantics are the core — messages
@@ -329,6 +329,16 @@ class PowerOutage(Base):
     available_mw is the MINIMUM quantity over the Available_Period step
     function (curveType A03) — the worst case, which is what the desk
     headline should count. offline = nominal_mw − available_mw.
+
+    A78 (spiked live 2026-07-21, DE_LU<->FR) describes an ASSET (line, PST,
+    transformer — Asset_RegisteredResource) instead of a production unit:
+    unit_name/unit_eic/location/psr_type are populated from that container instead
+    of production_RegisteredResource.*, and nominal_mw is ALWAYS null — the schema
+    never publishes a capacity baseline for transmission assets, only the reduced
+    available_mw. counterparty_zone is A78-only (null for A77): ENTSO-E requires a
+    DIRECTED zone pair for A78 (in_Domain/out_Domain), so ingest stores one row per
+    queried direction under zone=in_Domain, counterparty_zone=out_Domain — mapped
+    through ZONE_REGISTRY where possible, kept as a raw EIC when unmapped.
     """
 
     __tablename__ = "power_outage"
@@ -336,8 +346,9 @@ class PowerOutage(Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     mrid: Mapped[str] = mapped_column(String, nullable=False, index=True)
     revision: Mapped[int] = mapped_column(Integer, nullable=False)
-    doc_type: Mapped[str] = mapped_column(String, nullable=False, default="A77")  # A77/A78/A80
+    doc_type: Mapped[str] = mapped_column(String, nullable=False, default="A77")  # A77 generation / A78 transmission
     zone: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    counterparty_zone: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # A78 only
     business_type: Mapped[str] = mapped_column(String, nullable=False)  # A53 planned / A54 forced
     psr_type: Mapped[Optional[str]] = mapped_column(String, nullable=True)   # raw B-code
     unit_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)

--- a/backend/power/capture.py
+++ b/backend/power/capture.py
@@ -139,6 +139,11 @@ def capture_metrics(prices: dict[int, float], generation: dict[int, float]) -> d
         "negative_gen_pct": round(
             100.0 * sum(g for p, g in zip(px, gen) if p < 0) / total_gen, 1
         ),
+        # The COUNT (not generation-weighted) of hours this technology was actually
+        # producing (gen > 0) while the auction price was negative — a volume-blind
+        # complement to negative_gen_pct: one hour of a small plant counts the same
+        # as one hour of a large one.
+        "negative_hours": sum(1 for p, g in zip(px, gen) if p < 0 and g > 0),
     }
 
 
@@ -182,7 +187,10 @@ SELECT g.series_id                                        AS sid,
        SUM(g.gen)                                         AS total_gen,
        COUNT(*)                                           AS hours,
        COUNT(DISTINCT date(g.ts_utc, 'unixepoch'))        AS days,
-       SUM(CASE WHEN p.price < 0 THEN g.gen ELSE 0 END)   AS neg_gen
+       SUM(CASE WHEN p.price < 0 THEN g.gen ELSE 0 END)   AS neg_gen,
+       -- COUNT (not generation-weighted) of hours this technology was actually
+       -- producing (gen > 0) while the price was negative — see capture_metrics().
+       SUM(CASE WHEN p.price < 0 AND g.gen > 0 THEN 1 ELSE 0 END) AS neg_hours
   FROM g JOIN p ON p.ts_utc = g.ts_utc
  GROUP BY sid, month
 """
@@ -202,7 +210,8 @@ def _aggregate(db: Session, zone: str, start_ts: int) -> tuple[dict, dict]:
     """(price_months, fuel_months) — the whole capture table in two aggregate queries.
 
     price_months: {month: (baseload, hours)}
-    fuel_months:  {psr: {month: {hours, days, generation_gwh, capture_price, negative_gen_pct}}}
+    fuel_months:  {psr: {month: {hours, days, generation_gwh, capture_price, negative_gen_pct,
+                                  negative_hours}}}
     """
     keys = [PRICE_SERIES] + [f"gen.{f}" for f in CAPTURE_FUELS]
     sids, zid = _ids(db, zone, keys)
@@ -222,7 +231,7 @@ def _aggregate(db: Session, zone: str, start_ts: int) -> tuple[dict, dict]:
         text(_FUEL_SQL).bindparams(bindparam("gids", expanding=True)),
         {**params, "gids": list(gids)},
     ).all()
-    for sid, month, pxg, total_gen, hours, days, neg_gen in rows:
+    for sid, month, pxg, total_gen, hours, days, neg_gen, neg_hours in rows:
         if not total_gen or total_gen <= 0:
             continue  # a technology that produced nothing has no capture price
         psr = gids[sid].removeprefix("gen.")
@@ -232,6 +241,7 @@ def _aggregate(db: Session, zone: str, start_ts: int) -> tuple[dict, dict]:
             "generation_gwh": round(total_gen / 1000.0, 1),  # hourly MW → MWh → GWh
             "capture_price": round(pxg / total_gen, 2),
             "negative_gen_pct": round(100.0 * (neg_gen or 0.0) / total_gen, 1),
+            "negative_hours": int(neg_hours or 0),
             # Unrounded, and it matters: the value factor divides this by the baseload, and
             # a numerator already rounded to cents moves the third decimal of the ratio.
             # Round the inputs OR round the result — doing both rounds twice.

--- a/backend/power/entsoe_balancing.py
+++ b/backend/power/entsoe_balancing.py
@@ -23,10 +23,15 @@ and a full-month window) — trust this over the pre-spike assumptions in the ta
     BUSINESS_TYPE, never the domain) is ENTSO-E's STRUCTURAL-rejection message — distinct
     from the "No matching data found" Acknowledgement A84 returns for a genuinely empty
     zone/window. Conclusion: activated-balancing-energy VOLUMES are not obtainable through
-    this public Web API / token today, independent of zone. The fetcher below treats the
-    rejection exactly like this codebase's existing "clean no-data ACK" convention
-    (entsoe_exchange.py's A09/A25 fetchers: any >=400 response → cache the emptiness, no
-    exception) so ingestion stays green and the 4 volume series simply go unwritten.
+    this public Web API / token today, independent of zone. The fetcher below recognises
+    BOTH of ENTSO-E's "genuinely nothing here" wordings — this structural rejection and
+    A84's "No matching data found" empty-window Acknowledgement — and, ONLY for those, caches
+    the emptiness like this codebase's existing convention (entsoe_exchange.py's A09/A25
+    fetchers) so ingestion stays green and the 4 volume series simply go unwritten. Any OTHER
+    >=400 (401 from a rotated/expired token, 429, 5xx) is deliberately NOT treated as no-data:
+    it raises and propagates to ingest_balancing's `except httpx.HTTPError`, which logs and
+    skips the month WITHOUT caching it — caching an outage would permanently poison that
+    zone-month in the write-once raw_cache for as long as the token stays broken.
     REVERIFY AT DEPLOY — if ENTSO-E ever restores A83 or a different access tier unlocks it,
     `parse_balancing_volumes` is ready: same Point-walk as prices, reading `quantity` (the
     element name every other MW-quantity ENTSO-E document in this repo uses — A75, A09, A25 —
@@ -101,9 +106,18 @@ _PRODUCT = {"A96": "afrr", "A97": "mfrr"}
 
 _DIRECTION = {"A01": "up", "A02": "down"}
 
-#: DE_LU's balancing energy has no country/bidding-zone-level publication (spiked 2026-07-20)
-#: — TenneT's control area is the one verified-working proxy. See module docstring.
-_CONTROL_AREA_OVERRIDE = {"DE_LU": "10YDE-EON------1"}
+#: Zones whose A83/A84 domain differs from their bidding-zone EIC: {zone: (control-area EIC,
+#: coverage caveat)}. DE_LU's balancing energy has no country/bidding-zone-level publication
+#: (spiked 2026-07-20) — TenneT's control area is the one verified-working proxy, but it is
+#: only one of Germany's four TSOs, not the national total. Kept as ONE dict (not a separate
+#: EIC map + caveat map) so `control_area_eic` and `coverage_caveat` can never drift apart —
+#: see module docstring.
+_CONTROL_AREA_OVERRIDE: dict[str, tuple[str, str]] = {
+    "DE_LU": (
+        "10YDE-EON------1",
+        "TenneT control area only (one of four German TSOs), not the national total.",
+    ),
+}
 
 PRICE_DOCTYPE = "A84"
 VOLUME_DOCTYPE = "A83"
@@ -113,9 +127,19 @@ VOLUME_CACHE_SOURCE = "entsoe_a83"
 
 def control_area_eic(zone: str) -> str | None:
     """Control-area domain EIC for A83/A84 (single-TSO zones = the bidding EIC)."""
-    if zone in _CONTROL_AREA_OVERRIDE:
-        return _CONTROL_AREA_OVERRIDE[zone]
+    override = _CONTROL_AREA_OVERRIDE.get(zone)
+    if override is not None:
+        return override[0]
     return ZONE_REGISTRY.get(zone, {}).get("eic")
+
+
+def coverage_caveat(zone: str) -> str | None:
+    """A short caveat for zones whose balancing-energy domain is a partial, single-TSO
+    override rather than the normal bidding-zone EIC (see module docstring) — None for every
+    other zone. Callers (e.g. GET /api/power/balancing) read this instead of hardcoding a
+    zone check, so the route can never drift from `_CONTROL_AREA_OVERRIDE`."""
+    override = _CONTROL_AREA_OVERRIDE.get(zone)
+    return override[1] if override is not None else None
 
 
 def _walk_points(xml_text: str, amount_tag: str) -> dict[tuple[str, str], dict[str, dict[int, list[float]]]]:
@@ -209,9 +233,14 @@ async def _fetch_balancing_month(
     Returns a LIST of inner XML documents: a ZIP archive (if the response is one — see module
     docstring, none was observed in the spike) can hold MULTIPLE members, unlike A85's
     single-doc ZIP, so every `.xml` member is decoded and returned rather than just the first.
-    A plain-XML response (the observed common case) comes back as a one-element list; any
-    >=400 response is a clean "no data" (matches entsoe_exchange.py's A09/A25 fetchers) and
-    comes back as `[""]`.
+    A plain-XML response (the observed common case) comes back as a one-element list.
+
+    Only a 400 whose body contains ENTSO-E's "No matching data found" or "is not valid"
+    wording (see module docstring) is a clean "no data" — cached and returned as `[""]`,
+    matching entsoe_exchange.py's A09/A25 fetchers. Every OTHER error response (401, 429, 5xx,
+    or a 400 with neither phrase) calls `resp.raise_for_status()` and propagates as
+    `httpx.HTTPError` — deliberately NOT cached, so a token outage or rate limit gets retried
+    next run instead of permanently freezing that zone-month as false emptiness.
 
     NOTE on window size: verified to work at full-calendar-month granularity for a single
     control area (1.57 MB / 469 TimeSeries, no timeout). If a future zone/month combination
@@ -232,12 +261,19 @@ async def _fetch_balancing_month(
         }
         async with httpx.AsyncClient(timeout=120) as client:
             resp = await client.get(ENTSOE_BASE, params=params)
-            if resp.status_code >= 400:
-                # A83 in particular answers 400 for volumes today (see module docstring), and
-                # any TSO/month/product combination can legitimately have nothing published.
-                # Treat exactly like entsoe_exchange.py's A09/A25 fetchers: a clean "no data"
-                # response is data, not an error — cache the emptiness so we never ask again.
+            if resp.status_code == 400 and (
+                b"No matching data found" in resp.content or b"is not valid" in resp.content
+            ):
+                # ENTSO-E's two "there is genuinely nothing here" wordings (see module
+                # docstring): A84's clean empty-window Acknowledgement, and A83's structural
+                # "combination... is not valid" rejection. ONLY this specific 400 shape is
+                # cacheable "no data" (matches entsoe_exchange.py's A09/A25 fetchers) —
+                # anything else must raise below. Caching every >=400 blindly would also
+                # cache a 401 from a rotated/expired token (CLAUDE.md flags rotation as
+                # pending) or a transient 429/5xx into the write-once raw_cache, permanently
+                # poisoning that zone-month for the life of the cache.
                 return {"xml": [""]}
+            resp.raise_for_status()
             body = resp.content
             if body[:2] == b"PK":  # ZIP archive — merge every inner .xml member
                 zf = zipfile.ZipFile(io.BytesIO(body))

--- a/backend/power/entsoe_balancing.py
+++ b/backend/power/entsoe_balancing.py
@@ -1,0 +1,328 @@
+"""ENTSO-E activated balancing energy (aFRR/mFRR) → hourly `balancing.<product>.<price|vol>.<up|down>`.
+
+LIVE SPIKE (2026-07-20, curl against https://web-api.tp.entsoe.eu/api, DE_LU/FR/NL, a 3-day
+and a full-month window) — trust this over the pre-spike assumptions in the task brief:
+
+  * PRICES (documentType A84, ENTSO-E data item 17.1.F "PRICES_OF_ACTIVATED_BALANCING_ENERGY_R3")
+    WORK over `controlArea_Domain`. Price element is `activation_Price.amount` (verified).
+    Resolution is PT15M exclusively in every response seen (matches the 2025-10-01 SDAC
+    15-min-MTU move noted elsewhere in this repo). A SINGLE fetch per zone-month with NO
+    businessType filter returns every business type present in one document — verified: a
+    TenneT full-month pull (no filter) contained 444 aFRR (A96) TimeSeries AND 25 mFRR (A97)
+    TimeSeries side by side. So the raw_cache key stays zone+month (no product component,
+    matching entsoe_imbalance's shape) and the PARSER splits by each TimeSeries' own
+    (businessType, flowDirection.direction), not by a request-time filter.
+
+  * VOLUMES (documentType A83, data item 17.1.E) FAIL UNIVERSALLY in this spike. Every
+    combination tried — DE country EIC (10Y1001A1001A83F), DE bidding-zone EIC
+    (10Y1001A1001A82H), TenneT's control-area EIC, FR's control-area EIC; with/without
+    businessType (A95-A98), with/without processType (A16/A60/A61/A68/A51), with
+    contract_MarketAgreement.Type, with psrType — every one answers HTTP 400 "The
+    combination of [DOCUMENT_TYPE=A83, ...] is not valid, or the requested data is not
+    allowed to be fetched via this service." That wording (naming only DOCUMENT_TYPE /
+    BUSINESS_TYPE, never the domain) is ENTSO-E's STRUCTURAL-rejection message — distinct
+    from the "No matching data found" Acknowledgement A84 returns for a genuinely empty
+    zone/window. Conclusion: activated-balancing-energy VOLUMES are not obtainable through
+    this public Web API / token today, independent of zone. The fetcher below treats the
+    rejection exactly like this codebase's existing "clean no-data ACK" convention
+    (entsoe_exchange.py's A09/A25 fetchers: any >=400 response → cache the emptiness, no
+    exception) so ingestion stays green and the 4 volume series simply go unwritten.
+    REVERIFY AT DEPLOY — if ENTSO-E ever restores A83 or a different access tier unlocks it,
+    `parse_balancing_volumes` is ready: same Point-walk as prices, reading `quantity` (the
+    element name every other MW-quantity ENTSO-E document in this repo uses — A75, A09, A25 —
+    but UNVERIFIED against an actual A83 payload, since none was ever returned).
+
+  * DE_LU HAS NO COUNTRY- OR BIDDING-ZONE-LEVEL BALANCING DATA. Unlike A85's reBAP (nationally
+    uniform, published once), aFRR/mFRR activation is published PER TSO CONTROL AREA. Both the
+    DE_LU country EIC (entsoe_imbalance's override, 10Y1001A1001A83F) and the DE_LU
+    bidding-zone EIC (ZONE_REGISTRY, 10Y1001A1001A82H) answer a clean "No matching data found"
+    for A84. TenneT's control area (10YDE-EON------1) DOES carry real aFRR+mFRR price data, so
+    DE_LU is mapped to it below — a PARTIAL, single-TSO proxy for the country (one of four
+    German control areas: TenneT/Amprion/50Hertz/TransnetBW), not the national total.
+    Documented rather than hidden, same honesty precedent as entsoe_imbalance.py's own
+    country-EIC override note.
+
+  * FR/NL use their bidding-zone EIC directly (`control_area_eic`'s ZONE_REGISTRY fallback,
+    same as entsoe_imbalance.py). In the spiked 3-day window, FR's A84 response carried FCR
+    (A95), mFRR (A97) and RR (A98) prices but NO aFRR (A96); NL's carried ONLY FCR (A95) — no
+    aFRR/mFRR at all. Coverage varies by zone AND by window (a quiet day can simply have no
+    activation in a given direction/product — see the curveType note below), so `product=afrr`
+    legitimately coming back empty for FR on a given day is ordinary "no data", not an error —
+    the same posture this vertical already takes for A85/A25 zone gaps.
+
+  * ZIP WRAPPING: NOT observed in this spike. A full-month, single-control-area A84 pull
+    (1.57 MB, 469 TimeSeries) came back as plain XML text, not a ZIP archive — contradicting
+    the assumption that A83/A84 always ZIP. The fetcher below still branches on the "PK" ZIP
+    magic bytes (unzip + merge every inner .xml member, unlike A85's single-doc unzip) since
+    that costs nothing and is a strict superset of "always plain XML" — a busier control area,
+    a longer window, or ENTSO-E batching multiple TSOs into one country response could still
+    ZIP in practice.
+
+  * curveType is declared A03 in every TimeSeries (the same code entsoe_exchange.py's A09 step
+    function reads) but does NOT behave like a step function here: a gap between two Periods
+    (e.g. one ends 08:00Z, the next starts 08:15Z) means NO activation happened in between —
+    genuinely absent, not a value to hold forward (verified by walking real Periods: gaps
+    exist at random points through the day, exactly where TenneT called on zero aFRR in that
+    direction). So this parser does a plain namespace-agnostic Point walk — entsoe_imbalance's
+    A85 pattern, not entsoe_exchange's `parse_step_series` — and never invents an hour nothing
+    activated in.
+
+HOURLY CANONICALIZATION: PRICES are the MEAN of the quarter-hour points inside each hour (a
+price is a rate — averaging is the only sound rollup, the same rule parse_imbalance_prices
+uses). VOLUMES are the SUM of the quarter-hour points inside each hour (MWh is additive: four
+25 MWh quarter-hour activations make a 100 MWh hour, not a 25 MWh one).
+
+FCR (A95) and RR (A98) business types, when present, are read off the wire and then dropped —
+this desk tracks aFRR/mFRR only for now.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import xml.etree.ElementTree as ET
+import zipfile
+from datetime import date, datetime, timedelta, timezone
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.gas import raw_cache
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
+from backend.power.hourly_store import upsert_day_hours
+from backend.power.zones import ZONE_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+_RESOLUTION_HOURS = {"PT60M": 1.0, "PT30M": 0.5, "PT15M": 0.25}
+
+#: aFRR/mFRR only (see module docstring) — FCR (A95) and RR (A98) are read but ignored.
+_PRODUCT = {"A96": "afrr", "A97": "mfrr"}
+
+_DIRECTION = {"A01": "up", "A02": "down"}
+
+#: DE_LU's balancing energy has no country/bidding-zone-level publication (spiked 2026-07-20)
+#: — TenneT's control area is the one verified-working proxy. See module docstring.
+_CONTROL_AREA_OVERRIDE = {"DE_LU": "10YDE-EON------1"}
+
+PRICE_DOCTYPE = "A84"
+VOLUME_DOCTYPE = "A83"
+PRICE_CACHE_SOURCE = "entsoe_a84"
+VOLUME_CACHE_SOURCE = "entsoe_a83"
+
+
+def control_area_eic(zone: str) -> str | None:
+    """Control-area domain EIC for A83/A84 (single-TSO zones = the bidding EIC)."""
+    if zone in _CONTROL_AREA_OVERRIDE:
+        return _CONTROL_AREA_OVERRIDE[zone]
+    return ZONE_REGISTRY.get(zone, {}).get("eic")
+
+
+def _walk_points(xml_text: str, amount_tag: str) -> dict[tuple[str, str], dict[str, dict[int, list[float]]]]:
+    """Shared Point walk for both A83 and A84: {(product, direction): {day: {hour: [values]}}}.
+
+    Namespace-agnostic (matches local tag names, like every other parser in this vertical). An
+    Acknowledgement document (no TimeSeries) yields {}. TimeSeries whose businessType isn't
+    aFRR/mFRR, or whose direction isn't recognised, are skipped — not accumulated under a
+    placeholder key.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E balancing XML parse error: {exc}") from exc
+
+    out: dict[tuple[str, str], dict[str, dict[int, list[float]]]] = {}
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        bt_el = next((e for e in ts.iter() if _localname(e.tag) == "businessType"), None)
+        dir_el = next((e for e in ts.iter() if _localname(e.tag) == "flowDirection.direction"), None)
+        product = _PRODUCT.get((bt_el.text or "").strip()) if bt_el is not None else None
+        direction = _DIRECTION.get((dir_el.text or "").strip()) if dir_el is not None else None
+        if product is None or direction is None:
+            continue  # FCR/RR or an unrecognised direction — not tracked by this desk
+
+        bucket = out.setdefault((product, direction), {})
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            start_el = next((e for e in period.iter() if _localname(e.tag) == "start"), None)
+            res_el = next((e for e in period.iter() if _localname(e.tag) == "resolution"), None)
+            if start_el is None or res_el is None:
+                continue
+            start = _parse_utc(start_el.text)
+            res_hours = _RESOLUTION_HOURS.get((res_el.text or "").strip())
+            if start is None or res_hours is None:
+                continue
+            for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+                pos = next((e.text for e in point if _localname(e.tag) == "position"), None)
+                amt = next((e.text for e in point if _localname(e.tag) == amount_tag), None)
+                if pos is None or amt is None:
+                    continue
+                try:
+                    t = start + timedelta(hours=res_hours * (int(pos) - 1))
+                    v = float(amt)
+                except (ValueError, TypeError):
+                    continue
+                utc = t.astimezone(timezone.utc)
+                bucket.setdefault(utc.strftime("%Y-%m-%d"), {}).setdefault(utc.hour, []).append(v)
+    return out
+
+
+def parse_balancing_prices(xml_text: str) -> dict[tuple[str, str], dict[str, dict[int, float]]]:
+    """A84 document → {(product, direction): {day: {hour: mean EUR/MWh}}}.
+
+    Reads `activation_Price.amount` (verified live — see module docstring). Sub-hourly slots
+    (PT15M) are AVERAGED to hourly: a price is a rate, not a quantity, so a mean is the only
+    sound rollup — the same rule parse_imbalance_prices (A85) uses.
+    """
+    raw = _walk_points(xml_text, "activation_Price.amount")
+    return {
+        key: {day: {h: sum(v) / len(v) for h, v in hours.items() if v} for day, hours in days.items()}
+        for key, days in raw.items()
+    }
+
+
+def parse_balancing_volumes(xml_text: str) -> dict[tuple[str, str], dict[str, dict[int, float]]]:
+    """A83 document → {(product, direction): {day: {hour: summed MWh}}}.
+
+    Reads `quantity` (UNVERIFIED against a live payload — A83 answered a structural rejection
+    for every combination tried in the 2026-07-20 spike; see module docstring). Sub-hourly
+    slots are SUMMED to hourly: MWh is additive energy, not a rate — four 25 MWh quarter-hour
+    activations make a 100 MWh hour, unlike the price mean above.
+    """
+    raw = _walk_points(xml_text, "quantity")
+    return {
+        key: {day: {h: sum(v) for h, v in hours.items() if v} for day, hours in days.items()}
+        for key, days in raw.items()
+    }
+
+
+def _month_bounds(month_start: date) -> tuple[str, str]:
+    nxt = (month_start.replace(day=28) + timedelta(days=4)).replace(day=1)
+    return f"{month_start:%Y%m%d}0000", f"{nxt:%Y%m%d}0000"
+
+
+async def _fetch_balancing_month(
+    document_type: str, cache_source: str, eic: str, month_start: date, *, overwrite: bool = False
+) -> list[str]:
+    """Fetch one control area's A83/A84 for a calendar month, disk-cached.
+
+    Returns a LIST of inner XML documents: a ZIP archive (if the response is one — see module
+    docstring, none was observed in the spike) can hold MULTIPLE members, unlike A85's
+    single-doc ZIP, so every `.xml` member is decoded and returned rather than just the first.
+    A plain-XML response (the observed common case) comes back as a one-element list; any
+    >=400 response is a clean "no data" (matches entsoe_exchange.py's A09/A25 fetchers) and
+    comes back as `[""]`.
+
+    NOTE on window size: verified to work at full-calendar-month granularity for a single
+    control area (1.57 MB / 469 TimeSeries, no timeout). If a future zone/month combination
+    times out, `ingest_net_positions`'s ISO-week fallback (backend/power/entsoe_exchange.py) is
+    the documented pattern to drop to — this function's window is a plain (start, end) pair
+    internally, so swapping the caller's chunking to weekly needs no change here.
+    """
+
+    period_start, period_end = _month_bounds(month_start)
+
+    async def _do() -> dict:
+        params = {
+            "securityToken": _token(),
+            "documentType": document_type,
+            "controlArea_Domain": eic,
+            "periodStart": period_start,
+            "periodEnd": period_end,
+        }
+        async with httpx.AsyncClient(timeout=120) as client:
+            resp = await client.get(ENTSOE_BASE, params=params)
+            if resp.status_code >= 400:
+                # A83 in particular answers 400 for volumes today (see module docstring), and
+                # any TSO/month/product combination can legitimately have nothing published.
+                # Treat exactly like entsoe_exchange.py's A09/A25 fetchers: a clean "no data"
+                # response is data, not an error — cache the emptiness so we never ask again.
+                return {"xml": [""]}
+            body = resp.content
+            if body[:2] == b"PK":  # ZIP archive — merge every inner .xml member
+                zf = zipfile.ZipFile(io.BytesIO(body))
+                names = [n for n in zf.namelist() if n.endswith(".xml")]
+                docs = [zf.read(n).decode("utf-8", "replace") for n in names] or [""]
+            else:
+                docs = [resp.text]
+            return {"xml": docs}
+
+    payload = await raw_cache.fetch_or_cache(
+        cache_source, f"{eic}_{month_start:%Y-%m}", month_start, _do, overwrite=overwrite
+    )
+    docs = payload.get("xml") if isinstance(payload, dict) else None
+    return docs or [""]
+
+
+def _merge_wanted(
+    acc: dict[tuple[str, str], dict[str, dict[int, float]]],
+    parsed: dict[tuple[str, str], dict[str, dict[int, float]]],
+    wanted: set[str],
+) -> None:
+    """Fold a parsed month's {(product, direction): {day: {hour: value}}} into the running
+    accumulator, keeping only days the caller actually asked for."""
+    for key, day_hours in parsed.items():
+        bucket = acc.setdefault(key, {})
+        for day, hours in day_hours.items():
+            if day in wanted:
+                bucket.setdefault(day, {}).update(hours)
+
+
+async def ingest_balancing(
+    db: Session, days: list[str], *, zone: str = "DE_LU", overwrite: bool = False
+) -> dict:
+    """Fetch + upsert activated-balancing-energy prices (A84) and volumes (A83) for `zone`
+    over the month(s) spanning `days`, writing up to 8 canonical series:
+    `balancing.{afrr,mfrr}.{price,vol}.{up,down}`.
+
+    Prices and volumes are fetched and folded independently — a failure or structural
+    rejection in one (see module docstring re: A83) must never block the other, matching the
+    per-step isolation the rest of the daily power ingest uses (backend/collectors/scheduler.py
+    ::_run_power_daily).
+    """
+    if not settings.entsoe_api_token:
+        return {"skipped": "no token"}
+    if not days:
+        return {"days": 0, "written": 0}
+    ca_eic = control_area_eic(zone)
+    if ca_eic is None:
+        return {"skipped": f"no balancing domain for zone {zone}"}
+
+    wanted = set(days)
+    months = sorted({datetime.strptime(d, "%Y-%m-%d").date().replace(day=1) for d in days})
+
+    price_acc: dict[tuple[str, str], dict[str, dict[int, float]]] = {}
+    vol_acc: dict[tuple[str, str], dict[str, dict[int, float]]] = {}
+
+    for month_start in months:
+        try:
+            price_docs = await _fetch_balancing_month(
+                PRICE_DOCTYPE, PRICE_CACHE_SOURCE, ca_eic, month_start, overwrite=overwrite
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("balancing prices [%s %s] fetch failed: %s", zone, month_start, exc)
+            price_docs = []
+        for xml in price_docs:
+            if xml:
+                _merge_wanted(price_acc, parse_balancing_prices(xml), wanted)
+
+        try:
+            vol_docs = await _fetch_balancing_month(
+                VOLUME_DOCTYPE, VOLUME_CACHE_SOURCE, ca_eic, month_start, overwrite=overwrite
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("balancing volumes [%s %s] fetch failed: %s", zone, month_start, exc)
+            vol_docs = []
+        for xml in vol_docs:
+            if xml:
+                _merge_wanted(vol_acc, parse_balancing_volumes(xml), wanted)
+
+    written = 0
+    for (product, direction), day_hours in price_acc.items():
+        if day_hours:
+            written += upsert_day_hours(db, f"balancing.{product}.price.{direction}", zone, day_hours, unit="EUR/MWh")
+    for (product, direction), day_hours in vol_acc.items():
+        if day_hours:
+            written += upsert_day_hours(db, f"balancing.{product}.vol.{direction}", zone, day_hours, unit="MWh")
+
+    return {"days": len(wanted), "written": written}

--- a/backend/power/entsoe_balancing.py
+++ b/backend/power/entsoe_balancing.py
@@ -35,7 +35,15 @@ and a full-month window) — trust this over the pre-spike assumptions in the ta
     REVERIFY AT DEPLOY — if ENTSO-E ever restores A83 or a different access tier unlocks it,
     `parse_balancing_volumes` is ready: same Point-walk as prices, reading `quantity` (the
     element name every other MW-quantity ENTSO-E document in this repo uses — A75, A09, A25 —
-    but UNVERIFIED against an actual A83 payload, since none was ever returned).
+    but UNVERIFIED against an actual A83 payload, since none was ever returned). ONE THING TO
+    RE-CHECK FIRST: `_walk_points` accumulates every Point from every TimeSeries matching a
+    given (product, direction) into one list per hour, and `parse_balancing_volumes` SUMS
+    that list. That is correct for genuinely-disjoint quarter-hours, but if a real A83
+    document ever has OVERLAPPING TimeSeries for the same (product, direction, hour) — e.g. a
+    revision superseding an earlier one, the way A85/A09 do — those values would be SUMMED
+    together (double-counted energy), not replaced or averaged. Prices average, so the same
+    overlap there is harmless; volumes are not — verify real A83 documents don't overlap like
+    that before trusting a sum.
 
   * DE_LU HAS NO COUNTRY- OR BIDDING-ZONE-LEVEL BALANCING DATA. Unlike A85's reBAP (nationally
     uniform, published once), aFRR/mFRR activation is published PER TSO CONTROL AREA. Both the
@@ -235,10 +243,12 @@ async def _fetch_balancing_month(
     single-doc ZIP, so every `.xml` member is decoded and returned rather than just the first.
     A plain-XML response (the observed common case) comes back as a one-element list.
 
-    Only a 400 whose body contains ENTSO-E's "No matching data found" or "is not valid"
-    wording (see module docstring) is a clean "no data" — cached and returned as `[""]`,
-    matching entsoe_exchange.py's A09/A25 fetchers. Every OTHER error response (401, 429, 5xx,
-    or a 400 with neither phrase) calls `resp.raise_for_status()` and propagates as
+    Only a 400 whose body contains ENTSO-E's "No matching data found", "not allowed to be
+    fetched via this service", or "combination of" wording (the distinctive tail of its two
+    "nothing here" messages — see module docstring) is a clean "no data" — cached and
+    returned as `[""]`, matching entsoe_exchange.py's A09/A25 fetchers. Every OTHER error
+    response (401, 429, 5xx, or a 400 matching none of those phrases — e.g. an ordinary
+    parameter-validation error) calls `resp.raise_for_status()` and propagates as
     `httpx.HTTPError` — deliberately NOT cached, so a token outage or rate limit gets retried
     next run instead of permanently freezing that zone-month as false emptiness.
 
@@ -262,16 +272,22 @@ async def _fetch_balancing_month(
         async with httpx.AsyncClient(timeout=120) as client:
             resp = await client.get(ENTSOE_BASE, params=params)
             if resp.status_code == 400 and (
-                b"No matching data found" in resp.content or b"is not valid" in resp.content
+                b"No matching data found" in resp.content
+                or b"not allowed to be fetched via this service" in resp.content
+                or b"combination of" in resp.content
             ):
                 # ENTSO-E's two "there is genuinely nothing here" wordings (see module
-                # docstring): A84's clean empty-window Acknowledgement, and A83's structural
-                # "combination... is not valid" rejection. ONLY this specific 400 shape is
-                # cacheable "no data" (matches entsoe_exchange.py's A09/A25 fetchers) —
-                # anything else must raise below. Caching every >=400 blindly would also
-                # cache a 401 from a rotated/expired token (CLAUDE.md flags rotation as
-                # pending) or a transient 429/5xx into the write-once raw_cache, permanently
-                # poisoning that zone-month for the life of the cache.
+                # docstring): A84's clean empty-window Acknowledgement ("No matching data
+                # found"), and A83's structural rejection ("The combination of [...] is not
+                # valid, or the requested data is not allowed to be fetched via this
+                # service."). Matched on the DISTINCTIVE tail of that sentence, not the bare
+                # "is not valid" fragment — that phrase alone is generic enough to appear in
+                # an ordinary parameter-validation error, which must NOT be cached as no-data.
+                # ONLY this specific 400 shape is cacheable (matches entsoe_exchange.py's
+                # A09/A25 fetchers) — anything else must raise below. Caching every >=400
+                # blindly would also cache a 401 from a rotated/expired token (CLAUDE.md flags
+                # rotation as pending) or a transient 429/5xx into the write-once raw_cache,
+                # permanently poisoning that zone-month for the life of the cache.
                 return {"xml": [""]}
             resp.raise_for_status()
             body = resp.content
@@ -296,7 +312,19 @@ def _merge_wanted(
     wanted: set[str],
 ) -> None:
     """Fold a parsed month's {(product, direction): {day: {hour: value}}} into the running
-    accumulator, keeping only days the caller actually asked for."""
+    accumulator, keeping only days the caller actually asked for.
+
+    WHY last-wins across documents: `ingest_balancing` calls this once per inner .xml member
+    of a fetch (plain-XML responses are a one-element list; see `_fetch_balancing_month`'s
+    ZIP-merge). `bucket.setdefault(day, {}).update(hours)` means if the SAME (product,
+    direction, day, hour) is present in TWO different documents, the later document's value
+    silently overwrites the earlier one — no averaging or summing across documents. That is
+    deliberate for the shape observed in the 2026-07-20 spike (a single plain-XML document per
+    zone-month, never multiple ZIP members), where there is nothing to merge. If ENTSO-E ever
+    starts batching several TSOs' documents into one ZIPped response for the SAME zone, this
+    would need real aggregation (sum for volumes, a defined tie-break for prices) instead of
+    last-wins — reassess before trusting it in that scenario.
+    """
     for key, day_hours in parsed.items():
         bucket = acc.setdefault(key, {})
         for day, hours in day_hours.items():
@@ -305,7 +333,12 @@ def _merge_wanted(
 
 
 async def ingest_balancing(
-    db: Session, days: list[str], *, zone: str = "DE_LU", overwrite: bool = False
+    db: Session,
+    days: list[str],
+    *,
+    zone: str = "DE_LU",
+    overwrite: bool = False,
+    overwrite_volumes: bool | None = None,
 ) -> dict:
     """Fetch + upsert activated-balancing-energy prices (A84) and volumes (A83) for `zone`
     over the month(s) spanning `days`, writing up to 8 canonical series:
@@ -315,6 +348,18 @@ async def ingest_balancing(
     rejection in one (see module docstring re: A83) must never block the other, matching the
     per-step isolation the rest of the daily power ingest uses (backend/collectors/scheduler.py
     ::_run_power_daily).
+
+    `overwrite_volumes` lets the A83 fetch use a DIFFERENT overwrite than the A84 fetch;
+    `None` (the default) means "same as `overwrite`", preserving the original one-flag
+    behaviour for every existing caller. This exists for the hourly job: A83's structural
+    rejection (see module docstring — it fails for every zone/param combination tried) is
+    stable and cheap to cache, but re-running with `overwrite=True` for BOTH doctypes every
+    hour would re-issue that known-futile A83 request for all 37 zones × 24 times a day —
+    ~888 guaranteed 400s against ENTSO-E for nothing. Passing `overwrite_volumes=False` lets
+    the cached `[""]` short-circuit with zero network once it exists, while prices (which
+    DO change hour to hour) keep refreshing via `overwrite=True`. The once-a-day full-overwrite
+    pass (both flags True) is deliberately kept as the "REVERIFY" probe for whether A83 has
+    come back.
     """
     if not settings.entsoe_api_token:
         return {"skipped": "no token"}
@@ -326,6 +371,7 @@ async def ingest_balancing(
 
     wanted = set(days)
     months = sorted({datetime.strptime(d, "%Y-%m-%d").date().replace(day=1) for d in days})
+    vol_overwrite = overwrite if overwrite_volumes is None else overwrite_volumes
 
     price_acc: dict[tuple[str, str], dict[str, dict[int, float]]] = {}
     vol_acc: dict[tuple[str, str], dict[str, dict[int, float]]] = {}
@@ -344,7 +390,7 @@ async def ingest_balancing(
 
         try:
             vol_docs = await _fetch_balancing_month(
-                VOLUME_DOCTYPE, VOLUME_CACHE_SOURCE, ca_eic, month_start, overwrite=overwrite
+                VOLUME_DOCTYPE, VOLUME_CACHE_SOURCE, ca_eic, month_start, overwrite=vol_overwrite
             )
         except httpx.HTTPError as exc:
             logger.warning("balancing volumes [%s %s] fetch failed: %s", zone, month_start, exc)

--- a/backend/power/entsoe_outages.py
+++ b/backend/power/entsoe_outages.py
@@ -1,6 +1,7 @@
-"""ENTSO-E A77 generation unavailability → PowerOutage events.
+"""ENTSO-E outage messages → PowerOutage events. A77 (generation units) and A78
+(transmission infrastructure — interconnectors/lines) share this pipeline.
 
-Spiked live 2026-07-11 (DE_LU): the API returns a ZIP with one
+Spiked live 2026-07-11 (DE_LU, A77): the API returns a ZIP with one
 Unavailability_MarketDocument per outage MESSAGE — and revision semantics are
 the whole game. Of 31 documents in a 2-day window, 26 carried docStatus A09
 (withdrawn); a naive reader would put 26 ghost outages on the desk. Ingest
@@ -21,6 +22,30 @@ Pagination — learned from the live API, both the hard way:
   * The request window must span less than one year, or HTTP 400
     ("must not span more than one year").
 We page in 200s until a page comes back non-full.
+
+A78 spike (2026-07-21, DE_LU<->FR/NL/BE/CZ/AT — see docs/findings/2026-07-20-umm-feasibility.md
+for why this task exists): A77's single `biddingZone_Domain` param does NOT work for A78
+("Mandatory parameter In_Domain is missing"). A78 needs a DIRECTED zone pair, `in_Domain` +
+`out_Domain` (same pattern as A09 scheduled exchanges / A25 net position). Querying the SAME
+zone as both (a common "give me everything for this area" trick on other ENTSO-E document
+types) answers an EMPTY zip — a real border pair is mandatory. And the two directions of one
+border are NOT mirrors of each other: DE_LU->FR and FR->DE_LU shared zero mRIDs across a
+2026-06-01→2026-07-20 window (26 documents each, fully disjoint) — each TSO evidently
+publishes its own side, so skipping either direction silently drops real outages. Ingest
+therefore reuses `border_registry.directed_pairs()` (already swept from ENTSO-E for A09) for
+BOTH directions of every canonical border instead of re-deriving its own list.
+
+Schema differences from A77: A78 describes an ASSET (line/PST/transformer —
+Asset_RegisteredResource), not a production unit. The name/EIC/location/psrType live
+NESTED inside that one container (`<Asset_RegisteredResource><mRID/><name/>
+<asset_PSRType.psrType/><location.name/></Asset_RegisteredResource>`) instead of A77's flat
+`production_RegisteredResource.*` element names, and — checked across 52 live-sampled
+documents — nominalP is NEVER published for a transmission asset; only the reduced
+available_mw exists, so nominal_mw/offline_mw stay null for every A78 row (existing code
+already guards `nominal_mw is not None` everywhere it sums offline capacity, so A78 rows
+self-exclude from every generation-only MW total by construction, not by a doc_type filter
+alone). businessType (A53 planned / A54 forced) and docStatus/revision withdrawal semantics
+are IDENTICAL to A77 (both seen live: 50 A53 + 2 A54, 8/52 withdrawn A09 across the sample).
 """
 
 from __future__ import annotations
@@ -37,7 +62,8 @@ from sqlalchemy.orm import Session
 from backend.config import settings
 from backend.gas.entsoe import ENTSOE_BASE, _localname, _token
 from backend.models.energy import PowerOutage
-from backend.power.zones import POWER_ZONES
+from backend.power.border_registry import directed_pairs
+from backend.power.zones import POWER_ZONES, ZONE_REGISTRY
 
 logger = logging.getLogger(__name__)
 
@@ -50,10 +76,41 @@ DEFAULT_LOOKAHEAD_DAYS = 355
 #: docStatus values that mean "this message no longer stands".
 _WITHDRAWN_STATUSES = {"A09", "A13"}  # cancelled / withdrawn
 
+#: ENTSO-E asset_PSRType codes for A78 (network elements — B21-B24 are deliberately
+#: excluded from entsoe_grid.PSR_LABELS, which is fuels-only; B21 is the only one seen
+#: live so far, 52/52 sampled documents).
+ASSET_TYPE_LABELS: dict[str, str] = {
+    "B21": "AC Line",
+    "B22": "DC Link",
+    "B23": "Substation",
+    "B24": "Transformer",
+}
+
+#: Reverse of ZONE_REGISTRY, for mapping A78's in_Domain/out_Domain EICs back to zone
+#: keys. Built from the full registry (not just the enabled POWER_ZONES subset) so a
+#: counterparty outside the enabled set still gets a readable key instead of a raw EIC.
+_EIC_TO_ZONE: dict[str, str] = {meta["eic"]: key for key, meta in ZONE_REGISTRY.items()}
+
 
 def _text(root: ET.Element, localname: str) -> str | None:
     """First element text matching a local tag name, namespace-agnostic."""
     for e in root.iter():
+        if _localname(e.tag) == localname:
+            return (e.text or "").strip() or None
+    return None
+
+
+def _child_text(parent: ET.Element | None, localname: str) -> str | None:
+    """First DIRECT child of `parent` matching a local tag name, namespace-agnostic.
+
+    Unlike `_text` (which walks the WHOLE subtree from an arbitrary root), this only
+    looks one level down — needed for A78's Asset_RegisteredResource container, whose
+    child <mRID> would otherwise be shadowed by the document's own top-level <mRID>
+    and the TimeSeries's <mRID>1</mRID> (all three share the same local tag name).
+    """
+    if parent is None:
+        return None
+    for e in parent:
         if _localname(e.tag) == localname:
             return (e.text or "").strip() or None
     return None
@@ -99,38 +156,76 @@ def parse_unavailability(xml_text: str) -> dict | None:
                 quantities.append(float(e.text))
             except (TypeError, ValueError):
                 continue
-    nominal = _text(root, "production_RegisteredResource.pSRType.powerSystemResources.nominalP")
+
+    # A78 (transmission) wraps its identity in <Asset_RegisteredResource> instead of A77's
+    # flat production_RegisteredResource.* names — branch on which container is present
+    # rather than trusting the document's <type> text, so any future doc type sharing this
+    # shape (A79 offshore grid?) is handled the same way without a new branch.
+    asset = next((e for e in root.iter() if _localname(e.tag) == "Asset_RegisteredResource"), None)
+    if asset is not None:
+        unit_name = _child_text(asset, "name")
+        unit_eic = _child_text(asset, "mRID")
+        location = _child_text(asset, "location.name")
+        psr_type = _child_text(asset, "asset_PSRType.psrType")
+        nominal_mw = None  # never published for a transmission asset (52/52 live-sampled)
+        in_domain_eic = _text(root, "in_Domain.mRID")
+        out_domain_eic = _text(root, "out_Domain.mRID")
+    else:
+        nominal = _text(root, "production_RegisteredResource.pSRType.powerSystemResources.nominalP")
+        unit_name = _text(root, "production_RegisteredResource.name")
+        unit_eic = _text(root, "production_RegisteredResource.mRID")
+        location = _text(root, "production_RegisteredResource.location.name")
+        psr_type = _text(root, "production_RegisteredResource.pSRType.psrType")
+        nominal_mw = float(nominal) if nominal else None
+        in_domain_eic = None
+        out_domain_eic = None
 
     return {
         "mrid": mrid,
         "revision": int(revision),
         "business_type": _text(root, "businessType") or "A53",
-        "psr_type": _text(root, "production_RegisteredResource.pSRType.psrType"),
-        "unit_name": _text(root, "production_RegisteredResource.name"),
-        "unit_eic": _text(root, "production_RegisteredResource.mRID"),
-        "location": _text(root, "production_RegisteredResource.location.name"),
-        "nominal_mw": float(nominal) if nominal else None,
+        "psr_type": psr_type,
+        "unit_name": unit_name,
+        "unit_eic": unit_eic,
+        "location": location,
+        "nominal_mw": nominal_mw,
         "available_mw": min(quantities) if quantities else None,
         "start_utc": start,
         "end_utc": end,
         "status": "withdrawn" if status_val in _WITHDRAWN_STATUSES else "active",
+        # Transient — consumed by ingest_outages to resolve zone/counterparty_zone via
+        # ZONE_REGISTRY, then popped before the dict reaches PowerOutage(**event). None
+        # for A77 (it carries no domain information at all).
+        "in_domain_eic": in_domain_eic,
+        "out_domain_eic": out_domain_eic,
     }
 
 
 async def _fetch_outages_page(
-    eic: str, window_start: str, window_end: str, offset: int, *, doc_type: str = "A77"
+    eic: str, window_start: str, window_end: str, offset: int, *,
+    doc_type: str = "A77", counterparty_eic: str | None = None,
 ) -> bytes | None:
-    """One page of the unavailability ZIP (raw bytes), or None on empty/no data."""
+    """One page of the unavailability ZIP (raw bytes), or None on empty/no data.
+
+    A78 needs a DIRECTED zone pair (in_Domain=eic / out_Domain=counterparty_eic) instead
+    of A77's single biddingZone_Domain — passing `counterparty_eic` switches the param
+    shape. Live-spiked 2026-07-21: in_Domain==out_Domain (same zone twice) answers an
+    empty ZIP, so this is not an optional convenience for A78, it is mandatory.
+    """
     params = {
         "securityToken": _token(),
         "documentType": doc_type,
-        "biddingZone_Domain": eic,
         "periodStart": window_start,
         "periodEnd": window_end,
         # ALWAYS explicit, including 0 — without it the API refuses to paginate
         # and answers >200-document windows with HTTP 400.
         "offset": str(offset),
     }
+    if counterparty_eic is not None:
+        params["in_Domain"] = eic
+        params["out_Domain"] = counterparty_eic
+    else:
+        params["biddingZone_Domain"] = eic
     async with httpx.AsyncClient(timeout=120) as client:
         resp = await client.get(ENTSOE_BASE, params=params)
         if resp.status_code == 400:
@@ -155,7 +250,14 @@ async def ingest_outages(
 ) -> dict:
     """Fetch the rolling outage window for `zones` and store new (mrid, revision)
     rows. No deep backfill by design — active + upcoming messages are the
-    product; history accumulates from running daily."""
+    product; history accumulates from running daily.
+
+    A78 (doc_type="A78") iterates BORDER PAIRS instead of zones — a directed
+    (in_Domain, out_Domain) query per side of every canonical border in
+    `border_registry.directed_pairs()`, restricted to pairs where both ends are in
+    `zones`. See the module docstring for why both directions are needed and why a
+    same-zone pair does not substitute for them.
+    """
     if not settings.entsoe_api_token:
         logger.warning("entsoe_outages: ENTSOE_API_TOKEN not set — skipping")
         return {"skipped": "no token"}
@@ -165,16 +267,31 @@ async def ingest_outages(
     window_start = (now - timedelta(days=lookback_days)).strftime("%Y%m%d0000")
     window_end = (now + timedelta(days=lookahead_days)).strftime("%Y%m%d0000")
 
+    if doc_type == "A78":
+        zone_set = set(zones)
+        pairs: list[tuple[str, str | None]] = [
+            (a, b) for a, b in directed_pairs() if a in zone_set and b in zone_set
+        ]
+    else:
+        pairs = [(zone, None) for zone in zones]
+
     written = 0
     seen_docs = 0
-    for zone in zones:
+    for zone, counterparty in pairs:
         eic = POWER_ZONES.get(zone, {}).get("eic")
         if not eic:
             continue
+        counterparty_eic = POWER_ZONES.get(counterparty, {}).get("eic") if counterparty else None
         offset = 0
         while True:
             try:
-                blob = await _fetch_outages_page(eic, window_start, window_end, offset, doc_type=doc_type)
+                if counterparty_eic is not None:
+                    blob = await _fetch_outages_page(
+                        eic, window_start, window_end, offset,
+                        doc_type=doc_type, counterparty_eic=counterparty_eic,
+                    )
+                else:
+                    blob = await _fetch_outages_page(eic, window_start, window_end, offset, doc_type=doc_type)
             except httpx.HTTPError as exc:
                 logger.warning("entsoe_outages [%s offset=%d]: fetch failed: %s", zone, offset, exc)
                 break
@@ -192,6 +309,18 @@ async def ingest_outages(
                 event = parse_unavailability(zf.read(name).decode("utf-8", "replace"))
                 if event is None:
                     continue
+                in_eic = event.pop("in_domain_eic", None)
+                out_eic = event.pop("out_domain_eic", None)
+                # The message's OWN domain pair is authoritative when present (A78) — trust
+                # it over the query loop variable, which only matters if ENTSO-E ever answers
+                # a broader match than what was asked. zone falls back to the query zone if
+                # in_Domain maps to nothing (should not happen: it is the zone we just queried
+                # with), counterparty_zone falls back to the raw EIC if unmapped.
+                row_zone = zone
+                counterparty_zone = None
+                if in_eic or out_eic:
+                    row_zone = _EIC_TO_ZONE.get(in_eic, zone)
+                    counterparty_zone = _EIC_TO_ZONE.get(out_eic, out_eic)
                 exists = (
                     db.query(PowerOutage.id)
                     .filter(PowerOutage.mrid == event["mrid"], PowerOutage.revision == event["revision"])
@@ -199,7 +328,7 @@ async def ingest_outages(
                 )
                 if exists:
                     continue
-                db.add(PowerOutage(zone=zone, doc_type=doc_type, **event))
+                db.add(PowerOutage(zone=row_zone, doc_type=doc_type, counterparty_zone=counterparty_zone, **event))
                 written += 1
             db.commit()
 
@@ -207,4 +336,4 @@ async def ingest_outages(
                 break
             offset += _PAGE_SIZE
 
-    return {"written": written, "documents": seen_docs, "zones": len(zones)}
+    return {"written": written, "documents": seen_docs, "zones": len(zones), "pairs": len(pairs)}

--- a/backend/power/entsoe_reserves.py
+++ b/backend/power/entsoe_reserves.py
@@ -1,0 +1,349 @@
+"""ENTSO-E procured balancing CAPACITY prices (FCR/aFRR/mFRR tenders) → hourly
+`capacity.<fcr|afrr.pos|afrr.neg|mfrr.pos|mfrr.neg>.price` (EUR/MW/h), DE_LU only.
+
+NOT to be confused with `backend/power/entsoe_capacity.py` (installed GENERATION capacity,
+A68, pan-EU) or `backend/power/entsoe_balancing.py` (activated balancing ENERGY, A83/A84,
+what the TSO actually called on). This module is the THIRD leg: what Germany pays to have
+reserve capacity on standby at all, before any of it is ever activated. See
+docs/findings/2026-07-20-regelleistung-capacity-prices.md for the feasibility spike that
+picked ENTSO-E documentType A15 over regelleistung.net (no data licence there).
+
+LIVE SPIKE (2026-07-21, curl against https://web-api.tp.entsoe.eu/api, DE-LU LFC block,
+2026-06-01) — trust this over the prior feasibility spike's pagination-limit assumption:
+
+  * documentType=A15, area_Domain=10Y1001A1001A82H (DE-LU LFC BLOCK — verified live: an
+    individual German TSO control area, e.g. TenneT's 10YDE-EON------1, returns a clean
+    empty Acknowledgement instead; must be the LFC block). processType A52=FCR / A51=aFRR /
+    A47=mFRR. The LFC block's EIC happens to be BYTE-IDENTICAL to the DE-LU bidding-zone EIC
+    (ZONE_REGISTRY["DE_LU"]["eic"]) — that is a coincidence for this one zone, not a general
+    rule, so it is re-exported as its own named constant below rather than silently reused.
+
+  * SHAPE: each response page is a ZIP (one `.xml` member observed every time, but every
+    member is still merged defensively) containing a `Balancing_MarketDocument` with a
+    document-level `process.processType` (A52/A51/A47 — read off the wire per document
+    rather than trusted from the request, matching this repo's convention of parsing what
+    ENTSO-E actually says). Each `TimeSeries` = ONE accepted bid: `businessType` B95,
+    `flowDirection.direction` (A01=up/positive, A02=down/negative for aFRR/mFRR; **A03
+    ("symmetric") for FCR — FCR is NOT split by direction**, confirming the finding doc's
+    "FCR is symmetric" call). Each TimeSeries has exactly one `Period`, whose
+    `timeInterval` (start/end) IS the traded 4-hour product block — the declared
+    `resolution` (PT15M) is boilerplate: there is only ONE `Point` (`position`=1) per
+    Period, and its `quantity` (MW) + `procurement_Price.amount` apply to the WHOLE block,
+    not a 15-minute slice of it. (Defensive fallback: if a Period ever carries more than one
+    Point — never observed — every point is still folded in as its own bid against that same
+    block rather than silently dropped or crashing.)
+
+  * PAGINATION: `offset` steps of 100 TimeSeries per page, as documented — but the prior
+    feasibility spike's "documented max 4900" is CONTRADICTED here: on the spiked day,
+    aFRR (A51) returned FULL 100-entry pages through offset=6700 (6893 TimeSeries total,
+    confirmed by bisection — offset=6800 gave a final short page of 93, offset=6900+ gave a
+    clean empty Acknowledgement) and FCR/mFRR total well under that anyway (771 / 1687). A
+    strict 4900 cutoff would have silently dropped ~2000 real aFRR bids on an ordinary day.
+    `_MAX_OFFSET` below is therefore a generous runaway-loop safety valve (20,000 — ~3x the
+    highest observed count), not an expected truncation point; a page short of 100 TimeSeries
+    (including a genuinely empty one) is the real, verified stop condition.
+
+  * ERROR DISCIPLINE DIFFERS FROM A83/A84: every "nothing here" case tried — a future date
+    (2030-01-01), a pre-tender date (2010-01-01), the wrong (control-area) domain, and
+    exhausted pagination — answered with a clean **HTTP 200** zero-TimeSeries
+    `Acknowledgement_MarketDocument`, never a 400. So, unlike entsoe_balancing.py's A83/A84
+    fetchers, there is NO "structural 400 = empty" text-matching special case for A15: every
+    4xx/5xx (401 verified for a bad token, 400 verified for an invalid processType) is a
+    genuine failure and must `raise_for_status()` / propagate as `httpx.HTTPError` — caching
+    it would risk poisoning the write-once raw_cache the same way a mis-cached auth failure
+    would elsewhere in this vertical.
+
+  * MARKET SEMANTICS (from the feasibility spike, unchanged): daily tenders, six 4-hour
+    blocks per day (00-04, 04-08, … 20-24 LOCAL time — hence a block's UTC boundaries shift
+    with DST, e.g. the spiked day's first block ran 2026-05-31T22:00Z–2026-06-01T02:00Z).
+    FCR is pay-as-CLEARED (uniform price — the highest accepted bid IS the clearing price
+    for every accepted MW in that block); aFRR/mFRR are pay-as-BID (each accepted bid is
+    paid its own price, so no single "the" price exists — a volume-weighted average is what
+    procurement actually cost per MW).
+
+CANONICAL STORAGE DECISION: only the volume-weighted average price is stored (5 series,
+zone DE_LU), normalized to **EUR/MW/h** so every series shares one unit — FCR's native
+EUR-per-4h-block price is divided by 4; aFRR/mFRR are already EUR/MW/h. The MARGINAL price
+(highest accepted bid — mathematically the same number as the pay-as-cleared FCR price) is
+computed by `aggregate_bids` for completeness/testability but deliberately NEVER stored: a
+second parallel set of 5 series would double the storage and the caption surface for a
+number that, for the two pay-as-bid products, describes only the single most expensive
+accepted bid — not what the TSO actually paid on average. A trader who wants the marginal
+bid can derive it from the raw ENTSO-E document; this desk publishes the cost number.
+
+Each block's single weighted-average value is written to EVERY hour it covers (a step
+function, like entsoe_exchange.py's A09) via `upsert_day_hours` — unlike activated-balancing
+energy's gaps (entsoe_balancing.py), a capacity-tender price genuinely HOLDS for its whole
+block, so densifying it across all 4 (or, at a DST boundary, 3/5) hours is correct, not a
+fabricated fill-forward.
+
+FIDELITY CAVEAT (carried into the route's `note`): FCR settles across borders under a single
+clearing mechanism, so a specific country's OWN settlement price can differ slightly from
+this DE-LU-block reconstruction on days when export limits bind (see the feasibility-spike
+finding doc). Acceptable for a German-desk view; must stay visible, not silently smoothed
+over.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import xml.etree.ElementTree as ET
+import zipfile
+from datetime import date, datetime, timedelta, timezone
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.config import settings
+from backend.gas import raw_cache
+from backend.gas.entsoe import ENTSOE_BASE, _localname, _parse_utc, _token
+from backend.power.hourly_store import upsert_day_hours
+from backend.power.zones import ZONE_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+#: DE-LU LFC block domain for A15. Verified live 2026-07-21 to be the ONLY domain that
+#: answers for this zone (an individual German TSO control area returns nothing) — and to
+#: be byte-identical to the DE-LU bidding-zone EIC, a coincidence documented in the module
+#: docstring, not assumed to generalise to any other zone.
+AREA_DOMAIN = ZONE_REGISTRY["DE_LU"]["eic"]
+
+DOCUMENT_TYPE = "A15"
+CACHE_SOURCE = "entsoe_a15"
+
+#: processType per product, as ENTSO-E's own code list defines them for A15.
+PROCESS_TYPES: dict[str, str] = {"fcr": "A52", "afrr": "A51", "mfrr": "A47"}
+
+#: direction code -> series-key direction segment. FCR (symmetric, A03) is handled
+#: separately below and never consults this map.
+_DIRECTION = {"A01": "pos", "A02": "neg"}
+
+#: (json_key, series_suffix) for the 5 canonical series, in a fixed display order.
+#: json_key is what the /api/power/capacity-prices response uses; series_suffix is the
+#: `capacity.<suffix>.price` hourly-store key. Single source of truth shared with the route.
+PRODUCT_SUFFIXES: list[tuple[str, str]] = [
+    ("fcr", "fcr"),
+    ("afrr_pos", "afrr.pos"),
+    ("afrr_neg", "afrr.neg"),
+    ("mfrr_pos", "mfrr.pos"),
+    ("mfrr_neg", "mfrr.neg"),
+]
+
+_PAGE_SIZE = 100
+#: Runaway-loop safety valve, NOT an expected truncation point — see module docstring's
+#: pagination finding (real aFRR volume on the spiked day: 6893, comfortably under this).
+_MAX_OFFSET = 20_000
+
+
+def aggregate_bids(bids: list[tuple[float, float]]) -> dict[str, float | None]:
+    """One (product, direction, block)'s accepted bids -> {weighted_avg, marginal, total_qty}.
+
+    `weighted_avg` (sum(qty*price)/sum(qty)) is the canonical stored number — see module
+    docstring. `marginal` (the highest accepted bid price) is returned for
+    completeness/testability only and must never be written to the hourly store. Bids with
+    non-positive quantity are excluded from both; an all-non-positive (or empty) list yields
+    all-None rather than a division by zero.
+    """
+    priced = [(q, p) for q, p in bids if q is not None and q > 0 and p is not None]
+    if not priced:
+        return {"weighted_avg": None, "marginal": None, "total_qty": 0.0}
+    total_qty = sum(q for q, _ in priced)
+    weighted_avg = sum(q * p for q, p in priced) / total_qty
+    marginal = max(p for _, p in priced)
+    return {"weighted_avg": weighted_avg, "marginal": marginal, "total_qty": total_qty}
+
+
+def _series_suffix(product: str, direction_code: str | None) -> str | None:
+    """product ('fcr'/'afrr'/'mfrr') + raw flowDirection code -> series-key suffix, or None
+    for a direction this desk doesn't recognise (skip rather than guess)."""
+    if product == "fcr":
+        return "fcr"  # symmetric — direction (A03) is deliberately ignored
+    direction = _DIRECTION.get(direction_code or "")
+    return f"{product}.{direction}" if direction else None
+
+
+def parse_capacity_document(xml_text: str) -> dict[str, dict[str, dict[int, float]]]:
+    """One A15 document -> {series_suffix: {day: {hour: normalized EUR/MW/h}}}.
+
+    Namespace-agnostic (matches local tag names, like every other parser in this vertical).
+    An Acknowledgement (no `process.processType`, no TimeSeries) yields {}. The document's
+    OWN `process.processType` decides the product for every TimeSeries in it — read off the
+    wire rather than trusted from the request, so a mislabelled or merged document can never
+    silently write to the wrong product's series.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"ENTSO-E A15 XML parse error: {exc}") from exc
+
+    process_el = next((e for e in root.iter() if _localname(e.tag) == "process.processType"), None)
+    process_type = (process_el.text or "").strip() if process_el is not None else None
+    product = next((p for p, code in PROCESS_TYPES.items() if code == process_type), None)
+    if product is None:
+        return {}  # Acknowledgement, or a processType this desk doesn't track
+
+    # (series_suffix, block_start_epoch, block_end_epoch) -> [(quantity, price), ...]
+    bids: dict[tuple[str, int, int], list[tuple[float, float]]] = {}
+
+    for ts in root.iter():
+        if _localname(ts.tag) != "TimeSeries":
+            continue
+        bt_el = next((e for e in ts.iter() if _localname(e.tag) == "businessType"), None)
+        if bt_el is None or (bt_el.text or "").strip() != "B95":
+            continue
+        dir_el = next((e for e in ts.iter() if _localname(e.tag) == "flowDirection.direction"), None)
+        direction_code = (dir_el.text or "").strip() if dir_el is not None else None
+        suffix = _series_suffix(product, direction_code)
+        if suffix is None:
+            continue
+
+        for period in (e for e in ts.iter() if _localname(e.tag) == "Period"):
+            start_el = next((e for e in period.iter() if _localname(e.tag) == "start"), None)
+            end_el = next((e for e in period.iter() if _localname(e.tag) == "end"), None)
+            if start_el is None or end_el is None:
+                continue
+            start = _parse_utc(start_el.text)
+            end = _parse_utc(end_el.text)
+            if start is None or end is None or end <= start:
+                continue
+            block_start = int(start.astimezone(timezone.utc).timestamp())
+            block_end = int(end.astimezone(timezone.utc).timestamp())
+            key = (suffix, block_start, block_end)
+
+            for point in (e for e in period.iter() if _localname(e.tag) == "Point"):
+                qty_el = next((e for e in point if _localname(e.tag) == "quantity"), None)
+                price_el = next((e for e in point if _localname(e.tag) == "procurement_Price.amount"), None)
+                if qty_el is None or price_el is None:
+                    continue
+                try:
+                    qty = float(qty_el.text)
+                    price = float(price_el.text)
+                except (TypeError, ValueError):
+                    continue
+                bids.setdefault(key, []).append((qty, price))
+
+    out: dict[str, dict[str, dict[int, float]]] = {}
+    for (suffix, block_start, block_end), pairs in bids.items():
+        agg = aggregate_bids(pairs)
+        weighted_avg = agg["weighted_avg"]
+        if weighted_avg is None:
+            continue
+        # FCR is quoted EUR per 4h block (pay-as-cleared); aFRR/mFRR are already EUR/MW/h
+        # (pay-as-bid) — divide only FCR so every stored series shares one unit.
+        value = weighted_avg / 4.0 if suffix == "fcr" else weighted_avg
+        day_hours = out.setdefault(suffix, {})
+        t = block_start
+        while t < block_end:
+            dt = datetime.fromtimestamp(t, tz=timezone.utc)
+            day_hours.setdefault(dt.strftime("%Y-%m-%d"), {})[dt.hour] = value
+            t += 3600
+
+    return out
+
+
+def _count_timeseries(xml_text: str) -> int:
+    """How many TimeSeries a page carries — the pagination stop signal. A malformed page
+    (never observed) counts as 0 (stop) rather than looping forever on unparsable input;
+    `parse_capacity_document` is the one that raises on real malformed XML during ingest."""
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return 0
+    return sum(1 for e in root.iter() if _localname(e.tag) == "TimeSeries")
+
+
+async def _fetch_capacity_day(process_type: str, day: date, *, overwrite: bool = False) -> list[str]:
+    """Fetch one processType's A15 documents for one calendar day, disk-cached, paginating
+    `offset` in steps of 100 TimeSeries until a short page (see module docstring — this
+    includes the genuinely-empty terminal Acknowledgement, which is NOT an error for A15).
+
+    Returns every inner `.xml` member across every page (each page is a ZIP; every member
+    decoded and merged, matching entsoe_balancing.py's multi-member convention even though
+    only one member per page has ever been observed).
+    """
+    nxt = day + timedelta(days=1)
+
+    async def _do() -> dict:
+        docs: list[str] = []
+        offset = 0
+        async with httpx.AsyncClient(timeout=120) as client:
+            while True:
+                params = {
+                    "securityToken": _token(),
+                    "documentType": DOCUMENT_TYPE,
+                    "processType": process_type,
+                    "area_Domain": AREA_DOMAIN,
+                    "periodStart": f"{day:%Y%m%d}0000",
+                    "periodEnd": f"{nxt:%Y%m%d}0000",
+                    "offset": offset,
+                }
+                resp = await client.get(ENTSOE_BASE, params=params)
+                # Every no-data case for A15 is a clean HTTP 200 empty Acknowledgement (see
+                # module docstring) — there is no "structural 400 = empty" text to match
+                # here, unlike A83/A84. Any 4xx/5xx is therefore a genuine failure.
+                resp.raise_for_status()
+                body = resp.content
+                if body[:2] == b"PK":
+                    zf = zipfile.ZipFile(io.BytesIO(body))
+                    names = [n for n in zf.namelist() if n.endswith(".xml")]
+                    page_docs = [zf.read(n).decode("utf-8", "replace") for n in names] or [""]
+                else:
+                    page_docs = [resp.text]
+                docs.extend(page_docs)
+                page_count = sum(_count_timeseries(d) for d in page_docs if d)
+                if page_count < _PAGE_SIZE or offset >= _MAX_OFFSET:
+                    break
+                offset += _PAGE_SIZE
+        return {"xml": docs}
+
+    payload = await raw_cache.fetch_or_cache(
+        CACHE_SOURCE, f"{process_type}_{day:%Y-%m-%d}", day, _do, overwrite=overwrite
+    )
+    docs = payload.get("xml") if isinstance(payload, dict) else None
+    return docs or []
+
+
+async def ingest_capacity_prices(db: Session, days: list[str], *, overwrite: bool = False) -> dict:
+    """Fetch + upsert FCR/aFRR/mFRR procured-capacity prices for DE_LU over `days` (a flat
+    list of 'YYYY-MM-DD' strings — fetched per DAY per processType, not batched by month; see
+    module docstring's pagination finding), writing up to 5 canonical series:
+    `capacity.{fcr,afrr.pos,afrr.neg,mfrr.pos,mfrr.neg}.price`.
+
+    DE_LU only, deliberately no `zone` parameter — the German balancing-capacity market has
+    no per-zone equivalent on this desk (see AREA_DOMAIN). Each day/processType fetch is
+    isolated (log + continue), matching the rest of this vertical's per-step failure
+    isolation — one bad day must never blank the others.
+    """
+    if not settings.entsoe_api_token:
+        return {"skipped": "no token"}
+    if not days:
+        return {"days": 0, "written": 0}
+
+    acc: dict[str, dict[str, dict[int, float]]] = {}
+    for day_str in days:
+        day = datetime.strptime(day_str, "%Y-%m-%d").date()
+        for process_type in PROCESS_TYPES.values():
+            try:
+                docs = await _fetch_capacity_day(process_type, day, overwrite=overwrite)
+            except httpx.HTTPError as exc:
+                logger.warning("capacity prices [%s %s] fetch failed: %s", process_type, day, exc)
+                continue
+            for xml in docs:
+                if not xml:
+                    continue
+                try:
+                    parsed = parse_capacity_document(xml)
+                except ValueError as exc:
+                    logger.warning("capacity prices [%s %s] parse failed: %s", process_type, day, exc)
+                    continue
+                for suffix, day_hours in parsed.items():
+                    bucket = acc.setdefault(suffix, {})
+                    for d, hours in day_hours.items():
+                        bucket.setdefault(d, {}).update(hours)
+
+    written = 0
+    for suffix, day_hours in acc.items():
+        if day_hours:
+            written += upsert_day_hours(db, f"capacity.{suffix}.price", "DE_LU", day_hours, unit="EUR/MW/h")
+
+    return {"days": len(days), "written": written}

--- a/backend/power/entsoe_reserves.py
+++ b/backend/power/entsoe_reserves.py
@@ -1,5 +1,10 @@
 """ENTSO-E procured balancing CAPACITY prices (FCR/aFRR/mFRR tenders) → hourly
-`capacity.<fcr|afrr.pos|afrr.neg|mfrr.pos|mfrr.neg>.price` (EUR/MW/h), DE_LU only.
+`capacity.<fcr.price|afrr.price.pos|afrr.price.neg|mfrr.price.pos|mfrr.price.neg>`
+(EUR/MW/h), DE_LU only. Series-key grammar unified 2026-07-21 to the repo-wide
+`family.product.measure[.direction]` shape (measure BEFORE direction — this module
+originally put the direction segment before the measure segment, diverging from
+entsoe_balancing.py's `balancing.afrr.price.up`). Nothing was deployed under the old
+grammar, so this was a rename, not a migration.
 
 NOT to be confused with `backend/power/entsoe_capacity.py` (installed GENERATION capacity,
 A68, pan-EU) or `backend/power/entsoe_balancing.py` (activated balancing ENERGY, A83/A84,
@@ -121,18 +126,23 @@ CACHE_SOURCE = "entsoe_a15"
 PROCESS_TYPES: dict[str, str] = {"fcr": "A52", "afrr": "A51", "mfrr": "A47"}
 
 #: direction code -> series-key direction segment. FCR (symmetric, A03) is handled
-#: separately below and never consults this map.
+#: separately below and never consults this map. Deliberately "pos"/"neg" — A15's own
+#: contract vocabulary (Positiv-/Negativsekundärleistung) — NOT activation's "up"/"down"
+#: (entsoe_balancing.py); the two vocabularies are kept distinct on purpose, not an
+#: inconsistency to fix.
 _DIRECTION = {"A01": "pos", "A02": "neg"}
 
 #: (json_key, series_suffix) for the 5 canonical series, in a fixed display order.
 #: json_key is what the /api/power/capacity-prices response uses; series_suffix is the
-#: `capacity.<suffix>.price` hourly-store key. Single source of truth shared with the route.
+#: tail of the `capacity.<suffix>` hourly-store key — it already carries the `price`
+#: segment ("fcr.price", "afrr.price.pos", ...) so the final key is simply
+#: `f"capacity.{suffix}"`. Single source of truth shared with the route.
 PRODUCT_SUFFIXES: list[tuple[str, str]] = [
-    ("fcr", "fcr"),
-    ("afrr_pos", "afrr.pos"),
-    ("afrr_neg", "afrr.neg"),
-    ("mfrr_pos", "mfrr.pos"),
-    ("mfrr_neg", "mfrr.neg"),
+    ("fcr", "fcr.price"),
+    ("afrr_pos", "afrr.price.pos"),
+    ("afrr_neg", "afrr.price.neg"),
+    ("mfrr_pos", "mfrr.price.pos"),
+    ("mfrr_neg", "mfrr.price.neg"),
 ]
 
 _PAGE_SIZE = 100
@@ -160,12 +170,14 @@ def aggregate_bids(bids: list[tuple[float, float]]) -> dict[str, float | None]:
 
 
 def _series_suffix(product: str, direction_code: str | None) -> str | None:
-    """product ('fcr'/'afrr'/'mfrr') + raw flowDirection code -> series-key suffix, or None
-    for a direction this desk doesn't recognise (skip rather than guess)."""
+    """product ('fcr'/'afrr'/'mfrr') + raw flowDirection code -> series-key suffix (already
+    including the `price` measure segment, e.g. 'fcr.price' / 'afrr.price.pos' — the final
+    hourly-store key is `f"capacity.{suffix}"`), or None for a direction this desk doesn't
+    recognise (skip rather than guess)."""
     if product == "fcr":
-        return "fcr"  # symmetric — direction (A03) is deliberately ignored
+        return "fcr.price"  # symmetric — direction (A03) is deliberately ignored
     direction = _DIRECTION.get(direction_code or "")
-    return f"{product}.{direction}" if direction else None
+    return f"{product}.price.{direction}" if direction else None
 
 
 def parse_capacity_bids(xml_text: str) -> dict[tuple[str, int, int], list[tuple[float, float]]]:
@@ -258,7 +270,7 @@ def _aggregate_and_densify(
             continue
         # FCR is quoted EUR per 4h block (pay-as-cleared); aFRR/mFRR are already EUR/MW/h
         # (pay-as-bid) — divide only FCR so every stored series shares one unit.
-        value = weighted_avg / 4.0 if suffix == "fcr" else weighted_avg
+        value = weighted_avg / 4.0 if suffix == "fcr.price" else weighted_avg
         day_hours = out.setdefault(suffix, {})
         t = block_start
         while t < block_end:
@@ -357,7 +369,7 @@ async def ingest_capacity_prices(db: Session, days: list[str], *, overwrite: boo
     """Fetch + upsert FCR/aFRR/mFRR procured-capacity prices for DE_LU over `days` (a flat
     list of 'YYYY-MM-DD' strings — fetched per DAY per processType, not batched by month; see
     module docstring's pagination finding), writing up to 5 canonical series:
-    `capacity.{fcr,afrr.pos,afrr.neg,mfrr.pos,mfrr.neg}.price`.
+    `capacity.{fcr.price,afrr.price.pos,afrr.price.neg,mfrr.price.pos,mfrr.price.neg}`.
 
     DE_LU only, deliberately no `zone` parameter — the German balancing-capacity market has
     no per-zone equivalent on this desk (see AREA_DOMAIN). Each day/processType fetch is
@@ -405,6 +417,6 @@ async def ingest_capacity_prices(db: Session, days: list[str], *, overwrite: boo
     written = 0
     for suffix, day_hours in acc.items():
         if day_hours:
-            written += upsert_day_hours(db, f"capacity.{suffix}.price", "DE_LU", day_hours, unit="EUR/MW/h")
+            written += upsert_day_hours(db, f"capacity.{suffix}", "DE_LU", day_hours, unit="EUR/MW/h")
 
     return {"days": len(days), "written": written}

--- a/backend/power/entsoe_reserves.py
+++ b/backend/power/entsoe_reserves.py
@@ -284,7 +284,7 @@ def parse_capacity_document(xml_text: str) -> dict[str, dict[str, dict[int, floa
 def _count_timeseries(xml_text: str) -> int:
     """How many TimeSeries a page carries — the pagination stop signal. A malformed page
     (never observed) counts as 0 (stop) rather than looping forever on unparsable input;
-    `parse_capacity_document` is the one that raises on real malformed XML during ingest."""
+    `parse_capacity_bids` is the one that raises on real malformed XML during ingest."""
     try:
         root = ET.fromstring(xml_text)
     except ET.ParseError:

--- a/backend/power/entsoe_reserves.py
+++ b/backend/power/entsoe_reserves.py
@@ -41,7 +41,13 @@ LIVE SPIKE (2026-07-21, curl against https://web-api.tp.entsoe.eu/api, DE-LU LFC
     strict 4900 cutoff would have silently dropped ~2000 real aFRR bids on an ordinary day.
     `_MAX_OFFSET` below is therefore a generous runaway-loop safety valve (20,000 — ~3x the
     highest observed count), not an expected truncation point; a page short of 100 TimeSeries
-    (including a genuinely empty one) is the real, verified stop condition.
+    (including a genuinely empty one) is the real, verified stop condition. Precisely BECAUSE
+    a block's bids routinely span many pages this way (~574 bids per block/direction on the
+    busiest spiked aFRR day), `parse_capacity_bids` returns raw, un-aggregated bids and
+    `ingest_capacity_prices` accumulates them across every page of a day BEFORE aggregating —
+    see those two docstrings. An earlier version of this module aggregated per page/document
+    and merged the results, which let the LAST page's partial (and, since ENTSO-E orders bids
+    by price, systematically skewed) average silently overwrite every earlier page's.
 
   * ERROR DISCIPLINE DIFFERS FROM A83/A84: every "nothing here" case tried — a future date
     (2030-01-01), a pre-tender date (2010-01-01), the wrong (control-area) domain, and
@@ -162,14 +168,26 @@ def _series_suffix(product: str, direction_code: str | None) -> str | None:
     return f"{product}.{direction}" if direction else None
 
 
-def parse_capacity_document(xml_text: str) -> dict[str, dict[str, dict[int, float]]]:
-    """One A15 document -> {series_suffix: {day: {hour: normalized EUR/MW/h}}}.
+def parse_capacity_bids(xml_text: str) -> dict[tuple[str, int, int], list[tuple[float, float]]]:
+    """One A15 document/page -> RAW, un-aggregated
+    {(series_suffix, block_start_epoch, block_end_epoch): [(quantity, price), ...]}.
 
     Namespace-agnostic (matches local tag names, like every other parser in this vertical).
     An Acknowledgement (no `process.processType`, no TimeSeries) yields {}. The document's
     OWN `process.processType` decides the product for every TimeSeries in it — read off the
     wire rather than trusted from the request, so a mislabelled or merged document can never
     silently write to the wrong product's series.
+
+    Deliberately returns raw bids rather than an aggregated price: a busy day's bids for ONE
+    block are split across many paginated pages (live-spiked: ~574 bids per block/direction on
+    the busiest aFRR day, ~69 pages total for that day). A caller that aggregated per page (as
+    an earlier version of this module did, via a since-removed per-document aggregation step)
+    would average only that page's partial subset — and since ENTSO-E returns bids in
+    ascending-price (merit) order, that silently biases every page's average toward whichever
+    price band it happened to land on, with the LAST page's partial average winning once pages
+    are merged. Callers MUST accumulate every page's raw bids for the SAME block across a
+    whole fetch (see `ingest_capacity_prices`) and call `aggregate_bids` on the COMBINED list
+    exactly once per block.
     """
     try:
         root = ET.fromstring(xml_text)
@@ -222,8 +240,18 @@ def parse_capacity_document(xml_text: str) -> dict[str, dict[str, dict[int, floa
                     continue
                 bids.setdefault(key, []).append((qty, price))
 
+    return bids
+
+
+def _aggregate_and_densify(
+    bids_by_block: dict[tuple[str, int, int], list[tuple[float, float]]],
+) -> dict[str, dict[str, dict[int, float]]]:
+    """{(series_suffix, block_start, block_end): [(qty, price), ...]} -> {series_suffix:
+    {day: {hour: normalized EUR/MW/h}}}. `aggregate_bids` runs EXACTLY ONCE per block here, on
+    the caller's already-fully-combined bid list — see `parse_capacity_bids`'s docstring for
+    why that combining must happen first."""
     out: dict[str, dict[str, dict[int, float]]] = {}
-    for (suffix, block_start, block_end), pairs in bids.items():
+    for (suffix, block_start, block_end), pairs in bids_by_block.items():
         agg = aggregate_bids(pairs)
         weighted_avg = agg["weighted_avg"]
         if weighted_avg is None:
@@ -239,6 +267,18 @@ def parse_capacity_document(xml_text: str) -> dict[str, dict[str, dict[int, floa
             t += 3600
 
     return out
+
+
+def parse_capacity_document(xml_text: str) -> dict[str, dict[str, dict[int, float]]]:
+    """One SINGLE, already-complete A15 document -> {series_suffix: {day: {hour: normalized
+    EUR/MW/h}}} — a thin convenience wrapper (`parse_capacity_bids` + `_aggregate_and_densify`)
+    for tests and any caller that genuinely has one whole document's bids for a block in hand.
+
+    Real (paginated) production fetches must NOT use this per-document: `ingest_capacity_prices`
+    accumulates raw bids across every page of a day via `parse_capacity_bids` before aggregating
+    — see that function's docstring for why per-page aggregation silently biases the result.
+    """
+    return _aggregate_and_densify(parse_capacity_bids(xml_text))
 
 
 def _count_timeseries(xml_text: str) -> int:
@@ -291,7 +331,17 @@ async def _fetch_capacity_day(process_type: str, day: date, *, overwrite: bool =
                     page_docs = [resp.text]
                 docs.extend(page_docs)
                 page_count = sum(_count_timeseries(d) for d in page_docs if d)
-                if page_count < _PAGE_SIZE or offset >= _MAX_OFFSET:
+                if page_count < _PAGE_SIZE:
+                    break  # natural end: a short (or empty-Acknowledgement) page
+                if offset >= _MAX_OFFSET:
+                    # A FULL page still sitting at the safety-valve ceiling means there is
+                    # real data beyond it we are choosing not to fetch. That truncated payload
+                    # is about to land in the write-once raw cache — silent truncation there
+                    # would be permanent on a backfill path, so this must be loud, not just a
+                    # comment in the source.
+                    logger.warning(
+                        "A15 %s %s hit _MAX_OFFSET (%d) — page truncated", process_type, day, _MAX_OFFSET
+                    )
                     break
                 offset += _PAGE_SIZE
         return {"xml": docs}
@@ -313,13 +363,24 @@ async def ingest_capacity_prices(db: Session, days: list[str], *, overwrite: boo
     no per-zone equivalent on this desk (see AREA_DOMAIN). Each day/processType fetch is
     isolated (log + continue), matching the rest of this vertical's per-step failure
     isolation — one bad day must never blank the others.
+
+    CROSS-PAGE ACCUMULATION (the correctness-critical part): every page/ZIP-member of every
+    day/processType fetch is parsed with `parse_capacity_bids` into RAW bids first, and all of
+    them are folded into ONE `all_bids` accumulator keyed by (series_suffix, block_start,
+    block_end) across the ENTIRE call — never aggregated per page or per document. Only after
+    every fetch has landed does `_aggregate_and_densify` run `aggregate_bids` exactly once per
+    block, on that block's COMPLETE bid list. See `parse_capacity_bids`'s docstring: a block's
+    bids routinely span many pages, and aggregating page-by-page then merging (an earlier,
+    incorrect version of this function did that, with the LAST page silently overwriting every
+    earlier one) would average only whichever partial subset of bids the last page happened to
+    contain.
     """
     if not settings.entsoe_api_token:
         return {"skipped": "no token"}
     if not days:
         return {"days": 0, "written": 0}
 
-    acc: dict[str, dict[str, dict[int, float]]] = {}
+    all_bids: dict[tuple[str, int, int], list[tuple[float, float]]] = {}
     for day_str in days:
         day = datetime.strptime(day_str, "%Y-%m-%d").date()
         for process_type in PROCESS_TYPES.values():
@@ -332,14 +393,14 @@ async def ingest_capacity_prices(db: Session, days: list[str], *, overwrite: boo
                 if not xml:
                     continue
                 try:
-                    parsed = parse_capacity_document(xml)
+                    parsed_bids = parse_capacity_bids(xml)
                 except ValueError as exc:
                     logger.warning("capacity prices [%s %s] parse failed: %s", process_type, day, exc)
                     continue
-                for suffix, day_hours in parsed.items():
-                    bucket = acc.setdefault(suffix, {})
-                    for d, hours in day_hours.items():
-                        bucket.setdefault(d, {}).update(hours)
+                for key, pairs in parsed_bids.items():
+                    all_bids.setdefault(key, []).extend(pairs)
+
+    acc = _aggregate_and_densify(all_bids)
 
     written = 0
     for suffix, day_hours in acc.items():

--- a/backend/power/hourly_store.py
+++ b/backend/power/hourly_store.py
@@ -141,3 +141,64 @@ def read_hourly(
     if max_rows is not None and len(rows) > max_rows:
         raise RowCapExceeded(max_rows)
     return rows
+
+
+def iter_border_points(
+    db: Session,
+    zone: str,
+    start_ts: int | None = None,
+    end_ts: int | None = None,
+    max_rows: int | None = None,
+) -> list[tuple[str, int, float]]:
+    """(neighbor, ts_utc, signed_mw) for every cross-border flow point touching
+    `zone` in [start_ts, end_ts) — the ONE place the flow sign convention is
+    implemented, so `/flows/hourly` (backend/routes/power.py::get_flows_hourly)
+    and the live-desk net-flow reader (backend/power/live.py) can never drift
+    apart on it.
+
+    Sign convention (see backend/power/energy_charts_flows.py's module
+    docstring): a border is stored ONCE, as series ``flow.<TO>`` under zone
+    ``<FROM>`` (the canonical alphabetically-first zone of the pair), with
+    net_mw > 0 meaning FROM exports. `zone` may be either side of any given
+    border:
+      * zone is the storing (FROM) side: its own exports live as
+        ``flow.<neighbor>`` under itself — read with the native sign (Case A).
+      * zone is the counterparty (TO) side: the series lives as
+        ``flow.<zone>`` under each neighbour instead — sign is flipped (Case B).
+
+    `max_rows` bounds each Case-A (native) per-neighbor read exactly like any
+    other `read_hourly` call. Case B (the counterparty side) combines every
+    neighbour that stores `zone` into ONE query and is intentionally NOT
+    capped the same way: it is bounded only by the caller's own
+    [start_ts, end_ts) window times this zone's border count — never large in
+    practice (the busiest European zone has a handful of borders), so an
+    explicit cap here would just be a second number to keep in sync with the
+    window every caller already chooses.
+    """
+    out: list[tuple[str, int, float]] = []
+
+    # Case A: zone is the canonical sorted-FIRST side of some borders — its own exports.
+    for (key,) in db.query(SeriesDim.key).filter(SeriesDim.key.like("flow.%")).all():
+        neighbor = key.removeprefix("flow.")
+        if neighbor == zone:
+            continue
+        for ts, v in read_hourly(db, key, zone, start_ts, end_ts, max_rows=max_rows):
+            out.append((neighbor, ts, v))
+
+    # Case B: zone is the canonical sorted-SECOND side — series flow.<zone> under the
+    # neighbours; flip sign (native value is FROM's export, i.e. zone's import).
+    sid = db.query(SeriesDim.id).filter(SeriesDim.key == f"flow.{zone}").scalar()
+    if sid is not None:
+        q = (
+            db.query(ZoneDim.key, PowerHourly.ts_utc, PowerHourly.value)
+            .join(PowerHourly, PowerHourly.zone_id == ZoneDim.id)
+            .filter(PowerHourly.series_id == sid)
+        )
+        if start_ts is not None:
+            q = q.filter(PowerHourly.ts_utc >= start_ts)
+        if end_ts is not None:
+            q = q.filter(PowerHourly.ts_utc < end_ts)
+        for neighbor, ts, v in q.order_by(PowerHourly.ts_utc.asc()).all():
+            out.append((neighbor, int(ts), -float(v)))
+
+    return out

--- a/backend/power/live.py
+++ b/backend/power/live.py
@@ -31,13 +31,19 @@ from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
-from backend.models.energy import PowerHourly, SeriesDim
-from backend.power.hourly_store import read_hourly
+from backend.models.energy import SeriesDim
+from backend.power.hourly_store import iter_border_points, read_hourly
 from backend.power.zones import POWER_ZONES
 
-#: A day is 24 hourly points; the flow-border scan touches a handful of series
-#: per zone. Every read below is capped well above what one day can hold, so a
-#: cap is never actually hit — it exists only to fail loudly if it ever were.
+#: A day is 24 hourly points. Every load/residual/forecast/price/per-fuel read
+#: below is capped at this — well above what one day can hold, so the cap is
+#: never actually hit; it exists only to fail loudly if it ever were. The one
+#: exception is the flow counterparty side (Case B inside
+#: hourly_store.iter_border_points, used by `_zone_net_flow` below): it
+#: combines every neighbour touching this zone into ONE query and is bounded
+#: only by the window × this zone's border count, not by this constant — see
+#: that function's docstring for why an explicit cap there would just be a
+#: second number to keep in sync.
 _MAX_ROWS = 48
 
 _DAY_SECONDS = 24 * 3600
@@ -87,40 +93,14 @@ def _zone_net_flow(db: Session, zone: str, start_ts: int, end_ts: int) -> dict[i
     = zone exports. Empty dict (never a false zero) when the zone has no flow
     series at all — callers must read it with `.get(ts)`, never `[ts]`.
 
-    Sign convention (see backend/power/energy_charts_flows.py's module docstring
-    and backend/routes/power.py::get_flows_hourly, which this mirrors exactly): a
-    border is stored ONCE, as series ``flow.<TO>`` under zone ``<FROM>`` (the
-    canonical-sorted first zone of the pair), with net_mw > 0 meaning FROM
-    exports. `zone` may be either side of any given border:
-      * zone is the storing (FROM) side: its exports live as ``flow.<neighbor>``
-        under itself — read with the native sign.
-      * zone is the counterparty (TO) side: the series lives as ``flow.<zone>``
-        under each neighbour instead — sign must be flipped.
+    The sign convention and storing-side/counterparty-side handling live in ONE
+    shared place, `backend.power.hourly_store.iter_border_points` — see its
+    docstring. `get_flows_hourly` (backend/routes/power.py) reads the same
+    helper so the two can never drift apart on the sign logic.
     """
     per_hour: dict[int, list[float]] = defaultdict(list)
-
-    flow_keys = [k for (k,) in db.query(SeriesDim.key).filter(SeriesDim.key.like("flow.%")).all()]
-    for key in flow_keys:
-        neighbor = key.removeprefix("flow.")
-        if neighbor == zone:
-            continue
-        for ts, v in read_hourly(db, key, zone, start_ts, end_ts, max_rows=_MAX_ROWS):
-            per_hour[ts].append(v)
-
-    sid = db.query(SeriesDim.id).filter(SeriesDim.key == f"flow.{zone}").scalar()
-    if sid is not None:
-        rows = (
-            db.query(PowerHourly.ts_utc, PowerHourly.value)
-            .filter(
-                PowerHourly.series_id == sid,
-                PowerHourly.ts_utc >= start_ts,
-                PowerHourly.ts_utc < end_ts,
-            )
-            .all()
-        )
-        for ts, v in rows:
-            per_hour[int(ts)].append(-float(v))
-
+    for _neighbor, ts, v in iter_border_points(db, zone, start_ts, end_ts, max_rows=_MAX_ROWS):
+        per_hour[ts].append(v)
     return {ts: sum(vs) for ts, vs in per_hour.items()}
 
 
@@ -129,6 +109,15 @@ def compute_live(db: Session, zone: str, *, now: datetime | None = None) -> dict
     actual load/residual/generation/net-flow alongside the day-ahead
     forecast/price for the same hour. Pure apart from `db`; `now` is injectable
     for tests and defaults to the real wall clock.
+
+    `hours[].gen` keys are the raw ENTSO-E production-type codes (``gen.<Bxx>``
+    → "B16", "B19", …) — this module makes no attempt at a friendly label; the
+    frontend maps them via `frontend/src/utils/fuels.js`, the one canonical
+    fuel palette/label source for the desk (PR #109). `summary.gen_total_now`
+    sums only the fuels that published a point for the SAME hour as
+    `latest_actual_ts` — a fuel whose A75 submission lags behind that hour
+    (e.g. a conventional/thermal unit reporting late) is silently absent from
+    the sum, which can under-report total generation for that hour.
     """
     if zone not in POWER_ZONES:
         return {"available": False, "zone": zone, "reason": f"Unknown zone {zone}."}
@@ -198,8 +187,20 @@ def compute_live(db: Session, zone: str, *, now: datetime | None = None) -> dict
 
     latest_actual_ts = max(load_actual)
     latest_actual_iso = _iso(latest_actual_ts)
-    lag_minutes = int((now - datetime.fromtimestamp(latest_actual_ts + 3600, tz=timezone.utc))
-                      .total_seconds() // 60)
+    # Clamped at 0: parse_load_hourly (backend/power/entsoe_grid.py) averages
+    # whatever quarter-hours ENTSO-E has published for an hour, with no
+    # completeness guard — an in-progress hour (say 2 of 4 quarter-hours in)
+    # can therefore already land a load.actual point. When that happens,
+    # latest_actual_ts + 1h is still in the future relative to `now`, and the
+    # raw subtraction goes negative (then more negative once floor-divided by
+    # 60). A lag can't be negative from the reader's perspective, so floor it
+    # at 0 — note this also means `load_vs_forecast_pct` below can be
+    # comparing a PARTIAL-hour actual mean against a FULL-hour forecast for
+    # that same hour, a known (unfixed) skew in the partial-hour case.
+    lag_minutes = max(0, int(
+        (now - datetime.fromtimestamp(latest_actual_ts + 3600, tz=timezone.utc))
+        .total_seconds() // 60
+    ))
 
     a = load_actual.get(latest_actual_ts)
     f = load_fc.get(latest_actual_ts)

--- a/backend/power/live.py
+++ b/backend/power/live.py
@@ -1,0 +1,231 @@
+"""Near-real-time read path: what happened TODAY, so far.
+
+The daily rollup tables (PowerPriceDaily/PowerGrid/…) that the situation hero and
+every panel read only ever hold COMPLETE days — the nightly job writes them once a
+day is over. The canonical hourly store (backend/power/hourly_store.py) already
+fills in hour by hour as ENTSO-E publishes (the ~30-min intraday scheduler job,
+`_run_power_intraday`), but nothing reads it that way: the desk simply has no view
+of "today" until tomorrow. `compute_live` is that missing read.
+
+WHAT IT SHOWS
+-------------
+Every hour of the shown day: the published ACTUAL (load, residual, per-fuel
+generation, net cross-border flow) where ENTSO-E has published it yet, alongside
+the day-ahead FORECAST and auction PRICE for that same hour — published up front,
+so future hours of today are real data, not a guess. An hour with no actual yet is
+a gap (null), never a zero and never a prediction of ours (Posture B): this module
+computes no forecast, it only joins ENTSO-E's own published forecast against its
+own later actual.
+
+FALLBACK
+--------
+Shortly after UTC midnight, ENTSO-E has not published today's first actual hour
+yet — `load.actual` for today is empty. Rather than show an empty desk for that
+window, the endpoint falls back to yesterday's (complete) day and says so
+(`showing: "yesterday"`).
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from backend.models.energy import PowerHourly, SeriesDim
+from backend.power.hourly_store import read_hourly
+from backend.power.zones import POWER_ZONES
+
+#: A day is 24 hourly points; the flow-border scan touches a handful of series
+#: per zone. Every read below is capped well above what one day can hold, so a
+#: cap is never actually hit — it exists only to fail loudly if it ever were.
+_MAX_ROWS = 48
+
+_DAY_SECONDS = 24 * 3600
+
+_NOTE = (
+    "Actuals lag ENTSO-E publication by roughly 1-2 hours; hours without a "
+    "published actual yet show as gaps. Forecast/price columns are the TSO's "
+    "and the auction's own day-ahead figures for the same hour — this desk "
+    "never predicts, it only compares what already happened to what was "
+    "already published in advance."
+)
+
+
+def _day_start(ts: datetime) -> int:
+    """Epoch seconds at 00:00 UTC of the calendar day `ts` falls on."""
+    start = ts.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    return int(start.timestamp())
+
+
+def _iso(ts: int) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _discover_gen_by_fuel(
+    db: Session, zone: str, start_ts: int, end_ts: int
+) -> dict[str, dict[int, float]]:
+    """{psr_code: {ts_utc: mw}} for every gen.<Bxx> series with at least one point
+    for `zone` in the window.
+
+    Series discovery mirrors the existing convention (backend/power/capture.py's
+    `_ids`, backend/routes/power.py::get_flows_hourly): SeriesDim is a small,
+    global dimension table (not per-zone), so candidate keys are listed from it
+    ONCE and then each is read for THIS zone with a bounded, indexed read — never
+    a scan filtered on the joined series_dim.key.
+    """
+    keys = [k for (k,) in db.query(SeriesDim.key).filter(SeriesDim.key.like("gen.%")).all()]
+    out: dict[str, dict[int, float]] = {}
+    for key in sorted(keys):
+        pts = read_hourly(db, key, zone, start_ts, end_ts, max_rows=_MAX_ROWS)
+        if pts:
+            out[key.removeprefix("gen.")] = dict(pts)
+    return out
+
+
+def _zone_net_flow(db: Session, zone: str, start_ts: int, end_ts: int) -> dict[int, float]:
+    """Per-hour net cross-border flow for `zone` across ALL its borders, positive
+    = zone exports. Empty dict (never a false zero) when the zone has no flow
+    series at all — callers must read it with `.get(ts)`, never `[ts]`.
+
+    Sign convention (see backend/power/energy_charts_flows.py's module docstring
+    and backend/routes/power.py::get_flows_hourly, which this mirrors exactly): a
+    border is stored ONCE, as series ``flow.<TO>`` under zone ``<FROM>`` (the
+    canonical-sorted first zone of the pair), with net_mw > 0 meaning FROM
+    exports. `zone` may be either side of any given border:
+      * zone is the storing (FROM) side: its exports live as ``flow.<neighbor>``
+        under itself — read with the native sign.
+      * zone is the counterparty (TO) side: the series lives as ``flow.<zone>``
+        under each neighbour instead — sign must be flipped.
+    """
+    per_hour: dict[int, list[float]] = defaultdict(list)
+
+    flow_keys = [k for (k,) in db.query(SeriesDim.key).filter(SeriesDim.key.like("flow.%")).all()]
+    for key in flow_keys:
+        neighbor = key.removeprefix("flow.")
+        if neighbor == zone:
+            continue
+        for ts, v in read_hourly(db, key, zone, start_ts, end_ts, max_rows=_MAX_ROWS):
+            per_hour[ts].append(v)
+
+    sid = db.query(SeriesDim.id).filter(SeriesDim.key == f"flow.{zone}").scalar()
+    if sid is not None:
+        rows = (
+            db.query(PowerHourly.ts_utc, PowerHourly.value)
+            .filter(
+                PowerHourly.series_id == sid,
+                PowerHourly.ts_utc >= start_ts,
+                PowerHourly.ts_utc < end_ts,
+            )
+            .all()
+        )
+        for ts, v in rows:
+            per_hour[int(ts)].append(-float(v))
+
+    return {ts: sum(vs) for ts, vs in per_hour.items()}
+
+
+def compute_live(db: Session, zone: str, *, now: datetime | None = None) -> dict:
+    """Every hour of TODAY (or yesterday, if today has no actuals yet): published
+    actual load/residual/generation/net-flow alongside the day-ahead
+    forecast/price for the same hour. Pure apart from `db`; `now` is injectable
+    for tests and defaults to the real wall clock.
+    """
+    if zone not in POWER_ZONES:
+        return {"available": False, "zone": zone, "reason": f"Unknown zone {zone}."}
+
+    now = now or datetime.now(timezone.utc)
+    zone_label = POWER_ZONES[zone]["label"]
+
+    today_start = _day_start(now)
+    today_end = today_start + _DAY_SECONDS
+
+    load_today = read_hourly(db, "load.actual", zone, today_start, today_end, max_rows=_MAX_ROWS)
+    if load_today:
+        showing = "today"
+        day_start, day_end = today_start, today_end
+        load_actual = dict(load_today)
+    else:
+        showing = "yesterday"
+        day_start, day_end = today_start - _DAY_SECONDS, today_start
+        load_actual = dict(
+            read_hourly(db, "load.actual", zone, day_start, day_end, max_rows=_MAX_ROWS)
+        )
+
+    if not load_actual:
+        return {
+            "available": False,
+            "zone": zone,
+            "zone_label": zone_label,
+            "reason": f"No recent load data for {zone_label} yet — check back shortly.",
+        }
+
+    load_fc = dict(read_hourly(db, "load.forecast", zone, day_start, day_end, max_rows=_MAX_ROWS))
+    price = dict(read_hourly(db, "price.dayahead", zone, day_start, day_end, max_rows=_MAX_ROWS))
+    residual_actual = dict(
+        read_hourly(db, "residual.actual", zone, day_start, day_end, max_rows=_MAX_ROWS)
+    )
+    residual_fc = dict(
+        read_hourly(db, "residual.forecast", zone, day_start, day_end, max_rows=_MAX_ROWS)
+    )
+    gen_fc = dict(
+        read_hourly(db, "generation.forecast", zone, day_start, day_end, max_rows=_MAX_ROWS)
+    )
+    gen_by_fuel = _discover_gen_by_fuel(db, zone, day_start, day_end)
+    net_flow = _zone_net_flow(db, zone, day_start, day_end)
+
+    def _mw(v: float | None) -> float | None:
+        return round(v, 1) if v is not None else None
+
+    def _eur(v: float | None) -> float | None:
+        return round(v, 2) if v is not None else None
+
+    hours: list[dict] = []
+    for h in range(24):
+        ts = day_start + h * 3600
+        gen_at_hour = {
+            fuel: _mw(vals[ts]) for fuel, vals in gen_by_fuel.items() if ts in vals
+        }
+        hours.append({
+            "ts_utc": _iso(ts),
+            "load": _mw(load_actual.get(ts)),
+            "load_fc": _mw(load_fc.get(ts)),
+            "price": _eur(price.get(ts)),
+            "residual": _mw(residual_actual.get(ts)),
+            "residual_fc": _mw(residual_fc.get(ts)),
+            "gen_fc": _mw(gen_fc.get(ts)),
+            "net_flow": _mw(net_flow.get(ts)),
+            "gen": gen_at_hour,
+        })
+
+    latest_actual_ts = max(load_actual)
+    latest_actual_iso = _iso(latest_actual_ts)
+    lag_minutes = int((now - datetime.fromtimestamp(latest_actual_ts + 3600, tz=timezone.utc))
+                      .total_seconds() // 60)
+
+    a = load_actual.get(latest_actual_ts)
+    f = load_fc.get(latest_actual_ts)
+    load_vs_forecast_pct = round((a - f) / f * 100.0, 2) if a is not None and f else None
+
+    gen_vals_now = [vals[latest_actual_ts] for vals in gen_by_fuel.values()
+                    if latest_actual_ts in vals]
+    gen_total_now = round(sum(gen_vals_now), 1) if gen_vals_now else None
+
+    now_hour_ts = int(now.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
+                      .timestamp())
+    price_now = _eur(price.get(now_hour_ts))
+
+    return {
+        "available": True,
+        "zone": zone,
+        "zone_label": zone_label,
+        "showing": showing,
+        "hours": hours,
+        "latest_actual_ts": latest_actual_iso,
+        "lag_minutes": lag_minutes,
+        "summary": {
+            "load_vs_forecast_pct": load_vs_forecast_pct,
+            "gen_total_now": gen_total_now,
+            "price_now": price_now,
+        },
+        "note": _NOTE,
+    }

--- a/backend/power/live.py
+++ b/backend/power/live.py
@@ -155,7 +155,6 @@ def compute_live(db: Session, zone: str, *, now: datetime | None = None) -> dict
         return {
             "available": False,
             "zone": zone,
-            "zone_label": zone_label,
             "reason": f"No recent load data for {zone_label} yet — check back shortly.",
         }
 

--- a/backend/power/series_catalog.py
+++ b/backend/power/series_catalog.py
@@ -1,0 +1,95 @@
+"""Server-side presentation metadata for the canonical hourly series (power_hourly).
+
+Single source of truth for what a series is CALLED and which GROUP it belongs to.
+Until now this lived only client-side (frontend/src/components/SeriesExplorer.jsx's
+SERIES_LABELS/GROUP_ORDER/GROUP_LABELS/seriesLabel) — fine for one hand-built
+Explorer, not for a planned Chart-Builder that needs the same answer without
+duplicating the mapping in JS. Migrated here so both can read it (the v1 catalog
+endpoint serves it; the frontend switch-over is a follow-on, not this change).
+
+Pure: no DB access, no imports of anything that touches a session. `series_label`
+and `series_group` must be safe to call on any string, known or not.
+"""
+from __future__ import annotations
+
+from backend.power.entsoe_grid import PSR_LABELS
+from backend.power.zones import ZONE_REGISTRY
+
+# Friendly names for the canonical series the desk itself charts. Everything else
+# (gen.<fuel>, consumption.<fuel>, flow.<zone>, sched.<zone>) gets a generated
+# label via the pattern rules in series_label() below, so a series added by a new
+# collector is readable in the catalog on day one, not just the raw key.
+SERIES_LABELS: dict[str, str] = {
+    "price.dayahead": "Day-ahead price · hourly",
+    "price.dayahead.qh": "Day-ahead price · 15-min",
+    "imbalance.price": "Imbalance price · hourly",
+    "imbalance.price.qh": "Imbalance price · 15-min",
+    "load.actual": "Load · actual",
+    "load.forecast": "Load · TSO forecast",
+    "residual.actual": "Residual load · actual",
+    "residual.forecast": "Residual load · TSO forecast",
+    "generation.forecast": "Generation · TSO forecast",
+    "hydro.reservoir": "Hydro reservoir filling · weekly",
+    "wind.actual": "Wind · actual",
+    "solar.actual": "Solar · actual",
+}
+
+# Display order for grouped pickers (e.g. the Explorer's <optgroup> list) and the
+# friendly name for each group key. Any group encountered that isn't listed here
+# (a future series prefix) sorts after these, keyed by its own group key.
+GROUP_ORDER: list[str] = [
+    "price", "imbalance", "load", "residual", "generation", "wind", "solar",
+    "gen", "consumption", "flow", "sched", "hydro",
+]
+GROUP_LABELS: dict[str, str] = {
+    "price": "Prices",
+    "imbalance": "Imbalance",
+    "load": "Load",
+    "residual": "Residual load",
+    "generation": "Generation forecast",
+    "wind": "Wind",
+    "solar": "Solar",
+    "gen": "Generation mix (per fuel)",
+    "consumption": "Consumption (pumped storage)",
+    "flow": "Cross-border flows (hourly)",
+    "sched": "Scheduled commercial exchange (hourly)",
+    "hydro": "Hydro",
+}
+
+
+def _zone_label(zone_key: str) -> str:
+    """Zone registry label for a key, falling back to the raw key for one the
+    registry doesn't know (e.g. a stale/typo'd series from an old ingest run)."""
+    meta = ZONE_REGISTRY.get(zone_key)
+    return meta["label"] if meta else zone_key
+
+
+def series_label(key: str) -> str:
+    """Human-readable label for a series key.
+
+    Static keys (the desk's own canonical series) resolve from SERIES_LABELS.
+    Dynamic keys are pattern-matched by their dot-prefix:
+      gen.<Bxx> / consumption.<Bxx>  → PSR_LABELS (ENTSO-E production-type codes)
+      flow.<ZONEKEY> / sched.<ZONEKEY> → the zone registry's label
+    An unrecognised key falls back to itself — never raise, never hide a series.
+    """
+    if key in SERIES_LABELS:
+        return SERIES_LABELS[key]
+    if key.startswith("flow."):
+        return f"Flow ↔ {_zone_label(key[len('flow.'):])}"
+    if key.startswith("sched."):
+        return f"Scheduled ↔ {_zone_label(key[len('sched.'):])}"
+    if key.startswith("gen."):
+        code = key[len("gen."):]
+        return f"Generation · {PSR_LABELS.get(code, code)}"
+    if key.startswith("consumption."):
+        code = key[len("consumption."):]
+        return f"Consumption · {PSR_LABELS.get(code, code)}"
+    return key
+
+
+def series_group(key: str) -> str:
+    """Stable group key for a series — its dot-prefix (e.g. 'price', 'gen',
+    'flow'), which is how every series in the store is namespaced. A key with
+    no dot is its own group; this never raises."""
+    return key.split(".", 1)[0]

--- a/backend/power/series_catalog.py
+++ b/backend/power/series_catalog.py
@@ -7,10 +7,15 @@ Explorer, not for a planned Chart-Builder that needs the same answer without
 duplicating the mapping in JS. Migrated here so both can read it (the v1 catalog
 endpoint serves it; the frontend switch-over is a follow-on, not this change).
 
-Pure: no DB access, no imports of anything that touches a session. `series_label`
-and `series_group` must be safe to call on any string, known or not.
+No DB access at call time — `series_label`/`series_group`/`catalog_groups` are safe
+to call on any string with no session in scope. That is not the same as import-side
+purity: importing PSR_LABELS from entsoe_grid transitively pulls in httpx/SQLAlchemy/
+settings/raw_cache at IMPORT time (entsoe_grid is a collector module, not a leaf
+constants file). Nothing in this module opens a session or issues a query.
 """
 from __future__ import annotations
+
+from collections.abc import Iterable
 
 from backend.power.entsoe_grid import PSR_LABELS
 from backend.power.zones import ZONE_REGISTRY
@@ -93,3 +98,16 @@ def series_group(key: str) -> str:
     'flow'), which is how every series in the store is namespaced. A key with
     no dot is its own group; this never raises."""
     return key.split(".", 1)[0]
+
+
+def catalog_groups(keys: Iterable[str]) -> list[dict]:
+    """[{key, label}] for exactly the groups present among `keys`, in GROUP_ORDER
+    order — the data a client needs to render grouped pickers (e.g. the
+    Explorer's <optgroup> list) without hardcoding its own copy of GROUP_ORDER/
+    GROUP_LABELS. A group not in GROUP_ORDER (a new series prefix nobody has
+    labelled yet) is appended afterward, sorted by its own key, so the response
+    is deterministic even for an unlabelled group."""
+    present = {series_group(k) for k in keys}
+    ordered = [g for g in GROUP_ORDER if g in present]
+    extra = sorted(present - set(GROUP_ORDER))
+    return [{"key": g, "label": GROUP_LABELS.get(g, g)} for g in ordered + extra]

--- a/backend/power/series_catalog.py
+++ b/backend/power/series_catalog.py
@@ -37,7 +37,14 @@ SERIES_LABELS: dict[str, str] = {
     "hydro.reservoir": "Hydro reservoir filling · weekly",
     "wind.actual": "Wind · actual",
     "solar.actual": "Solar · actual",
+    "outage.offline": "Outages · capacity offline",
+    "outage.forced": "Outages · forced offline",
+    "netpos.dayahead": "Net position · day-ahead",
 }
+
+#: aFRR/mFRR product-code -> display name, shared by the balancing.*/capacity.* pattern
+#: rules below (FCR/aFRR/mFRR are ENTSO-E's own product names, not this desk's invention).
+_RESERVE_PRODUCT_LABELS: dict[str, str] = {"fcr": "FCR", "afrr": "aFRR", "mfrr": "mFRR"}
 
 # Display order for grouped pickers (e.g. the Explorer's <optgroup> list) and the
 # friendly name for each group key. Any group encountered that isn't listed here
@@ -45,6 +52,7 @@ SERIES_LABELS: dict[str, str] = {
 GROUP_ORDER: list[str] = [
     "price", "imbalance", "load", "residual", "generation", "wind", "solar",
     "gen", "consumption", "flow", "sched", "hydro",
+    "balancing", "capacity", "outage", "netpos",
 ]
 GROUP_LABELS: dict[str, str] = {
     "price": "Prices",
@@ -59,6 +67,10 @@ GROUP_LABELS: dict[str, str] = {
     "flow": "Cross-border flows (hourly)",
     "sched": "Scheduled commercial exchange (hourly)",
     "hydro": "Hydro",
+    "balancing": "Balancing energy",
+    "capacity": "Balancing capacity",
+    "outage": "Outages",
+    "netpos": "Net position",
 }
 
 
@@ -76,6 +88,11 @@ def series_label(key: str) -> str:
     Dynamic keys are pattern-matched by their dot-prefix:
       gen.<Bxx> / consumption.<Bxx>  → PSR_LABELS (ENTSO-E production-type codes)
       flow.<ZONEKEY> / sched.<ZONEKEY> → the zone registry's label
+      balancing.<product>.<price|vol>.<up|down> → activated balancing ENERGY (A83/A84)
+      capacity.<fcr.price | <product>.price.<pos|neg>> → procured balancing CAPACITY (A15)
+    The "Balancing capacity ·" prefix on the latter is deliberate: this is NOT the same
+    thing as `/api/v1/capacity` (installed generation capacity, A68) — the label must say
+    so on sight, not just via a different key.
     An unrecognised key falls back to itself — never raise, never hide a series.
     """
     if key in SERIES_LABELS:
@@ -90,6 +107,25 @@ def series_label(key: str) -> str:
     if key.startswith("consumption."):
         code = key[len("consumption."):]
         return f"Consumption · {PSR_LABELS.get(code, code)}"
+    if key.startswith("balancing."):
+        parts = key.split(".")
+        if len(parts) == 4:
+            _, product, measure, direction = parts
+            name = _RESERVE_PRODUCT_LABELS.get(product, product.upper())
+            if measure == "price":
+                return f"Balancing · {name} activation price ({direction})"
+            if measure == "vol":
+                return f"Balancing · {name} activated volume ({direction})"
+        return f"Balancing · {key[len('balancing.'):]}"
+    if key.startswith("capacity."):
+        parts = key.split(".")
+        if parts[1:] == ["fcr", "price"]:
+            return "Balancing capacity · FCR price"
+        if len(parts) == 4 and parts[2] == "price":
+            _, product, _measure, direction = parts
+            name = _RESERVE_PRODUCT_LABELS.get(product, product.upper())
+            return f"Balancing capacity · {name} price ({direction})"
+        return f"Balancing capacity · {key[len('capacity.'):]}"
     return key
 
 

--- a/backend/routes/api_v1.py
+++ b/backend/routes/api_v1.py
@@ -20,7 +20,7 @@ from backend.collectors.freshness import evaluate_freshness
 from backend.database import get_db
 from backend.models.energy import InstalledCapacity, PowerGenMix, PowerHourly, SeriesDim, ZoneDim
 from backend.power.hourly_store import RowCapExceeded, read_hourly
-from backend.power.series_catalog import series_group, series_label
+from backend.power.series_catalog import catalog_groups, series_group, series_label
 from backend.power.zones import DEFAULT_ZONE, POWER_ZONES, ZONE_REGISTRY
 
 router = APIRouter(prefix="/api/v1", tags=["v1"])
@@ -370,45 +370,68 @@ def _coverage_window(db: Session) -> dict:
 
 
 def _coverage_by_series(db: Session) -> list[dict]:
-    """Per-(series,zone) coverage: one MIN/MAX(ts_utc) point lookup for every pair
-    that has rows, not one GROUP BY over the whole table.
+    """Per-(series,zone) coverage: two single-aggregate point lookups (one
+    `MIN(ts_utc)`, one `MAX(ts_utc)`) for every pair that has rows, not one
+    GROUP BY over the whole table.
 
     power_hourly's PK is (series_id, zone_id, ts_utc) WITHOUT ROWID — the table's
-    clustering key — so a query that pins (series_id, zone_id) and aggregates
-    ts_utc is a seek to that pair's first/last leaf (SQLite's min/max-over-index
-    optimization), not a scan. A GROUP BY series_id, zone_id would instead walk
-    every one of the multi-million rows once. There are only series-count ×
-    zone-count pairs (low hundreds), so the N cheap seeks beat the one full scan.
-    Pairs with no rows are skipped. Cached (see catalog()) since the ingest only
-    moves this hourly.
+    clustering key — so filtering on (series_id, zone_id) and asking for a SINGLE
+    min/max aggregate is a seek straight to that pair's first/last leaf (SQLite's
+    min/max-over-index optimization). That optimization only fires when the query
+    has exactly one min/max aggregate: a combined `SELECT MIN(ts_utc), MAX(ts_utc)
+    WHERE ...` does NOT qualify, and falls back to scanning every matching row in
+    the pair's slice of the index — cheaper than a scan of the whole multi-million
+    row table, but still O(rows in that pair), not O(1). `EXPLAIN QUERY PLAN`
+    prints the identical "SEARCH power_hourly USING PRIMARY KEY" line for both
+    forms, so this can only be told apart by timing, not by reading the plan —
+    verified empirically (10k vs 100k rows in one pair, ~constant time either way).
+    Splitting into two separate single-aggregate queries per pair is what actually
+    buys the seek. There are only series-count × zone-count pairs (low hundreds),
+    so the 2N cheap seeks beat the one full scan _coverage_window does.
+
+    Pairs with no rows are skipped. Output is sorted by (series, zone) for a
+    deterministic response. Cached (see catalog()) since the ingest only moves
+    this hourly.
     """
     series_rows = db.query(SeriesDim.id, SeriesDim.key).all()
     zone_rows = db.query(ZoneDim.id, ZoneDim.key).all()
     out: list[dict] = []
     for sid, skey in series_rows:
         for zid, zkey in zone_rows:
-            lo, hi = (
-                db.query(func.min(PowerHourly.ts_utc), func.max(PowerHourly.ts_utc))
+            lo = (
+                db.query(func.min(PowerHourly.ts_utc))
                 .filter(PowerHourly.series_id == sid, PowerHourly.zone_id == zid)
-                .first()
+                .scalar()
             )
             if lo is None:
                 continue
+            hi = (
+                db.query(func.max(PowerHourly.ts_utc))
+                .filter(PowerHourly.series_id == sid, PowerHourly.zone_id == zid)
+                .scalar()
+            )
             out.append({
                 "series": skey,
                 "zone": zkey,
                 "from": datetime.fromtimestamp(lo, UTC).isoformat(),
                 "to": datetime.fromtimestamp(hi, UTC).isoformat(),
             })
+    out.sort(key=lambda r: (r["series"], r["zone"]))
     return out
 
 
 @router.get("/series/catalog")
 def catalog(db: Session = Depends(get_db), _rl: None = Depends(_rate_limit), _g: None = Depends(heavy_query_guard)):
-    """What's queryable: every series (key+unit+label+group), enabled zones, the
-    overall hourly coverage window, and per-(series,zone) coverage — so a
-    Chart-Builder can grey out a zone with no data for the selected series
-    instead of letting the pick 404 downstream."""
+    """What's queryable: every series (key+unit+label+group), its groups
+    (key+label, in display order), enabled zones, the overall hourly coverage
+    window, and per-(series,zone) coverage — so a Chart-Builder can grey out a
+    zone with no data for the selected series instead of letting the pick 404
+    downstream.
+
+    `coverage_by_series` is cached for an hour (see cached_value below), same as
+    `coverage`: it can lag `series` by up to that TTL, so a pair's absence there
+    means "not yet reflected", not "definitely no data".
+    """
     series = [
         {"key": k, "unit": u, "label": series_label(k), "group": series_group(k)}
         for k, u in db.query(SeriesDim.key, SeriesDim.unit).order_by(SeriesDim.key).all()
@@ -416,6 +439,7 @@ def catalog(db: Session = Depends(get_db), _rl: None = Depends(_rate_limit), _g:
     return {
         "available": bool(series),
         "series": series,
+        "groups": catalog_groups(s["key"] for s in series),
         "zones": [{"key": k, "label": v["label"]} for k, v in POWER_ZONES.items()],
         "coverage": cached_coverage(lambda: _coverage_window(db)),
         "coverage_by_series": cached_value("coverage_by_series", lambda: _coverage_by_series(db)),

--- a/backend/routes/api_v1.py
+++ b/backend/routes/api_v1.py
@@ -14,12 +14,13 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from backend.api_guard import cached_coverage, heavy_query_guard
+from backend.api_guard import cached_coverage, cached_value, heavy_query_guard
 from backend.auth.ratelimit import allow, client_ip
 from backend.collectors.freshness import evaluate_freshness
 from backend.database import get_db
 from backend.models.energy import InstalledCapacity, PowerGenMix, PowerHourly, SeriesDim, ZoneDim
 from backend.power.hourly_store import RowCapExceeded, read_hourly
+from backend.power.series_catalog import series_group, series_label
 from backend.power.zones import DEFAULT_ZONE, POWER_ZONES, ZONE_REGISTRY
 
 router = APIRouter(prefix="/api/v1", tags=["v1"])
@@ -368,16 +369,56 @@ def _coverage_window(db: Session) -> dict:
     }
 
 
+def _coverage_by_series(db: Session) -> list[dict]:
+    """Per-(series,zone) coverage: one MIN/MAX(ts_utc) point lookup for every pair
+    that has rows, not one GROUP BY over the whole table.
+
+    power_hourly's PK is (series_id, zone_id, ts_utc) WITHOUT ROWID — the table's
+    clustering key — so a query that pins (series_id, zone_id) and aggregates
+    ts_utc is a seek to that pair's first/last leaf (SQLite's min/max-over-index
+    optimization), not a scan. A GROUP BY series_id, zone_id would instead walk
+    every one of the multi-million rows once. There are only series-count ×
+    zone-count pairs (low hundreds), so the N cheap seeks beat the one full scan.
+    Pairs with no rows are skipped. Cached (see catalog()) since the ingest only
+    moves this hourly.
+    """
+    series_rows = db.query(SeriesDim.id, SeriesDim.key).all()
+    zone_rows = db.query(ZoneDim.id, ZoneDim.key).all()
+    out: list[dict] = []
+    for sid, skey in series_rows:
+        for zid, zkey in zone_rows:
+            lo, hi = (
+                db.query(func.min(PowerHourly.ts_utc), func.max(PowerHourly.ts_utc))
+                .filter(PowerHourly.series_id == sid, PowerHourly.zone_id == zid)
+                .first()
+            )
+            if lo is None:
+                continue
+            out.append({
+                "series": skey,
+                "zone": zkey,
+                "from": datetime.fromtimestamp(lo, UTC).isoformat(),
+                "to": datetime.fromtimestamp(hi, UTC).isoformat(),
+            })
+    return out
+
+
 @router.get("/series/catalog")
 def catalog(db: Session = Depends(get_db), _rl: None = Depends(_rate_limit), _g: None = Depends(heavy_query_guard)):
-    """What's queryable: every series (key+unit), enabled zones, and the overall
-    hourly coverage window."""
-    series = [{"key": k, "unit": u} for k, u in db.query(SeriesDim.key, SeriesDim.unit).order_by(SeriesDim.key).all()]
+    """What's queryable: every series (key+unit+label+group), enabled zones, the
+    overall hourly coverage window, and per-(series,zone) coverage — so a
+    Chart-Builder can grey out a zone with no data for the selected series
+    instead of letting the pick 404 downstream."""
+    series = [
+        {"key": k, "unit": u, "label": series_label(k), "group": series_group(k)}
+        for k, u in db.query(SeriesDim.key, SeriesDim.unit).order_by(SeriesDim.key).all()
+    ]
     return {
         "available": bool(series),
         "series": series,
         "zones": [{"key": k, "label": v["label"]} for k, v in POWER_ZONES.items()],
         "coverage": cached_coverage(lambda: _coverage_window(db)),
+        "coverage_by_series": cached_value("coverage_by_series", lambda: _coverage_by_series(db)),
         "series_count": len(series),
     }
 

--- a/backend/routes/embed.py
+++ b/backend/routes/embed.py
@@ -78,6 +78,12 @@ def _badge_svg(text: str, *, bg: str, border: str, fill: str, title: str) -> str
         f'<rect x="0.5" y="0.5" width="{width - 1}" height="{_HEIGHT - 1}" rx="3" '
         f'fill="none" stroke="{border}"/>'
         f'<text x="{_PAD_X}" y="14" font-family="{_FONT}" font-size="{_FONT_SIZE}" '
+        # textLength + lengthAdjust: the SVG renderer compresses glyph spacing (and,
+        # if still needed, the glyphs themselves) to fit exactly this width instead of
+        # letting the text overflow the pill. `_CHAR_W` is only an average — real
+        # Verdana-at-11px glyphs (especially caps/digits) run a bit wider, so without
+        # this a long badge could clip past its own rounded-rect background.
+        f'textLength="{width - 2 * _PAD_X}" lengthAdjust="spacingAndGlyphs" '
         f'fill="{fill}">{esc_text}</text>'
         f"</svg>"
     )
@@ -95,6 +101,20 @@ def _no_data_badge(text: str) -> str:
         text, bg=_GREY_BG, border=_GREY_BORDER, fill=_GREY_TEXT,
         title=f"OBSYD · {text}",
     )
+
+
+def _fmt_eur_per_mwh(value: float) -> str:
+    """€X/MWh — sign BEFORE the currency symbol for a negative price (e.g. "−€5/MWh",
+    never Python's default "€-5/MWh": the minus reads as "negative five euros", not
+    "euro-negative-five"). Negative day-ahead prices are a real, headline state for
+    this product (renewable oversupply), not an edge case to hide.
+
+    `round()` on a float with no `ndigits` returns a plain Python `int` — ints have no
+    signed zero, so a value like -0.2 rounds to the int `0`, not a float `-0.0` that
+    would otherwise format as the confusing "€-0/MWh".
+    """
+    n = round(value)
+    return f"−€{abs(n)}/MWh" if n < 0 else f"€{n}/MWh"
 
 
 def _svg_response(svg: str) -> Response:
@@ -118,33 +138,41 @@ def badge(
     metric=load   -> latest published load.actual hourly point (GW) + its UTC hour.
 
     Unknown zone/metric or genuinely no data yet: a neutral grey "no data" pill,
-    HTTP 200 (see module docstring — badges must never break a README).
+    HTTP 200 (see module docstring — badges must never break a README). A transient
+    DB error inside the reads degrades to the same grey pill; the one residual case
+    this guard cannot reach is a failure inside the `get_db` dependency itself,
+    which still surfaces as a 500 before this function runs.
     """
     if zone not in POWER_ZONES or metric not in VALID_METRICS:
         return _svg_response(_no_data_badge(f"{zone} · no data"))
 
     zone_label = POWER_ZONES[zone]["label"]
 
-    if metric == "price":
-        row = (
-            db.query(PowerPriceDaily)
-            .filter(PowerPriceDaily.zone == zone)
-            .order_by(PowerPriceDaily.date.desc())
-            .first()
-        )
-        if row is None:
-            return _svg_response(_no_data_badge(f"{zone_label} · no data"))
-        text = f"{zone_label} day-ahead · €{row.mean_price:.0f}/MWh · {row.date}"
-        return _svg_response(_ok_badge(text))
+    try:
+        if metric == "price":
+            row = (
+                db.query(PowerPriceDaily)
+                .filter(PowerPriceDaily.zone == zone)
+                .order_by(PowerPriceDaily.date.desc())
+                .first()
+            )
+            if row is None:
+                return _svg_response(_no_data_badge(f"{zone_label} · no data"))
+            text = f"{zone_label} day-ahead · {_fmt_eur_per_mwh(row.mean_price)} · {row.date}"
+            return _svg_response(_ok_badge(text))
 
-    # metric == "load"
-    now = datetime.now(timezone.utc)
-    start_ts = int(now.timestamp()) - 6 * 3600  # a handful of recent hours — bounded read
-    points = read_hourly(db, "load.actual", zone, start_ts=start_ts, max_rows=12)
-    if not points:
+        # metric == "load"
+        now = datetime.now(timezone.utc)
+        start_ts = int(now.timestamp()) - 6 * 3600  # a handful of recent hours — bounded read
+        points = read_hourly(db, "load.actual", zone, start_ts=start_ts, max_rows=12)
+        if not points:
+            return _svg_response(_no_data_badge(f"{zone_label} · no data"))
+        ts, value = points[-1]
+        hh = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%H:%M")
+        gw = value / 1000.0
+        text = f"{zone_label} load · {gw:.1f} GW · {hh} UTC"
+        return _svg_response(_ok_badge(text))
+    except Exception:
+        # The docstrings promise an unconditional 200 — a momentary DB hiccup must
+        # render as the same grey pill as "no data yet", never a broken image.
         return _svg_response(_no_data_badge(f"{zone_label} · no data"))
-    ts, value = points[-1]
-    hh = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%H:%M")
-    gw = value / 1000.0
-    text = f"{zone_label} load · {gw:.1f} GW · {hh} UTC"
-    return _svg_response(_ok_badge(text))

--- a/backend/routes/embed.py
+++ b/backend/routes/embed.py
@@ -1,0 +1,142 @@
+"""Embeddable SVG badges — tiny, dependency-free status images for READMEs/dashboards.
+
+GET /api/v1/badge/{zone}/{metric}.svg   metric in {price, load}
+
+Template-based f-string SVG (no cairosvg/matplotlib/pillow — one more dependency for a
+20x220px pill is not worth it). Reads go through the SAME bounded paths every other v1
+endpoint uses (PowerPriceDaily for price, hourly_store.read_hourly for load) — this route
+adds no new query patterns, just a tiny image encoding of numbers other endpoints already
+serve as JSON.
+
+Badges are rendered as <img> tags inside someone else's README/dashboard, which the
+*viewer's* browser (or a caching proxy/bot) fetches independently of anything Obsyd
+controls — hence the 15-minute Cache-Control (badges refresh far slower than the desk's
+own panels) and the unconditional HTTP 200: an <img> with a broken-image icon in a
+stranger's README reflects badly on the whole project, so an unknown zone/metric or a
+momentary data gap degrades to a neutral grey "no data" pill rather than a 404/500 that
+GitHub renders as a broken image.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from xml.sax.saxutils import escape
+
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models.energy import PowerPriceDaily
+from backend.power.hourly_store import read_hourly
+from backend.power.zones import POWER_ZONES
+from backend.routes.api_v1 import _rate_limit  # same v1 per-IP budget — badges ARE v1 traffic
+
+router = APIRouter(prefix="/api/v1/badge", tags=["embed"])
+
+VALID_METRICS = {"price", "load"}
+
+#: A viewer's browser/bot refetches an <img> on its own schedule — 15 min matches the
+#: ~30-min ingest cadence closely enough without hammering us on every README render.
+CACHE_CONTROL = "public, max-age=900"
+
+_ATTRIBUTION = "data: ENTSO-E Transparency Platform, via obsyd.dev"
+
+# ── Flat, dark badge chrome — same palette family as the desk (cyan-glow accent,
+#    #0f1115-ish surface) so a badge dropped into a README still reads as "Obsyd". ──
+_HEIGHT = 20
+_PAD_X = 8
+_CHAR_W = 6.35  # rough average glyph width @ 11px sans-serif — generous, never clips
+_FONT = "Verdana,Geneva,DejaVu Sans,sans-serif"
+_FONT_SIZE = 11
+_MIN_WIDTH = 90
+
+_OK_BG = "#12141a"
+_OK_BORDER = "#262a33"
+_OK_TEXT = "#c9ccd6"
+
+_GREY_BG = "#1a1c22"
+_GREY_BORDER = "#2a2d36"
+_GREY_TEXT = "#6b7280"
+
+
+def _badge_svg(text: str, *, bg: str, border: str, fill: str, title: str) -> str:
+    width = max(_MIN_WIDTH, int(_PAD_X * 2 + len(text) * _CHAR_W))
+    esc_text = escape(text)
+    esc_title = escape(title)
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{_HEIGHT}" '
+        f'role="img" aria-label="{esc_text}">'
+        f"<title>{esc_title}</title>"
+        f'<rect width="{width}" height="{_HEIGHT}" rx="3" fill="{bg}"/>'
+        f'<rect x="0.5" y="0.5" width="{width - 1}" height="{_HEIGHT - 1}" rx="3" '
+        f'fill="none" stroke="{border}"/>'
+        f'<text x="{_PAD_X}" y="14" font-family="{_FONT}" font-size="{_FONT_SIZE}" '
+        f'fill="{fill}">{esc_text}</text>'
+        f"</svg>"
+    )
+
+
+def _ok_badge(text: str) -> str:
+    return _badge_svg(
+        text, bg=_OK_BG, border=_OK_BORDER, fill=_OK_TEXT,
+        title=f"OBSYD · {text} — {_ATTRIBUTION}",
+    )
+
+
+def _no_data_badge(text: str) -> str:
+    return _badge_svg(
+        text, bg=_GREY_BG, border=_GREY_BORDER, fill=_GREY_TEXT,
+        title=f"OBSYD · {text}",
+    )
+
+
+def _svg_response(svg: str) -> Response:
+    return Response(
+        content=svg,
+        media_type="image/svg+xml",
+        headers={"Cache-Control": CACHE_CONTROL},
+    )
+
+
+@router.get("/{zone}/{metric}.svg")
+def badge(
+    zone: str,
+    metric: str,
+    db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
+):
+    """One data point as a tiny flat SVG pill — for READMEs, wikis, status dashboards.
+
+    metric=price  -> latest PowerPriceDaily mean (EUR/MWh) + its delivery date.
+    metric=load   -> latest published load.actual hourly point (GW) + its UTC hour.
+
+    Unknown zone/metric or genuinely no data yet: a neutral grey "no data" pill,
+    HTTP 200 (see module docstring — badges must never break a README).
+    """
+    if zone not in POWER_ZONES or metric not in VALID_METRICS:
+        return _svg_response(_no_data_badge(f"{zone} · no data"))
+
+    zone_label = POWER_ZONES[zone]["label"]
+
+    if metric == "price":
+        row = (
+            db.query(PowerPriceDaily)
+            .filter(PowerPriceDaily.zone == zone)
+            .order_by(PowerPriceDaily.date.desc())
+            .first()
+        )
+        if row is None:
+            return _svg_response(_no_data_badge(f"{zone_label} · no data"))
+        text = f"{zone_label} day-ahead · €{row.mean_price:.0f}/MWh · {row.date}"
+        return _svg_response(_ok_badge(text))
+
+    # metric == "load"
+    now = datetime.now(timezone.utc)
+    start_ts = int(now.timestamp()) - 6 * 3600  # a handful of recent hours — bounded read
+    points = read_hourly(db, "load.actual", zone, start_ts=start_ts, max_rows=12)
+    if not points:
+        return _svg_response(_no_data_badge(f"{zone_label} · no data"))
+    ts, value = points[-1]
+    hh = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%H:%M")
+    gw = value / 1000.0
+    text = f"{zone_label} load · {gw:.1f} GW · {hh} UTC"
+    return _svg_response(_ok_badge(text))

--- a/backend/routes/embed.py
+++ b/backend/routes/embed.py
@@ -62,9 +62,17 @@ def _badge_svg(text: str, *, bg: str, border: str, fill: str, title: str) -> str
     width = max(_MIN_WIDTH, int(_PAD_X * 2 + len(text) * _CHAR_W))
     esc_text = escape(text)
     esc_title = escape(title)
+    # `escape()` alone only handles & < > — safe for an ELEMENT BODY (<title>/<text>
+    # above and below), but `aria-label` is an ATTRIBUTE VALUE: a `"` in `text` would
+    # close the attribute early and let whatever follows (e.g. a zone path segment
+    # like `x" onload="alert(1)//`) be parsed as a new attribute. `text` here can
+    # originate straight from the URL's `{zone}` path segment (see the unknown-
+    # zone/metric branch in `badge()` below), so it's untrusted — escape quotes too,
+    # for this attribute sink specifically.
+    esc_attr = escape(text, {'"': "&quot;", "'": "&apos;"})
     return (
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{_HEIGHT}" '
-        f'role="img" aria-label="{esc_text}">'
+        f'role="img" aria-label="{esc_attr}">'
         f"<title>{esc_title}</title>"
         f'<rect width="{width}" height="{_HEIGHT}" rx="3" fill="{bg}"/>'
         f'<rect x="0.5" y="0.5" width="{width - 1}" height="{_HEIGHT - 1}" rx="3" '

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -741,6 +741,7 @@ PANEL_MAX_AGE_DAYS = {
     "imbalance": 4,     # mirrors SPECS "imbalance_qh" — reBAP settles late
     "spark": 4,  # gas leg is yfinance TTF — ~3 trading days plus weekends
     "load_forecast": 2,
+    "balancing": 2,  # mirrors SPECS "balancing_energy"
 }
 
 #: /api/power/live's own freshness threshold — day granularity like every
@@ -1734,6 +1735,96 @@ def get_imbalance(
             for t, v in points
         ],
         **_freshness(as_of, datetime.utcnow().date(), PANEL_MAX_AGE_DAYS["imbalance"]),
+    }
+
+
+# ─── Activated balancing energy (free) ────────────────────────────────────────
+
+
+@router.get("/balancing")
+def get_balancing(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    days: int = Query(30, ge=1, le=90),
+    product: str = Query("afrr", pattern="^(afrr|mfrr)$"),
+    db: Session = Depends(get_db),
+):
+    """Activated balancing energy (ENTSO-E A84 prices EUR/MWh + A83 volumes MWh) for aFRR or
+    mFRR, split by direction — what the TSO actually called on beyond the day-ahead price, in
+    real time. Free tier, descriptive (Posture B: context, not a forecast).
+
+    Coverage varies by zone/product — see backend/power/entsoe_balancing.py's module
+    docstring for the live-spiked specifics: DE_LU is TenneT's control area only (one of four
+    German TSOs, not the national total), and activation VOLUMES (A83) are not currently
+    served by the public API at all for any zone (prices still populate).
+    """
+    from backend.power.hourly_store import read_hourly
+
+    resolved_zone = _resolve_zone(zone)
+    start_ts = int((datetime.now(timezone.utc) - timedelta(days=days)).timestamp())
+
+    def _direction_rows(direction: str) -> list[tuple[int, float | None, float | None]]:
+        prices = dict(read_hourly(db, f"balancing.{product}.price.{direction}", resolved_zone, start_ts=start_ts))
+        vols = dict(read_hourly(db, f"balancing.{product}.vol.{direction}", resolved_zone, start_ts=start_ts))
+        return [(t, prices.get(t), vols.get(t)) for t in sorted(set(prices) | set(vols))]
+
+    up_rows = _direction_rows("up")
+    down_rows = _direction_rows("down")
+    if not up_rows and not down_rows:
+        return {
+            "available": False,
+            "zone": resolved_zone,
+            "zone_label": POWER_ZONES[resolved_zone]["label"],
+            "zones": _ZONE_KEYS,
+            "product": product,
+            "reason": (
+                f"No {product} activated-balancing-energy series for "
+                f"{POWER_ZONES[resolved_zone]['label']} — A83/A84 coverage varies by zone "
+                "(and activation volumes aren't currently served by the public API at all; "
+                "see backend/power/entsoe_balancing.py)."
+            ),
+        }
+
+    def _fmt(rows: list[tuple[int, float | None, float | None]]) -> list[dict]:
+        return [
+            {
+                "t": _dt.fromtimestamp(t, tz=timezone.utc).isoformat(),
+                "price": round(p, 2) if p is not None else None,
+                "vol": round(v, 2) if v is not None else None,
+            }
+            for t, p, v in rows
+        ]
+
+    all_rows = up_rows + down_rows
+    priced_rows = [(t, p) for t, p, _ in all_rows if p is not None]
+    latest_t, latest_p, latest_v = max(all_rows, key=lambda r: r[0])
+    peak_row = max(priced_rows, key=lambda r: abs(r[1])) if priced_rows else None
+    as_of = _dt.fromtimestamp(max(r[0] for r in all_rows), tz=timezone.utc).strftime("%Y-%m-%d")
+
+    return {
+        "available": True,
+        "zone": resolved_zone,
+        "zone_label": POWER_ZONES[resolved_zone]["label"],
+        "zones": _ZONE_KEYS,
+        "product": product,
+        "unit": "EUR/MWh",
+        "days": days,
+        "up": _fmt(up_rows),
+        "down": _fmt(down_rows),
+        "latest": {
+            "t": _dt.fromtimestamp(latest_t, tz=timezone.utc).isoformat(),
+            "price": round(latest_p, 2) if latest_p is not None else None,
+            "vol": round(latest_v, 2) if latest_v is not None else None,
+        },
+        "peak": (
+            {"t": _dt.fromtimestamp(peak_row[0], tz=timezone.utc).isoformat(), "price": round(peak_row[1], 2)}
+            if peak_row is not None else None
+        ),
+        "note": (
+            "Activated balancing energy — what the TSO actually called on to keep the grid "
+            "balanced, beyond the day-ahead auction. Descriptive context, not a forecast "
+            "(Posture B)."
+        ),
+        **_freshness(as_of, datetime.utcnow().date(), PANEL_MAX_AGE_DAYS["balancing"]),
     }
 
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1649,6 +1649,45 @@ def get_spread(
     return compute_spread(db, a, b, days=days)
 
 
+# ─── Live (near-real-time TODAY) ──────────────────────────────────────────────
+
+
+@router.get("/live")
+def get_live(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    db: Session = Depends(get_db),
+):
+    """Near-real-time read of TODAY, hour by hour. Free tier.
+
+    The situation hero and every daily panel read the DAILY rollup tables, which
+    only ever hold COMPLETE days — so the desk has no view of today until the
+    nightly job closes it out, even though the canonical hourly store already
+    fills in every ~30 minutes as ENTSO-E publishes. This is that missing read:
+    published actual load/residual/per-fuel generation/net cross-border flow
+    alongside the day-ahead forecast/price for the SAME hours, straight from
+    backend/power/live.py::compute_live. Descriptive (Posture B): actuals are
+    compared against ENTSO-E's/the auction's own published day-ahead figures,
+    never predicted.
+
+    `zone` defaults to DE_LU; unknown zones fall back (same convention as every
+    other endpoint on this router — see `_resolve_zone`). Shortly after UTC
+    midnight, before today's first actual has published, falls back to
+    yesterday's complete day (`showing: "yesterday"`).
+    """
+    from backend.power.live import compute_live
+
+    resolved_zone = _resolve_zone(zone)
+    result = compute_live(db, resolved_zone)
+    if not result.get("available"):
+        return result
+
+    as_of_date = result["latest_actual_ts"][:10] if result.get("latest_actual_ts") else None
+    return {
+        **result,
+        **_freshness(as_of_date, datetime.now(timezone.utc).date(), max_age_days=1),
+    }
+
+
 # ─── Imbalance prices (free) ──────────────────────────────────────────────────
 
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -6,7 +6,7 @@ GET /api/power/day-ahead?days=120&zone=DE_LU  — FREE
     Returns EnergyPrice rows + richer PowerPriceDaily stats (negative prices etc.)
     Each response includes `zone` (resolved) and `zones` (all supported zone keys).
 
-GET /api/power/spark-spread?days=120  — PRO
+GET /api/power/spark-spread?days=120  — FREE
     Historical spark spread (power − gas × heat_rate).
     DE-LU only (SparkSpreadHistory has no zone column); stays DE-only intentionally.
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -2020,17 +2020,27 @@ def get_outages(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     horizon_days: int = Query(30, ge=1, le=400,
                               description="Include outages starting up to this many days out"),
+    kind: str = Query("all", pattern="^(generation|transmission|all)$",
+                      description="generation = A77 unit unavailability, transmission = "
+                                  "A78 interconnector/line unavailability, all = both"),
     db: Session = Depends(get_db),
 ):
-    """Generation unavailability (ENTSO-E A77) for a bidding zone. Free tier.
+    """Generation unavailability (ENTSO-E A77) AND transmission-infrastructure
+    unavailability (ENTSO-E A78) for a bidding zone. Free tier.
 
     Revision semantics: only the HIGHEST revision per message counts, and
-    withdrawn messages (docStatus A09) hide the event — of 31 live documents
-    sampled, 26 were withdrawn. `total_offline_mw` counts only outages running
-    RIGHT NOW; the list also includes ones starting within `horizon_days`.
-    Descriptive: what capacity is off and why, not a price call.
+    withdrawn messages (docStatus A09) hide the event — of 31 live A77 documents
+    sampled, 26 were withdrawn; A78 shares the identical semantics (spiked live
+    2026-07-21). `total_offline_mw`/`forced_offline_mw` are GENERATION-only (A78
+    never publishes a nominal capacity for the asset, so there is no baseline to
+    subtract from — see `transmission[].available_mw` instead); both count only
+    outages running RIGHT NOW, the lists also include ones starting within
+    `horizon_days`. `transmission[]` entries carry `counterparty_zone` — the
+    OTHER end of the interconnector/line. Descriptive: what capacity is off and
+    why, not a price call.
     """
     from backend.models.energy import PowerOutage
+    from backend.power.entsoe_outages import ASSET_TYPE_LABELS
     from backend.signals.detectors.power import latest_outage_revisions
 
     resolved_zone = _resolve_zone(zone)
@@ -2038,11 +2048,17 @@ def get_outages(
     now_iso = now.strftime("%Y-%m-%dT%H:%MZ")
     horizon_iso = (now + timedelta(days=horizon_days)).strftime("%Y-%m-%dT%H:%MZ")
 
-    # Highest revision per mRID wins; withdrawn events disappear. The dedupe
-    # runs in SQL (shared with the radar detector) instead of loading every
-    # revision row into Python.
-    latest_rows = latest_outage_revisions(db, resolved_zone)
-    if not latest_rows:
+    want_generation = kind in ("generation", "all")
+    want_transmission = kind in ("transmission", "all")
+
+    # Highest revision per mRID wins; withdrawn events disappear. The dedupe runs in SQL
+    # (shared with the radar detector) instead of loading every revision row into Python.
+    # doc_type scopes each query to its own section — A77 and A78 share this table but
+    # must never mix into one list (see latest_outage_revisions docstring).
+    latest_rows = latest_outage_revisions(db, resolved_zone, doc_type="A77") if want_generation else []
+    transmission_rows = latest_outage_revisions(db, resolved_zone, doc_type="A78") if want_transmission else []
+
+    if not latest_rows and not transmission_rows:
         return {
             "available": False,
             "zone": resolved_zone,
@@ -2051,48 +2067,90 @@ def get_outages(
         }
 
     outages: list[dict] = []
-    total_offline = 0.0
-    forced_offline = 0.0
-    # Names for the EICs, in ONE query. PowerOutage.unit_eic has been written since the outage
-    # ingest was built and read by nothing; the unit registry (A71/A33) is what it was waiting
-    # for. Hydrating per row would repeat the 0.25 s / 8.5k-entity mistake the outage board has
-    # already made once.
-    unit_names = _unit_names_for(db, [r.unit_eic for r in latest_rows if r.unit_eic])
+    total_offline: float | None = None
+    forced_offline: float | None = None
 
-    for r in latest_rows:
-        if r.status != "active":
-            continue
-        if r.end_utc < now_iso or r.start_utc > horizon_iso:
-            continue
-        offline = (
-            round(r.nominal_mw - (r.available_mw or 0.0), 1)
-            if r.nominal_mw is not None else None
-        )
-        running_now = r.start_utc <= now_iso <= r.end_utc
-        if running_now and offline:
-            total_offline += offline
-            if r.business_type == "A54":
-                forced_offline += offline
-        outages.append({
-            "mrid": r.mrid,
-            # The message's own name if it carries one, else the registry's. Many A77 messages
-            # carry no name at all — which is why the board used to print raw EICs.
-            "unit_name": r.unit_name or unit_names.get(r.unit_eic),
-            "unit_eic": r.unit_eic,
-            "location": r.location,
-            "fuel": PSR_LABELS.get(r.psr_type, r.psr_type),
-            "kind": _OUTAGE_KIND.get(r.business_type, r.business_type),
-            "nominal_mw": r.nominal_mw,
-            "available_mw": r.available_mw,
-            "offline_mw": offline,
-            "start_utc": r.start_utc,
-            "end_utc": r.end_utc,
-            "running_now": running_now,
-        })
+    if want_generation:
+        total_offline = 0.0
+        forced_offline = 0.0
+        # Names for the EICs, in ONE query. PowerOutage.unit_eic has been written since the outage
+        # ingest was built and read by nothing; the unit registry (A71/A33) is what it was waiting
+        # for. Hydrating per row would repeat the 0.25 s / 8.5k-entity mistake the outage board has
+        # already made once.
+        unit_names = _unit_names_for(db, [r.unit_eic for r in latest_rows if r.unit_eic])
 
-    outages.sort(key=lambda o: (not o["running_now"], -(o["offline_mw"] or 0.0)))
-    # Freshness = newest message we EVER ingested for the zone (any revision) —
-    # a superseded revision still proves the collector is alive.
+        for r in latest_rows:
+            if r.status != "active":
+                continue
+            if r.end_utc < now_iso or r.start_utc > horizon_iso:
+                continue
+            offline = (
+                round(r.nominal_mw - (r.available_mw or 0.0), 1)
+                if r.nominal_mw is not None else None
+            )
+            running_now = r.start_utc <= now_iso <= r.end_utc
+            if running_now and offline:
+                total_offline += offline
+                if r.business_type == "A54":
+                    forced_offline += offline
+            outages.append({
+                "mrid": r.mrid,
+                # The message's own name if it carries one, else the registry's. Many A77 messages
+                # carry no name at all — which is why the board used to print raw EICs.
+                "unit_name": r.unit_name or unit_names.get(r.unit_eic),
+                "unit_eic": r.unit_eic,
+                "location": r.location,
+                "fuel": PSR_LABELS.get(r.psr_type, r.psr_type),
+                "kind": _OUTAGE_KIND.get(r.business_type, r.business_type),
+                "nominal_mw": r.nominal_mw,
+                "available_mw": r.available_mw,
+                "offline_mw": offline,
+                "start_utc": r.start_utc,
+                "end_utc": r.end_utc,
+                "running_now": running_now,
+            })
+        outages.sort(key=lambda o: (not o["running_now"], -(o["offline_mw"] or 0.0)))
+        total_offline = round(total_offline, 1)
+        forced_offline = round(forced_offline, 1)
+
+    transmission: list[dict] = []
+    if want_transmission:
+        for r in transmission_rows:
+            if r.status != "active":
+                continue
+            if r.end_utc < now_iso or r.start_utc > horizon_iso:
+                continue
+            # nominal_mw is always null for a transmission asset (no capacity baseline is
+            # ever published — see entsoe_outages.py), so offline_mw stays null too; the
+            # honest figure to show is the reduced available_mw itself.
+            offline = (
+                round(r.nominal_mw - (r.available_mw or 0.0), 1)
+                if r.nominal_mw is not None else None
+            )
+            running_now = r.start_utc <= now_iso <= r.end_utc
+            transmission.append({
+                "mrid": r.mrid,
+                "asset_name": r.unit_name or r.unit_eic,
+                "asset_eic": r.unit_eic,
+                "counterparty_zone": r.counterparty_zone,
+                "asset_type": ASSET_TYPE_LABELS.get(r.psr_type, r.psr_type),
+                "kind": _OUTAGE_KIND.get(r.business_type, r.business_type),
+                "nominal_mw": r.nominal_mw,
+                "available_mw": r.available_mw,
+                "offline_mw": offline,
+                "start_utc": r.start_utc,
+                "end_utc": r.end_utc,
+                "running_now": running_now,
+            })
+        # Most-constrained first: lowest remaining transfer capacity is the one worth
+        # noticing. offline_mw is not a usable sort key here (near-always null).
+        transmission.sort(key=lambda o: (
+            not o["running_now"],
+            o["available_mw"] if o["available_mw"] is not None else float("inf"),
+        ))
+
+    # Freshness = newest message we EVER ingested for the zone (any revision, either doc
+    # type) — a superseded revision still proves the collector is alive.
     newest_msg = (
         db.query(func.max(PowerOutage.created_at))
         .filter(PowerOutage.zone == resolved_zone)
@@ -2103,10 +2161,11 @@ def get_outages(
         "zone": resolved_zone,
         "zones": _ZONE_KEYS,
         "unit": "MW",
-        "total_offline_mw": round(total_offline, 1),
-        "forced_offline_mw": round(forced_offline, 1),
+        "total_offline_mw": total_offline,
+        "forced_offline_mw": forced_offline,
         "horizon_days": horizon_days,
         "outages": outages,
+        "transmission": transmission,
         **_freshness(newest_msg.strftime("%Y-%m-%d") if newest_msg else None,
                      now.date(), 2),
     }

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -762,6 +762,7 @@ PANEL_MAX_AGE_DAYS = {
     "spark": 4,  # gas leg is yfinance TTF — ~3 trading days plus weekends
     "load_forecast": 2,
     "balancing": 2,  # mirrors SPECS "balancing_energy"
+    "capacity_prices": 2,  # mirrors SPECS "capacity_prices"
 }
 
 #: /api/power/live's own freshness threshold — day granularity like every
@@ -1857,6 +1858,90 @@ def get_balancing(
         ),
         "coverage": caveat,
         **_freshness(as_of, datetime.utcnow().date(), PANEL_MAX_AGE_DAYS["balancing"]),
+    }
+
+
+# ─── Procured balancing-capacity prices (FCR/aFRR/mFRR, free) ─────────────────
+
+
+@router.get("/capacity-prices")
+def get_capacity_prices(
+    zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
+    days: int = Query(30, ge=1, le=90),
+    db: Session = Depends(get_db),
+):
+    """German procured balancing-CAPACITY prices (ENTSO-E A15: FCR/aFRR/mFRR daily tenders) —
+    the DE-LU LFC block only, structurally (not a coverage gap): individual German control
+    areas publish nothing at this domain, and no other enabled zone has an equivalent tender.
+    See backend/power/entsoe_reserves.py's module docstring for the live-spiked XML shape and
+    pagination findings. Free tier, descriptive (Posture B: context, not a forecast).
+    """
+    from backend.power.entsoe_reserves import PRODUCT_SUFFIXES
+    from backend.power.hourly_store import read_hourly
+
+    resolved_zone = _resolve_zone(zone)
+    if resolved_zone != "DE_LU":
+        return {
+            "available": False,
+            "zone": resolved_zone,
+            "zone_label": POWER_ZONES[resolved_zone]["label"],
+            "zones": ["DE_LU"],
+            "reason": (
+                "German balancing-capacity market — DE-LU LFC block only "
+                f"(no equivalent tender for {POWER_ZONES[resolved_zone]['label']})."
+            ),
+        }
+
+    start_ts = int((datetime.now(timezone.utc) - timedelta(days=days)).timestamp())
+
+    products: dict[str, list[dict]] = {}
+    latest: dict[str, dict | None] = {}
+    newest_ts: list[int] = []
+    for json_key, suffix in PRODUCT_SUFFIXES:
+        rows = read_hourly(db, f"capacity.{suffix}.price", "DE_LU", start_ts=start_ts)
+        series = [
+            {"t": _dt.fromtimestamp(t, tz=timezone.utc).isoformat(), "price": round(p, 4)}
+            for t, p in rows
+        ]
+        products[json_key] = series
+        latest[json_key] = series[-1] if series else None
+        if rows:
+            newest_ts.append(rows[-1][0])
+
+    zone_label = POWER_ZONES["DE_LU"]["label"]
+    if not newest_ts:
+        return {
+            "available": False,
+            "zone": "DE_LU",
+            "zone_label": zone_label,
+            "zones": ["DE_LU"],
+            "reason": "No German balancing-capacity data yet for DE-LU — check back shortly.",
+        }
+
+    as_of = _dt.fromtimestamp(max(newest_ts), tz=timezone.utc).strftime("%Y-%m-%d")
+
+    return {
+        "available": True,
+        "zone": "DE_LU",
+        "zone_label": zone_label,
+        "zones": ["DE_LU"],
+        "unit": "EUR/MW/h",
+        "days": days,
+        "products": products,
+        "latest": latest,
+        "note": (
+            "German balancing-capacity market (ENTSO-E A15, GL EB 12.3.F) — DE-LU LFC block "
+            "only. Each series is the VOLUME-WEIGHTED AVERAGE of that day's accepted capacity "
+            "bids per 4-hour product block, normalized to EUR/MW/h (FCR's native EUR-per-4h-"
+            "block price is divided by 4; aFRR/mFRR are already EUR/MW/h). FCR is pay-as-"
+            "CLEARED and symmetric (no up/down split); aFRR/mFRR are pay-as-BID and split by "
+            "direction, so the weighted average reflects what procurement actually cost, not "
+            "a single clearing price. FCR settles across borders under one clearing "
+            "mechanism, so a specific country's own settlement price can differ slightly from "
+            "this DE-LU-block reconstruction on days when export limits bind. Source: ENTSO-E "
+            "Transparency Platform. Descriptive, not a forecast (Posture B)."
+        ),
+        **_freshness(as_of, datetime.utcnow().date(), PANEL_MAX_AGE_DAYS["capacity_prices"]),
     }
 
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -311,6 +311,12 @@ def get_day_ahead_hourly(
 def get_spark_spread(
     days: int = Query(120, ge=7, le=1500),
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key: DE_LU, FR, NL, …"),
+    efficiency: float | None = Query(
+        None, ge=0.30, le=0.65,
+        description="Override the CCGT electrical efficiency (0.30–0.65) used for this "
+        "request's heat rate. Defaults to settings.gas_ccgt_efficiency. A PPA/asset-modelling "
+        "knob: the desk's own fleet-average assumption may not match a specific plant.",
+    ),
     db: Session = Depends(get_db),
 ):
     """DIRTY spark spread (power − gas × heat_rate, EUR/MWh) for any zone — and the carbon
@@ -329,10 +335,17 @@ def get_spark_spread(
     The gas leg is TTF for every zone (a per-zone hub is a later refinement) and its raw close is
     NOT returned: yfinance's TTF is Yahoo's copy of the ICE Endex front-month, licensed exchange
     data this project does not redistribute. That is a mitigation, not a cure — see spark.py.
+
+    `efficiency`, when given, overrides settings.gas_ccgt_efficiency for THIS request only — the
+    heat rate and everything derived from it (the spread, the break-even carbon price, the carbon
+    intensity) are recomputed at the requested efficiency. The raw gas price stays unexposed
+    regardless: the override changes the arithmetic applied to it, not what leaves the response.
+    The efficiency actually used (requested or defaulted) is always echoed back as `efficiency`.
     """
     resolved_zone = _resolve_zone(zone)
     symbol = POWER_ZONES[resolved_zone]["price_symbol"]
-    heat_rate = round(1.0 / settings.gas_ccgt_efficiency, 4)
+    eff = efficiency if efficiency is not None else settings.gas_ccgt_efficiency
+    heat_rate = round(1.0 / eff, 4)
     date_from, date_to = _window(days)
 
     def _prices(sym: str) -> dict[str, float]:
@@ -353,6 +366,7 @@ def get_spark_spread(
             "available": False,
             "zone": resolved_zone,
             "zones": _ZONE_KEYS,
+            "efficiency": eff,
             "reason": f"Spark spread isn't available for {POWER_ZONES[resolved_zone]['label']} yet — check back shortly.",
         }
 
@@ -376,7 +390,13 @@ def get_spark_spread(
         "zone": resolved_zone,
         "zones": _ZONE_KEYS,
         "unit": "EUR/MWh",
-        "heat_rate_note": "1 / CCGT_efficiency; default efficiency = 0.50",
+        "efficiency": eff,
+        "heat_rate_note": (
+            "1 / CCGT_efficiency; default efficiency = "
+            f"{settings.gas_ccgt_efficiency}, this request used {eff}"
+            if efficiency is not None
+            else f"1 / CCGT_efficiency; default efficiency = {settings.gas_ccgt_efficiency}"
+        ),
         "co2_intensity_t_per_mwh": round(co2_intensity(heat_rate), 4),
         "gas_leg_note": (
             "Gas leg = TTF front-month for every zone (a per-zone hub is a later refinement). Its "

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1757,9 +1757,11 @@ def get_balancing(
     German TSOs, not the national total), and activation VOLUMES (A83) are not currently
     served by the public API at all for any zone (prices still populate).
     """
+    from backend.power.entsoe_balancing import coverage_caveat
     from backend.power.hourly_store import read_hourly
 
     resolved_zone = _resolve_zone(zone)
+    caveat = coverage_caveat(resolved_zone)
     start_ts = int((datetime.now(timezone.utc) - timedelta(days=days)).timestamp())
 
     def _direction_rows(direction: str) -> list[tuple[int, float | None, float | None]]:
@@ -1782,6 +1784,7 @@ def get_balancing(
                 "(and activation volumes aren't currently served by the public API at all; "
                 "see backend/power/entsoe_balancing.py)."
             ),
+            "coverage": caveat,
         }
 
     def _fmt(rows: list[tuple[int, float | None, float | None]]) -> list[dict]:
@@ -1824,6 +1827,7 @@ def get_balancing(
             "balanced, beyond the day-ahead auction. Descriptive context, not a forecast "
             "(Posture B)."
         ),
+        "coverage": caveat,
         **_freshness(as_of, datetime.utcnow().date(), PANEL_MAX_AGE_DAYS["balancing"]),
     }
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1797,9 +1797,12 @@ def get_balancing(
             for t, p, v in rows
         ]
 
-    all_rows = up_rows + down_rows
-    priced_rows = [(t, p) for t, p, _ in all_rows if p is not None]
-    latest_t, latest_p, latest_v = max(all_rows, key=lambda r: r[0])
+    # Tag each row with its direction before merging so latest/peak can report which half
+    # of the market they came from — a bare number doesn't say whether the TSO was paying
+    # for upward or downward regulation.
+    all_rows = [(t, p, v, "up") for t, p, v in up_rows] + [(t, p, v, "down") for t, p, v in down_rows]
+    priced_rows = [(t, p, d) for t, p, _, d in all_rows if p is not None]
+    latest_t, latest_p, latest_v, latest_dir = max(all_rows, key=lambda r: r[0])
     peak_row = max(priced_rows, key=lambda r: abs(r[1])) if priced_rows else None
     as_of = _dt.fromtimestamp(max(r[0] for r in all_rows), tz=timezone.utc).strftime("%Y-%m-%d")
 
@@ -1817,9 +1820,14 @@ def get_balancing(
             "t": _dt.fromtimestamp(latest_t, tz=timezone.utc).isoformat(),
             "price": round(latest_p, 2) if latest_p is not None else None,
             "vol": round(latest_v, 2) if latest_v is not None else None,
+            "direction": latest_dir,
         },
         "peak": (
-            {"t": _dt.fromtimestamp(peak_row[0], tz=timezone.utc).isoformat(), "price": round(peak_row[1], 2)}
+            {
+                "t": _dt.fromtimestamp(peak_row[0], tz=timezone.utc).isoformat(),
+                "price": round(peak_row[1], 2),
+                "direction": peak_row[2],
+            }
             if peak_row is not None else None
         ),
         "note": (

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -743,6 +743,15 @@ PANEL_MAX_AGE_DAYS = {
     "load_forecast": 2,
 }
 
+#: /api/power/live's own freshness threshold — day granularity like every
+#: other panel caption above (the endpoint's own `lag_minutes` field carries
+#: the real-time precision). Kept in sync with the "live_load" FreshnessSpec
+#: (backend/collectors/freshness.py) by
+#: test_power_live.py::test_route_max_age_matches_live_load_freshness_spec,
+#: the same pattern PANEL_MAX_AGE_DAYS uses against SPECS above
+#: (test_power_panel_freshness.py::test_panel_thresholds_match_health_specs).
+LIVE_MAX_AGE_DAYS = 1
+
 
 def _freshness(as_of: str | None, today: _date | None,
                max_age_days: int = SITUATION_STALE_DAYS) -> dict:
@@ -1455,37 +1464,17 @@ def get_flows_hourly(
     Country-level source — sub-zones without an Energy-Charts country (Italian
     sub-zones, DK1/DK2 …) return available:false with the reason, not a blank.
     """
-    from backend.models.energy import PowerHourly, SeriesDim, ZoneDim
-    from backend.power.hourly_store import read_hourly
+    from backend.power.hourly_store import iter_border_points
 
     resolved_zone = _resolve_zone(zone)
     start_ts = int((datetime.now(timezone.utc) - timedelta(hours=hours)).timestamp())
 
+    # Sign convention + storing-side/counterparty-side handling now lives in ONE
+    # place (iter_border_points) shared with backend/power/live.py — see its
+    # docstring for the Case A/B mechanics this used to duplicate here.
     borders: dict[str, list[tuple[int, float]]] = {}
-
-    # Case A — resolved zone is the canonical sorted-FIRST zone: its exports
-    # live as series flow.<neighbor> under itself.
-    for (key,) in db.query(SeriesDim.key).filter(SeriesDim.key.like("flow.%")).all():
-        neighbor = key[len("flow."):]
-        if neighbor == resolved_zone:
-            continue
-        pts = read_hourly(db, key, resolved_zone, start_ts=start_ts)
-        if pts:
-            borders[neighbor] = pts  # net > 0 = resolved zone exports (native sign)
-
-    # Case B — resolved zone is sorted-SECOND: series flow.<resolved> under the
-    # neighbours. One query across all zones; flip the sign to "selected exports".
-    sid = db.query(SeriesDim.id).filter(SeriesDim.key == f"flow.{resolved_zone}").scalar()
-    if sid is not None:
-        rows = (
-            db.query(ZoneDim.key, PowerHourly.ts_utc, PowerHourly.value)
-            .join(PowerHourly, PowerHourly.zone_id == ZoneDim.id)
-            .filter(PowerHourly.series_id == sid, PowerHourly.ts_utc >= start_ts)
-            .order_by(PowerHourly.ts_utc.asc())
-            .all()
-        )
-        for neighbor, ts, v in rows:
-            borders.setdefault(neighbor, []).append((int(ts), -float(v)))
+    for neighbor, ts, v in iter_border_points(db, resolved_zone, start_ts=start_ts):
+        borders.setdefault(neighbor, []).append((ts, v))
 
     if not borders:
         return {
@@ -1670,21 +1659,25 @@ def get_live(
     never predicted.
 
     `zone` defaults to DE_LU; unknown zones fall back (same convention as every
-    other endpoint on this router — see `_resolve_zone`). Shortly after UTC
+    other endpoint on this router — see `_resolve_zone`; `zones` in the response
+    lists every valid key, exactly like its siblings). Shortly after UTC
     midnight, before today's first actual has published, falls back to
-    yesterday's complete day (`showing: "yesterday"`).
+    yesterday's complete day (`showing: "yesterday"`) — in that mode
+    `summary.price_now` is null until today's first actual has landed, because
+    only the shown (yesterday's) day-ahead prices are loaded.
     """
     from backend.power.live import compute_live
 
     resolved_zone = _resolve_zone(zone)
     result = compute_live(db, resolved_zone)
     if not result.get("available"):
-        return result
+        return {**result, "zones": _ZONE_KEYS}
 
     as_of_date = result["latest_actual_ts"][:10] if result.get("latest_actual_ts") else None
     return {
         **result,
-        **_freshness(as_of_date, datetime.now(timezone.utc).date(), max_age_days=1),
+        "zones": _ZONE_KEYS,
+        **_freshness(as_of_date, datetime.now(timezone.utc).date(), max_age_days=LIVE_MAX_AGE_DAYS),
     }
 
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -2035,9 +2035,11 @@ def get_outages(
     never publishes a nominal capacity for the asset, so there is no baseline to
     subtract from — see `transmission[].available_mw` instead); both count only
     outages running RIGHT NOW, the lists also include ones starting within
-    `horizon_days`. `transmission[]` entries carry `counterparty_zone` — the
-    OTHER end of the interconnector/line. Descriptive: what capacity is off and
-    why, not a price call.
+    `horizon_days`. `transmission[]` entries carry `counterparty_zone` — the OTHER
+    end of the interconnector/line, RELATIVE to the requested `zone` (a message
+    published from the counterparty's own query still surfaces here, since A78
+    matches on either side — see latest_outage_revisions). Descriptive: what
+    capacity is off and why, not a price call.
     """
     from backend.models.energy import PowerOutage
     from backend.power.entsoe_outages import ASSET_TYPE_LABELS
@@ -2128,11 +2130,26 @@ def get_outages(
                 if r.nominal_mw is not None else None
             )
             running_now = r.start_utc <= now_iso <= r.end_utc
+            # latest_outage_revisions(doc_type="A78") now matches rows where resolved_zone
+            # is EITHER end (zone OR counterparty_zone — review fix), because a border
+            # publishes once per queried direction and the two directions are DISJOINT
+            # messages (live spike: zero mRID overlap). A row filed as zone=FR/
+            # counterparty_zone=DE_LU IS just as much DE_LU's outage, so "the other end"
+            # must be reported RELATIVE to resolved_zone, not read off the row verbatim —
+            # otherwise DE_LU's own panel would show "DE_LU" as its own counterparty.
+            # `reported_by` keeps the row's raw filing zone visible (which direction's
+            # query surfaced this message) — mostly diagnostic today.
+            # Accepted consequence: the SAME physical asset can appear TWICE on one
+            # zone's panel (once per queried direction), and the two rows' available_mw
+            # can legitimately differ (each TSO reports its own side). Display-dedupe by
+            # (asset_eic, start, end) only if this looks noisy in production.
+            other_zone = r.zone if r.counterparty_zone == resolved_zone else r.counterparty_zone
             transmission.append({
                 "mrid": r.mrid,
                 "asset_name": r.unit_name or r.unit_eic,
                 "asset_eic": r.unit_eic,
-                "counterparty_zone": r.counterparty_zone,
+                "counterparty_zone": other_zone,
+                "reported_by": r.zone,
                 "asset_type": ASSET_TYPE_LABELS.get(r.psr_type, r.psr_type),
                 "kind": _OUTAGE_KIND.get(r.business_type, r.business_type),
                 "nominal_mw": r.nominal_mw,

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1898,7 +1898,7 @@ def get_capacity_prices(
     latest: dict[str, dict | None] = {}
     newest_ts: list[int] = []
     for json_key, suffix in PRODUCT_SUFFIXES:
-        rows = read_hourly(db, f"capacity.{suffix}.price", "DE_LU", start_ts=start_ts)
+        rows = read_hourly(db, f"capacity.{suffix}", "DE_LU", start_ts=start_ts)
         series = [
             {"t": _dt.fromtimestamp(t, tz=timezone.utc).isoformat(), "price": round(p, 4)}
             for t, p in rows

--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -36,7 +36,7 @@ BACKFILL_START = date(2015, 1, 1)  # ENTSO-E Transparency era; override with --s
 # "flows" is zone-independent (one /cbpf sweep covers every border) and runs once
 # per month after the zone loop. Moderate history is the point (--start 2024-01-01
 # per roadmap Block 2.4) — deep flow history adds little over the daily means.
-ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "balancing", "flows", "scheduled", "netpos")
+ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "balancing", "flows", "scheduled", "netpos", "capacity")
 # Small pause between zone-months to stay under ENTSO-E's ~400 req/min token limit.
 THROTTLE_SECONDS = 1.0
 
@@ -189,9 +189,32 @@ async def run_backfill(
             logger.info("power_backfill: netpos %s done (%d/%d)",
                         f"{m_start:%Y-%m}", netpos_months, len(windows))
 
+    # Balancing-capacity prices (FCR/aFRR/mFRR, A15) are DE_LU-only and zone-independent —
+    # one sweep per month covers the whole German market, like flows/scheduled/netpos above.
+    # NOTE: each day fetches 3 processTypes, each individually offset-paginated (see
+    # backend/power/entsoe_reserves.py) — a deep multi-year --start on this source alone is a
+    # much heavier pull than the other zone-independent sources; pass a narrower --start
+    # (the market's daily-tender history only goes back to ~2018/2019) when backfilling it.
+    capacity_months = 0
+    if "capacity" in sources:
+        from backend.power.entsoe_reserves import ingest_capacity_prices
+
+        for m_start, m_end in windows:
+            if dry_run:
+                capacity_months += 1
+                continue
+            days = _daterange(m_start, m_end)
+            await _with_retry(
+                lambda d=days: ingest_capacity_prices(db, d, overwrite=overwrite),
+                f"capacity {m_start:%Y-%m}",
+            )
+            capacity_months += 1
+            logger.info("power_backfill: capacity %s done (%d/%d)",
+                        f"{m_start:%Y-%m}", capacity_months, len(windows))
+
     return {"zone_months": done, "zones": zones, "months": len(windows),
             "flow_months": flow_months, "scheduled_months": sched_months,
-            "netpos_months": netpos_months, "dry_run": dry_run}
+            "netpos_months": netpos_months, "capacity_months": capacity_months, "dry_run": dry_run}
 
 
 def _weeks_in(m_start, m_end) -> list:

--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -11,6 +11,13 @@ ingest_load_forecast (which now also populate power_hourly). Every write is an
 upsert and every raw payload is disk-cached (raw_cache), so a crashed run resumes
 from cache for free. Meant to run in the ingest process (never the API worker) —
 a mass backfill is a throttled, multi-day marathon against ENTSO-E's rate limit.
+
+FIRST DEPLOY of the balancing/capacity collectors: right after the service restart
+that ships them, run `--sources balancing` and `--sources capacity` once each. Not
+a launch blocker if skipped — the 09:00 UTC collector watchdog will email a
+balancing_energy/capacity_prices stale alert until the 11:30 UTC daily job fills the
+series in on its own (self-heals within 24h) — but the backfill closes the gap
+immediately instead of waiting out one noisy watchdog cycle.
 """
 
 from __future__ import annotations

--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -24,6 +24,7 @@ from datetime import date, datetime, timedelta
 from backend.database import SessionLocal
 from backend.observability import install_log_redaction
 from backend.power.energy_charts_flows import ingest_cbpf
+from backend.power.entsoe_balancing import ingest_balancing
 from backend.power.entsoe_grid import ingest_grid, ingest_load_forecast
 from backend.power.entsoe_imbalance import ingest_imbalance
 from backend.power.entsoe_prices import ingest_day_ahead
@@ -35,7 +36,7 @@ BACKFILL_START = date(2015, 1, 1)  # ENTSO-E Transparency era; override with --s
 # "flows" is zone-independent (one /cbpf sweep covers every border) and runs once
 # per month after the zone loop. Moderate history is the point (--start 2024-01-01
 # per roadmap Block 2.4) — deep flow history adds little over the daily means.
-ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "flows", "scheduled", "netpos")
+ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "balancing", "flows", "scheduled", "netpos")
 # Small pause between zone-months to stay under ENTSO-E's ~400 req/min token limit.
 THROTTLE_SECONDS = 1.0
 
@@ -106,7 +107,7 @@ async def run_backfill(
     done = 0
     # A flows-only run must not walk the zone×month loop — it would do nothing
     # but sleep through the throttle (37 zones × months × 1 s on prod).
-    zone_sources = sources & {"price", "grid", "forecast", "imbalance"}
+    zone_sources = sources & {"price", "grid", "forecast", "imbalance", "balancing"}
     for zone in zones if zone_sources else []:
         cfg = POWER_ZONES[zone]
         eic = cfg["eic"]
@@ -127,6 +128,8 @@ async def run_backfill(
                 await _with_retry(lambda d=days: ingest_load_forecast(db, d, eic=eic, zone=zone, overwrite=overwrite), f"forecast {tag}")
             if "imbalance" in sources:
                 await _with_retry(lambda d=days: ingest_imbalance(db, d, zone=zone, overwrite=overwrite), f"imbalance {tag}")
+            if "balancing" in sources:
+                await _with_retry(lambda d=days: ingest_balancing(db, d, zone=zone, overwrite=overwrite), f"balancing {tag}")
             done += 1
             logger.info("power_backfill: %s done (%d/%d)", tag, done, plan)
             if throttle:

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -239,7 +239,8 @@ def forced_outage_severity(total_mw: float, installed_mw: float | None) -> str |
 
 
 def latest_outage_revisions(
-    db, zone: str | None = None, *, ending_after: str | None = None
+    db, zone: str | None = None, *, ending_after: str | None = None,
+    doc_type: str | None = "A77",
 ) -> list:
     """Highest revision per (zone, mRID), resolved in SQL via a window function.
 
@@ -254,6 +255,16 @@ def latest_outage_revisions(
     running/upcoming no matter which revision wins. The filter is per-mRID, not
     per-row: dropping single rows on end_utc would let an older longer revision
     beat a newer shortened one.
+
+    `doc_type` scopes the ranked population — default "A77" (generation
+    unavailability), so every EXISTING caller (the forced-outage helpers below, the
+    outage-history snapshot, the /outages generation list) keeps ranking only among
+    generation events now that A78 (transmission) rows share this table. Pass
+    doc_type="A78" for the transmission section, or None to rank across both (no
+    caller needs that today: nominal_mw is always null for A78, so a mixed MW total
+    would silently be missing capacity rather than double-counting it — but partition
+    correctness does not depend on doc_type at all, since mRIDs are unique per message
+    regardless of type).
     """
     from sqlalchemy import func
 
@@ -270,10 +281,14 @@ def latest_outage_revisions(
     ranked = db.query(PowerOutage.id.label("oid"), rn)
     if zone is not None:
         ranked = ranked.filter(PowerOutage.zone == zone)
+    if doc_type is not None:
+        ranked = ranked.filter(PowerOutage.doc_type == doc_type)
     if ending_after is not None:
         relevant = db.query(PowerOutage.mrid).filter(PowerOutage.end_utc >= ending_after)
         if zone is not None:
             relevant = relevant.filter(PowerOutage.zone == zone)
+        if doc_type is not None:
+            relevant = relevant.filter(PowerOutage.doc_type == doc_type)
         ranked = ranked.filter(PowerOutage.mrid.in_(relevant.subquery().select()))
     ranked = ranked.subquery()
     return (
@@ -319,6 +334,13 @@ def forced_outage_totals_now(db) -> dict[str, float]:
     one SUM per zone; _running_forced's filters move into the outer query,
     which is exactly why ranking (all revisions) and filtering (rn=1 only)
     stay separate stages.
+
+    A77-only: unlike latest_outage_revisions this bypasses that helper (its own
+    ranked/relevant subqueries, kept inline for the SQL-side SUM above), so the
+    doc_type filter is repeated here explicitly rather than inherited. Belt-and-
+    braces — nominal_mw.isnot(None) below already excludes every A78 row on its own,
+    since a transmission asset never publishes one — but an explicit filter does not
+    depend on that schema fact staying true forever.
     """
     from datetime import datetime, timezone
 
@@ -335,7 +357,9 @@ def forced_outage_totals_now(db) -> dict[str, float]:
         )
         .label("rn")
     )
-    relevant = db.query(PowerOutage.mrid).filter(PowerOutage.end_utc >= now_iso)
+    relevant = db.query(PowerOutage.mrid).filter(
+        PowerOutage.end_utc >= now_iso, PowerOutage.doc_type == "A77",
+    )
     ranked = (
         db.query(PowerOutage.id.label("oid"), rn)
         .filter(PowerOutage.mrid.in_(relevant.subquery().select()))
@@ -347,6 +371,7 @@ def forced_outage_totals_now(db) -> dict[str, float]:
         .join(ranked, PowerOutage.id == ranked.c.oid)
         .filter(
             ranked.c.rn == 1,
+            PowerOutage.doc_type == "A77",
             PowerOutage.status == "active",
             PowerOutage.business_type == "A54",
             PowerOutage.nominal_mw.isnot(None),

--- a/backend/signals/detectors/power.py
+++ b/backend/signals/detectors/power.py
@@ -265,10 +265,30 @@ def latest_outage_revisions(
     would silently be missing capacity rather than double-counting it — but partition
     correctness does not depend on doc_type at all, since mRIDs are unique per message
     regardless of type).
+
+    A78 zone matching is BOTH-SIDED (review fix): a transmission message is published
+    once per QUERIED direction and stored as zone=in_Domain / counterparty_zone=
+    out_Domain — the live spike found the two directions of one border are DISJOINT
+    messages, not duplicates, so an FR->DE_LU-direction row is filed under zone="FR"
+    even though it is just as much DE_LU's outage. Asking for zone="DE_LU" with
+    doc_type="A78" must therefore match rows where DE_LU is EITHER `zone` OR
+    `counterparty_zone`, or half of all border events never reach the affected zone's
+    own panel. This only widens the filter for doc_type=="A78" — for A77,
+    counterparty_zone is always NULL by construction, so the OR is a no-op there, and
+    skipping it on the far higher-volume A77 default keeps that (hot-path: /overview,
+    the 5-minute radar detector) query on the indexed `zone` equality plan instead of
+    an unindexed OR.
     """
-    from sqlalchemy import func
+    from sqlalchemy import func, or_
 
     from backend.models.energy import PowerOutage
+
+    def _apply_zone_filter(q):
+        if zone is None:
+            return q
+        if doc_type == "A78":
+            return q.filter(or_(PowerOutage.zone == zone, PowerOutage.counterparty_zone == zone))
+        return q.filter(PowerOutage.zone == zone)
 
     rn = (
         func.row_number()
@@ -278,15 +298,11 @@ def latest_outage_revisions(
         )
         .label("rn")
     )
-    ranked = db.query(PowerOutage.id.label("oid"), rn)
-    if zone is not None:
-        ranked = ranked.filter(PowerOutage.zone == zone)
+    ranked = _apply_zone_filter(db.query(PowerOutage.id.label("oid"), rn))
     if doc_type is not None:
         ranked = ranked.filter(PowerOutage.doc_type == doc_type)
     if ending_after is not None:
-        relevant = db.query(PowerOutage.mrid).filter(PowerOutage.end_utc >= ending_after)
-        if zone is not None:
-            relevant = relevant.filter(PowerOutage.zone == zone)
+        relevant = _apply_zone_filter(db.query(PowerOutage.mrid).filter(PowerOutage.end_utc >= ending_after))
         if doc_type is not None:
             relevant = relevant.filter(PowerOutage.doc_type == doc_type)
         ranked = ranked.filter(PowerOutage.mrid.in_(relevant.subquery().select()))

--- a/backend/tests/test_api_guard.py
+++ b/backend/tests/test_api_guard.py
@@ -1,0 +1,48 @@
+"""Unit tests for backend.api_guard's keyed TTL cache (cached_value)."""
+from __future__ import annotations
+
+import pytest
+
+from backend.api_guard import _reset_coverage_cache, cached_value
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    _reset_coverage_cache()  # process-global; would leak values between tests
+    yield
+    _reset_coverage_cache()
+
+
+def test_cached_value_keys_are_independent():
+    """Two different cache keys must not share a slot or a recompute."""
+    calls = {"a": 0, "b": 0}
+
+    def compute_a():
+        calls["a"] += 1
+        return "A"
+
+    def compute_b():
+        calls["b"] += 1
+        return "B"
+
+    assert cached_value("a", compute_a) == "A"
+    assert cached_value("b", compute_b) == "B"
+    assert cached_value("a", compute_a) == "A"
+    assert cached_value("b", compute_b) == "B"
+    assert calls == {"a": 1, "b": 1}, "each key's compute must run exactly once"
+
+
+def test_cached_value_expiry_honored_via_now_param():
+    """Within the TTL the cached value is returned without recomputing; once
+    `now` has advanced past `expires`, it recomputes."""
+    calls = {"n": 0}
+
+    def compute():
+        calls["n"] += 1
+        return calls["n"]
+
+    assert cached_value("x", compute, ttl=10.0, now=0.0) == 1
+    assert cached_value("x", compute, ttl=10.0, now=5.0) == 1  # still within TTL
+    assert cached_value("x", compute, ttl=10.0, now=9.999) == 1  # just under TTL
+    assert cached_value("x", compute, ttl=10.0, now=10.0) == 2  # TTL elapsed
+    assert calls["n"] == 2

--- a/backend/tests/test_api_v1.py
+++ b/backend/tests/test_api_v1.py
@@ -404,3 +404,78 @@ def test_catalog_is_rate_limited(db_session):
     c = _client(db_session)
     codes = {c.get("/api/v1/series/catalog").status_code for _ in range(130)}
     assert 429 in codes, "catalog must be throttled like the other data endpoints"
+
+
+# ── Catalog metadata: server-side labels/groups + per-(series,zone) coverage
+#    (Chart-Builder P1) ────────────────────────────────────────────────────
+
+def test_catalog_series_carry_label_and_group(db_session):
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(_BASE, 40.0)], unit="EUR/MWh")
+    body = _client(db_session).get("/api/v1/series/catalog").json()
+    by_key = {s["key"]: s for s in body["series"]}
+    assert by_key["price.dayahead"]["label"] == "Day-ahead price · hourly"
+    assert by_key["price.dayahead"]["group"] == "price"
+
+
+def test_catalog_pattern_labels_resolve_gen_and_flow(db_session):
+    upsert_hourly(db_session, "gen.B16", "DE_LU", [(_BASE, 5_000.0)], unit="MW")
+    upsert_hourly(db_session, "flow.FR", "DE_LU", [(_BASE, 100.0)], unit="MW")
+    body = _client(db_session).get("/api/v1/series/catalog").json()
+    by_key = {s["key"]: s for s in body["series"]}
+    assert by_key["gen.B16"]["label"] == "Generation · Solar"
+    assert by_key["gen.B16"]["group"] == "gen"
+    assert by_key["flow.FR"]["label"] == "Flow ↔ FR"
+    assert by_key["flow.FR"]["group"] == "flow"
+
+
+def test_catalog_unknown_series_label_falls_back_to_raw_key(db_session):
+    upsert_hourly(db_session, "mystery.metric", "DE_LU", [(_BASE, 1.0)], unit=None)
+    body = _client(db_session).get("/api/v1/series/catalog").json()
+    entry = next(s for s in body["series"] if s["key"] == "mystery.metric")
+    assert entry["label"] == "mystery.metric"
+    assert entry["group"] == "mystery"
+
+
+def test_catalog_coverage_by_series_matches_seeded_pairs(db_session):
+    # Two distinct (series, zone) pairs, different windows — coverage_by_series
+    # must report exactly these two, each with its own from/to.
+    upsert_hourly(db_session, "price.dayahead", "DE_LU",
+                  [(_BASE + i * _H, 40.0 + i) for i in range(3)], unit="EUR/MWh")
+    upsert_hourly(db_session, "load.actual", "FR",
+                  [(_BASE + i * _H, 30_000.0 + i) for i in range(5)], unit="MW")
+    body = _client(db_session).get("/api/v1/series/catalog").json()
+    pairs = {(c["series"], c["zone"]): c for c in body["coverage_by_series"]}
+    assert set(pairs) == {("price.dayahead", "DE_LU"), ("load.actual", "FR")}
+    pd = pairs[("price.dayahead", "DE_LU")]
+    assert pd["from"] == datetime.fromtimestamp(_BASE, UTC).isoformat()
+    assert pd["to"] == datetime.fromtimestamp(_BASE + 2 * _H, UTC).isoformat()
+    la = pairs[("load.actual", "FR")]
+    assert la["from"] == datetime.fromtimestamp(_BASE, UTC).isoformat()
+    assert la["to"] == datetime.fromtimestamp(_BASE + 4 * _H, UTC).isoformat()
+
+
+def test_catalog_coverage_by_series_empty_on_empty_db(db_session):
+    body = _client(db_session).get("/api/v1/series/catalog").json()
+    assert body["coverage_by_series"] == []
+    assert body["available"] is False  # no series at all yet — catalog still responds
+
+
+def test_catalog_coverage_by_series_is_cached_across_calls(db_session, monkeypatch):
+    """Same DoS concern as the global coverage window: the per-pair scan must
+    run at most once per TTL, not once per request."""
+    import backend.routes.api_v1 as v1
+
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(_BASE, 40.0)], unit="EUR/MWh")
+    calls = {"n": 0}
+    real = v1._coverage_by_series
+
+    def counting(db):
+        calls["n"] += 1
+        return real(db)
+
+    monkeypatch.setattr(v1, "_coverage_by_series", counting)
+    c = _client(db_session)
+    c.get("/api/v1/series/catalog")
+    c.get("/api/v1/series/catalog")
+    c.get("/api/v1/series/catalog")
+    assert calls["n"] == 1, "per-series coverage scan ran more than once despite the cache"

--- a/backend/tests/test_api_v1.py
+++ b/backend/tests/test_api_v1.py
@@ -479,3 +479,35 @@ def test_catalog_coverage_by_series_is_cached_across_calls(db_session, monkeypat
     c.get("/api/v1/series/catalog")
     c.get("/api/v1/series/catalog")
     assert calls["n"] == 1, "per-series coverage scan ran more than once despite the cache"
+
+
+def test_catalog_coverage_by_series_is_sorted(db_session):
+    # Insert in an order that is NOT already alphabetical, so a passing test
+    # actually exercises the sort rather than an accidental insertion order.
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(_BASE, 1.0)], unit="EUR/MWh")
+    upsert_hourly(db_session, "load.actual", "FR", [(_BASE, 1.0)], unit="MW")
+    body = _client(db_session).get("/api/v1/series/catalog").json()
+    pairs = [(c["series"], c["zone"]) for c in body["coverage_by_series"]]
+    assert pairs == sorted(pairs)
+    assert pairs == [("load.actual", "FR"), ("price.dayahead", "DE_LU")]
+
+
+def test_catalog_groups_field_lists_present_groups_in_order(db_session):
+    # gen.* seeded before price.* — GROUP_ORDER still puts price first.
+    upsert_hourly(db_session, "gen.B16", "DE_LU", [(_BASE, 1.0)], unit="MW")
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(_BASE, 1.0)], unit="EUR/MWh")
+    body = _client(db_session).get("/api/v1/series/catalog").json()
+    keys = [g["key"] for g in body["groups"]]
+    assert keys == ["price", "gen"]
+    by_key = {g["key"]: g for g in body["groups"]}
+    assert by_key["price"]["label"] == "Prices"
+    assert by_key["gen"]["label"] == "Generation mix (per fuel)"
+
+
+def test_catalog_groups_field_appends_unknown_group_sorted_by_key(db_session):
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(_BASE, 1.0)], unit="EUR/MWh")
+    upsert_hourly(db_session, "zzz.mystery", "DE_LU", [(_BASE, 1.0)], unit=None)
+    body = _client(db_session).get("/api/v1/series/catalog").json()
+    keys = [g["key"] for g in body["groups"]]
+    assert keys == ["price", "zzz"]
+    assert next(g for g in body["groups"] if g["key"] == "zzz")["label"] == "zzz"

--- a/backend/tests/test_api_v1.py
+++ b/backend/tests/test_api_v1.py
@@ -428,6 +428,30 @@ def test_catalog_pattern_labels_resolve_gen_and_flow(db_session):
     assert by_key["flow.FR"]["group"] == "flow"
 
 
+def test_catalog_pattern_labels_resolve_balancing_capacity_outage_netpos(db_session):
+    """New branch-added prefixes: activated balancing ENERGY, procured balancing
+    CAPACITY (disambiguated from /api/v1/capacity's installed generation capacity),
+    outages and net position all need readable labels + groups on day one."""
+    upsert_hourly(db_session, "balancing.afrr.price.up", "DE_LU", [(_BASE, 5.0)], unit="EUR/MWh")
+    upsert_hourly(db_session, "balancing.mfrr.vol.down", "DE_LU", [(_BASE, 5.0)], unit="MWh")
+    upsert_hourly(db_session, "capacity.fcr.price", "DE_LU", [(_BASE, 3.0)], unit="EUR/MW/h")
+    upsert_hourly(db_session, "capacity.afrr.price.pos", "DE_LU", [(_BASE, 8.0)], unit="EUR/MW/h")
+    upsert_hourly(db_session, "outage.offline", "DE_LU", [(_BASE, 1_000.0)], unit="MW")
+    upsert_hourly(db_session, "netpos.dayahead", "DE_LU", [(_BASE, 500.0)], unit="MW")
+    body = _client(db_session).get("/api/v1/series/catalog").json()
+    by_key = {s["key"]: s for s in body["series"]}
+    assert by_key["balancing.afrr.price.up"]["label"] == "Balancing · aFRR activation price (up)"
+    assert by_key["balancing.afrr.price.up"]["group"] == "balancing"
+    assert by_key["balancing.mfrr.vol.down"]["label"] == "Balancing · mFRR activated volume (down)"
+    assert by_key["capacity.fcr.price"]["label"] == "Balancing capacity · FCR price"
+    assert by_key["capacity.fcr.price"]["group"] == "capacity"
+    assert by_key["capacity.afrr.price.pos"]["label"] == "Balancing capacity · aFRR price (pos)"
+    assert by_key["outage.offline"]["label"] == "Outages · capacity offline"
+    assert by_key["outage.offline"]["group"] == "outage"
+    assert by_key["netpos.dayahead"]["label"] == "Net position · day-ahead"
+    assert by_key["netpos.dayahead"]["group"] == "netpos"
+
+
 def test_catalog_unknown_series_label_falls_back_to_raw_key(db_session):
     upsert_hourly(db_session, "mystery.metric", "DE_LU", [(_BASE, 1.0)], unit=None)
     body = _client(db_session).get("/api/v1/series/catalog").json()

--- a/backend/tests/test_balancing.py
+++ b/backend/tests/test_balancing.py
@@ -1,0 +1,431 @@
+"""ENTSO-E activated balancing energy (A83 volumes / A84 prices) → hourly series
+`balancing.<afrr|mfrr>.<price|vol>.<up|down>`. Mirrors test_imbalance.py's shape."""
+from __future__ import annotations
+
+import pytest
+
+from backend.models.energy import PowerHourly, SeriesDim, ZoneDim  # noqa: F401 — register tables
+from backend.power import entsoe_balancing as bal
+from backend.power.entsoe_balancing import (
+    control_area_eic,
+    parse_balancing_prices,
+    parse_balancing_volumes,
+)
+from backend.power.hourly_store import read_hourly
+
+NS = "urn:iec62325.351:tc57wg16:451-6:balancingdocument:4:1"
+
+
+def _balancing_doc(series: list[dict], start="2026-06-01T00:00Z", end="2026-06-02T00:00Z") -> str:
+    """Build a Balancing_MarketDocument with one TimeSeries per `series` entry.
+
+    Each entry: {"business_type": "A96", "direction": "A01", "amounts": [...],
+    "tag": "activation_Price.amount", "res": "PT15M"}.
+    """
+    ts_blocks = []
+    for s in series:
+        pts = "".join(
+            f"<Point><position>{i + 1}</position><{s['tag']}>{v}</{s['tag']}></Point>"
+            for i, v in enumerate(s["amounts"])
+        )
+        ts_blocks.append(
+            f"<TimeSeries><mRID>1</mRID><businessType>{s['business_type']}</businessType>"
+            f"<flowDirection.direction>{s['direction']}</flowDirection.direction>"
+            f"<curveType>A03</curveType><Period>"
+            f"<timeInterval><start>{start}</start><end>{end}</end></timeInterval>"
+            f"<resolution>{s.get('res', 'PT15M')}</resolution>{pts}</Period></TimeSeries>"
+        )
+    return (
+        f'<?xml version="1.0"?><Balancing_MarketDocument xmlns="{NS}">'
+        + "".join(ts_blocks)
+        + "</Balancing_MarketDocument>"
+    )
+
+
+def _afrr_up_prices(amounts, **kw):
+    return _balancing_doc(
+        [{"business_type": "A96", "direction": "A01", "amounts": amounts,
+          "tag": "activation_Price.amount", **kw}]
+    )
+
+
+# ─── control-area domain resolution ───────────────────────────────────────────
+
+
+def test_control_area_eic_de_uses_tennet_not_country_code():
+    """Spiked 2026-07-20 live: unlike A85's reBAP, DE aFRR/mFRR prices are NOT published at
+    the country EIC (10Y1001A1001A83F) or the DE_LU bidding-zone EIC — both answer a clean
+    'No matching data found'. TenneT's control area (10YDE-EON------1) carries real data."""
+    assert control_area_eic("DE_LU") == "10YDE-EON------1"
+    assert control_area_eic("FR") == "10YFR-RTE------C"
+    assert control_area_eic("NL") == "10YNL----------L"
+
+
+# ─── parse_balancing_prices ────────────────────────────────────────────────────
+
+
+def test_parse_prices_hourly_mean_afrr_up():
+    xml = _afrr_up_prices([100.0 + i for i in range(96)])  # 96 PT15M -> 24 hourly means
+    out = parse_balancing_prices(xml)
+    assert set(out.keys()) == {("afrr", "up")}
+    day = out[("afrr", "up")]["2026-06-01"]
+    assert len(day) == 24
+    # hour 0 = mean of positions 1-4 -> 100,101,102,103 -> mean 101.5
+    assert day[0] == pytest.approx(101.5)
+
+
+def test_parse_prices_splits_by_direction_and_product():
+    xml = _balancing_doc([
+        {"business_type": "A96", "direction": "A01", "amounts": [150.0] * 4, "tag": "activation_Price.amount"},
+        {"business_type": "A96", "direction": "A02", "amounts": [50.0] * 4, "tag": "activation_Price.amount"},
+        {"business_type": "A97", "direction": "A01", "amounts": [200.0] * 4, "tag": "activation_Price.amount"},
+    ])
+    out = parse_balancing_prices(xml)
+    assert out[("afrr", "up")]["2026-06-01"][0] == 150.0
+    assert out[("afrr", "down")]["2026-06-01"][0] == 50.0
+    assert out[("mfrr", "up")]["2026-06-01"][0] == 200.0
+    assert ("mfrr", "down") not in out
+
+
+def test_parse_prices_ignores_fcr_and_rr():
+    """FCR (A95) and RR (A98) are out of scope for this desk (aFRR/mFRR only)."""
+    xml = _balancing_doc([
+        {"business_type": "A95", "direction": "A01", "amounts": [999.0] * 4, "tag": "activation_Price.amount"},
+        {"business_type": "A98", "direction": "A01", "amounts": [888.0] * 4, "tag": "activation_Price.amount"},
+    ])
+    assert parse_balancing_prices(xml) == {}
+
+
+def test_parse_prices_gap_between_periods_is_not_filled():
+    """curveType A03 is declared but does NOT behave like A09's step function here: a gap
+    between two Periods means genuinely no activation happened, not a value to hold forward
+    (spiked live 2026-07-20 — see module docstring). A second Period starting after a gap
+    must not smuggle in the first period's last value for the missing slot."""
+    xml = (
+        f'<?xml version="1.0"?><Balancing_MarketDocument xmlns="{NS}"><TimeSeries>'
+        "<businessType>A96</businessType><flowDirection.direction>A01</flowDirection.direction>"
+        "<curveType>A03</curveType>"
+        '<Period><timeInterval><start>2026-06-01T00:00Z</start><end>2026-06-01T01:00Z</end></timeInterval>'
+        "<resolution>PT15M</resolution>"
+        "<Point><position>1</position><activation_Price.amount>10.0</activation_Price.amount></Point>"
+        "<Point><position>2</position><activation_Price.amount>10.0</activation_Price.amount></Point>"
+        "<Point><position>3</position><activation_Price.amount>10.0</activation_Price.amount></Point>"
+        "<Point><position>4</position><activation_Price.amount>10.0</activation_Price.amount></Point>"
+        "</Period>"
+        # gap: 01:00-01:30 has no Period at all
+        '<Period><timeInterval><start>2026-06-01T01:30Z</start><end>2026-06-01T02:00Z</end></timeInterval>'
+        "<resolution>PT15M</resolution>"
+        "<Point><position>1</position><activation_Price.amount>20.0</activation_Price.amount></Point>"
+        "<Point><position>2</position><activation_Price.amount>20.0</activation_Price.amount></Point>"
+        "</Period></TimeSeries></Balancing_MarketDocument>"
+    )
+    out = parse_balancing_prices(xml)[("afrr", "up")]["2026-06-01"]
+    assert len(out) == 2  # only hours 0 and 1 exist; nothing invented for the gap
+    assert out[0] == 10.0
+    # hour 1 only has the 01:30/01:45 quarter-hours (2 points), not 4 — no fill-forward
+    assert out[1] == 20.0
+
+
+def test_parse_acknowledgement_is_empty():
+    ack = '<?xml version="1.0"?><Acknowledgement_MarketDocument><mRID>x</mRID></Acknowledgement_MarketDocument>'
+    assert parse_balancing_prices(ack) == {}
+    assert parse_balancing_volumes(ack) == {}
+
+
+def test_parse_malformed_raises():
+    with pytest.raises(ValueError):
+        parse_balancing_prices("<not-xml")
+    with pytest.raises(ValueError):
+        parse_balancing_volumes("<not-xml")
+
+
+# ─── parse_balancing_volumes ────────────────────────────────────────────────────
+
+
+def test_parse_volumes_hourly_sum_not_mean():
+    """Volumes (MWh) are SUMMED per hour — 4 quarter-hour MWh amounts add up to the hour's
+    total energy, unlike prices which are averaged."""
+    xml = _balancing_doc([
+        {"business_type": "A96", "direction": "A01", "amounts": [10.0, 20.0, 30.0, 40.0], "tag": "quantity"},
+    ])
+    out = parse_balancing_volumes(xml)[("afrr", "up")]["2026-06-01"]
+    assert out[0] == 100.0  # sum, not mean (25.0)
+
+
+def test_parse_volumes_splits_by_direction_and_product():
+    xml = _balancing_doc([
+        {"business_type": "A97", "direction": "A02", "amounts": [5.0] * 4, "tag": "quantity"},
+    ])
+    out = parse_balancing_volumes(xml)
+    assert set(out.keys()) == {("mfrr", "down")}
+    assert out[("mfrr", "down")]["2026-06-01"][0] == 20.0
+
+
+# ─── ZIP unwrap: multiple inner XML documents merge ────────────────────────────
+
+
+def test_parse_multi_xml_zip_members_merge(tmp_path, monkeypatch):
+    """A83/A84 ZIP archives can hold MULTIPLE inner .xml documents — every member must be
+    parsed and merged, not just the first (unlike A85's single-doc ZIP)."""
+    import asyncio
+    import io
+    import zipfile
+
+    doc1 = _balancing_doc([{"business_type": "A96", "direction": "A01", "amounts": [111.0] * 4,
+                             "tag": "activation_Price.amount"}])
+    doc2 = _balancing_doc([{"business_type": "A96", "direction": "A02", "amounts": [222.0] * 4,
+                             "tag": "activation_Price.amount"}])
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("doc1.xml", doc1)
+        zf.writestr("doc2.xml", doc2)
+    zip_bytes = buf.getvalue()
+
+    class _FakeResp:
+        status_code = 200
+        content = zip_bytes
+        text = ""
+
+        def raise_for_status(self):
+            pass
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, *a, **kw):
+            return _FakeResp()
+
+    monkeypatch.setattr(bal.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(bal, "_token", lambda: "tok")
+
+    from datetime import date
+
+    docs = asyncio.run(
+        bal._fetch_balancing_month("A84", "entsoe_a84_test", "10YDE-EON------1", date(2026, 6, 1))
+    )
+    merged: dict = {}
+    for xml in docs:
+        for key, days in parse_balancing_prices(xml).items():
+            merged.setdefault(key, {}).update(days)
+    assert merged[("afrr", "up")]["2026-06-01"][0] == 111.0
+    assert merged[("afrr", "down")]["2026-06-01"][0] == 222.0
+
+
+# ─── ingest_balancing ───────────────────────────────────────────────────────────
+
+
+async def test_ingest_no_token_skips(db_session, monkeypatch):
+    monkeypatch.setattr(bal.settings, "entsoe_api_token", None)
+    r = await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR")
+    assert r == {"skipped": "no token"}
+
+
+async def test_ingest_no_days_returns_zero(db_session, monkeypatch):
+    monkeypatch.setattr(bal.settings, "entsoe_api_token", "x")
+    r = await bal.ingest_balancing(db_session, [], zone="FR")
+    assert r["days"] == 0
+
+
+async def test_ingest_writes_eight_series(db_session, monkeypatch):
+    """One month of both aFRR+mFRR, up+down, price+volume -> all 8 canonical series land."""
+    monkeypatch.setattr(bal.settings, "entsoe_api_token", "x")
+
+    price_xml = _balancing_doc([
+        {"business_type": "A96", "direction": "A01", "amounts": [150.0] * 4, "tag": "activation_Price.amount"},
+        {"business_type": "A96", "direction": "A02", "amounts": [50.0] * 4, "tag": "activation_Price.amount"},
+        {"business_type": "A97", "direction": "A01", "amounts": [200.0] * 4, "tag": "activation_Price.amount"},
+        {"business_type": "A97", "direction": "A02", "amounts": [80.0] * 4, "tag": "activation_Price.amount"},
+    ])
+    vol_xml = _balancing_doc([
+        {"business_type": "A96", "direction": "A01", "amounts": [10.0] * 4, "tag": "quantity"},
+        {"business_type": "A96", "direction": "A02", "amounts": [5.0] * 4, "tag": "quantity"},
+        {"business_type": "A97", "direction": "A01", "amounts": [20.0] * 4, "tag": "quantity"},
+        {"business_type": "A97", "direction": "A02", "amounts": [8.0] * 4, "tag": "quantity"},
+    ])
+
+    async def fake_fetch(document_type, cache_source, eic, month_start, *, overwrite=False):
+        return [price_xml] if document_type == "A84" else [vol_xml]
+
+    monkeypatch.setattr(bal, "_fetch_balancing_month", fake_fetch)
+    r = await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True)
+    assert r["written"] > 0
+
+    for product, price in (("afrr", 150.0), ("mfrr", 200.0)):
+        series = read_hourly(db_session, f"balancing.{product}.price.up", "FR")
+        assert series[0][1] == price
+    for product, price in (("afrr", 50.0), ("mfrr", 80.0)):
+        series = read_hourly(db_session, f"balancing.{product}.price.down", "FR")
+        assert series[0][1] == price
+    for product, vol in (("afrr", 40.0), ("mfrr", 80.0)):  # sum of 4 quarter-hours, not the mean
+        series = read_hourly(db_session, f"balancing.{product}.vol.up", "FR")
+        assert series[0][1] == vol
+    for product, vol in (("afrr", 20.0), ("mfrr", 32.0)):
+        series = read_hourly(db_session, f"balancing.{product}.vol.down", "FR")
+        assert series[0][1] == vol
+
+
+async def test_ingest_volumes_structurally_rejected_is_graceful(db_session, monkeypatch):
+    """Spiked live 2026-07-20: A83 answers a structural 400 ('combination not valid') for
+    every zone/param combination tried — treated exactly like the codebase's existing
+    'clean no-data ACK' convention (entsoe_exchange.py's A09/A25 fetchers): ingestion must
+    stay green, prices still write, volumes just come back empty."""
+    monkeypatch.setattr(bal.settings, "entsoe_api_token", "x")
+    price_xml = _afrr_up_prices([150.0] * 4)
+
+    async def fake_fetch(document_type, cache_source, eic, month_start, *, overwrite=False):
+        return [price_xml] if document_type == "A84" else [""]
+
+    monkeypatch.setattr(bal, "_fetch_balancing_month", fake_fetch)
+    r = await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True)
+    assert r["written"] > 0
+    assert read_hourly(db_session, "balancing.afrr.price.up", "FR")
+    assert read_hourly(db_session, "balancing.afrr.vol.up", "FR") == []
+
+
+async def test_ingest_fetch_error_is_isolated_per_doctype(db_session, monkeypatch):
+    """A price-fetch failure must not stop volumes (and vice versa) — each documentType is
+    fetched and handled independently, matching the rest of this vertical's isolate-and-log
+    convention."""
+    import httpx
+
+    monkeypatch.setattr(bal.settings, "entsoe_api_token", "x")
+    vol_xml = _balancing_doc([
+        {"business_type": "A96", "direction": "A01", "amounts": [10.0] * 4, "tag": "quantity"},
+    ])
+
+    async def fake_fetch(document_type, cache_source, eic, month_start, *, overwrite=False):
+        if document_type == "A84":
+            raise httpx.HTTPError("boom")
+        return [vol_xml]
+
+    monkeypatch.setattr(bal, "_fetch_balancing_month", fake_fetch)
+    r = await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True)
+    assert read_hourly(db_session, "balancing.afrr.vol.up", "FR")
+    assert read_hourly(db_session, "balancing.afrr.price.up", "FR") == []
+    assert r["written"] > 0
+
+
+# ─── GET /api/power/balancing ───────────────────────────────────────────────────
+
+
+def _client(db):
+    from fastapi.testclient import TestClient
+
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+    app.dependency_overrides.clear()
+
+
+def _seed_balancing(db, zone="DE_LU", product="afrr"):
+    import time as _time
+
+    from backend.power.hourly_store import upsert_hourly
+
+    now = (int(_time.time()) // 3600) * 3600
+    up_prices = [(now - i * 3600, 100.0 + i) for i in range(24, 0, -1)]
+    down_prices = [(now - i * 3600, -50.0 - i) for i in range(24, 0, -1)]
+    up_vols = [(now - i * 3600, 5.0 + i) for i in range(24, 0, -1)]
+    down_vols = [(now - i * 3600, 2.0 + i) for i in range(24, 0, -1)]
+    upsert_hourly(db, f"balancing.{product}.price.up", zone, up_prices, unit="EUR/MWh")
+    upsert_hourly(db, f"balancing.{product}.price.down", zone, down_prices, unit="EUR/MWh")
+    upsert_hourly(db, f"balancing.{product}.vol.up", zone, up_vols, unit="MWh")
+    upsert_hourly(db, f"balancing.{product}.vol.down", zone, down_vols, unit="MWh")
+
+
+def test_route_happy_path(db_session):
+    _seed_balancing(db_session)
+    body = _client(db_session).get("/api/power/balancing?zone=DE_LU&product=afrr").json()
+    assert body["available"] is True
+    assert body["zone"] == "DE_LU"
+    assert body["product"] == "afrr"
+    assert body["unit"] == "EUR/MWh"
+    assert len(body["up"]) >= 24
+    assert len(body["down"]) >= 24
+    assert body["latest"] is not None
+    assert body["peak"] is not None
+    assert body["as_of"] is not None
+    assert "stale" in body and "age_days" in body
+
+
+def test_route_defaults_to_afrr_and_30_days(db_session):
+    _seed_balancing(db_session, product="afrr")
+    body = _client(db_session).get("/api/power/balancing?zone=DE_LU").json()
+    assert body["product"] == "afrr"
+    assert body["days"] == 30
+
+
+def test_route_mfrr_product(db_session):
+    _seed_balancing(db_session, product="mfrr")
+    body = _client(db_session).get("/api/power/balancing?zone=DE_LU&product=mfrr").json()
+    assert body["available"] is True
+    assert body["product"] == "mfrr"
+
+
+def test_route_invalid_product_is_rejected(db_session):
+    resp = _client(db_session).get("/api/power/balancing?zone=DE_LU&product=bogus")
+    assert resp.status_code == 422
+
+
+def test_route_days_clamped(db_session):
+    resp_low = _client(db_session).get("/api/power/balancing?zone=DE_LU&days=0")
+    resp_high = _client(db_session).get("/api/power/balancing?zone=DE_LU&days=91")
+    assert resp_low.status_code == 422
+    assert resp_high.status_code == 422
+
+
+def test_route_unknown_zone_falls_back(db_session):
+    """Mirrors get_imbalance / _resolve_zone: an unknown zone falls back to DEFAULT_ZONE
+    rather than 400ing (the `zones` list in the response tells the caller what's valid)."""
+    _seed_balancing(db_session, zone="DE_LU")
+    body = _client(db_session).get("/api/power/balancing?zone=NOPE").json()
+    assert body["zone"] == "DE_LU"
+
+
+def test_route_no_data_is_honest(db_session):
+    body = _client(db_session).get("/api/power/balancing?zone=NL&product=mfrr").json()
+    assert body["available"] is False
+    assert "reason" in body
+    assert body["zone"] == "NL"
+
+
+def test_route_zones_list_present(db_session):
+    _seed_balancing(db_session)
+    body = _client(db_session).get("/api/power/balancing?zone=DE_LU").json()
+    assert "zones" in body and "DE_LU" in body["zones"]
+
+
+# ─── freshness spec ─────────────────────────────────────────────────────────────
+
+
+def test_freshness_spec_registered():
+    from backend.collectors.freshness import SPECS
+
+    spec = next((s for s in SPECS if s.key == "balancing_energy"), None)
+    assert spec is not None
+    assert spec.hourly_series == "balancing.afrr.price.up"
+    assert spec.max_age.days == 2
+
+
+# ─── backfill registration ──────────────────────────────────────────────────────
+
+
+def test_backfill_source_registered():
+    from backend.scripts import power_backfill as pb
+
+    assert "balancing" in pb.ALL_SOURCES

--- a/backend/tests/test_balancing.py
+++ b/backend/tests/test_balancing.py
@@ -2,6 +2,7 @@
 `balancing.<afrr|mfrr>.<price|vol>.<up|down>`. Mirrors test_imbalance.py's shape."""
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from backend.models.energy import PowerHourly, SeriesDim, ZoneDim  # noqa: F401 — register tables
@@ -59,6 +60,19 @@ def test_control_area_eic_de_uses_tennet_not_country_code():
     assert control_area_eic("DE_LU") == "10YDE-EON------1"
     assert control_area_eic("FR") == "10YFR-RTE------C"
     assert control_area_eic("NL") == "10YNL----------L"
+
+
+def test_coverage_caveat_present_for_override_zone_absent_otherwise():
+    """The route layer must derive its coverage caveat from the same override mapping
+    control_area_eic reads, rather than hardcoding a zone check — this is that single
+    source of truth."""
+    from backend.power.entsoe_balancing import coverage_caveat
+
+    caveat = coverage_caveat("DE_LU")
+    assert caveat is not None
+    assert "TenneT" in caveat and "not the national total" in caveat
+    assert coverage_caveat("FR") is None
+    assert coverage_caveat("NL") is None
 
 
 # ─── parse_balancing_prices ────────────────────────────────────────────────────
@@ -202,6 +216,9 @@ def test_parse_multi_xml_zip_members_merge(tmp_path, monkeypatch):
         async def get(self, *a, **kw):
             return _FakeResp()
 
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
     monkeypatch.setattr(bal.httpx, "AsyncClient", _FakeClient)
     monkeypatch.setattr(bal, "_token", lambda: "tok")
 
@@ -216,6 +233,125 @@ def test_parse_multi_xml_zip_members_merge(tmp_path, monkeypatch):
             merged.setdefault(key, {}).update(days)
     assert merged[("afrr", "up")]["2026-06-01"][0] == 111.0
     assert merged[("afrr", "down")]["2026-06-01"][0] == 222.0
+
+
+# ─── _fetch_balancing_month: which 400s are cacheable "no data" vs. real failures ──────
+#
+# ENTSO-E answers a genuinely-empty or structurally-unsupported request with HTTP 400 (see
+# the module docstring's A83 spike findings) — that specific shape is safe to cache as
+# emptiness. But a 400 is ALSO what a rotated/expired token or an ENTSO-E-side incident could
+# produce, and those must NOT be cached: the raw_cache is write-once, so caching a transient
+# failure would permanently poison that zone-month across the outage (a real, live risk per
+# CLAUDE.md's pending ENTSO-E token rotation note).
+
+
+class _FakeAsyncClient:
+    """Minimal async-context-manager httpx.AsyncClient stand-in returning one canned
+    httpx.Response — a REAL Response (not a hand-rolled stub) so .raise_for_status()
+    behaves exactly like the library."""
+
+    def __init__(self, status_code: int, content: bytes):
+        self._status_code = status_code
+        self._content = content
+
+    def __call__(self, *a, **kw):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, params=None):
+        return httpx.Response(self._status_code, content=self._content, request=httpx.Request("GET", url))
+
+
+async def test_fetch_structural_400_is_cached_as_empty(tmp_path, monkeypatch):
+    """The exact wording ENTSO-E uses for a genuinely-empty/unsupported combination — 'is not
+    valid' (A83's structural rejection) or 'No matching data found' (A84's clean empty-window
+    ACK) — is the ONLY 400 shape treated as cacheable no-data."""
+    from datetime import date
+
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    body = (
+        b"<Acknowledgement_MarketDocument><Reason><code>999</code>"
+        b"<text>The combination of [DOCUMENT_TYPE=A83] is not valid, or the requested data "
+        b"is not allowed to be fetched via this service.</text></Reason></Acknowledgement_MarketDocument>"
+    )
+    monkeypatch.setattr(bal.httpx, "AsyncClient", _FakeAsyncClient(400, body))
+    monkeypatch.setattr(bal, "_token", lambda: "tok")
+
+    docs = await bal._fetch_balancing_month("A83", "entsoe_a83_structural_test", "10YDE-EON------1", date(2026, 6, 1))
+    assert docs == [""]
+    # cached: read_cached now finds it without hitting the (removed) client again.
+    assert rc.read_cached("entsoe_a83_structural_test", "10YDE-EON------1_2026-06", date(2026, 6, 1)) == {"xml": [""]}
+
+
+async def test_fetch_no_matching_data_400_is_cached_as_empty(tmp_path, monkeypatch):
+    from datetime import date
+
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    body = b"<Acknowledgement_MarketDocument><Reason><code>999</code><text>No matching data found for Data item X</text></Reason></Acknowledgement_MarketDocument>"
+    monkeypatch.setattr(bal.httpx, "AsyncClient", _FakeAsyncClient(400, body))
+    monkeypatch.setattr(bal, "_token", lambda: "tok")
+
+    docs = await bal._fetch_balancing_month("A84", "entsoe_a84_nodata_test", "10YDE-EON------1", date(2026, 6, 1))
+    assert docs == [""]
+
+
+async def test_fetch_401_raises_and_is_not_cached(tmp_path, monkeypatch):
+    """A bad/rotated token must raise, not be swallowed as 'no data' — and must NOT be
+    written to the write-once raw_cache (that would poison the month for good)."""
+    from datetime import date
+
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(bal.httpx, "AsyncClient", _FakeAsyncClient(401, b"Unauthorized"))
+    monkeypatch.setattr(bal, "_token", lambda: "tok")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await bal._fetch_balancing_month("A84", "entsoe_a84_authfail_test", "10YDE-EON------1", date(2026, 6, 1))
+
+    assert rc.read_cached("entsoe_a84_authfail_test", "10YDE-EON------1_2026-06", date(2026, 6, 1)) is None
+
+
+async def test_fetch_500_raises_and_is_not_cached(tmp_path, monkeypatch):
+    """An ENTSO-E-side incident (5xx) is exactly the transient failure the retry logic in
+    power_backfill.py's _with_retry exists for — it must propagate, not get cached as empty."""
+    from datetime import date
+
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(bal.httpx, "AsyncClient", _FakeAsyncClient(503, b"Service Unavailable"))
+    monkeypatch.setattr(bal, "_token", lambda: "tok")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await bal._fetch_balancing_month("A83", "entsoe_a83_5xx_test", "10YDE-EON------1", date(2026, 6, 1))
+
+    assert rc.read_cached("entsoe_a83_5xx_test", "10YDE-EON------1_2026-06", date(2026, 6, 1)) is None
+
+
+async def test_ingest_401_is_isolated_and_logged_not_cached(db_session, tmp_path, monkeypatch):
+    """End-to-end: ingest_balancing must not blow up on an auth failure (matches every other
+    per-step try/except in this vertical) — the month is skipped this run and retried next
+    time, rather than being cached as a permanent false 'no data'."""
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(bal.settings, "entsoe_api_token", "x")
+    monkeypatch.setattr(bal.httpx, "AsyncClient", _FakeAsyncClient(401, b"Unauthorized"))
+    monkeypatch.setattr(bal, "_token", lambda: "tok")
+
+    r = await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True)
+    assert r["written"] == 0
+    assert read_hourly(db_session, "balancing.afrr.price.up", "FR") == []
 
 
 # ─── ingest_balancing ───────────────────────────────────────────────────────────
@@ -361,6 +497,26 @@ def test_route_happy_path(db_session):
     assert body["peak"] is not None
     assert body["as_of"] is not None
     assert "stale" in body and "age_days" in body
+
+
+def test_route_de_lu_carries_tennet_coverage_caveat(db_session):
+    """DE_LU uses a control-area override (TenneT, one of four German TSOs) — the JSON
+    response itself must say so, not just docstrings, so an API consumer without the source
+    open still learns the scope."""
+    _seed_balancing(db_session, zone="DE_LU")
+    body = _client(db_session).get("/api/power/balancing?zone=DE_LU").json()
+    assert body["available"] is True
+    assert body["coverage"] is not None
+    assert "TenneT" in body["coverage"]
+    assert "not the national total" in body["coverage"]
+
+
+def test_route_non_override_zone_has_no_coverage_caveat(db_session):
+    """FR uses its normal bidding-zone EIC directly — there's nothing to caveat."""
+    _seed_balancing(db_session, zone="FR")
+    body = _client(db_session).get("/api/power/balancing?zone=FR").json()
+    assert body["available"] is True
+    assert body["coverage"] is None
 
 
 def test_route_defaults_to_afrr_and_30_days(db_session):

--- a/backend/tests/test_balancing.py
+++ b/backend/tests/test_balancing.py
@@ -268,9 +268,10 @@ class _FakeAsyncClient:
 
 
 async def test_fetch_structural_400_is_cached_as_empty(tmp_path, monkeypatch):
-    """The exact wording ENTSO-E uses for a genuinely-empty/unsupported combination — 'is not
-    valid' (A83's structural rejection) or 'No matching data found' (A84's clean empty-window
-    ACK) — is the ONLY 400 shape treated as cacheable no-data."""
+    """The exact wording ENTSO-E uses for a genuinely-empty/unsupported combination — A83's
+    structural rejection ('combination of ... not allowed to be fetched via this service') or
+    A84's 'No matching data found' empty-window ACK — is the ONLY 400 shape treated as
+    cacheable no-data."""
     from datetime import date
 
     import backend.gas.raw_cache as rc
@@ -302,6 +303,28 @@ async def test_fetch_no_matching_data_400_is_cached_as_empty(tmp_path, monkeypat
 
     docs = await bal._fetch_balancing_month("A84", "entsoe_a84_nodata_test", "10YDE-EON------1", date(2026, 6, 1))
     assert docs == [""]
+
+
+async def test_fetch_400_with_only_generic_is_not_valid_text_raises(tmp_path, monkeypatch):
+    """A 400 whose body merely happens to contain the generic phrase 'is not valid' (e.g. an
+    ordinary parameter-validation error, nothing to do with A83/A84's structural rejection)
+    must NOT be treated as cacheable no-data — the matcher keys on the distinctive TAIL of
+    ENTSO-E's actual 'nothing here' wordings ('No matching data found' / 'not allowed to be
+    fetched via this service' / 'combination of'), not the generic phrase alone."""
+    from datetime import date
+
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    body = b"Input parameter periodStart is not valid"
+    monkeypatch.setattr(bal.httpx, "AsyncClient", _FakeAsyncClient(400, body))
+    monkeypatch.setattr(bal, "_token", lambda: "tok")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await bal._fetch_balancing_month(
+            "A84", "entsoe_a84_genericfail_test", "10YDE-EON------1", date(2026, 6, 1)
+        )
+    assert rc.read_cached("entsoe_a84_genericfail_test", "10YDE-EON------1_2026-06", date(2026, 6, 1)) is None
 
 
 async def test_fetch_401_raises_and_is_not_cached(tmp_path, monkeypatch):
@@ -352,6 +375,76 @@ async def test_ingest_401_is_isolated_and_logged_not_cached(db_session, tmp_path
     r = await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True)
     assert r["written"] == 0
     assert read_hourly(db_session, "balancing.afrr.price.up", "FR") == []
+
+
+# ─── per-doctype overwrite: don't re-issue a known-futile A83 request every hour ───────
+#
+# The hourly job refreshes prices every run (overwrite=True) but must NOT re-issue A83's
+# known-futile request 37 zones × 24 times a day once its structural rejection is cached —
+# that's ~888 guaranteed 400s/day against ENTSO-E for nothing. The once-a-day full-overwrite
+# pass is the deliberate "REVERIFY" probe and must keep re-fetching.
+
+
+class _CountingAsyncClient:
+    """Fake httpx.AsyncClient that answers every request with a real, clean structural
+    'no data' 400 httpx.Response and counts calls per documentType — so the caching/
+    overwrite behavior can be verified without touching the network."""
+
+    def __init__(self):
+        self.calls: dict[str, int] = {"A83": 0, "A84": 0}
+
+    def __call__(self, *a, **kw):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, params=None):
+        doc_type = params["documentType"]
+        self.calls[doc_type] = self.calls.get(doc_type, 0) + 1
+        body = b"No matching data found for Data item X"
+        return httpx.Response(400, content=body, request=httpx.Request("GET", url, params=params))
+
+
+async def test_hourly_shaped_call_does_not_refetch_cached_a83(db_session, tmp_path, monkeypatch):
+    """overwrite=True + overwrite_volumes=False (the hourly job's shape): prices are
+    refetched every run, but once A83's rejection is cached, the second run must not hit the
+    network for it again."""
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(bal.settings, "entsoe_api_token", "x")
+    monkeypatch.setattr(bal, "_token", lambda: "tok")
+    client = _CountingAsyncClient()
+    monkeypatch.setattr(bal.httpx, "AsyncClient", client)
+
+    await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True, overwrite_volumes=False)
+    await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True, overwrite_volumes=False)
+
+    assert client.calls["A84"] == 2  # prices: always refreshed
+    assert client.calls["A83"] == 1  # volumes: cached "no data" short-circuits the 2nd run
+
+
+async def test_daily_shaped_call_always_refetches_a83(db_session, tmp_path, monkeypatch):
+    """overwrite=True with no overwrite_volumes override (the nightly job's shape, and the
+    default for any caller that doesn't pass it): both doctypes refetch every run — this is
+    the once-a-day REVERIFY probe for whether A83 has come back."""
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(bal.settings, "entsoe_api_token", "x")
+    monkeypatch.setattr(bal, "_token", lambda: "tok")
+    client = _CountingAsyncClient()
+    monkeypatch.setattr(bal.httpx, "AsyncClient", client)
+
+    await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True)
+    await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True)
+
+    assert client.calls["A84"] == 2
+    assert client.calls["A83"] == 2
 
 
 # ─── ingest_balancing ───────────────────────────────────────────────────────────
@@ -448,6 +541,35 @@ async def test_ingest_fetch_error_is_isolated_per_doctype(db_session, monkeypatc
     assert r["written"] > 0
 
 
+async def test_ingest_excludes_days_outside_the_wanted_window(db_session, monkeypatch):
+    """A month document naturally spans every day in that calendar month, but
+    ingest_balancing is asked for SPECIFIC days — _merge_wanted's day filter must drop
+    everything else. Every other ingest test in this file uses a single-day document, which
+    never actually exercised that filter (a doc with only one day trivially passes it)."""
+    monkeypatch.setattr(bal.settings, "entsoe_api_token", "x")
+
+    two_day_doc = _balancing_doc(
+        [{"business_type": "A96", "direction": "A01", "amounts": [100.0 + i for i in range(48)],
+          "tag": "activation_Price.amount", "res": "PT60M"}],
+        start="2026-06-01T00:00Z", end="2026-06-03T00:00Z",
+    )
+
+    async def fake_fetch(document_type, cache_source, eic, month_start, *, overwrite=False):
+        return [two_day_doc] if document_type == "A84" else [""]
+
+    monkeypatch.setattr(bal, "_fetch_balancing_month", fake_fetch)
+    r = await bal.ingest_balancing(db_session, ["2026-06-01"], zone="FR", overwrite=True)
+
+    series = read_hourly(db_session, "balancing.afrr.price.up", "FR")
+    assert len(series) == 24  # only 2026-06-01's 24 hours...
+    assert r["written"] == 24
+    from datetime import datetime as _dt_
+    from datetime import timezone as _tz_
+    assert all(
+        _dt_.fromtimestamp(t, tz=_tz_.utc).strftime("%Y-%m-%d") == "2026-06-01" for t, _ in series
+    )  # ...never 2026-06-02, even though the fetched document covers both days
+
+
 # ─── GET /api/power/balancing ───────────────────────────────────────────────────
 
 
@@ -494,9 +616,32 @@ def test_route_happy_path(db_session):
     assert len(body["up"]) >= 24
     assert len(body["down"]) >= 24
     assert body["latest"] is not None
+    assert body["latest"]["direction"] in ("up", "down")
     assert body["peak"] is not None
+    assert body["peak"]["direction"] in ("up", "down")
     assert body["as_of"] is not None
     assert "stale" in body and "age_days" in body
+
+
+def test_route_latest_and_peak_report_correct_direction(db_session):
+    """`direction` must reflect whichever row actually won — not just always 'up' — so a
+    consumer knows which half of the market a latest/peak number came from."""
+    import time as _time
+
+    from backend.power.hourly_store import upsert_hourly
+
+    now = (int(_time.time()) // 3600) * 3600
+    upsert_hourly(db_session, "balancing.afrr.price.up", "DE_LU",
+                  [(now - 7200, 10.0), (now - 3600, 11.0)], unit="EUR/MWh")
+    upsert_hourly(db_session, "balancing.afrr.price.down", "DE_LU",
+                  [(now - 3600, -12.0), (now, -500.0)], unit="EUR/MWh")
+
+    body = _client(db_session).get("/api/power/balancing?zone=DE_LU&product=afrr").json()
+    assert body["available"] is True
+    assert body["latest"]["direction"] == "down"
+    assert body["latest"]["price"] == -500.0
+    assert body["peak"]["direction"] == "down"
+    assert body["peak"]["price"] == -500.0
 
 
 def test_route_de_lu_carries_tennet_coverage_caveat(db_session):

--- a/backend/tests/test_capacity_prices.py
+++ b/backend/tests/test_capacity_prices.py
@@ -1,6 +1,8 @@
 """ENTSO-E procured balancing-capacity prices (A15: FCR/aFRR/mFRR) → hourly
-`capacity.<fcr|afrr.pos|afrr.neg|mfrr.pos|mfrr.neg>.price`. Mirrors test_balancing.py's shape,
-adapted for A15's different pagination/error semantics (see entsoe_reserves.py's docstring)."""
+`capacity.<fcr.price|afrr.price.pos|afrr.price.neg|mfrr.price.pos|mfrr.price.neg>` (measure
+BEFORE direction — unified 2026-07-21 to the repo-wide `family.product.measure[.direction]`
+grammar, matching `balancing.afrr.price.up`). Mirrors test_balancing.py's shape, adapted for
+A15's different pagination/error semantics (see entsoe_reserves.py's docstring)."""
 from __future__ import annotations
 
 import httpx
@@ -87,10 +89,10 @@ def test_parse_fcr_symmetric_weighted_average_and_quartered_normalization():
         {"direction": "A03", "quantity": 30.0, "price": 10.0},
     ])
     out = parse_capacity_document(xml)
-    assert set(out.keys()) == {"fcr"}
+    assert set(out.keys()) == {"fcr.price"}
     weighted_avg_block = (10 * 20 + 30 * 10) / 40  # 12.5 EUR/MW per 4h block
     expected = weighted_avg_block / 4.0  # 3.125 EUR/MW/h
-    day = out["fcr"]["2026-06-01"]
+    day = out["fcr.price"]["2026-06-01"]
     assert day == {0: pytest.approx(expected), 1: pytest.approx(expected),
                    2: pytest.approx(expected), 3: pytest.approx(expected)}
 
@@ -102,9 +104,9 @@ def test_parse_afrr_splits_by_direction_no_normalization():
         {"direction": "A02", "quantity": 50.0, "price": 3.0},
     ])
     out = parse_capacity_document(xml)
-    assert set(out.keys()) == {"afrr.pos", "afrr.neg"}
-    assert out["afrr.pos"]["2026-06-01"][0] == 8.0
-    assert out["afrr.neg"]["2026-06-01"][0] == 3.0
+    assert set(out.keys()) == {"afrr.price.pos", "afrr.price.neg"}
+    assert out["afrr.price.pos"]["2026-06-01"][0] == 8.0
+    assert out["afrr.price.neg"]["2026-06-01"][0] == 3.0
 
 
 def test_parse_mfrr_splits_by_direction():
@@ -113,9 +115,9 @@ def test_parse_mfrr_splits_by_direction():
         {"direction": "A02", "quantity": 10.0, "price": 2.0},
     ])
     out = parse_capacity_document(xml)
-    assert set(out.keys()) == {"mfrr.pos", "mfrr.neg"}
-    assert out["mfrr.pos"]["2026-06-01"][0] == 5.0
-    assert out["mfrr.neg"]["2026-06-01"][0] == 2.0
+    assert set(out.keys()) == {"mfrr.price.pos", "mfrr.price.neg"}
+    assert out["mfrr.price.pos"]["2026-06-01"][0] == 5.0
+    assert out["mfrr.price.neg"]["2026-06-01"][0] == 2.0
 
 
 def test_parse_marginal_is_never_the_stored_value():
@@ -126,7 +128,7 @@ def test_parse_marginal_is_never_the_stored_value():
         {"direction": "A01", "quantity": 10.0, "price": 50.0},
     ])
     out = parse_capacity_document(xml)
-    stored = out["afrr.pos"]["2026-06-01"][0]
+    stored = out["afrr.price.pos"]["2026-06-01"][0]
     agg = aggregate_bids([(90.0, 5.0), (10.0, 50.0)])
     assert stored == pytest.approx(agg["weighted_avg"])
     assert stored != agg["marginal"]
@@ -136,7 +138,7 @@ def test_parse_marginal_is_never_the_stored_value():
 def test_parse_densifies_across_all_hours_in_the_block():
     xml = _capacity_doc("A51", [{"direction": "A01", "quantity": 1.0, "price": 42.0}],
                         start="2026-06-01T08:00Z", end="2026-06-01T12:00Z")
-    day = parse_capacity_document(xml)["afrr.pos"]["2026-06-01"]
+    day = parse_capacity_document(xml)["afrr.price.pos"]["2026-06-01"]
     assert set(day.keys()) == {8, 9, 10, 11}
     assert all(v == 42.0 for v in day.values())
 
@@ -147,7 +149,7 @@ def test_parse_block_crossing_midnight_splits_across_two_days():
     not all be attributed to one day."""
     xml = _capacity_doc("A52", [{"direction": "A03", "quantity": 5.0, "price": 8.0}],
                         start="2026-05-31T22:00Z", end="2026-06-01T02:00Z")
-    out = parse_capacity_document(xml)["fcr"]
+    out = parse_capacity_document(xml)["fcr.price"]
     assert set(out["2026-05-31"].keys()) == {22, 23}
     assert set(out["2026-06-01"].keys()) == {0, 1}
     expected = 8.0 / 4.0
@@ -242,8 +244,8 @@ async def test_fetch_multi_xml_zip_members_merge(tmp_path, monkeypatch):
     for xml in docs:
         for key, days in parse_capacity_document(xml).items():
             merged.setdefault(key, {}).update(days)
-    assert merged["afrr.pos"]["2026-06-01"][0] == 111.0
-    assert merged["afrr.neg"]["2026-06-01"][0] == 222.0
+    assert merged["afrr.price.pos"]["2026-06-01"][0] == 111.0
+    assert merged["afrr.price.neg"]["2026-06-01"][0] == 222.0
 
 
 # ─── pagination loop ────────────────────────────────────────────────────────────
@@ -281,7 +283,7 @@ class _PagingClient:
 async def test_pagination_stops_on_short_page(db_session, tmp_path, monkeypatch):
     """Two full 100-entry pages then a short (< 100) page: 3 requests, all docs merged.
 
-    All 240 bids across the 3 pages belong to the SAME (afrr.pos) block — this is the
+    All 240 bids across the 3 pages belong to the SAME (afrr.price.pos) block — this is the
     regression case for aggregating per page and merging via dict.update: the LAST page's
     partial average would silently win instead of the weighted average over all 240 bids.
     """
@@ -312,7 +314,7 @@ async def test_pagination_stops_on_short_page(db_session, tmp_path, monkeypatch)
             merged_raw.setdefault(key, []).extend(pairs)
     assert len(merged_raw) == 1  # one block only
     ((suffix, _start, _end), pairs), = merged_raw.items()
-    assert suffix == "afrr.pos"
+    assert suffix == "afrr.price.pos"
     assert len(pairs) == 240
     correct_avg = aggregate_bids(pairs)["weighted_avg"]
     assert correct_avg == pytest.approx((5050 + 24950 + 16780) / 240)  # 194.91666...
@@ -325,8 +327,8 @@ async def test_pagination_stops_on_short_page(db_session, tmp_path, monkeypatch)
     old_style_value = None
     for xml in docs:
         parsed = parse_capacity_document(xml)
-        if "afrr.pos" in parsed:
-            old_style_value = parsed["afrr.pos"]["2026-06-01"][0]
+        if "afrr.price.pos" in parsed:
+            old_style_value = parsed["afrr.price.pos"]["2026-06-01"][0]
     assert old_style_value == pytest.approx(419.5)  # mean of the LAST page alone (400..439)
     assert old_style_value != pytest.approx(correct_avg)
 
@@ -339,7 +341,7 @@ async def test_pagination_stops_on_short_page(db_session, tmp_path, monkeypatch)
     monkeypatch.setattr(cap, "_fetch_capacity_day", fake_fetch)
     r = await cap.ingest_capacity_prices(db_session, ["2026-06-01"], overwrite=True)
     assert r["written"] > 0
-    stored = read_hourly(db_session, "capacity.afrr.pos.price", "DE_LU")
+    stored = read_hourly(db_session, "capacity.afrr.price.pos", "DE_LU")
     assert stored
     assert stored[0][1] == pytest.approx(correct_avg)
     assert stored[0][1] != pytest.approx(old_style_value)
@@ -511,10 +513,10 @@ async def test_ingest_writes_all_five_series(db_session, monkeypatch):
     assert r["written"] > 0
 
     assert read_hourly(db_session, "capacity.fcr.price", "DE_LU")[0][1] == pytest.approx(10.0)
-    assert read_hourly(db_session, "capacity.afrr.pos.price", "DE_LU")[0][1] == 8.0
-    assert read_hourly(db_session, "capacity.afrr.neg.price", "DE_LU")[0][1] == 3.0
-    assert read_hourly(db_session, "capacity.mfrr.pos.price", "DE_LU")[0][1] == 5.0
-    assert read_hourly(db_session, "capacity.mfrr.neg.price", "DE_LU")[0][1] == 2.0
+    assert read_hourly(db_session, "capacity.afrr.price.pos", "DE_LU")[0][1] == 8.0
+    assert read_hourly(db_session, "capacity.afrr.price.neg", "DE_LU")[0][1] == 3.0
+    assert read_hourly(db_session, "capacity.mfrr.price.pos", "DE_LU")[0][1] == 5.0
+    assert read_hourly(db_session, "capacity.mfrr.price.neg", "DE_LU")[0][1] == 2.0
 
 
 async def test_ingest_isolates_fetch_failure_per_process_type(db_session, monkeypatch):
@@ -528,7 +530,7 @@ async def test_ingest_isolates_fetch_failure_per_process_type(db_session, monkey
 
     monkeypatch.setattr(cap, "_fetch_capacity_day", fake_fetch)
     r = await cap.ingest_capacity_prices(db_session, ["2026-06-01"], overwrite=True)
-    assert read_hourly(db_session, "capacity.afrr.pos.price", "DE_LU")
+    assert read_hourly(db_session, "capacity.afrr.price.pos", "DE_LU")
     assert read_hourly(db_session, "capacity.fcr.price", "DE_LU") == []
     assert r["written"] > 0
 
@@ -628,10 +630,11 @@ def _seed_capacity(db):
 
     now = (int(_time.time()) // 3600) * 3600
     for suffix, price in (
-        ("fcr", 3.0), ("afrr.pos", 8.0), ("afrr.neg", 3.5), ("mfrr.pos", 5.0), ("mfrr.neg", 2.0),
+        ("fcr.price", 3.0), ("afrr.price.pos", 8.0), ("afrr.price.neg", 3.5),
+        ("mfrr.price.pos", 5.0), ("mfrr.price.neg", 2.0),
     ):
         points = [(now - i * 3600, price + i * 0.01) for i in range(24, 0, -1)]
-        upsert_hourly(db, f"capacity.{suffix}.price", "DE_LU", points, unit="EUR/MW/h")
+        upsert_hourly(db, f"capacity.{suffix}", "DE_LU", points, unit="EUR/MW/h")
 
 
 def test_route_happy_path(db_session):
@@ -685,8 +688,8 @@ def test_route_stale_data_is_declared(db_session):
     from backend.power.hourly_store import upsert_hourly
 
     old = int((datetime.now(timezone.utc) - timedelta(days=10)).timestamp() // 3600) * 3600
-    for suffix in ("fcr", "afrr.pos", "afrr.neg", "mfrr.pos", "mfrr.neg"):
-        upsert_hourly(db_session, f"capacity.{suffix}.price", "DE_LU", [(old, 5.0)], unit="EUR/MW/h")
+    for suffix in ("fcr.price", "afrr.price.pos", "afrr.price.neg", "mfrr.price.pos", "mfrr.price.neg"):
+        upsert_hourly(db_session, f"capacity.{suffix}", "DE_LU", [(old, 5.0)], unit="EUR/MW/h")
 
     body = _client(db_session).get("/api/power/capacity-prices?zone=DE_LU").json()
     assert body["available"] is True

--- a/backend/tests/test_capacity_prices.py
+++ b/backend/tests/test_capacity_prices.py
@@ -1,0 +1,648 @@
+"""ENTSO-E procured balancing-capacity prices (A15: FCR/aFRR/mFRR) → hourly
+`capacity.<fcr|afrr.pos|afrr.neg|mfrr.pos|mfrr.neg>.price`. Mirrors test_balancing.py's shape,
+adapted for A15's different pagination/error semantics (see entsoe_reserves.py's docstring)."""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from backend.models.energy import PowerHourly, SeriesDim, ZoneDim  # noqa: F401 — register tables
+from backend.power import entsoe_reserves as cap
+from backend.power.entsoe_reserves import (
+    aggregate_bids,
+    parse_capacity_document,
+)
+from backend.power.hourly_store import read_hourly
+
+NS = "urn:iec62325.351:tc57wg16:451-6:balancingdocument:4:1"
+
+
+def _capacity_doc(process_type, bids, start="2026-06-01T00:00Z", end="2026-06-01T04:00Z"):
+    """Build a Balancing_MarketDocument with one TimeSeries per bid.
+
+    `bids`: list of {"direction": "A01"/"A02"/"A03", "quantity": float, "price": float}.
+    All bids share the SAME block [start, end) unless a bid overrides start/end itself.
+    """
+    ts_blocks = []
+    for i, b in enumerate(bids, start=1):
+        b_start = b.get("start", start)
+        b_end = b.get("end", end)
+        ts_blocks.append(
+            f"<TimeSeries><mRID>{i}</mRID><businessType>B95</businessType>"
+            f"<flowDirection.direction>{b['direction']}</flowDirection.direction>"
+            f"<curveType>A03</curveType><Period>"
+            f"<timeInterval><start>{b_start}</start><end>{b_end}</end></timeInterval>"
+            f"<resolution>PT15M</resolution>"
+            f"<Point><position>1</position><quantity>{b['quantity']}</quantity>"
+            f"<procurement_Price.amount>{b['price']}</procurement_Price.amount></Point>"
+            f"</Period></TimeSeries>"
+        )
+    return (
+        f'<?xml version="1.0"?><Balancing_MarketDocument xmlns="{NS}">'
+        f"<process.processType>{process_type}</process.processType>"
+        + "".join(ts_blocks)
+        + "</Balancing_MarketDocument>"
+    )
+
+
+# ─── aggregate_bids ────────────────────────────────────────────────────────────
+
+
+def test_aggregate_bids_weighted_average():
+    out = aggregate_bids([(10.0, 20.0), (30.0, 10.0)])
+    assert out["weighted_avg"] == pytest.approx((10 * 20 + 30 * 10) / 40)
+    assert out["marginal"] == 20.0
+    assert out["total_qty"] == 40.0
+
+
+def test_aggregate_bids_marginal_is_max_not_weighted_avg():
+    """The marginal (highest accepted bid) and the weighted average must differ whenever bid
+    sizes aren't uniform — proving these are genuinely two different numbers, not aliases."""
+    out = aggregate_bids([(90.0, 5.0), (10.0, 50.0)])
+    assert out["weighted_avg"] == pytest.approx((90 * 5 + 10 * 50) / 100)
+    assert out["marginal"] == 50.0
+    assert out["weighted_avg"] != out["marginal"]
+
+
+def test_aggregate_bids_ignores_non_positive_quantity():
+    out = aggregate_bids([(0.0, 100.0), (-5.0, 200.0), (10.0, 30.0)])
+    assert out["weighted_avg"] == 30.0
+    assert out["marginal"] == 30.0
+    assert out["total_qty"] == 10.0
+
+
+def test_aggregate_bids_empty_is_all_none():
+    out = aggregate_bids([])
+    assert out == {"weighted_avg": None, "marginal": None, "total_qty": 0.0}
+
+
+# ─── parse_capacity_document ────────────────────────────────────────────────────
+
+
+def test_parse_fcr_symmetric_weighted_average_and_quartered_normalization():
+    """FCR (A52) ignores flowDirection entirely (symmetric) and its block price (EUR per 4h)
+    is divided by 4 to land in the shared EUR/MW/h unit every series uses."""
+    xml = _capacity_doc("A52", [
+        {"direction": "A03", "quantity": 10.0, "price": 20.0},
+        {"direction": "A03", "quantity": 30.0, "price": 10.0},
+    ])
+    out = parse_capacity_document(xml)
+    assert set(out.keys()) == {"fcr"}
+    weighted_avg_block = (10 * 20 + 30 * 10) / 40  # 12.5 EUR/MW per 4h block
+    expected = weighted_avg_block / 4.0  # 3.125 EUR/MW/h
+    day = out["fcr"]["2026-06-01"]
+    assert day == {0: pytest.approx(expected), 1: pytest.approx(expected),
+                   2: pytest.approx(expected), 3: pytest.approx(expected)}
+
+
+def test_parse_afrr_splits_by_direction_no_normalization():
+    """aFRR (A51) is already EUR/MW/h (pay-as-bid) — no /4 division — and splits pos/neg."""
+    xml = _capacity_doc("A51", [
+        {"direction": "A01", "quantity": 100.0, "price": 8.0},
+        {"direction": "A02", "quantity": 50.0, "price": 3.0},
+    ])
+    out = parse_capacity_document(xml)
+    assert set(out.keys()) == {"afrr.pos", "afrr.neg"}
+    assert out["afrr.pos"]["2026-06-01"][0] == 8.0
+    assert out["afrr.neg"]["2026-06-01"][0] == 3.0
+
+
+def test_parse_mfrr_splits_by_direction():
+    xml = _capacity_doc("A47", [
+        {"direction": "A01", "quantity": 10.0, "price": 5.0},
+        {"direction": "A02", "quantity": 10.0, "price": 2.0},
+    ])
+    out = parse_capacity_document(xml)
+    assert set(out.keys()) == {"mfrr.pos", "mfrr.neg"}
+    assert out["mfrr.pos"]["2026-06-01"][0] == 5.0
+    assert out["mfrr.neg"]["2026-06-01"][0] == 2.0
+
+
+def test_parse_marginal_is_never_the_stored_value():
+    """The canonical stored series is the weighted average, not the marginal (highest
+    accepted) bid — the two must differ here, and the stored value must equal the former."""
+    xml = _capacity_doc("A51", [
+        {"direction": "A01", "quantity": 90.0, "price": 5.0},
+        {"direction": "A01", "quantity": 10.0, "price": 50.0},
+    ])
+    out = parse_capacity_document(xml)
+    stored = out["afrr.pos"]["2026-06-01"][0]
+    agg = aggregate_bids([(90.0, 5.0), (10.0, 50.0)])
+    assert stored == pytest.approx(agg["weighted_avg"])
+    assert stored != agg["marginal"]
+    assert agg["marginal"] == 50.0
+
+
+def test_parse_densifies_across_all_hours_in_the_block():
+    xml = _capacity_doc("A51", [{"direction": "A01", "quantity": 1.0, "price": 42.0}],
+                        start="2026-06-01T08:00Z", end="2026-06-01T12:00Z")
+    day = parse_capacity_document(xml)["afrr.pos"]["2026-06-01"]
+    assert set(day.keys()) == {8, 9, 10, 11}
+    assert all(v == 42.0 for v in day.values())
+
+
+def test_parse_block_crossing_midnight_splits_across_two_days():
+    """A real block's UTC boundaries shift with DST (spiked live: the first local block of a
+    CEST day runs 22:00Z the PREVIOUS day to 02:00Z) — hours must land under their OWN date,
+    not all be attributed to one day."""
+    xml = _capacity_doc("A52", [{"direction": "A03", "quantity": 5.0, "price": 8.0}],
+                        start="2026-05-31T22:00Z", end="2026-06-01T02:00Z")
+    out = parse_capacity_document(xml)["fcr"]
+    assert set(out["2026-05-31"].keys()) == {22, 23}
+    assert set(out["2026-06-01"].keys()) == {0, 1}
+    expected = 8.0 / 4.0
+    assert out["2026-05-31"][22] == pytest.approx(expected)
+    assert out["2026-06-01"][1] == pytest.approx(expected)
+
+
+def test_parse_unrecognised_direction_is_skipped_not_guessed():
+    xml = _capacity_doc("A51", [{"direction": "A99", "quantity": 1.0, "price": 1.0}])
+    assert parse_capacity_document(xml) == {}
+
+
+def test_parse_ignores_non_b95_business_type():
+    xml = (
+        f'<?xml version="1.0"?><Balancing_MarketDocument xmlns="{NS}">'
+        "<process.processType>A51</process.processType>"
+        "<TimeSeries><mRID>1</mRID><businessType>A96</businessType>"
+        "<flowDirection.direction>A01</flowDirection.direction><curveType>A03</curveType>"
+        "<Period><timeInterval><start>2026-06-01T00:00Z</start><end>2026-06-01T04:00Z</end>"
+        "</timeInterval><resolution>PT15M</resolution>"
+        "<Point><position>1</position><quantity>1</quantity>"
+        "<procurement_Price.amount>1</procurement_Price.amount></Point></Period></TimeSeries>"
+        "</Balancing_MarketDocument>"
+    )
+    assert parse_capacity_document(xml) == {}
+
+
+def test_parse_acknowledgement_is_empty():
+    ack = (
+        '<?xml version="1.0"?><Acknowledgement_MarketDocument>'
+        "<mRID>x</mRID></Acknowledgement_MarketDocument>"
+    )
+    assert parse_capacity_document(ack) == {}
+
+
+def test_parse_unknown_process_type_is_empty():
+    xml = _capacity_doc("A99", [{"direction": "A01", "quantity": 1.0, "price": 1.0}])
+    assert parse_capacity_document(xml) == {}
+
+
+def test_parse_malformed_raises():
+    with pytest.raises(ValueError):
+        parse_capacity_document("<not-xml")
+
+
+# ─── ZIP unwrap: multiple inner XML documents merge ────────────────────────────
+
+
+async def test_fetch_multi_xml_zip_members_merge(tmp_path, monkeypatch):
+    import io
+    import zipfile
+
+    doc1 = _capacity_doc("A51", [{"direction": "A01", "quantity": 1.0, "price": 111.0}])
+    doc2 = _capacity_doc("A51", [{"direction": "A02", "quantity": 1.0, "price": 222.0}])
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("doc1.xml", doc1)
+        zf.writestr("doc2.xml", doc2)
+    zip_bytes = buf.getvalue()
+
+    class _FakeResp:
+        status_code = 200
+        content = zip_bytes
+        text = ""
+
+        def raise_for_status(self):
+            pass
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, *a, **kw):
+            return _FakeResp()
+
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(cap.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(cap, "_token", lambda: "tok")
+
+    from datetime import date
+
+    docs = await cap._fetch_capacity_day("A51", date(2026, 6, 1))
+    merged: dict = {}
+    for xml in docs:
+        for key, days in parse_capacity_document(xml).items():
+            merged.setdefault(key, {}).update(days)
+    assert merged["afrr.pos"]["2026-06-01"][0] == 111.0
+    assert merged["afrr.neg"]["2026-06-01"][0] == 222.0
+
+
+# ─── pagination loop ────────────────────────────────────────────────────────────
+
+
+def _n_bid_doc(n, price_start=1.0):
+    """A single-page A51 document with N distinct-priced TimeSeries."""
+    bids = [{"direction": "A01", "quantity": 1.0, "price": price_start + i} for i in range(n)]
+    return _capacity_doc("A51", bids)
+
+
+class _PagingClient:
+    """Fake httpx.AsyncClient serving canned pages by offset, counting calls."""
+
+    def __init__(self, pages: dict[int, bytes]):
+        self._pages = pages
+        self.calls: list[int] = []
+
+    def __call__(self, *a, **kw):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, params=None):
+        offset = params["offset"]
+        self.calls.append(offset)
+        body = self._pages[offset]
+        return httpx.Response(200, content=body, request=httpx.Request("GET", url, params=params))
+
+
+async def test_pagination_stops_on_short_page(tmp_path, monkeypatch):
+    """Two full 100-entry pages then a short (< 100) page: 3 requests, all docs merged."""
+    import backend.gas.raw_cache as rc
+
+    pages = {
+        0: _n_bid_doc(100, price_start=1.0).encode(),
+        100: _n_bid_doc(100, price_start=200.0).encode(),
+        200: _n_bid_doc(40, price_start=400.0).encode(),
+    }
+    client = _PagingClient(pages)
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(cap.httpx, "AsyncClient", client)
+    monkeypatch.setattr(cap, "_token", lambda: "tok")
+
+    from datetime import date
+
+    docs = await cap._fetch_capacity_day("A51", date(2026, 6, 1))
+    assert client.calls == [0, 100, 200]
+    assert len(docs) == 3
+
+
+async def test_pagination_stops_on_clean_empty_acknowledgement(tmp_path, monkeypatch):
+    """A15's real 'no more data' shape: a clean HTTP 200 zero-TimeSeries Acknowledgement,
+    not a 400 (see module docstring) — a single request must be enough to recognise it."""
+    import backend.gas.raw_cache as rc
+
+    ack = (
+        b'<?xml version="1.0"?><Acknowledgement_MarketDocument>'
+        b"<mRID>x</mRID></Acknowledgement_MarketDocument>"
+    )
+    client = _PagingClient({0: ack})
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(cap.httpx, "AsyncClient", client)
+    monkeypatch.setattr(cap, "_token", lambda: "tok")
+
+    from datetime import date
+
+    docs = await cap._fetch_capacity_day("A51", date(2026, 6, 1))
+    assert client.calls == [0]
+    assert docs == [ack.decode()]
+
+
+async def test_pagination_hard_stop_is_a_safety_valve_not_the_real_limit(tmp_path, monkeypatch):
+    """If a feed pathologically never returned a short page, the loop must still terminate at
+    _MAX_OFFSET rather than looping forever — verified live 2026-07-21 that real ENTSO-E data
+    can exceed the PRIOR feasibility spike's assumed 4900 cap (a real aFRR day reached 6893),
+    so this cap must be generous, but it must still exist."""
+    import backend.gas.raw_cache as rc
+
+    class _AlwaysFullClient:
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, *a, **kw):
+            return self
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, params=None):
+            self.calls += 1
+            body = _n_bid_doc(100, price_start=float(params["offset"])).encode()
+            return httpx.Response(200, content=body, request=httpx.Request("GET", url, params=params))
+
+    client = _AlwaysFullClient()
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(cap.httpx, "AsyncClient", client)
+    monkeypatch.setattr(cap, "_token", lambda: "tok")
+    monkeypatch.setattr(cap, "_MAX_OFFSET", 300)  # shrink the cap so the test is fast
+
+    from datetime import date
+
+    docs = await cap._fetch_capacity_day("A51", date(2026, 6, 1))
+    # offsets 0,100,200,300 all fetched (300 == the shrunk cap, inclusive), then stop.
+    assert client.calls == 4
+    assert len(docs) == 4
+
+
+# ─── error discipline: A15 has no "structural 400 = empty" case (unlike A83/A84) ───────────
+
+
+async def test_fetch_400_always_raises_never_cached_as_empty(tmp_path, monkeypatch):
+    """Verified live 2026-07-21: EVERY no-data case for A15 (future date, wrong domain,
+    exhausted pagination) comes back as a clean HTTP 200 empty Acknowledgement, never a 400.
+    So, unlike entsoe_balancing.py's A83/A84 fetchers, ANY 400 here is a genuine failure and
+    must raise — there is no text to match as 'this 400 actually means no data'."""
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    body = b"The provided parameters do not match the definition of the request"
+    monkeypatch.setattr(cap.httpx, "AsyncClient", _PagingClientRaising(400, body))
+    monkeypatch.setattr(cap, "_token", lambda: "tok")
+
+    from datetime import date
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await cap._fetch_capacity_day("A51", date(2026, 6, 1))
+    assert rc.read_cached("entsoe_a15", "A51_2026-06-01", date(2026, 6, 1)) is None
+
+
+async def test_fetch_401_raises_and_is_not_cached(tmp_path, monkeypatch):
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(cap.httpx, "AsyncClient", _PagingClientRaising(401, b"Unauthorized"))
+    monkeypatch.setattr(cap, "_token", lambda: "tok")
+
+    from datetime import date
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await cap._fetch_capacity_day("A51", date(2026, 6, 1))
+    assert rc.read_cached("entsoe_a15", "A51_2026-06-01", date(2026, 6, 1)) is None
+
+
+async def test_fetch_500_raises_and_is_not_cached(tmp_path, monkeypatch):
+    import backend.gas.raw_cache as rc
+
+    monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(cap.httpx, "AsyncClient", _PagingClientRaising(503, b"Service Unavailable"))
+    monkeypatch.setattr(cap, "_token", lambda: "tok")
+
+    from datetime import date
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await cap._fetch_capacity_day("A47", date(2026, 6, 1))
+    assert rc.read_cached("entsoe_a15", "A47_2026-06-01", date(2026, 6, 1)) is None
+
+
+class _PagingClientRaising:
+    """Fake httpx.AsyncClient answering every request with one canned error Response."""
+
+    def __init__(self, status_code: int, content: bytes):
+        self._status_code = status_code
+        self._content = content
+
+    def __call__(self, *a, **kw):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, params=None):
+        return httpx.Response(self._status_code, content=self._content, request=httpx.Request("GET", url, params=params))
+
+
+# ─── ingest_capacity_prices ──────────────────────────────────────────────────────
+
+
+async def test_ingest_no_token_skips(db_session, monkeypatch):
+    monkeypatch.setattr(cap.settings, "entsoe_api_token", None)
+    r = await cap.ingest_capacity_prices(db_session, ["2026-06-01"])
+    assert r == {"skipped": "no token"}
+
+
+async def test_ingest_no_days_returns_zero(db_session, monkeypatch):
+    monkeypatch.setattr(cap.settings, "entsoe_api_token", "x")
+    r = await cap.ingest_capacity_prices(db_session, [])
+    assert r["days"] == 0
+
+
+async def test_ingest_writes_all_five_series(db_session, monkeypatch):
+    monkeypatch.setattr(cap.settings, "entsoe_api_token", "x")
+
+    fcr_xml = _capacity_doc("A52", [{"direction": "A03", "quantity": 10.0, "price": 40.0}])
+    afrr_xml = _capacity_doc("A51", [
+        {"direction": "A01", "quantity": 10.0, "price": 8.0},
+        {"direction": "A02", "quantity": 10.0, "price": 3.0},
+    ])
+    mfrr_xml = _capacity_doc("A47", [
+        {"direction": "A01", "quantity": 10.0, "price": 5.0},
+        {"direction": "A02", "quantity": 10.0, "price": 2.0},
+    ])
+
+    async def fake_fetch(process_type, day, *, overwrite=False):
+        return {"A52": [fcr_xml], "A51": [afrr_xml], "A47": [mfrr_xml]}[process_type]
+
+    monkeypatch.setattr(cap, "_fetch_capacity_day", fake_fetch)
+    r = await cap.ingest_capacity_prices(db_session, ["2026-06-01"], overwrite=True)
+    assert r["written"] > 0
+
+    assert read_hourly(db_session, "capacity.fcr.price", "DE_LU")[0][1] == pytest.approx(10.0)
+    assert read_hourly(db_session, "capacity.afrr.pos.price", "DE_LU")[0][1] == 8.0
+    assert read_hourly(db_session, "capacity.afrr.neg.price", "DE_LU")[0][1] == 3.0
+    assert read_hourly(db_session, "capacity.mfrr.pos.price", "DE_LU")[0][1] == 5.0
+    assert read_hourly(db_session, "capacity.mfrr.neg.price", "DE_LU")[0][1] == 2.0
+
+
+async def test_ingest_isolates_fetch_failure_per_process_type(db_session, monkeypatch):
+    monkeypatch.setattr(cap.settings, "entsoe_api_token", "x")
+    afrr_xml = _capacity_doc("A51", [{"direction": "A01", "quantity": 1.0, "price": 9.0}])
+
+    async def fake_fetch(process_type, day, *, overwrite=False):
+        if process_type == "A52":
+            raise httpx.HTTPError("boom")
+        return [afrr_xml] if process_type == "A51" else []
+
+    monkeypatch.setattr(cap, "_fetch_capacity_day", fake_fetch)
+    r = await cap.ingest_capacity_prices(db_session, ["2026-06-01"], overwrite=True)
+    assert read_hourly(db_session, "capacity.afrr.pos.price", "DE_LU")
+    assert read_hourly(db_session, "capacity.fcr.price", "DE_LU") == []
+    assert r["written"] > 0
+
+
+async def test_ingest_has_no_zone_parameter():
+    """DE_LU only, by design — this ingest function must not accept a `zone` kwarg."""
+    import inspect
+
+    sig = inspect.signature(cap.ingest_capacity_prices)
+    assert "zone" not in sig.parameters
+
+
+# ─── freshness spec + PANEL_MAX_AGE_DAYS mirror ─────────────────────────────────
+
+
+def test_freshness_spec_registered():
+    from backend.collectors.freshness import SPECS
+
+    spec = next((s for s in SPECS if s.key == "capacity_prices"), None)
+    assert spec is not None
+    assert spec.hourly_series == "capacity.fcr.price"
+    assert spec.max_age.days == 2
+
+
+def test_panel_max_age_mirrors_freshness_spec():
+    from backend.collectors.freshness import SPECS
+    from backend.routes.power import PANEL_MAX_AGE_DAYS
+
+    spec = next(s for s in SPECS if s.key == "capacity_prices")
+    assert PANEL_MAX_AGE_DAYS["capacity_prices"] == spec.max_age.days
+
+
+# ─── backfill registration ──────────────────────────────────────────────────────
+
+
+def test_backfill_source_registered():
+    from backend.scripts import power_backfill as pb
+
+    assert "capacity" in pb.ALL_SOURCES
+
+
+async def test_backfill_capacity_runs_once_per_month_not_per_zone(monkeypatch):
+    """`ingest_capacity_prices` is imported LOCALLY inside run_backfill's "capacity" branch
+    (like the "scheduled"/"netpos" sources) rather than at power_backfill.py's module level —
+    so the fake must be patched on the SOURCE module, which the local import re-resolves at
+    call time, not on the `pb` module itself."""
+    from datetime import date
+
+    from backend.scripts import power_backfill as pb
+
+    calls = []
+
+    async def _capacity(db, days, **kwargs):
+        calls.append((days[0], days[-1], kwargs))
+
+    async def _noop(*a, **k):
+        pass
+
+    monkeypatch.setattr(cap, "ingest_capacity_prices", _capacity)
+    monkeypatch.setattr(pb, "ingest_day_ahead", _noop)
+
+    res = await pb.run_backfill(
+        db=None, start=date(2026, 1, 1), end=date(2026, 2, 28),
+        zones=["DE_LU", "FR"], sources={"price", "capacity"},
+        overwrite=False, dry_run=False, throttle=0,
+    )
+    assert res["capacity_months"] == 2
+    assert [(c[0], c[1]) for c in calls] == [
+        ("2026-01-01", "2026-01-31"), ("2026-02-01", "2026-02-28"),
+    ]
+
+
+# ─── GET /api/power/capacity-prices ─────────────────────────────────────────────
+
+
+def _client(db):
+    from fastapi.testclient import TestClient
+
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+    app.dependency_overrides.clear()
+
+
+def _seed_capacity(db):
+    import time as _time
+
+    from backend.power.hourly_store import upsert_hourly
+
+    now = (int(_time.time()) // 3600) * 3600
+    for suffix, price in (
+        ("fcr", 3.0), ("afrr.pos", 8.0), ("afrr.neg", 3.5), ("mfrr.pos", 5.0), ("mfrr.neg", 2.0),
+    ):
+        points = [(now - i * 3600, price + i * 0.01) for i in range(24, 0, -1)]
+        upsert_hourly(db, f"capacity.{suffix}.price", "DE_LU", points, unit="EUR/MW/h")
+
+
+def test_route_happy_path(db_session):
+    _seed_capacity(db_session)
+    body = _client(db_session).get("/api/power/capacity-prices?zone=DE_LU").json()
+    assert body["available"] is True
+    assert body["zone"] == "DE_LU"
+    assert body["zones"] == ["DE_LU"]
+    assert body["unit"] == "EUR/MW/h"
+    for key in ("fcr", "afrr_pos", "afrr_neg", "mfrr_pos", "mfrr_neg"):
+        assert key in body["products"]
+        assert len(body["products"][key]) >= 24
+        assert body["latest"][key] is not None
+    assert body["as_of"] is not None
+    assert "stale" in body and "age_days" in body
+
+
+def test_route_note_mentions_fcr_cross_border_caveat(db_session):
+    _seed_capacity(db_session)
+    body = _client(db_session).get("/api/power/capacity-prices?zone=DE_LU").json()
+    note = body["note"].lower()
+    assert "fcr" in note
+    assert "settlement" in note or "cross-border" in note or "settles" in note
+    assert "weighted" in note
+    assert "4" in note  # the /4 normalization is called out
+
+
+def test_route_non_de_lu_zone_is_a_structural_absence(db_session):
+    body = _client(db_session).get("/api/power/capacity-prices?zone=FR").json()
+    assert body["available"] is False
+    assert "DE-LU" in body["reason"]
+    assert body["zone"] == "FR"
+
+
+def test_route_days_clamped(db_session):
+    resp_low = _client(db_session).get("/api/power/capacity-prices?zone=DE_LU&days=0")
+    resp_high = _client(db_session).get("/api/power/capacity-prices?zone=DE_LU&days=91")
+    assert resp_low.status_code == 422
+    assert resp_high.status_code == 422
+
+
+def test_route_no_data_yet_is_honest(db_session):
+    body = _client(db_session).get("/api/power/capacity-prices?zone=DE_LU").json()
+    assert body["available"] is False
+    assert "reason" in body
+
+
+def test_route_stale_data_is_declared(db_session):
+    from datetime import datetime, timedelta, timezone
+
+    from backend.power.hourly_store import upsert_hourly
+
+    old = int((datetime.now(timezone.utc) - timedelta(days=10)).timestamp() // 3600) * 3600
+    for suffix in ("fcr", "afrr.pos", "afrr.neg", "mfrr.pos", "mfrr.neg"):
+        upsert_hourly(db_session, f"capacity.{suffix}.price", "DE_LU", [(old, 5.0)], unit="EUR/MW/h")
+
+    body = _client(db_session).get("/api/power/capacity-prices?zone=DE_LU").json()
+    assert body["available"] is True
+    assert body["stale"] is True
+    assert body["age_days"] >= 9

--- a/backend/tests/test_capacity_prices.py
+++ b/backend/tests/test_capacity_prices.py
@@ -278,14 +278,19 @@ class _PagingClient:
         return httpx.Response(200, content=body, request=httpx.Request("GET", url, params=params))
 
 
-async def test_pagination_stops_on_short_page(tmp_path, monkeypatch):
-    """Two full 100-entry pages then a short (< 100) page: 3 requests, all docs merged."""
+async def test_pagination_stops_on_short_page(db_session, tmp_path, monkeypatch):
+    """Two full 100-entry pages then a short (< 100) page: 3 requests, all docs merged.
+
+    All 240 bids across the 3 pages belong to the SAME (afrr.pos) block — this is the
+    regression case for aggregating per page and merging via dict.update: the LAST page's
+    partial average would silently win instead of the weighted average over all 240 bids.
+    """
     import backend.gas.raw_cache as rc
 
     pages = {
-        0: _n_bid_doc(100, price_start=1.0).encode(),
-        100: _n_bid_doc(100, price_start=200.0).encode(),
-        200: _n_bid_doc(40, price_start=400.0).encode(),
+        0: _n_bid_doc(100, price_start=1.0).encode(),      # prices 1..100,   sum=5050
+        100: _n_bid_doc(100, price_start=200.0).encode(),  # prices 200..299, sum=24950
+        200: _n_bid_doc(40, price_start=400.0).encode(),    # prices 400..439, sum=16780
     }
     client = _PagingClient(pages)
     monkeypatch.setattr(rc, "DATA_ROOT", tmp_path)
@@ -297,6 +302,47 @@ async def test_pagination_stops_on_short_page(tmp_path, monkeypatch):
     docs = await cap._fetch_capacity_day("A51", date(2026, 6, 1))
     assert client.calls == [0, 100, 200]
     assert len(docs) == 3
+
+    # Combining every page's RAW bids for the block before aggregating (the fix) yields the
+    # true weighted average over all 240 bids (quantity is uniform 1.0, so this is a plain
+    # mean): (5050 + 24950 + 16780) / 240.
+    merged_raw: dict = {}
+    for xml in docs:
+        for key, pairs in cap.parse_capacity_bids(xml).items():
+            merged_raw.setdefault(key, []).extend(pairs)
+    assert len(merged_raw) == 1  # one block only
+    ((suffix, _start, _end), pairs), = merged_raw.items()
+    assert suffix == "afrr.pos"
+    assert len(pairs) == 240
+    correct_avg = aggregate_bids(pairs)["weighted_avg"]
+    assert correct_avg == pytest.approx((5050 + 24950 + 16780) / 240)  # 194.91666...
+
+    # The regression this guards: aggregating PER PAGE (parse_capacity_document, which runs
+    # aggregate_bids WITHIN one document) and then merging by (day, hour) via dict.update lets
+    # the LAST page's partial average silently overwrite every earlier page's — concretely a
+    # different (and, since bids arrive in ascending-price/merit order, systematically biased
+    # high) number here, not the correct 194.92.
+    old_style_value = None
+    for xml in docs:
+        parsed = parse_capacity_document(xml)
+        if "afrr.pos" in parsed:
+            old_style_value = parsed["afrr.pos"]["2026-06-01"][0]
+    assert old_style_value == pytest.approx(419.5)  # mean of the LAST page alone (400..439)
+    assert old_style_value != pytest.approx(correct_avg)
+
+    # And the production entry point (ingest_capacity_prices) must land on the CORRECT
+    # cross-page value in the actual hourly store, not the old per-page-last-wins one.
+    async def fake_fetch(process_type, day, *, overwrite=False):
+        return docs if process_type == "A51" else []
+
+    monkeypatch.setattr(cap.settings, "entsoe_api_token", "x")
+    monkeypatch.setattr(cap, "_fetch_capacity_day", fake_fetch)
+    r = await cap.ingest_capacity_prices(db_session, ["2026-06-01"], overwrite=True)
+    assert r["written"] > 0
+    stored = read_hourly(db_session, "capacity.afrr.pos.price", "DE_LU")
+    assert stored
+    assert stored[0][1] == pytest.approx(correct_avg)
+    assert stored[0][1] != pytest.approx(old_style_value)
 
 
 async def test_pagination_stops_on_clean_empty_acknowledgement(tmp_path, monkeypatch):

--- a/backend/tests/test_capture.py
+++ b/backend/tests/test_capture.py
@@ -125,14 +125,21 @@ def test_a_technology_that_produced_nothing_has_no_capture_price():
 # ─── DB-backed ────────────────────────────────────────────────────────────────
 
 
-def _seed(db, zone="DE_LU", days=75, *, solar_days=None):
+def _seed(db, zone="DE_LU", days=75, *, solar_days=None, anchor=None):
     """Solar produces in the cheap half of the day and writes NO row at night — the
     real ENTSO-E shape. Gas runs in the dear half. 75 days back guarantees at least
     one COMPLETE calendar month; capture is a monthly figure.
 
     `solar_days`: if set, solar only appears on that many days — a broken feed.
+    `anchor`: override for "now" (tz-aware UTC); defaults to the real wall clock. A test
+    that jumps `today` FORWARD afterwards (to check staleness) needs an anchor whose
+    CURRENT, still-running month (partial at seed time) stays under MIN_DAYS/
+    MIN_PRICE_HOURS forever — otherwise, on any real day of the month ≥ MIN_DAYS (the
+    20th onward), that partial month already has enough volume to qualify once `today`
+    moves past it, and the `as_of`/`latest_month` the test assumes stays fixed drifts
+    forward too, silently erasing the staleness under test.
     """
-    now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    now = (anchor or datetime.now(timezone.utc)).replace(minute=0, second=0, microsecond=0)
     start = now - timedelta(days=days)
     price_pts, solar_pts, gas_pts = [], [], []
     for i in range(days * 24):
@@ -238,9 +245,41 @@ def test_the_running_month_is_not_reported_as_a_month(db_session):
 def test_freshness_is_the_newest_hour_used_not_the_month_label(db_session):
     """The panel convention: as_of is a date, and it is the newest hour the numbers
     were actually built from. A monthly figure is legitimately weeks behind — a month
-    only completes once — so it goes stale on a wider window than any daily panel."""
-    _seed(db_session)
-    out = compute_capture(db_session, "DE_LU", months=3)
+    only completes once — so it goes stale on a wider window than any daily panel.
+
+    Anchored to a FIXED reference date rather than the real wall clock (unlike every
+    other DB-backed test here, which is deliberately allowed to float with real "now").
+    This test simulates `today` jumping forward past STALE_AFTER_DAYS to prove staleness
+    trips — and with the ordinary `_seed()` (anchored to real `now`), that jump used to
+    make the test's own pass/fail outcome depend on which day of the REAL month it
+    happened to run on:
+
+    `_seed()` writes data all the way up to "now", so at seed time the still-running
+    month is only PARTIAL. On the 20th of any real month or later, that partial month
+    already has ≥ MIN_DAYS (20) distinct days and ≥ MIN_PRICE_HOURS (480 = 20×24) hours
+    — enough to pass both thresholds by volume alone, even though it is still incomplete.
+    The only thing keeping it out of the baseline is the SEPARATE `month < running` rule
+    in compute_capture(), which is evaluated against `today`. Jump `today` forward (as
+    this test does, to check staleness) and that same partial month is no longer
+    "running" — so it gets admitted retroactively, becomes the new (much more recent)
+    `latest_month`, and drags `as_of` forward with it, quietly cancelling the very
+    staleness this test exists to prove. Verified against the unpatched version by
+    seeding at several fixed anchor days-of-month and reproducing the exact assertion
+    above: day 1/5/20 stayed green, day 21/28 failed exactly like the original flake
+    (the precise cutover shifts by up to a day with the anchor's hour-of-day, since
+    what actually matters is accumulated HOURS/DAYS crossing MIN_PRICE_HOURS/MIN_DAYS,
+    not the calendar day number itself).
+
+    The fix anchors the seed to a fixed 2024-01-05 — day 5, nowhere near MIN_DAYS — so
+    the run's own partial month (Jan 2024, 5 days/120 hours) can NEVER cross either
+    threshold, no matter how far `today` is later pushed; only the two already-COMPLETE
+    months before it (Nov/Dec 2023) ever qualify, so `as_of`/`latest_month` are pinned for
+    real. (Anchoring at day 21 or 28 instead would reproduce the original bug — this is
+    exactly the failure mode above, just deterministically on those two dates.)
+    """
+    anchor = datetime(2024, 1, 5, tzinfo=timezone.utc)
+    _seed(db_session, anchor=anchor)
+    out = compute_capture(db_session, "DE_LU", months=3, today=anchor.date())
 
     assert date.fromisoformat(out["as_of"]), "an ISO date, not '2026-06'"
     assert out["as_of"].startswith(out["latest_month"])

--- a/backend/tests/test_capture.py
+++ b/backend/tests/test_capture.py
@@ -101,7 +101,18 @@ def test_no_value_factor_through_a_zero_baseload():
 def test_negative_generation_share_is_the_technologys_own_output():
     prices = _hours(0, {0: -5.0, 1: 50.0, 2: 50.0, 3: 50.0})
     gen = _hours(0, {0: 300.0, 1: 100.0, 2: 100.0, 3: 100.0})
-    assert capture_metrics(prices, gen)["negative_gen_pct"] == 50.0  # 300 of 600 MWh
+    m = capture_metrics(prices, gen)
+    assert m["negative_gen_pct"] == 50.0  # 300 of 600 MWh
+    assert m["negative_hours"] == 1  # only hour 0 is both negative-price and producing
+
+
+def test_negative_hours_counts_hours_not_generation():
+    """negative_hours is a volume-blind COUNT: an hour of a small plant counts the
+    same as an hour of a large one, unlike negative_gen_pct which is weighted."""
+    prices = _hours(0, {0: -5.0, 1: -1.0, 2: 50.0, 3: -2.0})
+    gen = _hours(0, {0: 1.0, 1: 900.0, 2: 100.0, 3: 0.0})  # hour 3: negative price, ZERO output
+    m = capture_metrics(prices, gen)
+    assert m["negative_hours"] == 2, "hours 0 and 1 — hour 3 had no output despite the negative price"
 
 
 def test_a_technology_that_produced_nothing_has_no_capture_price():
@@ -251,6 +262,9 @@ def test_route(db_session):
     assert body["available"] is True
     assert body["baseload_price"] == 60.0
     assert body["fuels"][0]["latest"]["capture_price"] is not None
+    # negative_hours travels next to negative_gen_pct in both `latest` and the monthly rows.
+    assert "negative_hours" in body["fuels"][0]["latest"]
+    assert all("negative_hours" in row for f in body["fuels"] for row in f["data"])
 
 
 def _seed_messy(db, zone="DE_LU", days=390):
@@ -313,7 +327,8 @@ def test_the_sql_and_the_definition_agree(db_session):
             # EXACT, not approximate. A rel=1e-3 tolerance is precisely wide enough to hide
             # the drift that actually happened.
             for key in ("capture_price", "baseload_price", "value_factor",
-                        "hours", "days", "generation_gwh", "negative_gen_pct"):
+                        "hours", "days", "generation_gwh", "negative_gen_pct",
+                        "negative_hours"):
                 assert got[key] == want[key], f"{fuel['psr']} {got['month']}.{key}"
             checked += 1
     assert checked >= 20, "too few month-fuel pairs to catch a boundary-crossing rounding"

--- a/backend/tests/test_embed_badge.py
+++ b/backend/tests/test_embed_badge.py
@@ -201,3 +201,44 @@ def test_price_badge_attribution_in_title(db_session):
     root = _parse_svg(resp.text)
     title_el = root.find("{http://www.w3.org/2000/svg}title")
     assert "ENTSO-E" in title_el.text
+
+
+def test_negative_price_badge_sign_before_currency(db_session):
+    """Negative day-ahead prices are a headline state for this product — the badge
+    must render them unambiguously: sign BEFORE the currency ("−€5/MWh"), never
+    Python's default "€-5/MWh"."""
+    _seed_price(db_session, mean=-5.4)
+    resp = _client(db_session).get("/api/v1/badge/DE_LU/price.svg")
+    assert resp.status_code == 200
+    text_el = _parse_svg(resp.text).find("{http://www.w3.org/2000/svg}text")
+    assert "−€5/MWh" in text_el.text
+    assert "€-" not in text_el.text
+
+
+def test_near_zero_negative_price_never_renders_minus_zero(db_session):
+    # -0.4 rounds to the int 0 (no signed zero) — must render "€0/MWh", not "€-0/MWh"
+    # or "−€0/MWh".
+    _seed_price(db_session, zone="FR", mean=-0.4)
+    resp = _client(db_session).get("/api/v1/badge/FR/price.svg")
+    text_el = _parse_svg(resp.text).find("{http://www.w3.org/2000/svg}text")
+    assert "€0/MWh" in text_el.text
+    # currency-scoped: a bare "-0" would also match the date ("2026-06-01")
+    assert "€-0" not in text_el.text and "−€0" not in text_el.text
+
+
+def test_db_error_degrades_to_grey_200(db_session, monkeypatch):
+    """The module docstring and API.md promise an unconditional 200 — a transient DB
+    error inside the data read must degrade to the grey pill, not a 500 broken image."""
+    import backend.routes.embed as embed_mod
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr(embed_mod, "read_hourly", _boom)
+    resp = _client(db_session).get("/api/v1/badge/DE_LU/load.svg")
+    assert resp.status_code == 200
+    root = _parse_svg(resp.text)
+    fill = root.find("{http://www.w3.org/2000/svg}rect").get("fill")
+    assert fill == "#1a1c22"  # grey, same as "no data yet"
+    text_el = root.find("{http://www.w3.org/2000/svg}text")
+    assert "no data" in text_el.text

--- a/backend/tests/test_embed_badge.py
+++ b/backend/tests/test_embed_badge.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 from datetime import UTC, datetime
+from urllib.parse import quote
 
 import pytest
 from fastapi.testclient import TestClient
@@ -116,6 +117,32 @@ def test_unknown_zone_returns_grey_200(db_session):
     assert fill == "#1a1c22"  # the grey "no data" background, not the ok-badge dark
     text_el = root.find("{http://www.w3.org/2000/svg}text")
     assert "no data" in text_el.text
+
+
+def test_unknown_zone_quote_injection_is_neutralized(db_session):
+    """Regression for a reflected-XSS finding: an unknown zone reaches `_no_data_badge`
+    with the RAW URL path segment as `text`, which `_badge_svg` places both in an
+    element body (<title>/<text>, safe with plain & < > escaping) and in an ATTRIBUTE
+    value (`aria-label="..."`). A `"` in the zone must not be able to close that
+    attribute early and inject a new one (e.g. `onload=`) — `_badge_svg` must escape
+    quotes specifically for the attribute sink."""
+    # No "/" in the payload — a URL-encoded %2F is decoded back to a literal "/" by
+    # the ASGI path before routing, which would split it into extra path segments
+    # (a routing quirk, not part of what this regression is about) rather than
+    # reach the handler as a single {zone} value.
+    payload = 'x" onload="alert(1)'
+    resp = _client(db_session).get(f"/api/v1/badge/{quote(payload, safe='')}/price.svg")
+    assert resp.status_code == 200
+    root = _parse_svg(resp.text)  # raises ET.ParseError if the injected attribute broke the XML
+    assert root.tag.endswith("svg")
+    # No element anywhere in the document may have picked up an "onload" attribute —
+    # the whole point of the injection would be a real, parseable onload="...".
+    for el in root.iter():
+        assert "onload" not in el.attrib
+    aria_label = root.get("aria-label")
+    assert aria_label is not None
+    assert '"' in aria_label  # the literal quote survived — safely, as &quot; on the wire
+    assert "onload" in aria_label  # present as inert TEXT inside the attribute value, not a new attribute
 
 
 def test_unknown_metric_returns_grey_200(db_session):

--- a/backend/tests/test_embed_badge.py
+++ b/backend/tests/test_embed_badge.py
@@ -1,0 +1,176 @@
+"""Embeddable SVG badges: GET /api/v1/badge/{zone}/{metric}.svg (Task P10).
+
+Covers: content-type/cache headers, the shared v1 rate-limit dependency, price/load
+happy paths, unknown zone/metric and no-data degrading to a grey 200 (never a broken
+image in a README), well-formed SVG (parses as XML), and zone-label correctness.
+"""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api_guard import _reset_coverage_cache
+from backend.auth.ratelimit import reset_limits
+from backend.database import get_db
+from backend.main import app
+from backend.models.energy import PowerHourly, PowerPriceDaily, SeriesDim, ZoneDim  # noqa: F401
+from backend.power.hourly_store import upsert_hourly
+
+_BASE = int(datetime(2026, 6, 1, tzinfo=UTC).timestamp())
+_H = 3600
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    reset_limits()
+    _reset_coverage_cache()
+    yield
+    app.dependency_overrides.clear()
+    reset_limits()
+    _reset_coverage_cache()
+
+
+def _client(db):
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _seed_price(db, zone="DE_LU", date="2026-06-01", mean=87.4):
+    db.add(PowerPriceDaily(
+        date=date, zone=zone, mean_price=mean, min_price=mean - 10,
+        max_price=mean + 10, negative_hours=0,
+    ))
+    db.commit()
+
+
+def _seed_load(db, zone="DE_LU", n=6):
+    # The badge route only looks back 6h from "now" (a live-status read, not a
+    # historical one) — seed near the current hour, not the fixed 2026-06-01 base
+    # the other v1 tests use for their (unrelated) window-math fixtures.
+    now_hour = int(datetime.now(UTC).timestamp()) // _H * _H
+    start = now_hour - (n - 1) * _H
+    upsert_hourly(db, "load.actual", zone,
+                  [(start + i * _H, 54_200.0 + i * 10) for i in range(n)], unit="MW")
+
+
+def _parse_svg(text: str) -> ET.Element:
+    return ET.fromstring(text)
+
+
+def test_price_badge_happy_path(db_session):
+    _seed_price(db_session)
+    resp = _client(db_session).get("/api/v1/badge/DE_LU/price.svg")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/svg+xml")
+    assert resp.headers["cache-control"] == "public, max-age=900"
+    root = _parse_svg(resp.text)
+    assert root.tag.endswith("svg")
+    text_el = root.find("{http://www.w3.org/2000/svg}text")
+    assert text_el is not None
+    assert "DE-LU" in text_el.text
+    assert "day-ahead" in text_el.text
+    assert "87" in text_el.text
+    assert "2026-06-01" in text_el.text
+
+
+def test_load_badge_happy_path(db_session):
+    _seed_load(db_session)
+    resp = _client(db_session).get("/api/v1/badge/DE_LU/load.svg")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/svg+xml")
+    root = _parse_svg(resp.text)
+    text_el = root.find("{http://www.w3.org/2000/svg}text")
+    assert "DE-LU" in text_el.text
+    assert "load" in text_el.text
+    assert "GW" in text_el.text
+    assert "UTC" in text_el.text
+
+
+def test_load_badge_uses_latest_point(db_session):
+    _seed_load(db_session, n=6)
+    resp = _client(db_session).get("/api/v1/badge/DE_LU/load.svg")
+    root = _parse_svg(resp.text)
+    text_el = root.find("{http://www.w3.org/2000/svg}text")
+    # last point: 54_200 + 5*10 = 54_250 -> 54.25 GW rounds to 54.2 or 54.3
+    assert "54.2" in text_el.text or "54.3" in text_el.text
+
+
+def test_zone_label_correctness_for_fr(db_session):
+    _seed_price(db_session, zone="FR", date="2026-06-02", mean=101.0)
+    resp = _client(db_session).get("/api/v1/badge/FR/price.svg")
+    root = _parse_svg(resp.text)
+    text_el = root.find("{http://www.w3.org/2000/svg}text")
+    assert text_el.text.startswith("FR ")
+    assert "101" in text_el.text
+
+
+def test_unknown_zone_returns_grey_200(db_session):
+    resp = _client(db_session).get("/api/v1/badge/NOPE/price.svg")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/svg+xml")
+    root = _parse_svg(resp.text)
+    fill = root.find("{http://www.w3.org/2000/svg}rect").get("fill")
+    assert fill == "#1a1c22"  # the grey "no data" background, not the ok-badge dark
+    text_el = root.find("{http://www.w3.org/2000/svg}text")
+    assert "no data" in text_el.text
+
+
+def test_unknown_metric_returns_grey_200(db_session):
+    _seed_price(db_session)
+    resp = _client(db_session).get("/api/v1/badge/DE_LU/genmix.svg")
+    assert resp.status_code == 200
+    root = _parse_svg(resp.text)
+    text_el = root.find("{http://www.w3.org/2000/svg}text")
+    assert "no data" in text_el.text
+
+
+def test_no_data_yet_returns_grey_200(db_session):
+    # Known zone, known metric, but nothing seeded — must still be a 200 grey pill.
+    resp = _client(db_session).get("/api/v1/badge/DE_LU/price.svg")
+    assert resp.status_code == 200
+    root = _parse_svg(resp.text)
+    fill = root.find("{http://www.w3.org/2000/svg}rect").get("fill")
+    assert fill == "#1a1c22"
+    text_el = root.find("{http://www.w3.org/2000/svg}text")
+    assert "no data" in text_el.text
+
+
+def test_svg_is_well_formed_for_ok_and_no_data_badges(db_session):
+    _seed_price(db_session)
+    for url in (
+        "/api/v1/badge/DE_LU/price.svg",
+        "/api/v1/badge/DE_LU/load.svg",       # no load data -> grey
+        "/api/v1/badge/NOPE/price.svg",       # unknown zone -> grey
+        "/api/v1/badge/DE_LU/bogus.svg",      # unknown metric -> grey
+    ):
+        resp = _client(db_session).get(url)
+        assert resp.status_code == 200
+        root = _parse_svg(resp.text)  # raises if malformed
+        assert root.tag.endswith("svg")
+        title_el = root.find("{http://www.w3.org/2000/svg}title")
+        assert title_el is not None and title_el.text
+
+
+def test_rate_limit_dependency_present(db_session, monkeypatch):
+    """Badges share the v1 per-IP budget (backend.routes.api_v1._rate_limit) —
+    patching its RATE_PER_MIN throttles the badge route exactly like /series."""
+    import backend.routes.api_v1 as v1
+
+    monkeypatch.setattr(v1, "RATE_PER_MIN", 2)
+    _seed_price(db_session)
+    c = _client(db_session)
+    url = "/api/v1/badge/DE_LU/price.svg"
+    assert c.get(url).status_code == 200
+    assert c.get(url).status_code == 200
+    assert c.get(url).status_code == 429  # third within the window
+
+
+def test_price_badge_attribution_in_title(db_session):
+    _seed_price(db_session)
+    resp = _client(db_session).get("/api/v1/badge/DE_LU/price.svg")
+    root = _parse_svg(resp.text)
+    title_el = root.find("{http://www.w3.org/2000/svg}title")
+    assert "ENTSO-E" in title_el.text

--- a/backend/tests/test_power_live.py
+++ b/backend/tests/test_power_live.py
@@ -168,6 +168,29 @@ def test_just_after_midnight_falls_back_to_yesterday(db_session):
     assert out["latest_actual_ts"] == expected_latest
     # hour 23 (23:00-24:00 yesterday) ended exactly at today's midnight; now is 00:15.
     assert out["lag_minutes"] == 15
+    # `now` (00:15 today) falls outside the shown (yesterday's) window, whose
+    # price series was never loaded — price_now is null until today's first
+    # actual lands and the endpoint switches back to showing="today".
+    assert out["summary"]["price_now"] is None
+
+
+def test_lag_minutes_never_negative_for_a_partial_current_hour(db_session):
+    """parse_load_hourly (backend/power/entsoe_grid.py) averages whatever
+    quarter-hours ENTSO-E has published for an hour with no completeness
+    guard, so an in-progress hour (e.g. 2 of 4 quarter-hours in) can already
+    land a load.actual point. That makes `latest_actual_ts + 1h` land in the
+    future relative to `now` — lag must clamp to 0, never go negative."""
+    now = datetime(2026, 7, 20, 13, 20, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    current_hour_ts = day_start + 13 * H  # 13:00-14:00, still in progress at 13:20
+    upsert_hourly(db_session, "load.actual", "DE_LU",
+                  [(current_hour_ts, 45_000.0)], unit="MW")
+
+    out = compute_live(db_session, "DE_LU", now=now)
+
+    expected_latest = datetime.fromtimestamp(current_hour_ts, tz=timezone.utc).isoformat()
+    assert out["latest_actual_ts"] == expected_latest
+    assert out["lag_minutes"] == 0
 
 
 def test_no_data_at_all_is_unavailable_not_an_error(db_session):
@@ -197,6 +220,7 @@ def test_missing_forecast_series_leaves_forecast_fields_null(db_session):
     assert all(h["load_fc"] is None for h in out["hours"])
     assert all(h["residual_fc"] is None for h in out["hours"])
     assert all(h["residual"] is None for h in out["hours"])
+    assert all(h["gen_fc"] is None for h in out["hours"]), "generation.forecast wasn't seeded either"
     assert out["summary"]["load_vs_forecast_pct"] is None, "no forecast to compare against"
 
 
@@ -265,6 +289,20 @@ def test_route_unknown_zone_mirrors_get_imbalance_fallback(db_session):
     # zone" — see backend/routes/power.py::_resolve_zone).
     assert live_resp["zone"] == DEFAULT_ZONE
     assert imbalance_resp["zone"] == DEFAULT_ZONE
+    # Every sibling endpoint tells the caller what zones ARE valid alongside the
+    # silent fallback (that's the justification for not 400ing) — /live must too.
+    assert set(live_resp["zones"]) == {"DE_LU", "FR", "NL"}
+
+
+def test_route_unavailable_shape_also_carries_zones(db_session):
+    """The unavailable branch (no data at all) must carry `zones` too — not
+    just the happy path. compute_live itself stays pure/zones-agnostic; the
+    route wrapper attaches it either way."""
+    resp = _client(db_session).get("/api/power/live?zone=DE_LU")
+    body = resp.json()
+
+    assert body["available"] is False
+    assert set(body["zones"]) == {"DE_LU", "FR", "NL"}
 
 
 # ─── HTTP route: freshness fields ──────────────────────────────────────────────
@@ -287,3 +325,38 @@ def test_route_carries_freshness_fields(db_session):
     assert "age_days" in body
     assert "stale" in body
     assert body["stale"] is False
+    assert set(body["zones"]) == {"DE_LU", "FR", "NL"}
+
+
+def test_route_fallback_freshness_is_one_day_old_not_stale(db_session):
+    """Real-clock yesterday-fallback via HTTP: seed ONLY yesterday's (relative
+    to whatever wall-clock time the suite runs at) load.actual + price, so
+    compute_live falls back regardless of what hour it actually is right now.
+    as_of then lands on yesterday's calendar date, so age_days is exactly 1 —
+    the boundary case for LIVE_MAX_AGE_DAYS=1 (not stale, not fresh-looking
+    either)."""
+    real_today_start = _day_start(datetime.now(timezone.utc))
+    yesterday_start = real_today_start - 24 * H
+
+    upsert_hourly(db_session, "load.actual", "DE_LU",
+                  [(yesterday_start + h * H, 50_000.0 + h * 10) for h in range(24)], unit="MW")
+    upsert_hourly(db_session, "price.dayahead", "DE_LU",
+                  [(yesterday_start + h * H, 70.0 + h) for h in range(24)], unit="EUR/MWh")
+
+    body = _client(db_session).get("/api/power/live?zone=DE_LU").json()
+
+    assert body["available"] is True
+    assert body["showing"] == "yesterday"
+    assert body["age_days"] == 1
+    assert body["stale"] is False
+
+
+def test_route_max_age_matches_live_load_freshness_spec():
+    """UI/route freshness threshold and the health-check spec must share one
+    truth — mirrors test_power_panel_freshness.py's
+    test_panel_thresholds_match_health_specs for PANEL_MAX_AGE_DAYS vs SPECS."""
+    from backend.collectors.freshness import SPECS
+    from backend.routes.power import LIVE_MAX_AGE_DAYS
+
+    spec = next(s for s in SPECS if s.key == "live_load")
+    assert spec.max_age.days == LIVE_MAX_AGE_DAYS

--- a/backend/tests/test_power_live.py
+++ b/backend/tests/test_power_live.py
@@ -1,0 +1,289 @@
+"""GET /api/power/live — the near-real-time read path for TODAY.
+
+The situation hero and daily panels read only the DAILY rollup tables, which
+exclude the running (incomplete) day — so the desk never shows today until
+the nightly job closes it out. This is the missing read path: it reads the
+canonical hourly store (backend/power/hourly_store.py) directly, joining
+today's published actuals against the published day-ahead forecast/price for
+the SAME hours. Descriptive (Posture B): actuals are compared against what
+ENTSO-E/the auction already published, never predicted.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.database import get_db
+from backend.main import app
+from backend.models.energy import PowerHourly, SeriesDim, ZoneDim  # noqa: F401 — register tables
+from backend.power.hourly_store import upsert_hourly
+from backend.power.live import compute_live
+from backend.power.zones import DEFAULT_ZONE
+
+H = 3600
+
+
+def _day_start(dt: datetime) -> int:
+    return int(dt.replace(hour=0, minute=0, second=0, microsecond=0).timestamp())
+
+
+def _client(db) -> TestClient:
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+# ─── mid-day: today is partially published ────────────────────────────────────
+
+
+def _seed_midday(db, day_start: int, zone: str = "DE_LU"):
+    # Actuals published through hour 12 only (13:45 read, ~1h ENTSO-E lag).
+    upsert_hourly(db, "load.actual", zone,
+                  [(day_start + h * H, 50_000.0 + h * 100) for h in range(13)], unit="MW")
+    upsert_hourly(db, "residual.actual", zone,
+                  [(day_start + h * H, 30_000.0 + h * 50) for h in range(13)], unit="MW")
+    # Forecast + price published for the whole day (day-ahead auction already ran).
+    upsert_hourly(db, "load.forecast", zone,
+                  [(day_start + h * H, 49_500.0 + h * 100) for h in range(24)], unit="MW")
+    upsert_hourly(db, "residual.forecast", zone,
+                  [(day_start + h * H, 29_500.0 + h * 50) for h in range(24)], unit="MW")
+    upsert_hourly(db, "price.dayahead", zone,
+                  [(day_start + h * H, 80.0 + h) for h in range(24)], unit="EUR/MWh")
+    # Solar only in daylight hours (6-12); wind onshore all morning (0-12) —
+    # exercises "gen omits fuels with no data that hour".
+    upsert_hourly(db, "gen.B16", zone,
+                  [(day_start + h * H, 200.0 + h * 10) for h in range(6, 13)], unit="MW")
+    upsert_hourly(db, "gen.B19", zone,
+                  [(day_start + h * H, 1_000.0 + h * 5) for h in range(13)], unit="MW")
+
+
+def test_midday_shows_today_with_actuals_stopping_at_the_published_hour(db_session):
+    now = datetime(2026, 7, 20, 13, 45, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    _seed_midday(db_session, day_start)
+
+    out = compute_live(db_session, "DE_LU", now=now)
+
+    assert out["available"] is True
+    assert out["zone"] == "DE_LU"
+    assert out["zone_label"] == "DE-LU"
+    assert out["showing"] == "today"
+    assert len(out["hours"]) == 24
+
+    h12, h13 = out["hours"][12], out["hours"][13]
+    assert h12["load"] == pytest.approx(51_200.0)
+    assert h13["load"] is None, "no published actual yet for hour 13"
+    assert h13["load_fc"] == pytest.approx(50_800.0), "forecast covers the whole day"
+    assert h13["price"] == pytest.approx(93.0)
+
+    expected_ts0 = datetime.fromtimestamp(day_start, tz=timezone.utc).isoformat()
+    assert out["hours"][0]["ts_utc"] == expected_ts0
+
+
+def test_midday_gen_dict_omits_fuels_absent_that_hour(db_session):
+    now = datetime(2026, 7, 20, 13, 45, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    _seed_midday(db_session, day_start)
+
+    out = compute_live(db_session, "DE_LU", now=now)
+
+    h3 = out["hours"][3]
+    assert h3["gen"] == {"B19": pytest.approx(1_015.0)}, "solar hasn't started yet at 03:00"
+
+    h8 = out["hours"][8]
+    assert h8["gen"]["B16"] == pytest.approx(280.0)
+    assert h8["gen"]["B19"] == pytest.approx(1_040.0)
+
+
+def test_midday_latest_actual_and_lag(db_session):
+    now = datetime(2026, 7, 20, 13, 45, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    _seed_midday(db_session, day_start)
+
+    out = compute_live(db_session, "DE_LU", now=now)
+
+    expected_latest = datetime.fromtimestamp(day_start + 12 * H, tz=timezone.utc).isoformat()
+    assert out["latest_actual_ts"] == expected_latest
+    # hour 12 (12:00-13:00) ended at 13:00; read at 13:45 -> 45 minutes of lag.
+    assert out["lag_minutes"] == 45
+
+
+def test_midday_summary(db_session):
+    now = datetime(2026, 7, 20, 13, 45, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    _seed_midday(db_session, day_start)
+
+    out = compute_live(db_session, "DE_LU", now=now)
+    summary = out["summary"]
+
+    # (51200 - 50700) / 50700 * 100 = 0.9861... -> rounded to 2dp
+    assert summary["load_vs_forecast_pct"] == pytest.approx(0.99, abs=1e-9)
+    # B16(h12)=320 + B19(h12)=1060
+    assert summary["gen_total_now"] == pytest.approx(1_380.0)
+    # now=13:45 falls in hour 13 (13:00-14:00): price = 80 + 13
+    assert summary["price_now"] == pytest.approx(93.0)
+
+
+def test_note_is_descriptive_not_predictive(db_session):
+    now = datetime(2026, 7, 20, 13, 45, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    _seed_midday(db_session, day_start)
+
+    out = compute_live(db_session, "DE_LU", now=now)
+    note = out["note"].lower()
+    assert "lag" in note or "publish" in note
+    assert "never predict" in note, "must explicitly disclaim any forecast of its own"
+
+
+# ─── just after midnight: today has no actuals yet → yesterday fallback ───────
+
+
+def test_just_after_midnight_falls_back_to_yesterday(db_session):
+    now = datetime(2026, 7, 21, 0, 15, tzinfo=timezone.utc)
+    yesterday_start = _day_start(now) - 24 * H
+
+    upsert_hourly(db_session, "load.actual", "DE_LU",
+                  [(yesterday_start + h * H, 50_000.0 + h * 10) for h in range(24)], unit="MW")
+    upsert_hourly(db_session, "load.forecast", "DE_LU",
+                  [(yesterday_start + h * H, 49_000.0 + h * 10) for h in range(24)], unit="MW")
+    upsert_hourly(db_session, "price.dayahead", "DE_LU",
+                  [(yesterday_start + h * H, 70.0 + h) for h in range(24)], unit="EUR/MWh")
+
+    out = compute_live(db_session, "DE_LU", now=now)
+
+    assert out["available"] is True
+    assert out["showing"] == "yesterday"
+    assert len(out["hours"]) == 24
+    expected_ts0 = datetime.fromtimestamp(yesterday_start, tz=timezone.utc).isoformat()
+    assert out["hours"][0]["ts_utc"] == expected_ts0
+
+    expected_latest = datetime.fromtimestamp(yesterday_start + 23 * H, tz=timezone.utc).isoformat()
+    assert out["latest_actual_ts"] == expected_latest
+    # hour 23 (23:00-24:00 yesterday) ended exactly at today's midnight; now is 00:15.
+    assert out["lag_minutes"] == 15
+
+
+def test_no_data_at_all_is_unavailable_not_an_error(db_session):
+    now = datetime(2026, 7, 21, 0, 15, tzinfo=timezone.utc)
+
+    out = compute_live(db_session, "DE_LU", now=now)
+
+    assert out["available"] is False
+    assert out["zone"] == "DE_LU"
+    assert "reason" in out
+
+
+# ─── missing forecast series entirely ──────────────────────────────────────────
+
+
+def test_missing_forecast_series_leaves_forecast_fields_null(db_session):
+    now = datetime(2026, 7, 20, 13, 45, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    upsert_hourly(db_session, "load.actual", "DE_LU",
+                  [(day_start + h * H, 50_000.0 + h * 100) for h in range(13)], unit="MW")
+    upsert_hourly(db_session, "price.dayahead", "DE_LU",
+                  [(day_start + h * H, 80.0 + h) for h in range(24)], unit="EUR/MWh")
+
+    out = compute_live(db_session, "DE_LU", now=now)
+
+    assert out["available"] is True
+    assert all(h["load_fc"] is None for h in out["hours"])
+    assert all(h["residual_fc"] is None for h in out["hours"])
+    assert all(h["residual"] is None for h in out["hours"])
+    assert out["summary"]["load_vs_forecast_pct"] is None, "no forecast to compare against"
+
+
+# ─── flow sign convention: zone may be the storing side OR the counterparty ───
+
+
+def test_flow_native_sign_for_the_storing_zone(db_session):
+    """Border DE_LU<->FR is canonically stored as series flow.FR under zone
+    DE_LU (DE_LU sorts first); positive = DE_LU exports. Querying DE_LU itself
+    reads the native sign."""
+    now = datetime(2026, 7, 20, 13, 45, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    upsert_hourly(db_session, "load.actual", "DE_LU",
+                  [(day_start + h * H, 50_000.0) for h in range(13)], unit="MW")
+    upsert_hourly(db_session, "flow.FR", "DE_LU",
+                  [(day_start + 12 * H, 500.0)], unit="MW")
+
+    out = compute_live(db_session, "DE_LU", now=now)
+    assert out["hours"][12]["net_flow"] == pytest.approx(500.0)
+
+
+def test_flow_sign_flips_for_the_counterparty_zone(db_session):
+    """Same stored row (DE_LU exports 500 MW to FR) queried from FR's side must
+    flip sign: FR is net IMPORTING, i.e. its own export figure is negative."""
+    now = datetime(2026, 7, 20, 13, 45, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    upsert_hourly(db_session, "load.actual", "FR",
+                  [(day_start + h * H, 40_000.0) for h in range(13)], unit="MW")
+    upsert_hourly(db_session, "flow.FR", "DE_LU",
+                  [(day_start + 12 * H, 500.0)], unit="MW")
+
+    out = compute_live(db_session, "FR", now=now)
+    assert out["hours"][12]["net_flow"] == pytest.approx(-500.0)
+
+
+def test_zone_with_no_flow_series_gets_null_not_zero(db_session):
+    now = datetime(2026, 7, 20, 13, 45, tzinfo=timezone.utc)
+    day_start = _day_start(now)
+    upsert_hourly(db_session, "load.actual", "NL",
+                  [(day_start + h * H, 20_000.0) for h in range(13)], unit="MW")
+    # A border exists elsewhere in the store, but never touches NL.
+    upsert_hourly(db_session, "flow.FR", "DE_LU",
+                  [(day_start + 12 * H, 500.0)], unit="MW")
+
+    out = compute_live(db_session, "NL", now=now)
+    assert all(h["net_flow"] is None for h in out["hours"])
+
+
+# ─── unknown zone ───────────────────────────────────────────────────────────────
+
+
+def test_compute_live_unknown_zone_is_structurally_unavailable(db_session):
+    out = compute_live(db_session, "NOT_A_ZONE")
+    assert out["available"] is False
+    assert "reason" in out
+
+
+def test_route_unknown_zone_mirrors_get_imbalance_fallback(db_session):
+    client = _client(db_session)
+
+    live_resp = client.get("/api/power/live?zone=NOT_A_ZONE").json()
+    imbalance_resp = client.get("/api/power/imbalance?zone=NOT_A_ZONE").json()
+
+    # Both endpoints resolve an unknown zone the SAME way: silent fallback to
+    # DEFAULT_ZONE (never a loud 400, never available:false framed as "unknown
+    # zone" — see backend/routes/power.py::_resolve_zone).
+    assert live_resp["zone"] == DEFAULT_ZONE
+    assert imbalance_resp["zone"] == DEFAULT_ZONE
+
+
+# ─── HTTP route: freshness fields ──────────────────────────────────────────────
+
+
+def test_route_carries_freshness_fields(db_session):
+    now = datetime.now(timezone.utc)
+    day_start = _day_start(now)
+    upsert_hourly(db_session, "load.actual", "DE_LU",
+                  [(day_start, 50_000.0)], unit="MW")
+    upsert_hourly(db_session, "price.dayahead", "DE_LU",
+                  [(day_start + h * H, 80.0 + h) for h in range(24)], unit="EUR/MWh")
+
+    resp = _client(db_session).get("/api/power/live?zone=DE_LU")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["available"] is True
+    assert "as_of" in body and body["as_of"] is not None
+    assert "age_days" in body
+    assert "stale" in body
+    assert body["stale"] is False

--- a/backend/tests/test_spark_spreads.py
+++ b/backend/tests/test_spark_spreads.py
@@ -204,6 +204,76 @@ def test_spark_route_computes_per_zone(db_session, monkeypatch):
     assert body["co2_intensity_t_per_mwh"] == pytest.approx(0.404)
 
 
+def test_spark_route_efficiency_override(db_session, monkeypatch):
+    """?efficiency= overrides settings.gas_ccgt_efficiency for THIS request's heat rate;
+    the spread, the break-even carbon price and the carbon intensity all re-derive
+    consistently from it. The default (unspecified) request still echoes the efficiency
+    it actually used."""
+    from datetime import date, timedelta
+
+    from fastapi.testclient import TestClient
+
+    from backend.config import settings as _settings
+    from backend.database import get_db
+    from backend.main import app
+    from backend.power.spark import breakeven_eua, co2_intensity
+
+    monkeypatch.setattr(_settings, "gas_ccgt_efficiency", 0.50)
+    d = (date.today() - timedelta(days=5)).isoformat()
+    _seed(db_session, "POWER_DE", [(d, 90.0)])
+    _seed(db_session, "TTF", [(d, 30.0)])
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    try:
+        default_body = TestClient(app).get("/api/power/spark-spread?zone=DE_LU&days=120").json()
+        override_body = TestClient(app).get(
+            "/api/power/spark-spread?zone=DE_LU&days=120&efficiency=0.60"
+        ).json()
+    finally:
+        app.dependency_overrides.clear()
+
+    # Default request: echoes the setting it defaulted to.
+    assert default_body["efficiency"] == pytest.approx(0.50)
+    assert default_body["latest"]["heat_rate"] == pytest.approx(2.0)
+
+    # Overridden request: heat rate, spread and breakeven all move together.
+    assert override_body["efficiency"] == pytest.approx(0.60)
+    expected_heat_rate = round(1.0 / 0.60, 4)
+    assert override_body["latest"]["heat_rate"] == pytest.approx(expected_heat_rate)
+    expected_spread = round(90.0 - 30.0 * expected_heat_rate, 4)
+    assert override_body["latest"]["dirty_spark_spread"] == pytest.approx(expected_spread)
+    assert override_body["latest"]["breakeven_eua_eur_t"] == breakeven_eua(
+        expected_spread, expected_heat_rate
+    )
+    assert override_body["co2_intensity_t_per_mwh"] == pytest.approx(
+        co2_intensity(expected_heat_rate), rel=1e-4
+    )
+    # The two requests must actually disagree — proof the override took effect at all.
+    assert override_body["latest"]["dirty_spark_spread"] != default_body["latest"]["dirty_spark_spread"]
+
+    # No raw TTF close leaves the endpoint regardless of which efficiency was used.
+    assert "gas_price" not in override_body["latest"]
+    assert all("gas_price" not in row for row in override_body["data"])
+
+
+def test_spark_route_efficiency_out_of_range_is_422(db_session):
+    """FastAPI's Query(ge=, le=) bounds — 0.30–0.65 — reject silently-wrong efficiencies
+    (e.g. a fraction typo'd as a percentage) rather than compute a nonsense heat rate."""
+    from fastapi.testclient import TestClient
+
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    try:
+        too_low = TestClient(app).get("/api/power/spark-spread?zone=DE_LU&efficiency=0.20")
+        too_high = TestClient(app).get("/api/power/spark-spread?zone=DE_LU&efficiency=0.90")
+    finally:
+        app.dependency_overrides.clear()
+    assert too_low.status_code == 422
+    assert too_high.status_code == 422
+
+
 def test_spark_route_unavailable_without_overlap(db_session):
     from fastapi.testclient import TestClient
 

--- a/backend/tests/test_transmission_outages.py
+++ b/backend/tests/test_transmission_outages.py
@@ -1,0 +1,557 @@
+"""A78 transmission-infrastructure unavailability → PowerOutage + /api/power/outages.
+
+Task P12 (see docs/findings/2026-07-20-umm-feasibility.md for why): A78 describes an
+ASSET (interconnector/line/transformer — Asset_RegisteredResource), not a production
+unit, and needs a DIRECTED zone pair (in_Domain/out_Domain) instead of A77's single
+biddingZone_Domain. Fixture structure mirrors the live API (spiked 2026-07-21,
+DE_LU<->FR): confirmed live findings this suite pins down —
+  * in_Domain/out_Domain, NOT biddingZone_Domain (that fails "Mandatory parameter
+    In_Domain is missing"); in_Domain==out_Domain (same zone twice) answers EMPTY.
+  * both directions of one border return DISJOINT message sets (zero mRID overlap
+    across a 7-week window) — ingest must query both, not just the canonical order.
+  * Asset_RegisteredResource nests its OWN <mRID>/<name>, which local-name lookups
+    must not confuse with the document's or the TimeSeries's <mRID>.
+  * nominal_mw is NEVER published for a transmission asset (0/52 sampled) — every
+    generation-only MW total (forced_outage_mw_now/_totals_now, outage_history's
+    offline_mw_at) must keep excluding these rows even though they now share the table.
+  * businessType (A53/A54) and docStatus/revision withdrawal semantics are IDENTICAL
+    to A77.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+from sqlalchemy import create_engine, text
+
+from backend.power import entsoe_outages as out
+
+NS = "urn:iec62325.351:tc57wg16:451-6:outagedocument:3:0"
+
+DE_LU_EIC = "10Y1001A1001A82H"
+FR_EIC = "10YFR-RTE------C"
+
+
+def _a77_doc(
+    mrid: str = "gen1",
+    revision: int = 1,
+    *,
+    business_type: str = "A53",
+    doc_status: str | None = None,
+    start: str = "2026-07-10T22:00Z",
+    end: str = "2026-08-21T14:00Z",
+) -> str:
+    status = f"<docStatus><value>{doc_status}</value></docStatus>" if doc_status else ""
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<Unavailability_MarketDocument xmlns="{NS}">
+  <mRID>{mrid}</mRID>
+  <revisionNumber>{revision}</revisionNumber>
+  <type>A77</type>
+  <unavailability_Time_Period.timeInterval>
+    <start>{start}</start><end>{end}</end>
+  </unavailability_Time_Period.timeInterval>
+  {status}
+  <TimeSeries>
+    <mRID>1</mRID>
+    <businessType>{business_type}</businessType>
+    <production_RegisteredResource.mRID codingScheme="A01">11WD43VIWXHOILLM</production_RegisteredResource.mRID>
+    <production_RegisteredResource.name>Kraftwerk X</production_RegisteredResource.name>
+    <production_RegisteredResource.pSRType.psrType>B14</production_RegisteredResource.pSRType.psrType>
+    <production_RegisteredResource.pSRType.powerSystemResources.nominalP unit="MAW">1400.0</production_RegisteredResource.pSRType.powerSystemResources.nominalP>
+    <Available_Period>
+      <timeInterval><start>{start}</start><end>{end}</end></timeInterval>
+      <resolution>PT1M</resolution>
+      <Point><position>1</position><quantity>400</quantity></Point>
+    </Available_Period>
+  </TimeSeries>
+</Unavailability_MarketDocument>"""
+
+
+def _a78_doc(
+    mrid: str = "asset1",
+    revision: int = 1,
+    *,
+    business_type: str = "A53",
+    doc_status: str | None = None,
+    start: str = "2026-06-15T05:30Z",
+    end: str = "2026-07-03T15:00Z",
+    in_domain: str = DE_LU_EIC,
+    out_domain: str = FR_EIC,
+    asset_name: str = "Eichstetten-Vogelgrun",
+    asset_eic: str = "10T-DE-FR-00003E",
+    location: str = "cross-zonal",
+    psr: str = "B21",
+    available: tuple[tuple[int, float], ...] = ((1, 2500.0), (6751, 1150.0)),
+) -> str:
+    """Byte-for-byte shape of the live A78 sample (spiked 2026-07-21, DE_LU->FR)."""
+    status = f"<docStatus><value>{doc_status}</value></docStatus>" if doc_status else ""
+    points = "".join(
+        f"<Point><position>{p}</position><quantity>{q}</quantity></Point>"
+        for p, q in available
+    )
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+<Unavailability_MarketDocument xmlns="{NS}">
+  <mRID>{mrid}</mRID>
+  <revisionNumber>{revision}</revisionNumber>
+  <type>A78</type>
+  <process.processType>A26</process.processType>
+  <createdDateTime>2026-06-23T15:34:35Z</createdDateTime>
+  <unavailability_Time_Period.timeInterval>
+    <start>{start}</start>
+    <end>{end}</end>
+  </unavailability_Time_Period.timeInterval>
+  {status}
+  <TimeSeries>
+    <mRID>1</mRID>
+    <businessType>{business_type}</businessType>
+    <in_Domain.mRID codingScheme="A01">{in_domain}</in_Domain.mRID>
+    <out_Domain.mRID codingScheme="A01">{out_domain}</out_Domain.mRID>
+    <quantity_Measure_Unit.name>MAW</quantity_Measure_Unit.name>
+    <curveType>A03</curveType>
+    <Asset_RegisteredResource>
+      <mRID codingScheme="A01">{asset_eic}</mRID>
+      <name>{asset_name}</name>
+      <asset_PSRType.psrType>{psr}</asset_PSRType.psrType>
+      <location.name>{location}</location.name>
+    </Asset_RegisteredResource>
+    <Available_Period>
+      <timeInterval>
+        <start>{start}</start>
+        <end>{end}</end>
+      </timeInterval>
+      <resolution>PT1M</resolution>
+      {points}
+    </Available_Period>
+  </TimeSeries>
+  <Reason>
+    <code>B19</code>
+    <text></text>
+  </Reason>
+</Unavailability_MarketDocument>"""
+
+
+def _zip(*docs: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for i, d in enumerate(docs):
+            zf.writestr(f"doc_{i}.xml", d)
+    return buf.getvalue()
+
+
+# ─── parse: A78's Asset_RegisteredResource shape ──────────────────────────────
+
+
+def test_parse_a78_extracts_asset_and_domains():
+    ev = out.parse_unavailability(_a78_doc())
+    assert ev["mrid"] == "asset1"
+    assert ev["unit_name"] == "Eichstetten-Vogelgrun"
+    assert ev["unit_eic"] == "10T-DE-FR-00003E"
+    assert ev["location"] == "cross-zonal"
+    assert ev["psr_type"] == "B21"
+    assert ev["business_type"] == "A53"
+    assert ev["status"] == "active"
+    assert ev["in_domain_eic"] == DE_LU_EIC
+    assert ev["out_domain_eic"] == FR_EIC
+
+
+def test_parse_a78_never_has_a_nominal_capacity():
+    """Live spike (0/52 sampled documents): a transmission asset never publishes a
+    nominalP-equivalent, only the reduced available_mw. offline_mw must therefore
+    stay derivable-as-null, not silently default to 0."""
+    ev = out.parse_unavailability(_a78_doc())
+    assert ev["nominal_mw"] is None
+    assert ev["available_mw"] == 1150.0  # min() over the step function, same rule as A77
+
+
+def test_parse_a78_asset_mrid_is_not_shadowed_by_document_or_timeseries_mrid():
+    """Document, TimeSeries, AND Asset_RegisteredResource each have their own <mRID> —
+    a naive first-match global lookup would return the document's ID as the asset EIC."""
+    ev = out.parse_unavailability(_a78_doc(mrid="DOC-ID-1", asset_eic="10T-REAL-ASSET-EIC"))
+    assert ev["mrid"] == "DOC-ID-1"
+    assert ev["unit_eic"] == "10T-REAL-ASSET-EIC"
+
+
+def test_parse_a78_docstatus_a09_is_withdrawn():
+    ev = out.parse_unavailability(_a78_doc(doc_status="A09"))
+    assert ev["status"] == "withdrawn"
+
+
+def test_parse_a78_forced_business_type():
+    ev = out.parse_unavailability(_a78_doc(business_type="A54"))
+    assert ev["business_type"] == "A54"
+
+
+# ─── regression: A77 parsing is untouched by the A78 branch ──────────────────
+
+
+def test_parse_a77_still_reads_production_registered_resource():
+    ev = out.parse_unavailability(_a77_doc())
+    assert ev["unit_name"] == "Kraftwerk X"
+    assert ev["unit_eic"] == "11WD43VIWXHOILLM"
+    assert ev["nominal_mw"] == 1400.0
+    assert ev["available_mw"] == 400.0
+
+
+def test_parse_a77_carries_no_domain_information():
+    """A77 has no in_Domain/out_Domain concept at all — must stay None, never leak a
+    stale value from a previous A78 parse in the same process."""
+    ev = out.parse_unavailability(_a77_doc())
+    assert ev["in_domain_eic"] is None
+    assert ev["out_domain_eic"] is None
+
+
+# ─── fetch: A78 needs in_Domain/out_Domain, not biddingZone_Domain ────────────
+
+
+async def test_fetch_a78_sends_in_and_out_domain(monkeypatch):
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+        content = b"PK\x03\x04fake"
+
+        def raise_for_status(self):
+            pass
+
+    class _FakeClient:
+        def __init__(self, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, params=None):
+            captured.update(params or {})
+            return _FakeResponse()
+
+    monkeypatch.setattr(out.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(out.settings, "entsoe_api_token", SecretStr("tok"))
+    await out._fetch_outages_page(
+        DE_LU_EIC, "202607040000", "202608040000", 0,
+        doc_type="A78", counterparty_eic=FR_EIC,
+    )
+    assert captured.get("in_Domain") == DE_LU_EIC
+    assert captured.get("out_Domain") == FR_EIC
+    assert "biddingZone_Domain" not in captured
+    assert captured.get("documentType") == "A78"
+
+
+# ─── ingest: A78 walks directed border pairs, not zones ───────────────────────
+
+
+async def test_ingest_a78_queries_both_directions_of_a_real_border(db_session, monkeypatch):
+    """DE_LU-FR is a real canonical border (border_registry.SCHEDULED_BORDERS). Both
+    directions must be queried — the live spike found them fully disjoint."""
+    calls = []
+
+    async def fake_fetch(eic, window_start, window_end, offset, *, doc_type="A77", counterparty_eic=None):
+        calls.append((eic, counterparty_eic))
+        if offset != 0:
+            return None
+        if eic == DE_LU_EIC and counterparty_eic == FR_EIC:
+            return _zip(_a78_doc(mrid="de-to-fr", in_domain=DE_LU_EIC, out_domain=FR_EIC))
+        if eic == FR_EIC and counterparty_eic == DE_LU_EIC:
+            return _zip(_a78_doc(mrid="fr-to-de", in_domain=FR_EIC, out_domain=DE_LU_EIC))
+        return None
+
+    monkeypatch.setattr(out, "_fetch_outages_page", fake_fetch)
+    monkeypatch.setattr(out.settings, "entsoe_api_token", SecretStr("tok"))
+    r = await out.ingest_outages(db_session, zones=["DE_LU", "FR"], doc_type="A78")
+
+    assert r["written"] == 2
+    assert r["pairs"] == 2
+    assert set(calls) == {(DE_LU_EIC, FR_EIC), (FR_EIC, DE_LU_EIC)}
+    rows = {(row.mrid, row.zone, row.counterparty_zone) for row in db_session.query(out.PowerOutage).all()}
+    assert rows == {("de-to-fr", "DE_LU", "FR"), ("fr-to-de", "FR", "DE_LU")}
+    assert all(row.doc_type == "A78" for row in db_session.query(out.PowerOutage).all())
+
+
+async def test_ingest_a78_falls_back_to_raw_eic_when_counterparty_unmapped(db_session, monkeypatch):
+    """A counterparty EIC outside ZONE_REGISTRY must not crash or vanish — keep it raw."""
+    async def fake_fetch(eic, window_start, window_end, offset, *, doc_type="A77", counterparty_eic=None):
+        if offset != 0:
+            return None
+        return _zip(_a78_doc(mrid="odd", in_domain=DE_LU_EIC, out_domain="10Y-UNMAPPED-EIC-X"))
+
+    monkeypatch.setattr(out, "_fetch_outages_page", fake_fetch)
+    monkeypatch.setattr(out.settings, "entsoe_api_token", SecretStr("tok"))
+    await out.ingest_outages(db_session, zones=["DE_LU", "FR"], doc_type="A78")
+
+    row = db_session.query(out.PowerOutage).filter_by(mrid="odd").first()
+    assert row is not None
+    assert row.zone == "DE_LU"
+    assert row.counterparty_zone == "10Y-UNMAPPED-EIC-X"
+
+
+async def test_ingest_a78_revision_and_withdrawal_semantics_match_a77(db_session, monkeypatch):
+    async def fake_fetch(eic, window_start, window_end, offset, *, doc_type="A77", counterparty_eic=None):
+        if offset != 0:
+            return None
+        if eic == DE_LU_EIC and counterparty_eic == FR_EIC:
+            return _zip(_a78_doc(mrid="w1", revision=2, doc_status="A09"))
+        return None
+
+    monkeypatch.setattr(out, "_fetch_outages_page", fake_fetch)
+    monkeypatch.setattr(out.settings, "entsoe_api_token", SecretStr("tok"))
+    await out.ingest_outages(db_session, zones=["DE_LU", "FR"], doc_type="A78")
+
+    row = db_session.query(out.PowerOutage).filter_by(mrid="w1").one()
+    assert row.status == "withdrawn"
+    assert row.revision == 2
+
+
+# ─── regression: A77 ingest is byte-identical (still single biddingZone_Domain) ──
+
+
+async def test_ingest_a77_still_uses_single_zone_loop_not_pairs(db_session, monkeypatch):
+    calls = []
+
+    async def fake_fetch(eic, window_start, window_end, offset, *, doc_type="A77"):
+        calls.append(eic)
+        return _zip(_a77_doc()) if offset == 0 else None
+
+    monkeypatch.setattr(out, "_fetch_outages_page", fake_fetch)
+    monkeypatch.setattr(out.settings, "entsoe_api_token", SecretStr("tok"))
+    r = await out.ingest_outages(db_session, zones=["DE_LU"])
+
+    assert r["written"] == 1
+    assert calls == [DE_LU_EIC]
+    row = db_session.query(out.PowerOutage).one()
+    assert row.zone == "DE_LU" and row.counterparty_zone is None and row.doc_type == "A77"
+
+
+# ─── latest_outage_revisions: doc_type scoping ────────────────────────────────
+
+
+def _mixed_zone_rows(db, now):
+    fmt = "%Y-%m-%dT%H:%MZ"
+    common = dict(zone="DE_LU", business_type="A53", status="active",
+                  start_utc=(now - timedelta(days=1)).strftime(fmt),
+                  end_utc=(now + timedelta(days=1)).strftime(fmt))
+    db.add(out.PowerOutage(mrid="gen", revision=1, doc_type="A77", **common))
+    db.add(out.PowerOutage(mrid="trans", revision=1, doc_type="A78", counterparty_zone="FR", **common))
+    db.commit()
+
+
+def test_latest_outage_revisions_defaults_to_a77_only(db_session):
+    from backend.signals.detectors.power import latest_outage_revisions
+
+    now = datetime.now(timezone.utc)
+    _mixed_zone_rows(db_session, now)
+
+    assert {r.mrid for r in latest_outage_revisions(db_session, "DE_LU")} == {"gen"}
+    assert {r.mrid for r in latest_outage_revisions(db_session, "DE_LU", doc_type="A78")} == {"trans"}
+    assert {r.mrid for r in latest_outage_revisions(db_session, "DE_LU", doc_type=None)} == {"gen", "trans"}
+
+
+def test_forced_outage_totals_ignore_transmission_rows_even_with_a_hypothetical_nominal(db_session):
+    """Belt-and-braces: even if a future A78 schema DID carry a nominal figure (it does
+    not today — 0/52 live-sampled), doc_type must still gate it out of the
+    generation-only forced-MW totals, not just the nominal_mw-is-null coincidence."""
+    from backend.signals.detectors.power import forced_outage_mw_now, forced_outage_totals_now
+
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    common = dict(zone="DE_LU", business_type="A54", status="active", available_mw=0.0,
+                  start_utc=(now - timedelta(days=1)).strftime(fmt),
+                  end_utc=(now + timedelta(days=1)).strftime(fmt))
+    db_session.add(out.PowerOutage(mrid="gen1", revision=1, doc_type="A77", nominal_mw=1000.0, **common))
+    db_session.add(out.PowerOutage(mrid="trans1", revision=1, doc_type="A78", counterparty_zone="FR",
+                                    nominal_mw=500.0, **common))
+    db_session.commit()
+
+    total, running = forced_outage_mw_now(db_session, "DE_LU")
+    assert total == 1000.0
+    assert {r.mrid for r in running} == {"gen1"}
+    assert forced_outage_totals_now(db_session) == {"DE_LU": 1000.0}
+
+
+# ─── route: /api/power/outages transmission section ───────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db) -> TestClient:
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _seed_generation(db, **kw):
+    now = datetime.now(timezone.utc)
+    defaults = dict(
+        mrid="g1", revision=1, doc_type="A77", zone="DE_LU", business_type="A53",
+        psr_type="B14", unit_name="Unit", unit_eic="11WXX", location="X",
+        nominal_mw=1400.0, available_mw=400.0,
+        start_utc=(now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%MZ"),
+        end_utc=(now + timedelta(days=5)).strftime("%Y-%m-%dT%H:%MZ"),
+        status="active",
+    )
+    defaults.update(kw)
+    db.add(out.PowerOutage(**defaults))
+    db.commit()
+
+
+def _seed_transmission(db, **kw):
+    now = datetime.now(timezone.utc)
+    defaults = dict(
+        mrid="t1", revision=1, doc_type="A78", zone="DE_LU", counterparty_zone="FR",
+        business_type="A53", psr_type="B21", unit_name="Eichstetten-Vogelgrun",
+        unit_eic="10T-DE-FR-00003E", location="cross-zonal",
+        nominal_mw=None, available_mw=1150.0,
+        start_utc=(now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%MZ"),
+        end_utc=(now + timedelta(days=5)).strftime("%Y-%m-%dT%H:%MZ"),
+        status="active",
+    )
+    defaults.update(kw)
+    db.add(out.PowerOutage(**defaults))
+    db.commit()
+
+
+def test_route_returns_transmission_section(db_session):
+    _seed_transmission(db_session)
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["available"] is True
+    assert body["outages"] == []
+    assert len(body["transmission"]) == 1
+    t = body["transmission"][0]
+    assert t["asset_name"] == "Eichstetten-Vogelgrun"
+    assert t["asset_eic"] == "10T-DE-FR-00003E"
+    assert t["counterparty_zone"] == "FR"
+    assert t["asset_type"] == "AC Line"
+    assert t["available_mw"] == 1150.0
+    assert t["offline_mw"] is None  # no nominal baseline to subtract from
+    assert t["kind"] == "planned"
+    assert t["running_now"] is True
+
+
+def test_route_generation_and_transmission_are_both_present_by_default(db_session):
+    _seed_generation(db_session)
+    _seed_transmission(db_session)
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert len(body["outages"]) == 1
+    assert len(body["transmission"]) == 1
+    assert body["total_offline_mw"] == pytest.approx(1000.0)  # generation-only, unaffected
+
+
+def test_route_kind_generation_excludes_transmission(db_session):
+    _seed_generation(db_session)
+    _seed_transmission(db_session)
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU&kind=generation").json()
+    assert len(body["outages"]) == 1
+    assert body["transmission"] == []
+
+
+def test_route_kind_transmission_excludes_generation(db_session):
+    _seed_generation(db_session)
+    _seed_transmission(db_session)
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU&kind=transmission").json()
+    assert body["outages"] == []
+    assert len(body["transmission"]) == 1
+    assert body["total_offline_mw"] is None
+    assert body["forced_offline_mw"] is None
+
+
+def test_route_forced_offline_mw_excludes_transmission(db_session):
+    _seed_generation(db_session, business_type="A54")
+    _seed_transmission(db_session, business_type="A54")
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["forced_offline_mw"] == pytest.approx(1000.0)
+
+
+def test_route_transmission_highest_revision_wins_and_withdrawal_hides(db_session):
+    _seed_transmission(db_session, revision=1)
+    _seed_transmission(db_session, revision=5, status="withdrawn")
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["transmission"] == []
+
+
+def test_route_transmission_only_zone_is_still_available(db_session):
+    """A zone with ONLY A78 messages (no A77 at all) must not hit the 'unavailable'
+    early return — it just has an empty generation list."""
+    _seed_transmission(db_session)
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["available"] is True
+
+
+def test_route_empty_kind_all_is_unavailable(db_session):
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert body["available"] is False
+
+
+# ─── freshness: A78 gets its own watchdog probe ───────────────────────────────
+
+
+def test_transmission_outage_collector_is_watched(db_session):
+    from backend.collectors.freshness import SPECS, evaluate_freshness
+
+    spec = next(s for s in SPECS if s.key == "power_outages_transmission")
+    assert spec.filter_col == "doc_type"
+    assert spec.filter_val == "A78"
+
+    db_session.add(out.PowerOutage(
+        mrid="t1", revision=1, doc_type="A78", zone="DE_LU", counterparty_zone="FR",
+        business_type="A53", start_utc="2026-07-01T00:00Z", end_utc="2026-08-01T00:00Z",
+        status="active",
+    ))
+    db_session.commit()
+    result = evaluate_freshness(db_session)
+    assert result["power_outages_transmission"]["fresh"] is True
+    # A78 volume is much lower than A77's — the window must not be TIGHTER than A77's,
+    # or quiet weeks on real borders would false-alarm.
+    a77_spec = next(s for s in SPECS if s.key == "power_outages")
+    assert spec.max_age >= a77_spec.max_age
+
+
+def test_transmission_outage_collector_reports_stale_when_silent(db_session):
+    from backend.collectors.freshness import evaluate_freshness
+
+    db_session.add(out.PowerOutage(
+        mrid="old", revision=1, doc_type="A78", zone="DE_LU", counterparty_zone="FR",
+        business_type="A53", start_utc="2020-01-01T00:00Z", end_utc="2020-02-01T00:00Z",
+        status="active",
+        created_at=datetime(2020, 1, 1),
+    ))
+    db_session.commit()
+    result = evaluate_freshness(db_session, now=datetime(2026, 7, 21, tzinfo=timezone.utc))
+    assert result["power_outages_transmission"]["fresh"] is False
+
+
+# ─── migration: counterparty_zone is idempotent ───────────────────────────────
+
+
+def test_counterparty_zone_migration_is_idempotent(tmp_path, monkeypatch):
+    import backend.migrations as migrations
+    from backend.database import Base
+
+    db_path = tmp_path / "mig.db"
+    test_engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(bind=test_engine)
+    monkeypatch.setattr(migrations, "engine", test_engine)
+
+    with test_engine.begin() as conn:
+        conn.execute(text("ALTER TABLE power_outage DROP COLUMN counterparty_zone"))
+    assert "counterparty_zone" not in migrations._existing_columns("power_outage")
+
+    migrations.run_migrations()
+    assert "counterparty_zone" in migrations._existing_columns("power_outage")
+
+    # Idempotent: running again must not raise or duplicate the column.
+    migrations.run_migrations()
+    assert "counterparty_zone" in migrations._existing_columns("power_outage")

--- a/backend/tests/test_transmission_outages.py
+++ b/backend/tests/test_transmission_outages.py
@@ -555,3 +555,211 @@ def test_counterparty_zone_migration_is_idempotent(tmp_path, monkeypatch):
     # Idempotent: running again must not raise or duplicate the column.
     migrations.run_migrations()
     assert "counterparty_zone" in migrations._existing_columns("power_outage")
+
+
+# ─── review fix #1: A78 zone matching must be both-sided ──────────────────────
+#
+# A border publishes ONE row per queried direction (zone=in_Domain,
+# counterparty_zone=out_Domain), and the live spike found the two directions are
+# DISJOINT messages, not duplicates. Filtering latest_outage_revisions on
+# PowerOutage.zone == z alone therefore missed every message filed under the OTHER
+# zone even though it is just as much z's outage — half of all border events never
+# reached the affected zone's panel.
+
+
+def test_latest_outage_revisions_a78_matches_either_side_of_the_border(db_session):
+    from backend.signals.detectors.power import latest_outage_revisions
+
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    common = dict(business_type="A53", status="active",
+                  start_utc=(now - timedelta(days=1)).strftime(fmt),
+                  end_utc=(now + timedelta(days=1)).strftime(fmt))
+    db_session.add(out.PowerOutage(mrid="de-side", revision=1, doc_type="A78",
+                                    zone="DE_LU", counterparty_zone="FR", **common))
+    db_session.add(out.PowerOutage(mrid="fr-side", revision=1, doc_type="A78",
+                                    zone="FR", counterparty_zone="DE_LU", **common))
+    db_session.commit()
+
+    rows = latest_outage_revisions(db_session, "DE_LU", doc_type="A78")
+    assert {r.mrid for r in rows} == {"de-side", "fr-side"}
+
+
+def test_latest_outage_revisions_a77_default_does_not_fall_back_to_counterparty(db_session):
+    """The both-sided OR-match is scoped to doc_type=='A78' only. A77 never carries a
+    counterparty_zone in real ingest — this row is constructed by hand purely to prove
+    the A77-default query stays a plain zone==z filter, not a behavior change."""
+    from backend.signals.detectors.power import latest_outage_revisions
+
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    db_session.add(out.PowerOutage(
+        mrid="not-de-lu", revision=1, doc_type="A77", zone="FR", counterparty_zone="DE_LU",
+        business_type="A53", status="active",
+        start_utc=(now - timedelta(days=1)).strftime(fmt),
+        end_utc=(now + timedelta(days=1)).strftime(fmt),
+    ))
+    db_session.commit()
+
+    assert latest_outage_revisions(db_session, "DE_LU") == []
+
+
+def test_latest_outage_revisions_a78_ending_after_prunes_both_sides(db_session):
+    """The `ending_after` mRID-relevance prune must also match either column, or an
+    event whose only zone-DE_LU-adjacent row already ended would wrongly survive via
+    a still-running counterparty-side row that the (unfixed) prune could not see."""
+    from backend.signals.detectors.power import latest_outage_revisions
+
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    now_iso = now.strftime(fmt)
+    db_session.add(out.PowerOutage(
+        mrid="fr-side-running", revision=1, doc_type="A78", zone="FR", counterparty_zone="DE_LU",
+        business_type="A53", status="active",
+        start_utc=(now - timedelta(days=1)).strftime(fmt),
+        end_utc=(now + timedelta(days=1)).strftime(fmt),
+    ))
+    db_session.commit()
+
+    rows = latest_outage_revisions(db_session, "DE_LU", doc_type="A78", ending_after=now_iso)
+    assert {r.mrid for r in rows} == {"fr-side-running"}
+
+
+def test_route_transmission_shows_reversed_direction_row_with_relative_counterparty(db_session):
+    """An FR->DE_LU-direction message (zone=FR, counterparty_zone=DE_LU) is just as
+    much DE_LU's outage — it must appear on DE_LU's panel, and its counterparty_zone
+    must read "FR" (relative to the requested zone), not "DE_LU" (a zone cannot be
+    its own counterparty)."""
+    _seed_transmission(db_session, mrid="rev1", zone="FR", counterparty_zone="DE_LU")
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert len(body["transmission"]) == 1
+    t = body["transmission"][0]
+    assert t["mrid"] == "rev1"
+    assert t["counterparty_zone"] == "FR"
+    assert t["reported_by"] == "FR"
+
+
+def test_route_transmission_normal_direction_counterparty_unchanged(db_session):
+    _seed_transmission(db_session, mrid="norm1", zone="DE_LU", counterparty_zone="FR")
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    t = next(x for x in body["transmission"] if x["mrid"] == "norm1")
+    assert t["counterparty_zone"] == "FR"
+    assert t["reported_by"] == "DE_LU"
+
+
+def test_route_transmission_both_directions_of_a_border_both_appear(db_session):
+    """Both directions can legitimately coexist as disjoint messages — the panel must
+    show both, not just the one filed under the exact zone value (accepted
+    consequence: the same physical asset can appear twice, per direction)."""
+    _seed_transmission(db_session, mrid="a", zone="DE_LU", counterparty_zone="FR")
+    _seed_transmission(db_session, mrid="b", zone="FR", counterparty_zone="DE_LU")
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert {t["mrid"] for t in body["transmission"]} == {"a", "b"}
+    assert all(t["counterparty_zone"] == "FR" for t in body["transmission"])
+
+
+def test_route_transmission_a77_generation_list_unaffected_by_reversed_direction_rows(db_session):
+    """Regression guard: the both-sided A78 match must not leak into the A77
+    generation list or its totals."""
+    _seed_generation(db_session)
+    _seed_transmission(db_session, mrid="rev1", zone="FR", counterparty_zone="DE_LU")
+    body = _client(db_session).get("/api/power/outages?zone=DE_LU").json()
+    assert len(body["outages"]) == 1
+    assert body["total_offline_mw"] == pytest.approx(1000.0)
+
+
+# ─── review fix #2: the shared scheduler session must survive a mid-pass error ──
+
+
+async def test_run_outages_rolls_back_after_a77_failure_so_a78_pass_still_runs(monkeypatch):
+    """_run_outages shares ONE Session across the A77 and A78 passes. Without
+    db.rollback() in the except, a DB-level error in the A77 pass leaves the session
+    in SQLAlchemy's failed-transaction state and the very next statement the A78 pass
+    tries to run raises PendingRollbackError instead of actually attempting anything
+    — silently defeating the "independent try/excepts" the docstring promises."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    import backend.power.entsoe_outages as entsoe_outages_mod
+    from backend.collectors import scheduler
+    from backend.database import Base
+    from backend.models.energy import PowerOutage
+
+    test_engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=test_engine)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
+    monkeypatch.setattr(scheduler, "SessionLocal", TestSessionLocal)
+
+    calls: list[str] = []
+    results: dict = {}
+
+    def _row(mrid, revision):
+        return PowerOutage(
+            mrid=mrid, revision=revision, doc_type="A77", zone="DE_LU",
+            business_type="A53", start_utc="2026-01-01T00:00Z", end_utc="2026-01-02T00:00Z",
+            status="active",
+        )
+
+    async def fake_ingest(db, *, doc_type="A77", **kw):
+        calls.append(doc_type)
+        if doc_type == "A77":
+            # A REAL IntegrityError — a raw "bad SELECT" does not actually poison a
+            # SQLAlchemy Session on SQLite the way a failed FLUSH does. Violating the
+            # (mrid, revision) unique constraint on commit is what genuinely puts the
+            # Session in the "failed transaction" state PendingRollbackError guards.
+            db.add(_row("dup", 1))
+            db.add(_row("dup", 1))
+            db.commit()
+            return {"written": 2}
+        # A78 pass: prove the session is still usable for real work. Without the
+        # rollback fix, this raises PendingRollbackError.
+        try:
+            results["a78_count"] = db.query(PowerOutage).count()
+            results["a78_ok"] = True
+        except Exception as exc:
+            results["a78_ok"] = False
+            results["a78_error"] = type(exc).__name__
+            raise
+        return {"written": 0}
+
+    monkeypatch.setattr(entsoe_outages_mod, "ingest_outages", fake_ingest)
+
+    await scheduler._run_outages()
+
+    assert calls == ["A77", "A78"]
+    assert results.get("a78_ok") is True, (
+        f"A78 pass failed against the shared session ({results.get('a78_error')}) — "
+        "the A77 except must call db.rollback() before the A78 pass runs"
+    )
+    assert results.get("a78_count") == 0
+
+
+# ─── review fix #3: the A77 freshness probe must not be masked by A78 traffic ──
+
+
+def test_a77_freshness_probe_is_not_masked_by_a78_only_traffic(db_session):
+    """The reverse of the masking power_outages_transmission already guards against:
+    A78 traffic alone must not keep the desk-critical A77 (generation) probe looking
+    healthy while the A77 pass is silently dead."""
+    from backend.collectors.freshness import evaluate_freshness
+
+    db_session.add(out.PowerOutage(
+        mrid="t-only", revision=1, doc_type="A78", zone="DE_LU", counterparty_zone="FR",
+        business_type="A53", start_utc="2026-07-01T00:00Z", end_utc="2026-08-01T00:00Z",
+        status="active",
+    ))
+    db_session.commit()
+    result = evaluate_freshness(db_session)
+    assert result["power_outages"]["fresh"] is False
+    assert result["power_outages"]["last_seen"] is None
+
+
+def test_a77_freshness_probe_is_scoped_to_doc_type(db_session):
+    from backend.collectors.freshness import SPECS
+
+    spec = next(s for s in SPECS if s.key == "power_outages")
+    assert spec.filter_col == "doc_type"
+    assert spec.filter_val == "A77"

--- a/deploy/install-caddy-integration.sh
+++ b/deploy/install-caddy-integration.sh
@@ -2,6 +2,25 @@
 # Integrate obsyd.dev into the existing Caddy reverse-proxy used by ValueKick.
 # Only touches: Caddyfile, docker-compose.prod.yml (Caddy service block),
 # obsyd.service (uvicorn bind), UFW (deny 8000 from outside).
+#
+# Deploying the /embed exception (Task P10) to an ALREADY-deployed obsyd.dev:
+# step [2/7] below is idempotent — it skips the whole obsyd.dev block (including
+# this new @embed handle) whenever "obsyd.dev" already appears in the live
+# Caddyfile, which it will on any server this script has already run on. So
+# picking up the @embed block on a live host is a MANUAL step, not something
+# re-running this script accomplishes:
+#   1. On the VPS, open the live Caddyfile (the one this script appends to,
+#      here /home/jo/valuekick/Caddyfile) and paste in the `@embed`
+#      matcher + `handle @embed { ... }` block from step [2/7] below, placed
+#      after `handle @api` and before the generic `handle { ... }` — matching
+#      order matters (Caddy's `handle` blocks are mutually exclusive and
+#      evaluated top-to-bottom, first match wins).
+#   2. Apply it exactly like step [6/7] does: `docker compose -f
+#      docker-compose.prod.yml up -d --force-recreate caddy` (a `caddy reload`
+#      inside the container works too if you'd rather not recreate it).
+# There is no live-server automation here on purpose — the script's own
+# guard against double-appending would otherwise make it easy to believe a
+# re-run had shipped this change when it silently no-opped.
 set -e
 TS=$(date +%s)
 cd /home/jo/valuekick
@@ -34,6 +53,21 @@ obsyd.dev, www.obsyd.dev {
             header_up X-Real-IP {remote_host}
             header_up X-Forwarded-For {remote_host}
         }
+    }
+
+    # Task P10 (embeddable zone widgets): /embed/* is the ONLY frameable part of the
+    # site. The global X-Frame-Options DENY above blocks ALL embedding by default —
+    # here we punch a narrow, path-scoped hole for the iframe widgets only, and only
+    # for that path. Must come AFTER @api (so /api/* keeps its own headers/proxy) and
+    # BEFORE the generic catch-all `handle` below (or its unscoped DENY wins first).
+    @embed path /embed/*
+    handle @embed {
+        header -X-Frame-Options
+        header Content-Security-Policy "frame-ancestors *"
+        header Cache-Control "public, max-age=300"
+        root * /srv/obsyd
+        try_files {path} /index.html
+        file_server
     }
 
     handle {

--- a/deploy/install-caddy-integration.sh
+++ b/deploy/install-caddy-integration.sh
@@ -59,7 +59,9 @@ obsyd.dev, www.obsyd.dev {
     # site. The global X-Frame-Options DENY above blocks ALL embedding by default —
     # here we punch a narrow, path-scoped hole for the iframe widgets only, and only
     # for that path. Must come AFTER @api (so /api/* keeps its own headers/proxy) and
-    # BEFORE the generic catch-all `handle` below (or its unscoped DENY wins first).
+    # BEFORE the generic catch-all `handle` below — handles are mutually exclusive in
+    # file order, and only THIS handle carries the `header -X-Frame-Options` delete;
+    # if the catch-all matched first, the site-global DENY header would survive.
     @embed path /embed/*
     handle @embed {
         header -X-Frame-Options

--- a/deploy/install-caddy-integration.sh
+++ b/deploy/install-caddy-integration.sh
@@ -21,6 +21,15 @@
 # There is no live-server automation here on purpose — the script's own
 # guard against double-appending would otherwise make it easy to believe a
 # re-run had shipped this change when it silently no-opped.
+#
+# First deploy of the balancing/capacity collectors (activated balancing energy +
+# procured balancing-capacity prices): right after step [4/7]'s `systemctl restart
+# obsyd`, manually run `python -m backend.scripts.power_backfill --sources balancing`
+# and `python -m backend.scripts.power_backfill --sources capacity` once. Skipping
+# this is not a launch blocker — the 09:00 UTC collector watchdog will email a
+# capacity_prices/balancing_energy stale alert until the 11:30 UTC daily job fills the
+# series in on its own (self-heals within 24h) — but running the backfill closes the
+# gap immediately instead of waiting out one noisy watchdog cycle.
 set -e
 TS=$(date +%s)
 cd /home/jo/valuekick

--- a/deploy/obsyd.nginx
+++ b/deploy/obsyd.nginx
@@ -1,3 +1,10 @@
+# LEGACY / self-hoster path: the included `deploy/setup-vps.sh` provisions this
+# standalone nginx config for people running their own instance. The hosted
+# obsyd.dev does NOT use this — it runs behind Caddy (deploy/install-caddy-
+# integration.sh), which is where the maintained /embed frame exception lives
+# first. Keep the two in sync when either changes; this file is not exercised
+# by CI or by the hosted deploy.
+#
 # HTTPS is handled by Let's Encrypt / certbot on the VPS.
 # This config shows the HTTP server block only.
 # Certbot auto-generates the SSL server block in /etc/nginx/sites-available/.
@@ -16,6 +23,25 @@ server {
 
     # SPA Routing
     location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # /embed/<zone>/<metric> iframe widgets — mirrors the Caddy @embed exception in
+    # deploy/install-caddy-integration.sh, the only frameable path on the site. nginx's
+    # add_header does NOT inherit into a location block that declares its own add_header,
+    # so every security header below is repeated on purpose — this list is identical to
+    # the server-level ones further down EXCEPT X-Frame-Options (omitted, dropping the
+    # site-wide DENY here) and Content-Security-Policy (a permissive frame-ancestors
+    # instead of the strict default-src one). Also serves the SPA (this is a client-side
+    # route, not a distinct static page) with a 5-minute cache for the embedded widget.
+    location /embed/ {
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header Content-Security-Policy "frame-ancestors *";
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Cache-Control "public, max-age=300";
         try_files $uri $uri/ /index.html;
     }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,10 +22,11 @@ One time series for one bidding zone over a date range — the core endpoint.
 | `resolution` | `hourly` | `hourly` (raw store resolution — `.qh` series return 15-min steps) or `daily` (daily mean; rows carry `hours`, 24 = a settled day) |
 | `format` | `json` | `json` (>100k points returns HTTP 200 with `available:false` + a reason — use csv/parquet), `csv` (streamed, unbounded), or `parquet` (unbounded; HTTP 501 if the server lacks pyarrow) |
 
-Rate limit: ~120 req/min/IP applies to `/series`, `/genmix` and `/snapshot`; the
-reference endpoints (`/meta`, `/zones`, `/status`, `/capacity`, `/units`,
-`/series/catalog`) are not rate-limited. "Nothing found" (unknown series, empty
-window) is HTTP 200 with `available:false` + `reason`, not a 4xx.
+Rate limit: ~120 req/min/IP applies to `/series`, `/genmix`, `/snapshot` and the
+`/badge/*.svg` widgets below; the reference endpoints (`/meta`, `/zones`,
+`/status`, `/capacity`, `/units`, `/series/catalog`) are not rate-limited.
+"Nothing found" (unknown series, empty window) is HTTP 200 with
+`available:false` + `reason`, not a 4xx.
 
 ```bash
 # JSON, daily mean, last 30 days
@@ -109,6 +110,63 @@ df = Obsyd().series("price.dayahead", "DE_LU", start="2024-01-01", resolution="d
 
 DataFrames with tz-aware UTC indexes, typed errors, built-in 429 backoff.
 Source + executable example notebooks: `clients/python/` in the repo.
+
+## Embedding
+
+Two ways to put live Obsyd data on your own page — no API key, no JS to write.
+
+### Iframe widgets — `/embed/<ZONE>/<metric>`
+
+A self-contained, auto-refreshing widget for one zone. `<metric>` is one of
+`price` (day-ahead hourly curve), `genmix` (stacked generation mix) or `load`
+(load vs. day-ahead forecast).
+
+```html
+<iframe
+  src="https://obsyd.dev/embed/DE_LU/price"
+  width="420" height="180"
+  style="border: 0;"
+  loading="lazy"
+  title="OBSYD — DE-LU day-ahead price">
+</iframe>
+```
+
+- The widget polls for fresh data every ~5 minutes on its own (matches the desk's
+  own `POLL_FAST_MS` refresh cadence) — reload the iframe yourself only if you
+  want to force it sooner.
+- An unrecognized `<ZONE>` or `<metric>` renders an explicit "unknown" card
+  linking back to obsyd.dev — never a silent fallback to a different zone. Check
+  `GET /api/v1/zones` for the current enabled set.
+- `/embed/*` is the **only** part of obsyd.dev that permits being framed —
+  every other path sends `X-Frame-Options: DENY`.
+
+### Status badges — `/api/v1/badge/<ZONE>/<metric>.svg`
+
+A tiny flat SVG pill for a README, wiki page or status dashboard. `<metric>` is
+`price` or `load`.
+
+```markdown
+![DE-LU day-ahead price](https://obsyd.dev/api/v1/badge/DE_LU/price.svg)
+```
+
+```html
+<img src="https://obsyd.dev/api/v1/badge/DE_LU/load.svg" alt="DE-LU load">
+```
+
+- Cached 15 minutes (`Cache-Control: public, max-age=900`) — a badge is fetched
+  by *your* readers' browsers/bots on their own schedule, not polled by us.
+- An unknown zone/metric, or a momentary data gap, degrades to a neutral grey
+  "no data" pill at HTTP 200 rather than a broken-image icon — a badge must
+  never break whatever page it's embedded in.
+- Shares the same ~120 req/min/IP budget as the rest of `/api/v1`.
+
+### Attribution
+
+Both forms already carry attribution baked in — the iframe widget's footer
+("OBSYD · obsyd.dev — data: ENTSO-E") and the badge's `<title>` tooltip — so no
+extra credit line is required on your page. If you build something custom on
+top of `/api/v1/series` instead, keep the "Attribution & license" note below in
+view somewhere.
 
 ## Attribution & license
 Attribute ENTSO-E, Fraunhofer Energy-Charts (CC BY 4.0) and GIE. The service and its

--- a/docs/API.md
+++ b/docs/API.md
@@ -92,7 +92,12 @@ delivery date), and an overall `healthy` flag. "Here is exactly what is fresh an
 | `generation.forecast` | Day-ahead total generation forecast (A71) | MW |
 | `consumption.<PSR>` | Consumption of consumption-type PSRs (e.g. pumped-storage pumping) | MW |
 | `flow.<ZONE>` | Cross-border physical flow to `<ZONE>`, stored under the FROM zone; positive = FROM exports | MW |
+| `sched.<ZONE>` | Scheduled (day-ahead auction) commercial exchange to `<ZONE>`, stored under the FROM zone on the same sorted-pair/net-sign convention as `flow.<ZONE>` — `flow − sched` is loop flow | MW |
 | `hydro.reservoir` | Weekly reservoir filling (A72; hydro zones only) | MWh |
+| `netpos.dayahead` | Signed day-ahead market net position (A25); positive = zone is a net exporter | MW |
+| `outage.offline` / `outage.forced` | Generation capacity offline right now — all published unavailability / the A54 forced-outage subset (A77; today-only snapshot series, not backfillable — see `backend/power/outage_history.py`) | MW |
+| `balancing.<product>.price.<up\|down>` / `balancing.<product>.vol.<up\|down>` | Activated balancing energy price/volume, `<product>` = `afrr`/`mfrr` (ENTSO-E A84/A83). Volume (A83) currently fails structurally at ENTSO-E for every zone tried — the `.vol.*` series are defined but empty. DE_LU is served via TenneT's control area only (one of four German TSOs), not the national total | EUR/MWh / MWh |
+| `capacity.fcr.price` / `capacity.<afrr\|mfrr>.price.<pos\|neg>` | Procured balancing-CAPACITY price — volume-weighted average of accepted tenders (ENTSO-E A15), normalized to EUR/MW/h (FCR's native EUR-per-4h-block price divided by 4). DE_LU only (German LFC block; no per-zone equivalent) | EUR/MW/h |
 
 Call `/api/v1/meta` for the live list. Values are hourly-canonical UTC; actuals carry a
 ~1 hour publication lag (the honest ceiling of free ENTSO-E data).

--- a/docs/findings/2026-07-20-regelleistung-capacity-prices.md
+++ b/docs/findings/2026-07-20-regelleistung-capacity-prices.md
@@ -1,0 +1,48 @@
+# Feasibility spike: German FCR/aFRR/mFRR capacity prices — 2026-07-20
+
+**Verdict: GO — via ENTSO-E documentType A15 (12.3.F), not regelleistung.net.**
+regelleistung.net has no data licence (Impressum reserves reproduction to the four TSOs);
+the identical data is live on the ENTSO-E Transparency Platform under the
+attribution-based reuse terms Obsyd already operates under for its 77 ENTSO-E series.
+
+## regelleistung.net: no licence, permission would be needed
+
+- Operator: the four German TSOs (50Hertz, Amprion, TenneT, TransnetBW). There is **no
+  Nutzungsbedingungen page and no data-licence statement** anywhere on the site (Impressum,
+  Datenschutz, SPA footers, robots.txt all checked). The only governing clause (Impressum,
+  "Use of this website"): *"Reproduction of the website or parts thereof … requires prior
+  written permission from the German TSOs unless reproduction is authorised by law."*
+- Systematic daily harvesting + public re-export plausibly falls under the sui-generis
+  database right (§§ 87a ff. UrhG). Public scrapers exist and enforcement risk against a
+  free attributed tool is low — but "probably tolerated" is not "licensed".
+- If its cleaner ready-made aggregates are ever wanted directly: the Datacenter SPA uses an
+  **unauthenticated JSON API** at `https://www.regelleistung.net/apps/crds/api/v2`
+  (`/tenders?…`, `/tenders/{id}/aggregated-product-results` with min/mean/max + full
+  anonymised bid ladder, `/tenders/{id}/local-marginal-prices` for FCR; tenderIds
+  `PRL|SRL|MRL_YYYYMMDD_D1`; history to 2018/2019). The documented xlsx download endpoint
+  (`…/cpp-publisher/api/v1/download/tenders/files/RESULT_OVERVIEW_CAPACITY_MARKET_…`) is
+  xlsx-only, mid-2022→today, empty-200 on missing dates. Ask the TSOs in writing first.
+
+## ENTSO-E path (chosen)
+
+- **A89/A81 are dead on web-api.tp.entsoe.eu** — live probe returns "combination … not
+  valid, or the requested data is not allowed to be fetched via this service" (token
+  sanity-checked against A44). Any library code path using them (e.g. entsoe-py
+  `query_contracted_reserve_prices`) fails against today's API.
+- **The live replacement is documentType A15 "Procured Balancing Capacity [GL EB 12.3.F]"**:
+  `area_Domain=10Y1001A1001A82H` (DE-LU LFC **block** — individual German control areas
+  return nothing), processType **A52=FCR / A51=aFRR / A47=mFRR**. Verified 2026-07-14:
+  aFRR 6,458 instances, mFRR 1,802, FCR non-empty. Responses are ZIPs of
+  `Balancing_MarketDocument` XMLs with per-bid `businessType B95`, `flowDirection`
+  (A01=up/A02=down), `quantity` [MW], `procurement_Price.amount`. Pagination: 100
+  documents per request via explicit `offset` (max 4900).
+- Aggregate client-side to min/avg/marginal per 4-h product block (daily tenders, six
+  blocks 00_04…20_24; FCR symmetric, aFRR/mFRR split pos/neg; FCR pay-as-cleared
+  EUR/MW per 4 h, aFRR/mFRR pay-as-bid EUR/MW/h).
+- **Fidelity caveat:** FCR per-country settlement prices under cross-border clearing (the
+  regelleistung.net local-marginal-prices view) are not exactly reconstructible from DE-LU
+  bid data alone; DE settlement price can differ from the cross-border price on
+  export-limit congestion days. Acceptable for a German-desk view; note it in the UI.
+- Publication timing (D-1, Europe/Berlin): FCR results ~08:30, aFRR ~09:30, mFRR ~11:00.
+- Unverified lead: SMARD (Bundesnetzagentur, CC BY 4.0) has a Regelenergie section that
+  may carry the same series.

--- a/docs/findings/2026-07-20-umm-feasibility.md
+++ b/docs/findings/2026-07-20-umm-feasibility.md
@@ -1,0 +1,62 @@
+# Feasibility spike: REMIT/UMM ingestion (Nord Pool, EEX) — 2026-07-20
+
+**Verdict: NO-GO as-of-right. GO only with express written consent from Nord Pool.**
+Storage + analysis of UMMs is permitted; public re-display on obsyd.dev is not, absent
+written consent. The legally clean substitute for the largest unique slice (transmission/
+interconnector unavailability) is ENTSO-E documentType **A78**, under the terms Obsyd
+already operates under.
+
+## The hard gate: Nord Pool terms fail
+
+Governing document: **"REMIT UMM Services General Terms"** (Nord Pool AS, valid from
+2021-05-15), linked from the UMM platform's own T&C dialog
+(<https://www.nordpoolgroup.com/4975a5/globalassets/download-center/remit/remit-umm-services-general-terms-valid-from-15.05.21-.pdf>).
+
+- Clause 11.1: users "may download, store and use" contents "for analysis or research
+  purposes", but "may not republish, retransmit, re-distribute or otherwise make the
+  contents … available … on any website … without the express written consent of Nord Pool."
+- Service Schedule 1C (READ-ONLY SERVICE): "Reading of data on Nord Pool web page **for
+  internal use only**."
+- API General T&Cs §9.2 lists "re-transmission, re-selling or publication in any form
+  whatsoever" as the first example of API misuse.
+
+REMIT II (Reg. (EU) 2024/1106, Art. 4) obliges Nord Pool as an IIP to make inside
+information freely publicly *accessible* — it does not grant third parties a licence to
+republish the IIP's feed over its contract terms. Commercial aggregators (Montel,
+EnAppSys) presumably hold exactly the written consent Clause 11.1 contemplates.
+
+**EEX transparency: confirmed NO** — the disclaimer
+(<https://www.eex-transparency.com/disclaimer>) forbids copying/dissemination without
+prior written approval; single personal non-commercial copy only.
+
+## Everything else scores well (for the record)
+
+- **API**: `https://ummapi.nordpoolgroup.com` is a documented, unauthenticated, public
+  REST/JSON API (OpenAPI at `/swagger/v1/swagger.json`; "Much of the API does not require
+  authentication and is public"). `GET /messages` with rich filters, `messageId`+`version`+
+  `eventStatus` versioning, max 2000 rows/call (HTTP 413 above), history back to 2013
+  (~113k current / ~586k incl. outdated messages), RSS + websocket push channels.
+- **Zone mapping**: of all 1,723 messages published 2026-06-20→2026-07-20, **86.3 %** map
+  cleanly onto Obsyd's 37-zone registry (DE TSO control areas folded to DE_LU); the gap is
+  almost entirely LT/LV/EE + GB. Adding the Baltic zones (config-only) lifts full
+  mappability to **98.9 %**. ES/PT/IT/CH are essentially absent from the platform.
+- **Message mix**: Production 47 %, Transmission 39 %, MarketInformation 9 %,
+  Consumption 5 %. Production UMMs largely duplicate ENTSO-E A77 by construction
+  (Nord Pool forwards the same disclosures to the Transparency Platform; est. 80–95 %
+  duplication for enabled zones). Unique value: transmission/interconnector outages,
+  consumption outages, richer free-text remarks, clean JSON, likely faster publication.
+
+## Paths forward
+
+1. **A78 transmission unavailability via ENTSO-E** (recommended, no new licence needed):
+   `backend/power/entsoe_outages.py` already parameterises `doc_type` (A77/A78/A80) and
+   `PowerOutage.doc_type` exists — ingesting transmission outages is an incremental change
+   to the existing pipeline, covering the biggest unique UMM slice for all 37 zones
+   (not just the Nordics-skewed Nord Pool population).
+2. **Link out** to `umm.nordpoolgroup.com` from the outage panel (per-message deep links
+   need no licence).
+3. **Owner option**: request express written consent from Nord Pool
+   (support@nordpoolgroup.com) for a free, AGPL, attributed public re-display —
+   Clause 11.1 makes consent the explicit unlock, and a non-commercial free site
+   re-displaying REMIT-mandated-public data is the strongest possible ask. Until/unless
+   granted: no Nord Pool UMM content on obsyd.dev.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,6 +37,7 @@ import BalancingPanel from './components/BalancingPanel'
 import RecordsPanel from './components/RecordsPanel'
 import EpisodeArchivePanel from './components/EpisodeArchivePanel'
 import CapturePanel from './components/CapturePanel'
+import SparkCalculatorPanel from './components/SparkCalculatorPanel'
 import BordersPanel from './components/BordersPanel'
 import DriversPanel from './components/DriversPanel'
 import ProductsPanel from './components/ProductsPanel'
@@ -732,6 +733,11 @@ function Dashboard() {
             <div className="mt-3">
               <ErrorBoundary name="power-capture">
                 <CapturePanel zone={energyZone} />
+              </ErrorBoundary>
+            </div>
+            <div className="mt-3">
+              <ErrorBoundary name="power-spark-calculator">
+                <SparkCalculatorPanel zone={energyZone} />
               </ErrorBoundary>
             </div>
             <div className="mt-3">

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,7 @@ import OutagePanel from './components/OutagePanel'
 import RecordChip from './components/RecordChip'
 import ImbalancePanel from './components/ImbalancePanel'
 import BalancingPanel from './components/BalancingPanel'
+import CapacityPricePanel from './components/CapacityPricePanel'
 import RecordsPanel from './components/RecordsPanel'
 import EpisodeArchivePanel from './components/EpisodeArchivePanel'
 import CapturePanel from './components/CapturePanel'
@@ -642,6 +643,9 @@ function Dashboard() {
               </ErrorBoundary>
               <ErrorBoundary name="power-balancing">
                 <BalancingPanel zone={energyZone} />
+              </ErrorBoundary>
+              <ErrorBoundary name="power-capacity-prices">
+                <CapacityPricePanel zone={energyZone} />
               </ErrorBoundary>
               <ErrorBoundary name="power-spark">
                 <SparkSpreadPanel zone={energyZone} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ import InsightsStrip from './components/InsightsStrip'
 import NarrativeHero from './components/NarrativeHero'
 import RangeSelector from './components/RangeSelector'
 import PowerSituationHeader from './components/PowerSituationHeader'
+import LiveNowPanel from './components/LiveNowPanel'
 import HydroReservoirPanel from './components/HydroReservoirPanel'
 import OutagePanel from './components/OutagePanel'
 import RecordChip from './components/RecordChip'
@@ -579,6 +580,9 @@ function Dashboard() {
 
             <ErrorBoundary name="power-situation">
               <PowerSituationHeader zone={energyZone} />
+            </ErrorBoundary>
+            <ErrorBoundary name="power-live">
+              <LiveNowPanel zone={energyZone} />
             </ErrorBoundary>
             <ErrorBoundary name="record-chip">
               <RecordChip zone={energyZone} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -138,6 +138,34 @@ function scrollToSection(id) {
   if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
+// /builder — the Chart-Builder as its own route: a slim shell (wordmark +
+// range picker, no sidebar/tabs/ticker) around the same SeriesExplorer the
+// EXPLORE tab renders, full-width. It needs its own ViewStateProvider (the
+// zone/range spine SeriesExplorer reads via useViewState()) since this route
+// never mounts the Dashboard tree that normally supplies one. No auth gate —
+// like /impressum, it's public.
+function BuilderShell() {
+  return (
+    <ViewStateProvider>
+      <div className="min-h-screen bg-surface">
+        <div className="flex items-center justify-between gap-3 px-4 py-3 border-b border-border">
+          <a href="/" className="font-mono text-sm font-bold tracking-widest text-cyan-glow">OBSYD</a>
+          <span className="font-mono text-[10px] text-neutral-600 tracking-wider">CHART BUILDER</span>
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[10px] text-neutral-600 tracking-wider hidden sm:inline">RANGE</span>
+            <RangeSelector />
+          </div>
+        </div>
+        <main className="w-full px-3 py-4">
+          <ErrorBoundary name="chart-builder">
+            <SeriesExplorer />
+          </ErrorBoundary>
+        </main>
+      </div>
+    </ViewStateProvider>
+  )
+}
+
 /**
  * Top-level router. Anonymous visitors hitting `/` see the marketing
  * Landing; signed-in users, the dashboard. Any `/app` path always
@@ -152,6 +180,9 @@ function App() {
   const pathname = typeof window !== 'undefined' ? window.location.pathname : '/'
   if (pathname === '/impressum' || pathname === '/datenschutz') {
     return <LegalPage page={pathname.slice(1)} />
+  }
+  if (pathname === '/builder') {
+    return <BuilderShell />
   }
   const wantsApp = pathname.startsWith('/app') || pathname.startsWith('/dashboard')
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -47,6 +47,7 @@ import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
 import LegalPage from './components/LegalPage'
 import CommandPalette from './components/CommandPalette'
+import EmbedPage from './components/embed/EmbedPage'
 import { useAuth } from './context/AuthContext'
 import { ViewStateProvider, useViewState } from './context/ViewStateContext'
 
@@ -141,6 +142,14 @@ function scrollToSection(id) {
   if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
+// /embed/<ZONE>/<metric> — parsed straight from the pathname, no router lib (matches
+// the rest of this file's convention). Returns nulls for a malformed path; EmbedPage
+// turns those into the explicit "unknown" card rather than guessing a zone.
+function parseEmbedPath(pathname) {
+  const parts = pathname.split('/').filter(Boolean) // "/embed/DE_LU/price" -> ["embed","DE_LU","price"]
+  return { zone: parts[1] || null, metric: parts[2] || null }
+}
+
 // /builder — the Chart-Builder as its own route: a slim shell (wordmark +
 // range picker, no sidebar/tabs/ticker) around the same SeriesExplorer the
 // EXPLORE tab renders, full-width. It needs its own ViewStateProvider (the
@@ -181,6 +190,19 @@ function App() {
   // Read once at module init — no need to react to client-side navigation
   // since neither route mutates the URL after mount.
   const pathname = typeof window !== 'undefined' ? window.location.pathname : '/'
+
+  // /embed/<zone>/<metric> — the embeddable iframe widgets (Task P10). Handled
+  // BEFORE and OUTSIDE ViewStateProvider: an embed is one fixed zone+metric, never
+  // a navigable desk, so it must skip ViewStateProvider's URL-query rewriting
+  // (?zone=&range=) and localStorage persistence entirely, not just Dashboard's own
+  // boot fetches. EmbedPage does its own (per-metric) zone validation against each
+  // endpoint's response rather than the silent DE_LU fallback the underlying
+  // /api/power/* routes use.
+  if (pathname.startsWith('/embed/')) {
+    const { zone, metric } = parseEmbedPath(pathname)
+    return <EmbedPage zone={zone} metric={metric} />
+  }
+
   if (pathname === '/impressum' || pathname === '/datenschutz') {
     return <LegalPage page={pathname.slice(1)} />
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ import HydroReservoirPanel from './components/HydroReservoirPanel'
 import OutagePanel from './components/OutagePanel'
 import RecordChip from './components/RecordChip'
 import ImbalancePanel from './components/ImbalancePanel'
+import BalancingPanel from './components/BalancingPanel'
 import RecordsPanel from './components/RecordsPanel'
 import EpisodeArchivePanel from './components/EpisodeArchivePanel'
 import CapturePanel from './components/CapturePanel'
@@ -637,6 +638,9 @@ function Dashboard() {
               </ErrorBoundary>
               <ErrorBoundary name="power-imbalance">
                 <ImbalancePanel zone={energyZone} />
+              </ErrorBoundary>
+              <ErrorBoundary name="power-balancing">
+                <BalancingPanel zone={energyZone} />
               </ErrorBoundary>
               <ErrorBoundary name="power-spark">
                 <SparkSpreadPanel zone={energyZone} />

--- a/frontend/src/components/BalancingPanel.jsx
+++ b/frontend/src/components/BalancingPanel.jsx
@@ -1,0 +1,215 @@
+import { useState } from 'react'
+import Panel from './Panel'
+import PanelTakeaway from './PanelTakeaway'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ReferenceLine,
+} from 'recharts'
+import { fmtTs, CHART_TOOLTIP_PROPS } from '../utils/chart'
+
+const API = '/api'
+
+// Colors mirror the house up/secondary convention (PowerGridPanel's
+// wind/solar pair, PowerLoadForecastPanel's actual/forecast pair): the
+// established default price-line cyan for the first series, amber for the
+// second. Direction is never color-alone — arrows + a legend carry identity too.
+const COLOR_UP = '#22d3ee'
+const COLOR_DOWN = '#fbbf24'
+
+function zoneLabel(zone) {
+  return zone === 'DE_LU' ? 'DE-LU' : zone
+}
+
+function ProductToggle({ product, onChange }) {
+  return (
+    <div className="flex gap-1">
+      {['afrr', 'mfrr'].map((p) => (
+        <button
+          key={p}
+          onClick={() => onChange(p)}
+          className={`font-mono text-[9px] tracking-wider px-1.5 py-0.5 rounded border transition-colors ${
+            product === p
+              ? 'border-cyan-glow/40 text-cyan-glow'
+              : 'border-border text-neutral-600 hover:text-neutral-400'
+          }`}
+        >
+          {p === 'afrr' ? 'aFRR' : 'mFRR'}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// "↑ €82.4" vs "↓ −€12.0" — direction as a glyph, never color alone.
+function fmtDirPrice(price, direction) {
+  if (price == null) return '—'
+  const arrow = direction === 'down' ? '↓' : direction === 'up' ? '↑' : ''
+  const sign = price < 0 ? '−' : ''
+  return `${arrow} ${sign}€${Math.abs(price).toFixed(1)}`.trim()
+}
+
+function dirColor(direction) {
+  return direction === 'down' ? COLOR_DOWN : direction === 'up' ? COLOR_UP : '#a3a3a3'
+}
+
+/**
+ * Activated balancing energy (ENTSO-E A84 aFRR/mFRR prices) — what the TSO
+ * actually called on beyond the day-ahead auction to keep the grid balanced,
+ * split by direction. Coverage is genuinely patchy: many zone/product
+ * combinations publish nothing on a given day, and that is normal, not an
+ * error (see backend/power/entsoe_balancing.py's live-spike docstring).
+ * Activation VOLUMES (A83) are not served by the public API at all today —
+ * this panel is prices only. Descriptive, not a forecast (Posture B).
+ */
+export default function BalancingPanel({ zone = 'DE_LU' }) {
+  const [product, setProduct] = useState('afrr')
+  const url = `${API}/power/balancing?zone=${zone}&days=30&product=${product}`
+  const { data, loading, error } = useFetchWithError(url, {
+    deps: [zone, product],
+    pollMs: POLL_SLOW_MS,
+  })
+
+  // A transient poll failure must not blank a chart that already has good (if
+  // slightly stale) data — mirrors LiveNowPanel/PowerSituationHeader.
+  if (error && !data)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">BALANCING // FETCH ERROR</div>
+      </div>
+    )
+
+  const zl = data?.zone_label ?? zoneLabel(zone)
+  const productLabel = product === 'afrr' ? 'aFRR' : 'mFRR'
+  const latest = data?.latest
+  const peak = data?.peak
+  const unit = data?.unit ?? 'EUR/MWh'
+
+  // Merge the up/down direction series on timestamp for a two-line chart —
+  // the two arrays don't share indices, only (usually) overlapping hours.
+  const rowsByT = new Map()
+  for (const p of data?.up ?? []) rowsByT.set(p.t, { t: p.t, up: p.price })
+  for (const p of data?.down ?? []) {
+    const row = rowsByT.get(p.t) ?? { t: p.t }
+    row.down = p.price
+    rowsByT.set(p.t, row)
+  }
+  const rows = [...rowsByT.values()].sort((a, b) => (a.t < b.t ? -1 : a.t > b.t ? 1 : 0))
+
+  return (
+    <Panel
+      id="power-balancing"
+      freshness={data}
+      title={`BALANCING · ${zl}`}
+      info={
+        data?.note ||
+        'Activated balancing energy (ENTSO-E A84) — what the TSO actually called on beyond ' +
+          'the day-ahead auction, by direction. Coverage varies by zone/product — many combinations ' +
+          "publish nothing on a given day. Activation volumes aren't currently served by the public " +
+          'API for any zone. All times UTC. Descriptive, not a forecast.'
+      }
+      collapsible
+      downloadUrl={
+        data?.available
+          ? `${API}/v1/series?series=balancing.${product}.price.up&zone=${zone}&format=csv`
+          : undefined
+      }
+      headerRight={
+        <div className="flex items-center gap-2">
+          <ProductToggle product={product} onChange={setProduct} />
+          {data?.available && latest?.price != null && (
+            <span className="font-mono text-[10px] font-bold" style={{ color: dirColor(latest.direction) }}>
+              {fmtDirPrice(latest.price, latest.direction)}
+            </span>
+          )}
+        </div>
+      }
+    >
+      {data?.coverage && (
+        <div className="px-4 pt-2 font-mono text-[9px] text-amber-400/80">
+          ⚠ {data.coverage}
+        </div>
+      )}
+
+      {loading && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Loading balancing prices…
+        </div>
+      )}
+
+      {/* available:false is the COMMON case (many zone/product combinations publish
+          nothing) — render it calmly, not as an error, and keep the product toggle
+          live so a reader can flip straight to the product that does have data. */}
+      {!loading && data && !data.available && (
+        <div className="px-4 py-3 font-mono text-[10px] text-neutral-500">
+          {data.reason || `No ${productLabel} activated-balancing-energy series for ${zl} yet.`}
+        </div>
+      )}
+
+      {!loading && data?.available && (
+        <>
+          <div className="px-4 pt-2">
+            <ResponsiveContainer width="100%" height={160}>
+              <LineChart data={rows} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
+                <XAxis
+                  dataKey="t"
+                  tickFormatter={fmtTs}
+                  tick={{ fontSize: 9, fill: '#525252' }}
+                  minTickGap={60}
+                />
+                <YAxis
+                  tick={{ fontSize: 9, fill: '#525252' }}
+                  width={44}
+                  tickFormatter={(v) => `${v}`}
+                />
+                <ReferenceLine y={0} stroke="#2a2a3a" strokeDasharray="2 2" />
+                <Tooltip
+                  {...CHART_TOOLTIP_PROPS}
+                  formatter={(v, name) => [v == null ? '—' : `${Number(v).toFixed(1)} ${unit}`, name]}
+                  labelFormatter={fmtTs}
+                />
+                <Line
+                  type="stepAfter"
+                  dataKey="up"
+                  name="up-regulation"
+                  stroke={COLOR_UP}
+                  strokeWidth={1}
+                  dot={false}
+                  connectNulls
+                  isAnimationActive={false}
+                />
+                <Line
+                  type="stepAfter"
+                  dataKey="down"
+                  name="down-regulation"
+                  stroke={COLOR_DOWN}
+                  strokeWidth={1}
+                  dot={false}
+                  connectNulls
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+            <div className="flex items-center justify-center gap-4 mt-1 font-mono text-[8px] text-neutral-600">
+              <span style={{ color: COLOR_UP }}>▬ up-regulation (↑)</span>
+              <span style={{ color: COLOR_DOWN }}>▬ down-regulation (↓)</span>
+            </div>
+          </div>
+          <div className="px-4 py-2">
+            <PanelTakeaway>
+              Latest {productLabel} activation: {fmtDirPrice(latest?.price, latest?.direction)}/MWh
+              {peak && ` · window peak ${fmtDirPrice(peak.price, peak.direction)}/MWh (${fmtTs(peak.t)})`}.{' '}
+              Volumes aren't published by the public API today — this is prices only.
+            </PanelTakeaway>
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/BalancingPanel.jsx
+++ b/frontend/src/components/BalancingPanel.jsx
@@ -112,7 +112,9 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
         'Activated balancing energy (ENTSO-E A84) — what the TSO actually called on beyond ' +
           'the day-ahead auction, by direction. Coverage varies by zone/product — many combinations ' +
           "publish nothing on a given day. Activation volumes aren't currently served by the public " +
-          'API for any zone. All times UTC. Descriptive, not a forecast.'
+          'API for any zone. Gaps in the chart mean no activation was published for that direction/' +
+          'hour, not missing data — the line never holds a price forward across them. All times UTC. ' +
+          'Descriptive, not a forecast.'
       }
       collapsible
       downloadUrl={
@@ -174,14 +176,19 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
                   formatter={(v, name) => [v == null ? '—' : `${Number(v).toFixed(1)} ${unit}`, name]}
                   labelFormatter={fmtTs}
                 />
+                {/* No connectNulls: the backend deliberately never holds a price
+                    forward across an hour nothing activated in (episodic mFRR
+                    especially — 25 vs 444 TimeSeries in the spiked TenneT month).
+                    A dot marks lone activation hours so they don't vanish; real
+                    gaps in either direction render as honest breaks, not a
+                    fabricated flat line. */}
                 <Line
                   type="stepAfter"
                   dataKey="up"
                   name="up-regulation"
                   stroke={COLOR_UP}
                   strokeWidth={1}
-                  dot={false}
-                  connectNulls
+                  dot={{ r: 1.5, strokeWidth: 0 }}
                   isAnimationActive={false}
                 />
                 <Line
@@ -190,8 +197,7 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
                   name="down-regulation"
                   stroke={COLOR_DOWN}
                   strokeWidth={1}
-                  dot={false}
-                  connectNulls
+                  dot={{ r: 1.5, strokeWidth: 0 }}
                   isAnimationActive={false}
                 />
               </LineChart>

--- a/frontend/src/components/BalancingPanel.jsx
+++ b/frontend/src/components/BalancingPanel.jsx
@@ -59,6 +59,21 @@ function dirColor(direction) {
   return direction === 'down' ? COLOR_DOWN : direction === 'up' ? COLOR_UP : '#a3a3a3'
 }
 
+const HOUR_MS = 60 * 60 * 1000
+const WINDOW_DAYS = 30
+
+// Static explanation of the panel — always shown, since the backend's own
+// `note` (present whenever available:true) is a shorter one-liner and would
+// otherwise replace this instead of supplementing it (like ImbalancePanel's
+// info popover, which is likewise always the full explanation).
+const INFO_TEXT =
+  'Activated balancing energy (ENTSO-E A84) — what the TSO actually called on beyond ' +
+  'the day-ahead auction, by direction. Coverage varies by zone/product — many combinations ' +
+  "publish nothing on a given day. Activation volumes aren't currently served by the public " +
+  'API for any zone. Gaps in the chart mean no activation was published for that direction/' +
+  'hour, not missing data — the line never holds a price forward across them. All times UTC. ' +
+  'Descriptive, not a forecast.'
+
 /**
  * Activated balancing energy (ENTSO-E A84 aFRR/mFRR prices) — what the TSO
  * actually called on beyond the day-ahead auction to keep the grid balanced,
@@ -70,7 +85,7 @@ function dirColor(direction) {
  */
 export default function BalancingPanel({ zone = 'DE_LU' }) {
   const [product, setProduct] = useState('afrr')
-  const url = `${API}/power/balancing?zone=${zone}&days=30&product=${product}`
+  const url = `${API}/power/balancing?zone=${zone}&days=${WINDOW_DAYS}&product=${product}`
   const { data, loading, error } = useFetchWithError(url, {
     deps: [zone, product],
     pollMs: POLL_SLOW_MS,
@@ -91,31 +106,37 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
   const peak = data?.peak
   const unit = data?.unit ?? 'EUR/MWh'
 
-  // Merge the up/down direction series on timestamp for a two-line chart —
-  // the two arrays don't share indices, only (usually) overlapping hours.
+  // Merge the up/down direction series on timestamp, keyed by hour-aligned
+  // epoch ms (not the raw string) so a real point always coalesces with its
+  // filler below instead of duplicating under a differently-formatted key.
   const rowsByT = new Map()
-  for (const p of data?.up ?? []) rowsByT.set(p.t, { t: p.t, up: p.price })
+  for (const p of data?.up ?? []) rowsByT.set(Date.parse(p.t), { t: p.t, up: p.price })
   for (const p of data?.down ?? []) {
-    const row = rowsByT.get(p.t) ?? { t: p.t }
+    const k = Date.parse(p.t)
+    const row = rowsByT.get(k) ?? { t: p.t }
     row.down = p.price
-    rowsByT.set(p.t, row)
+    rowsByT.set(k, row)
   }
-  const rows = [...rowsByT.values()].sort((a, b) => (a.t < b.t ? -1 : a.t > b.t ? 1 : 0))
+  // Densify over the full hourly grid, window-start (now − 30d, aligned to the
+  // hour) to the latest published hour: an hour where NEITHER direction
+  // activated must still get its own category, or two activations days apart
+  // would sit in adjacent chart categories joined by a line — the exact
+  // fabricated continuity dropping connectNulls (below) is meant to prevent.
+  if (rowsByT.size) {
+    const latestMs = Math.max(...rowsByT.keys())
+    const startMs = Math.floor((new Date().getTime() - WINDOW_DAYS * 24 * HOUR_MS) / HOUR_MS) * HOUR_MS
+    for (let ms = startMs; ms <= latestMs; ms += HOUR_MS) {
+      if (!rowsByT.has(ms)) rowsByT.set(ms, { t: new Date(ms).toISOString() })
+    }
+  }
+  const rows = [...rowsByT.entries()].sort(([a], [b]) => a - b).map(([, row]) => row)
 
   return (
     <Panel
       id="power-balancing"
       freshness={data}
       title={`BALANCING · ${zl}`}
-      info={
-        data?.note ||
-        'Activated balancing energy (ENTSO-E A84) — what the TSO actually called on beyond ' +
-          'the day-ahead auction, by direction. Coverage varies by zone/product — many combinations ' +
-          "publish nothing on a given day. Activation volumes aren't currently served by the public " +
-          'API for any zone. Gaps in the chart mean no activation was published for that direction/' +
-          'hour, not missing data — the line never holds a price forward across them. All times UTC. ' +
-          'Descriptive, not a forecast.'
-      }
+      info={data?.note ? `${data.note} ${INFO_TEXT}` : INFO_TEXT}
       collapsible
       downloadUrl={
         data?.available
@@ -179,16 +200,20 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
                 {/* No connectNulls: the backend deliberately never holds a price
                     forward across an hour nothing activated in (episodic mFRR
                     especially — 25 vs 444 TimeSeries in the spiked TenneT month).
-                    A dot marks lone activation hours so they don't vanish; real
-                    gaps in either direction render as honest breaks, not a
-                    fabricated flat line. */}
+                    The hourly grid above densifies `rows` so a genuinely silent
+                    hour always gets its own null category instead of vanishing —
+                    without that, two activations days apart would sit in
+                    adjacent categories joined by a line, the very thing dropping
+                    connectNulls is meant to prevent. A dot (explicitly filled —
+                    Recharts' own default dot fill is white, not the line color)
+                    keeps a lone activation hour visible without a line to carry it. */}
                 <Line
                   type="stepAfter"
                   dataKey="up"
                   name="up-regulation"
                   stroke={COLOR_UP}
                   strokeWidth={1}
-                  dot={{ r: 1.5, strokeWidth: 0 }}
+                  dot={{ r: 1.5, strokeWidth: 0, fill: COLOR_UP }}
                   isAnimationActive={false}
                 />
                 <Line
@@ -197,7 +222,7 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
                   name="down-regulation"
                   stroke={COLOR_DOWN}
                   strokeWidth={1}
-                  dot={{ r: 1.5, strokeWidth: 0 }}
+                  dot={{ r: 1.5, strokeWidth: 0, fill: COLOR_DOWN }}
                   isAnimationActive={false}
                 />
               </LineChart>
@@ -209,7 +234,8 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
           </div>
           <div className="px-4 py-2">
             <PanelTakeaway>
-              Latest {productLabel} activation: {fmtDirPrice(latest?.price, latest?.direction)}/MWh
+              Last {data?.days ?? WINDOW_DAYS}d · latest {productLabel} activation:{' '}
+              {fmtDirPrice(latest?.price, latest?.direction)}/MWh
               {peak && ` · window peak ${fmtDirPrice(peak.price, peak.direction)}/MWh (${fmtTs(peak.t)})`}.{' '}
               Volumes aren't published by the public API today — this is prices only.
             </PanelTakeaway>

--- a/frontend/src/components/CapacityPricePanel.jsx
+++ b/frontend/src/components/CapacityPricePanel.jsx
@@ -1,0 +1,204 @@
+import { useState } from 'react'
+import Panel from './Panel'
+import PanelTakeaway from './PanelTakeaway'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from 'recharts'
+import { fmtTs, CHART_TOOLTIP_PROPS } from '../utils/chart'
+
+const API = '/api'
+
+// Deliberately NOT the fuel palette (frontend/src/utils/fuels.js) — this is a price chart,
+// not a generation mix. FCR is neutral/gray (symmetric, no direction). aFRR reuses
+// BalancingPanel's own up/down convention (cyan/amber) so the two capacity+activation panels
+// share one mental model; mFRR gets its own cool/warm pair so all 5 lines stay distinguishable.
+const PRODUCTS = [
+  { key: 'fcr', label: 'FCR', color: '#e5e5e5' },
+  { key: 'afrr_pos', label: 'aFRR ↑', color: '#22d3ee' },
+  { key: 'afrr_neg', label: 'aFRR ↓', color: '#fbbf24' },
+  { key: 'mfrr_pos', label: 'mFRR ↑', color: '#e879f9' },
+  { key: 'mfrr_neg', label: 'mFRR ↓', color: '#a3e635' },
+]
+
+const WINDOW_DAYS = 30
+
+function zoneLabel(zone) {
+  return zone === 'DE_LU' ? 'DE-LU' : zone
+}
+
+function fmtPrice(v) {
+  if (v == null) return '—'
+  return `€${v.toFixed(2)}`
+}
+
+// Static explanation of the panel — always shown, since the backend's own `note` (present
+// whenever available:true) is a shorter one-liner and would otherwise replace this instead of
+// supplementing it (BalancingPanel's INFO_TEXT pattern).
+const INFO_TEXT =
+  'German balancing-capacity market (ENTSO-E A15) — DE-LU LFC block only, structurally: ' +
+  'individual German control areas publish nothing at this domain, and no other enabled zone ' +
+  'has an equivalent tender. Each line is the volume-weighted average of that block\'s ' +
+  "accepted capacity bids, normalized to EUR/MW/h (FCR's native EUR-per-4h-block price is " +
+  'divided by 4). FCR is pay-as-cleared and symmetric; aFRR/mFRR are pay-as-bid and split by ' +
+  'direction. FCR settlement can differ slightly from this DE-LU-block reconstruction on days ' +
+  'when cross-border export limits bind. All times UTC. Descriptive, not a forecast.'
+
+/**
+ * German procured balancing-CAPACITY prices (ENTSO-E A15: FCR/aFRR/mFRR daily tenders) — what
+ * Germany pays to have reserve capacity on standby, before any of it is ever activated (the
+ * companion number to BalancingPanel's activation prices). DE-LU LFC block only, structurally
+ * — not a coverage gap, so every other zone renders a calm explanation instead of vanishing.
+ * Descriptive, not a forecast (Posture B).
+ */
+export default function CapacityPricePanel({ zone = 'DE_LU' }) {
+  const [hidden, setHidden] = useState(() => new Set())
+  const url = `${API}/power/capacity-prices?zone=${zone}&days=${WINDOW_DAYS}`
+  const { data, loading, error } = useFetchWithError(url, {
+    deps: [zone],
+    pollMs: POLL_SLOW_MS,
+  })
+
+  // A transient poll failure must not blank a chart that already has good (if slightly
+  // stale) data — mirrors BalancingPanel/LiveNowPanel.
+  if (error && !data)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">CAPACITY PRICES // FETCH ERROR</div>
+      </div>
+    )
+
+  const zl = data?.zone_label ?? zoneLabel(zone)
+  const latest = data?.latest ?? {}
+
+  // Merge the 5 product series on timestamp (hour-aligned epoch ms, not the raw string) —
+  // each series is already densified per-hour by the backend (a block's weighted-average
+  // price holds for every hour it covers), so no client-side gap-filling is needed here,
+  // unlike BalancingPanel's genuinely-intermittent activation data.
+  const rowsByT = new Map()
+  for (const p of PRODUCTS) {
+    for (const point of data?.products?.[p.key] ?? []) {
+      const k = Date.parse(point.t)
+      const row = rowsByT.get(k) ?? { t: point.t }
+      row[p.key] = point.price
+      rowsByT.set(k, row)
+    }
+  }
+  const rows = [...rowsByT.entries()].sort(([a], [b]) => a - b).map(([, row]) => row)
+
+  function toggle(key) {
+    setHidden((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  return (
+    <Panel
+      id="power-capacity-prices"
+      freshness={data}
+      title={`CAPACITY PRICES · ${zl}`}
+      info={data?.note ? `${data.note} ${INFO_TEXT}` : INFO_TEXT}
+      collapsible
+      downloadUrl={
+        data?.available
+          ? `${API}/v1/series?series=capacity.fcr.price&zone=DE_LU&format=csv`
+          : undefined
+      }
+      headerRight={
+        data?.available &&
+        latest.fcr?.price != null && (
+          <span className="font-mono text-[10px] font-bold text-neutral-300">
+            FCR {fmtPrice(latest.fcr.price)}/MW/h
+          </span>
+        )
+      }
+    >
+      {loading && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Loading capacity prices…
+        </div>
+      )}
+
+      {/* available:false is the common, structural case for every zone except DE_LU — render
+          it calmly, not as an error, and never let the panel vanish. */}
+      {!loading && data && !data.available && (
+        <div className="px-4 py-3 font-mono text-[10px] text-neutral-500">
+          {data.reason || `No German balancing-capacity data for ${zl} yet.`}
+        </div>
+      )}
+
+      {!loading && data?.available && (
+        <>
+          <div className="px-4 pt-2">
+            <ResponsiveContainer width="100%" height={170}>
+              <LineChart data={rows} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
+                <XAxis
+                  dataKey="t"
+                  tickFormatter={fmtTs}
+                  tick={{ fontSize: 9, fill: '#525252' }}
+                  minTickGap={60}
+                />
+                <YAxis
+                  tick={{ fontSize: 9, fill: '#525252' }}
+                  width={44}
+                  tickFormatter={(v) => `${v}`}
+                />
+                <Tooltip
+                  {...CHART_TOOLTIP_PROPS}
+                  formatter={(v, name) => [v == null ? '—' : `€${Number(v).toFixed(2)}/MW/h`, name]}
+                  labelFormatter={fmtTs}
+                />
+                {/* stepAfter: each point is a 4-hour tender block's price holding constant —
+                    a true step function, not an interpolated trend. No dots (unlike
+                    BalancingPanel) — capacity blocks are densely populated every day, so a
+                    lone-point marker isn't needed to keep a sparse activation visible. */}
+                {PRODUCTS.map((p) => (
+                  <Line
+                    key={p.key}
+                    type="stepAfter"
+                    dataKey={p.key}
+                    name={p.label}
+                    stroke={p.color}
+                    strokeWidth={1.25}
+                    dot={false}
+                    hide={hidden.has(p.key)}
+                    isAnimationActive={false}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+            <div className="flex items-center justify-center flex-wrap gap-3 mt-1 font-mono text-[8px]">
+              {PRODUCTS.map((p) => (
+                <button
+                  key={p.key}
+                  onClick={() => toggle(p.key)}
+                  className="transition-opacity"
+                  style={{ color: p.color, opacity: hidden.has(p.key) ? 0.35 : 1 }}
+                  title={hidden.has(p.key) ? `Show ${p.label}` : `Hide ${p.label}`}
+                >
+                  ▬ {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="px-4 py-2">
+            <PanelTakeaway>
+              Last {data?.days ?? WINDOW_DAYS}d · FCR {fmtPrice(latest.fcr?.price)} · aFRR{' '}
+              {fmtPrice(latest.afrr_pos?.price)}/{fmtPrice(latest.afrr_neg?.price)} · mFRR{' '}
+              {fmtPrice(latest.mfrr_pos?.price)}/{fmtPrice(latest.mfrr_neg?.price)} per MW/h.
+            </PanelTakeaway>
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/CapturePanel.jsx
+++ b/frontend/src/components/CapturePanel.jsx
@@ -1,13 +1,36 @@
+import { useEffect, useState } from 'react'
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { POLL_SLOW_MS } from '../utils/poll'
 import {
   ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine, Legend,
 } from 'recharts'
-import { CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS } from '../utils/chart'
 import { fuelColor } from '../utils/fuels'
 
 const API = '/api'
+
+// Segmented toggle idiom shared with GasBalancePanel's RESIDUAL / IMPLIED-ACTUAL switch.
+function ToggleBtn({ id, label, view, setView }) {
+  return (
+    <button
+      type="button"
+      onClick={() => setView(id)}
+      className={`font-mono text-[9px] tracking-wider px-2 py-0.5 rounded border transition-colors ${
+        view === id ? 'text-cyan-glow border-cyan-glow/50 bg-cyan-glow/5' : 'text-neutral-600 border-border hover:text-neutral-400'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+// `?strike=` is shareable, same replaceState-on-every-edit idiom as SeriesExplorer's
+// `rows=`/`res=` params — read once at mount, rewritten (or removed, when cleared) on change.
+function readStrikeParam() {
+  if (typeof window === 'undefined') return ''
+  return new URLSearchParams(window.location.search).get('strike') ?? ''
+}
 
 /**
  * Capture rate — what a MWh of each technology actually earned.
@@ -21,6 +44,21 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
   const { data, loading, error } = useFetchWithError(
     `${API}/power/capture?zone=${zone}&months=36`, { deps: [zone], pollMs: POLL_SLOW_MS },
   )
+  // 'vf' = value factor (the cannibalisation story) · 'price' = raw capture €/MWh (PPA framing).
+  const [chartMode, setChartMode] = useState('vf')
+  // A PPA strike is a €/MWh floor a buyer negotiated — empty means off. Kept as the raw input
+  // string (not a number) so a user can type "45" through an intermediate empty/partial state
+  // without the field fighting back.
+  const [strikeInput, setStrikeInput] = useState(() => readStrikeParam())
+
+  // Rewrite the URL on every edit, same idiom as SeriesExplorer's rows=/res= sync: set when
+  // present, delete when cleared, so an empty strike never leaves a stale `?strike=` behind.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (strikeInput !== '') params.set('strike', strikeInput); else params.delete('strike')
+    const qs = params.toString()
+    history.replaceState(null, '', `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`)
+  }, [strikeInput])
 
   if (error) {
     return (
@@ -41,17 +79,29 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
 
   const fuels = data?.fuels ?? []
 
-  // One row per month, one column per technology: the value-factor history.
+  // One row per month, one column per technology — value factor or raw capture price,
+  // whichever the toggle currently shows.
   const months = [...new Set(fuels.flatMap((f) => f.data.map((r) => r.month)))].sort()
+  const chartField = chartMode === 'price' ? 'capture_price' : 'value_factor'
   const chart = months.map((month) => {
     const row = { month }
     for (const f of fuels) {
       const hit = f.data.find((r) => r.month === month)
-      if (hit) row[f.psr] = hit.value_factor
+      if (hit) row[f.psr] = hit[chartField]
     }
     return row
   })
   const worst = fuels[0]?.latest
+
+  // PPA framing: a strike is a floor a buyer negotiated. Backward-looking only — how many of
+  // the cannibalised technology's OWN recent months would have landed below it.
+  const strike = strikeInput === '' ? null : Number(strikeInput)
+  const hasStrike = strike != null && Number.isFinite(strike)
+  const worstFuel = fuels[0]
+  const worstRecent = worstFuel ? worstFuel.data.slice(-12) : []
+  const belowStrikeCount = hasStrike
+    ? worstRecent.filter((r) => r.capture_price < strike).length
+    : null
 
   return (
     <Panel
@@ -89,6 +139,7 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
                   <th className="text-right px-2 py-1" title="Capture price ÷ the month's baseload price. Below 1.00 = earned less than baseload.">Value factor</th>
                   <th className="px-2 py-1"></th>
                   <th className="text-right px-2 py-1" title="Share of this technology's own output that landed in negative-price hours">Neg. output</th>
+                  <th className="text-right px-2 py-1" title="Hours this technology was producing while the day-ahead price was negative (a count, not generation-weighted)">Neg. hours</th>
                   <th className="text-right px-2 py-1">Volume</th>
                 </tr>
               </thead>
@@ -130,6 +181,9 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
                       <td className={`px-2 py-1.5 text-right ${L.negative_gen_pct > 0 ? 'text-orange-400' : 'text-neutral-700'}`}>
                         {L.negative_gen_pct > 0 ? `${L.negative_gen_pct.toFixed(1)}%` : '—'}
                       </td>
+                      <td className={`px-2 py-1.5 text-right ${L.negative_hours > 0 ? 'text-orange-400' : 'text-neutral-700'}`}>
+                        {L.negative_hours > 0 ? L.negative_hours : '—'}
+                      </td>
                       <td className="px-2 py-1.5 text-right text-neutral-500">{L.generation_gwh.toFixed(0)} GWh</td>
                     </tr>
                   )
@@ -140,20 +194,51 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
 
           {chart.length > 1 && (
             <div className="px-2 pb-2">
-              <div className="px-2 pb-1 font-mono text-[9px] text-neutral-600 uppercase tracking-wider">
-                Value factor by month
+              <div className="px-2 pb-1.5 flex items-center justify-between gap-2 flex-wrap">
+                <span className="font-mono text-[9px] text-neutral-600 uppercase tracking-wider">
+                  {chartMode === 'price' ? 'Capture price by month' : 'Value factor by month'}
+                </span>
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-1.5">
+                    <ToggleBtn id="vf" label="VALUE FACTOR" view={chartMode} setView={setChartMode} />
+                    <ToggleBtn id="price" label="CAPTURE €/MWh" view={chartMode} setView={setChartMode} />
+                  </div>
+                  {chartMode === 'price' && (
+                    <label className="flex items-center gap-1.5 font-mono text-[9px] text-neutral-500">
+                      PPA strike
+                      <input
+                        type="number"
+                        inputMode="decimal"
+                        step="any"
+                        placeholder="off"
+                        value={strikeInput}
+                        onChange={(e) => setStrikeInput(e.target.value)}
+                        className="w-16 bg-[#0a0a12] border border-border rounded px-1.5 py-0.5 font-mono text-[10px] text-neutral-200 outline-none focus:border-cyan-glow/40"
+                      />
+                      €/MWh
+                    </label>
+                  )}
+                </div>
               </div>
               <ResponsiveContainer width="100%" height={170}>
                 <LineChart data={chart} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
                   <XAxis dataKey="month" tick={{ fontSize: 8, fill: '#737373' }} minTickGap={40} />
                   <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={34}
-                    tickFormatter={(v) => `×${v.toFixed(1)}`} />
-                  {/* Baseload itself. Everything below this line earned less than the base product. */}
-                  <ReferenceLine y={1} stroke="#525252" strokeDasharray="4 4" />
+                    tickFormatter={(v) => chartMode === 'price' ? `€${v.toFixed(0)}` : `×${v.toFixed(1)}`} />
+                  {chartMode === 'vf' ? (
+                    // Baseload itself. Everything below this line earned less than the base product.
+                    <ReferenceLine y={1} stroke="#525252" strokeDasharray="4 4" />
+                  ) : hasStrike && (
+                    <ReferenceLine y={strike} stroke="#fbbf24" strokeDasharray="4 4"
+                      label={{ value: `strike €${strike}`, position: 'insideTopLeft', fontSize: 8, fill: '#fbbf24' }} />
+                  )}
                   <Tooltip
-                    contentStyle={CHART_TOOLTIP_STYLE}
-                    formatter={(v, n) => [v == null ? '—' : `×${Number(v).toFixed(2)}`, n]}
+                    {...CHART_TOOLTIP_PROPS}
+                    formatter={(v, n) => [
+                      v == null ? '—' : chartMode === 'price' ? `€${Number(v).toFixed(1)}` : `×${Number(v).toFixed(2)}`,
+                      n,
+                    ]}
                   />
                   <Legend wrapperStyle={{ fontSize: 9, color: '#737373' }} iconSize={6} />
                   {fuels.map((f) => (
@@ -163,6 +248,12 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
                   ))}
                 </LineChart>
               </ResponsiveContainer>
+              {chartMode === 'price' && hasStrike && worstFuel && (
+                <div className="px-2 pt-1 font-mono text-[9px] text-amber-400/90">
+                  {belowStrikeCount} of the last {worstRecent.length} month{worstRecent.length === 1 ? '' : 's'} closed
+                  below the €{strike}/MWh strike for {worstFuel.label} — realised, not a projection.
+                </div>
+              )}
             </div>
           )}
 

--- a/frontend/src/components/CapturePanel.jsx
+++ b/frontend/src/components/CapturePanel.jsx
@@ -44,12 +44,15 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
   const { data, loading, error } = useFetchWithError(
     `${API}/power/capture?zone=${zone}&months=36`, { deps: [zone], pollMs: POLL_SLOW_MS },
   )
-  // 'vf' = value factor (the cannibalisation story) · 'price' = raw capture €/MWh (PPA framing).
-  const [chartMode, setChartMode] = useState('vf')
   // A PPA strike is a €/MWh floor a buyer negotiated — empty means off. Kept as the raw input
   // string (not a number) so a user can type "45" through an intermediate empty/partial state
   // without the field fighting back.
   const [strikeInput, setStrikeInput] = useState(() => readStrikeParam())
+  // 'vf' = value factor (the cannibalisation story) · 'price' = raw capture €/MWh (PPA framing).
+  // Seeded from whether a `?strike=` link was actually shared: a strike is invisible in VF
+  // mode, so a shared link must land on CAPTURE €/MWh, not the mode default. Not itself
+  // persisted to the URL — the strike value already round-trips the intent.
+  const [chartMode, setChartMode] = useState(() => (readStrikeParam() !== '' ? 'price' : 'vf'))
 
   // Rewrite the URL on every edit, same idiom as SeriesExplorer's rows=/res= sync: set when
   // present, delete when cleared, so an empty strike never leaves a stale `?strike=` behind.
@@ -96,7 +99,10 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
   // PPA framing: a strike is a floor a buyer negotiated. Backward-looking only — how many of
   // the cannibalised technology's OWN recent months would have landed below it.
   const strike = strikeInput === '' ? null : Number(strikeInput)
-  const hasStrike = strike != null && Number.isFinite(strike)
+  // A negative €/MWh floor isn't a PPA strike anyone negotiates — reject it rather than
+  // draw a ReferenceLine and a summary that both imply a number that doesn't mean anything.
+  // Zero stays legitimate (a strike of "never pay less than nothing" is a real floor).
+  const hasStrike = strike != null && Number.isFinite(strike) && strike >= 0
   const worstFuel = fuels[0]
   const worstRecent = worstFuel ? worstFuel.data.slice(-12) : []
   const belowStrikeCount = hasStrike
@@ -210,6 +216,7 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
                         type="number"
                         inputMode="decimal"
                         step="any"
+                        min="0"
                         placeholder="off"
                         value={strikeInput}
                         onChange={(e) => setStrikeInput(e.target.value)}
@@ -230,7 +237,10 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
                     // Baseload itself. Everything below this line earned less than the base product.
                     <ReferenceLine y={1} stroke="#525252" strokeDasharray="4 4" />
                   ) : hasStrike && (
-                    <ReferenceLine y={strike} stroke="#fbbf24" strokeDasharray="4 4"
+                    // extendDomain: Recharts' default ("discard") silently drops the line when
+                    // the strike sits outside the y-axis's auto-computed range — leaving the
+                    // chart mute while the summary line below still asserts a count against it.
+                    <ReferenceLine y={strike} stroke="#fbbf24" strokeDasharray="4 4" ifOverflow="extendDomain"
                       label={{ value: `strike €${strike}`, position: 'insideTopLeft', fontSize: 8, fill: '#fbbf24' }} />
                   )}
                   <Tooltip

--- a/frontend/src/components/LiveNowPanel.jsx
+++ b/frontend/src/components/LiveNowPanel.jsx
@@ -120,7 +120,7 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
                 value={loadPct != null ? `${loadPct >= 0 ? '+' : ''}${loadPct.toFixed(1)}%` : '—'}
               />
               <StatTile label="Generation now" value={genGw != null ? `${genGw} GW` : '—'} />
-              <StatTile label="Day-ahead price now" value={priceNow != null ? `€${priceNow.toFixed(1)}` : 'n/a'} />
+              <StatTile label="Day-ahead price now" value={priceNow != null ? `€${priceNow.toFixed(1)}/MWh` : 'n/a'} />
             </div>
             <PanelTakeaway className="mt-2">
               {showingToday
@@ -232,7 +232,7 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
                       x={nowHour}
                       stroke="#22d3ee"
                       strokeDasharray="3 3"
-                      label={{ value: 'now', position: 'top', fill: '#22d3ee', fontSize: 9 }}
+                      label={{ value: 'now', position: 'insideTop', fill: '#22d3ee', fontSize: 9 }}
                     />
                   )}
                   <Tooltip

--- a/frontend/src/components/LiveNowPanel.jsx
+++ b/frontend/src/components/LiveNowPanel.jsx
@@ -44,7 +44,9 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
   const url = `${API}/power/live?zone=${zone}`
   const { data, loading, error } = useFetchWithError(url, { deps: [zone], pollMs: POLL_FAST_MS })
 
-  if (error)
+  // A transient poll failure must not blank a chart that already has good (if
+  // slightly stale) data — mirrors PowerSituationHeader/OutagePanel/GenMixHistoryPanel.
+  if (error && !data)
     return (
       <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
         <div className="font-mono text-[10px] text-red-400">LIVE NOW // FETCH ERROR</div>
@@ -119,8 +121,14 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
                 label="Load vs forecast"
                 value={loadPct != null ? `${loadPct >= 0 ? '+' : ''}${loadPct.toFixed(1)}%` : '—'}
               />
-              <StatTile label="Generation now" value={genGw != null ? `${genGw} GW` : '—'} />
-              <StatTile label="Day-ahead price now" value={priceNow != null ? `€${priceNow.toFixed(1)}/MWh` : 'n/a'} />
+              <StatTile
+                label={showingToday ? 'Generation now' : 'Generation, latest hour'}
+                value={genGw != null ? `${genGw} GW` : '—'}
+              />
+              <StatTile
+                label={showingToday ? 'Day-ahead price now' : 'Day-ahead price, latest hour'}
+                value={priceNow != null ? `€${priceNow.toFixed(1)}/MWh` : 'n/a'}
+              />
             </div>
             <PanelTakeaway className="mt-2">
               {showingToday
@@ -178,7 +186,6 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
                       fillOpacity={0.18}
                       strokeWidth={1}
                       dot={false}
-                      connectNulls
                       isAnimationActive={false}
                     />
                   ))}

--- a/frontend/src/components/LiveNowPanel.jsx
+++ b/frontend/src/components/LiveNowPanel.jsx
@@ -1,0 +1,261 @@
+import { useState } from 'react'
+import Panel from './Panel'
+import PanelTakeaway from './PanelTakeaway'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_FAST_MS } from '../utils/poll'
+import {
+  ResponsiveContainer, ComposedChart, Area, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
+} from 'recharts'
+import { fmtHour, fmtTs, CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fuelColor, fuelLabel, sortFuels } from '../utils/fuels'
+
+const API = '/api'
+
+function zoneLabel(zone) {
+  return zone === 'DE_LU' ? 'DE-LU' : zone
+}
+
+// Negative day-ahead hours get a red marker, same idea as PowerDayAheadPanel's
+// NegativeDot but keyed off the point's own price sign (there is no daily flag here).
+function NegativeHourDot({ cx, cy, payload }) {
+  if (payload?.price == null || payload.price >= 0 || cx == null || cy == null) return null
+  return <circle cx={cx} cy={cy} r={3} fill="#f87171" stroke="none" />
+}
+
+function StatTile({ label, value }) {
+  return (
+    <div className="min-w-0">
+      <div className="font-mono text-[9px] text-neutral-600 tracking-wider uppercase">{label}</div>
+      <div className="font-mono text-sm font-bold text-neutral-200 truncate">{value}</div>
+    </div>
+  )
+}
+
+/**
+ * The desk's missing "today" read — the daily rollup panels only ever show
+ * COMPLETE days, so nothing on the desk showed today until the nightly job
+ * closed it out. This reads backend/power/live.py::compute_live directly:
+ * today's published actuals (load, per-fuel generation) hour by hour, gaps
+ * where ENTSO-E hasn't published yet, next to the day-ahead forecast/price for
+ * the SAME hours. Descriptive (Posture B) — never a prediction of its own.
+ */
+export default function LiveNowPanel({ zone = 'DE_LU' }) {
+  const [view, setView] = useState('generation')
+  const url = `${API}/power/live?zone=${zone}`
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone], pollMs: POLL_FAST_MS })
+
+  if (error)
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">LIVE NOW // FETCH ERROR</div>
+      </div>
+    )
+  // Never vanish silently: say why there is no live read instead of rendering nothing.
+  if (!data?.available && !loading)
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          LIVE NOW · {zoneLabel(zone)} — {data?.reason || 'no live data for this zone yet.'}
+        </div>
+      </div>
+    )
+
+  const hours = data?.hours ?? []
+  const zl = data?.zone_label ?? zoneLabel(zone)
+  const showingToday = data?.showing === 'today'
+  const summary = data?.summary ?? {}
+
+  // Every fuel that published at least one point today, canonically colored/ordered
+  // (the raw ENTSO-E gen.<Bxx> codes — fuelColor/sortFuels/fuelLabel all resolve them).
+  const seenFuels = new Set()
+  for (const h of hours) for (const k of Object.keys(h.gen || {})) seenFuels.add(k)
+  const fuels = sortFuels([...seenFuels])
+
+  const genRows = hours.map((h, i) => ({ hour: i, load: h.load, load_fc: h.load_fc, ...h.gen }))
+  const priceRows = hours.map((h, i) => ({ hour: i, price: h.price }))
+  // "now" marker on the price chart: the current UTC hour is meaningless once we've
+  // fallen back to showing yesterday (there is no "now" on that axis).
+  const nowHour = showingToday ? new Date().getUTCHours() : null
+
+  const loadPct = summary.load_vs_forecast_pct
+  const genGw = summary.gen_total_now != null ? (summary.gen_total_now / 1000).toFixed(1) : null
+  const priceNow = summary.price_now
+
+  return (
+    <Panel
+      id="power-live"
+      freshness={data}
+      title={`LIVE NOW · ${zl}`}
+      info={data?.note || "Today's published actuals vs the day-ahead forecast/price, hour by hour."}
+      collapsible
+      headerRight={
+        data?.available && (
+          showingToday ? (
+            <span className="inline-flex items-center gap-1 font-mono text-[9px] text-green-glow border border-green-500/30 rounded px-1.5 py-0.5">
+              <span className="w-1.5 h-1.5 rounded-full bg-green-glow animate-pulse" />
+              LIVE · lag {data.lag_minutes}m
+            </span>
+          ) : (
+            <span
+              className="font-mono text-[9px] text-orange-400 border border-orange-500/30 rounded px-1.5 py-0.5"
+              title="Today has no published actuals yet — showing yesterday's complete day instead."
+            >
+              YESTERDAY
+            </span>
+          )
+        )
+      }
+    >
+      {loading && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Loading live power…
+        </div>
+      )}
+      {!loading && data?.available && (
+        <>
+          <div className="px-4 py-3 border-b border-border/30">
+            <div className="grid grid-cols-3 gap-3">
+              <StatTile
+                label="Load vs forecast"
+                value={loadPct != null ? `${loadPct >= 0 ? '+' : ''}${loadPct.toFixed(1)}%` : '—'}
+              />
+              <StatTile label="Generation now" value={genGw != null ? `${genGw} GW` : '—'} />
+              <StatTile label="Day-ahead price now" value={priceNow != null ? `€${priceNow.toFixed(1)}` : 'n/a'} />
+            </div>
+            <PanelTakeaway className="mt-2">
+              {showingToday
+                ? `Actuals published through ${fmtTs(data.latest_actual_ts)} (${data.lag_minutes}m lag).`
+                : "Today's first actual hasn't published yet — this is yesterday's complete day."}
+            </PanelTakeaway>
+          </div>
+
+          <div className="flex items-center gap-1 px-4 pt-2">
+            {['generation', 'price'].map((v) => (
+              <button
+                key={v}
+                onClick={() => setView(v)}
+                className={`font-mono text-[9px] px-2 py-0.5 rounded border ${
+                  view === v
+                    ? 'text-cyan-glow border-cyan-glow/40 bg-cyan-glow/10'
+                    : 'text-neutral-500 border-border hover:text-neutral-300'
+                }`}
+              >
+                {v === 'generation' ? 'GENERATION' : 'PRICE'}
+              </button>
+            ))}
+          </div>
+
+          {view === 'generation' ? (
+            <div className="px-2 py-2">
+              <ResponsiveContainer width="100%" height={200}>
+                <ComposedChart data={genRows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <XAxis
+                    dataKey="hour"
+                    tickFormatter={fmtHour}
+                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    interval={2}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                    width={36}
+                    tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
+                  />
+                  <Tooltip
+                    {...CHART_TOOLTIP_PROPS}
+                    formatter={(v, name) => [v == null ? '—' : `${Math.round(v).toLocaleString()} MW`, name]}
+                    labelFormatter={(h) => `${fmtHour(h)} UTC`}
+                  />
+                  {fuels.map((fuel) => (
+                    <Area
+                      key={fuel}
+                      type="monotone"
+                      dataKey={fuel}
+                      name={fuelLabel(fuel)}
+                      stackId="gen"
+                      stroke={fuelColor(fuel)}
+                      fill={fuelColor(fuel)}
+                      fillOpacity={0.18}
+                      strokeWidth={1}
+                      dot={false}
+                      connectNulls
+                      isAnimationActive={false}
+                    />
+                  ))}
+                  <Line
+                    type="monotone"
+                    dataKey="load"
+                    name="load"
+                    stroke="#e5e7eb"
+                    strokeWidth={1.5}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="load_fc"
+                    name="load forecast"
+                    stroke="#e5e7eb"
+                    strokeDasharray="4 3"
+                    strokeWidth={1}
+                    dot={false}
+                    connectNulls
+                    isAnimationActive={false}
+                  />
+                </ComposedChart>
+              </ResponsiveContainer>
+              {fuels.length > 0 && (
+                <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 mt-1 font-mono text-[8px] text-neutral-600">
+                  {fuels.map((fuel) => (
+                    <span key={fuel} style={{ color: fuelColor(fuel) }}>▬ {fuelLabel(fuel)}</span>
+                  ))}
+                  <span>— load</span>
+                  <span>┄ forecast</span>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="px-2 py-2">
+              <ResponsiveContainer width="100%" height={160}>
+                <ComposedChart data={priceRows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <XAxis
+                    dataKey="hour"
+                    tickFormatter={fmtHour}
+                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    interval={2}
+                  />
+                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={36} />
+                  <ReferenceLine y={0} stroke="#2a2a3a" strokeDasharray="2 2" />
+                  {nowHour != null && (
+                    <ReferenceLine
+                      x={nowHour}
+                      stroke="#22d3ee"
+                      strokeDasharray="3 3"
+                      label={{ value: 'now', position: 'top', fill: '#22d3ee', fontSize: 9 }}
+                    />
+                  )}
+                  <Tooltip
+                    {...CHART_TOOLTIP_PROPS}
+                    formatter={(v) => [v == null ? '—' : `${Number(v).toFixed(1)} €/MWh`, 'day-ahead']}
+                    labelFormatter={(h) => `${fmtHour(h)} UTC`}
+                  />
+                  <Area
+                    type="stepAfter"
+                    dataKey="price"
+                    stroke="#22d3ee"
+                    fill="#22d3ee"
+                    fillOpacity={0.08}
+                    strokeWidth={1.5}
+                    dot={<NegativeHourDot />}
+                    isAnimationActive={false}
+                  />
+                </ComposedChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/OutagePanel.jsx
+++ b/frontend/src/components/OutagePanel.jsx
@@ -21,6 +21,7 @@ function ToggleBtn({ id, label, view, setView }) {
   return (
     <button
       type="button"
+      aria-pressed={view === id}
       onClick={() => setView(id)}
       className={`font-mono text-[9px] tracking-wider px-2 py-0.5 rounded border transition-colors ${
         view === id ? 'text-cyan-glow border-cyan-glow/50 bg-cyan-glow/5' : 'text-neutral-600 border-border hover:text-neutral-400'
@@ -112,8 +113,10 @@ export default function OutagePanel({ zone = 'DE_LU' }) {
             <>
               <div className="px-4 py-3 border-b border-border/30">
                 <PanelTakeaway tone={forced > 1000 ? 'warn' : 'info'}>
-                  {`${fmtGw(data.total_offline_mw)} of generation is offline right now` +
-                    (forced > 0 ? ` — ${fmtGw(forced)} of it forced (unplanned).` : ', all of it planned maintenance.')}
+                  {data.total_offline_mw > 0
+                    ? `${fmtGw(data.total_offline_mw)} of generation is offline right now` +
+                      (forced > 0 ? ` — ${fmtGw(forced)} of it forced (unplanned).` : ', all of it planned maintenance.')
+                    : `${fmtGw(data.total_offline_mw)} of generation is offline right now.`}
                   {upcoming.length > 0 ? ` ${upcoming.length} more outage${upcoming.length === 1 ? '' : 's'} start within 30 days.` : ''}
                 </PanelTakeaway>
               </div>
@@ -161,7 +164,7 @@ export default function OutagePanel({ zone = 'DE_LU' }) {
                 )}
                 {running.length > 12 && (
                   <div className="font-mono text-[9px] text-neutral-600 px-2 pt-1">
-                    + {running.length - 12} smaller outages running
+                    + {running.length - 12} more running
                   </div>
                 )}
               </div>
@@ -220,7 +223,7 @@ export default function OutagePanel({ zone = 'DE_LU' }) {
                 )}
                 {transRunning.length > 12 && (
                   <div className="font-mono text-[9px] text-neutral-600 px-2 pt-1">
-                    + {transRunning.length - 12} smaller outages running
+                    + {transRunning.length - 12} more running
                   </div>
                 )}
               </div>

--- a/frontend/src/components/OutagePanel.jsx
+++ b/frontend/src/components/OutagePanel.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import Panel from './Panel'
 import PanelTakeaway from './PanelTakeaway'
 import useFetchWithError from '../hooks/useFetchWithError'
@@ -16,15 +17,37 @@ function fmtEnd(iso) {
   return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
 }
 
+function ToggleBtn({ id, label, view, setView }) {
+  return (
+    <button
+      type="button"
+      onClick={() => setView(id)}
+      className={`font-mono text-[9px] tracking-wider px-2 py-0.5 rounded border transition-colors ${
+        view === id ? 'text-cyan-glow border-cyan-glow/50 bg-cyan-glow/5' : 'text-neutral-600 border-border hover:text-neutral-400'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
 /**
  * Generation unavailability (ENTSO-E A77) — which plants are off, how much
  * capacity that is, and whether it was planned. No free EU product shows this
  * legibly; it is the desk's clearest edge. Only the highest revision per
  * message is shown and withdrawn messages are hidden (the backend enforces
  * that — most raw messages are withdrawn revisions).
+ *
+ * GENERATION | TRANSMISSION toggle (Task P12): the SAME endpoint (`kind=all` by
+ * default) already returns both sections in one response, so switching views is a
+ * local re-render, not a re-fetch. Transmission = ENTSO-E A78 interconnector/line
+ * unavailability — a legally clean substitute for the biggest unique slice of Nord
+ * Pool's UMM feed (39% of volume), which cannot be re-displayed here without Nord
+ * Pool's written consent (docs/findings/2026-07-20-umm-feasibility.md).
  */
 export default function OutagePanel({ zone = 'DE_LU' }) {
   const { data, loading, error } = useFetchWithError(`${API}/power/outages?zone=${zone}`, { deps: [zone], pollMs: POLL_SLOW_MS })
+  const [view, setView] = useState('generation') // 'generation' | 'transmission'
 
   if (error && !data) {
     return (
@@ -49,74 +72,176 @@ export default function OutagePanel({ zone = 'DE_LU' }) {
   const upcoming = outages.filter((o) => !o.running_now)
   const forced = data?.forced_offline_mw ?? 0
 
+  const transmission = data?.transmission ?? []
+  const transRunning = transmission.filter((o) => o.running_now)
+  const transUpcoming = transmission.filter((o) => !o.running_now)
+
+  const zoneLabel = data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)
+
   return (
     <Panel
       id="power-outages"
-      title={`GENERATION OUTAGES · ${data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)}`}
+      title={`${view === 'transmission' ? 'TRANSMISSION' : 'GENERATION'} OUTAGES · ${zoneLabel}`}
       freshness={data}
-      info="ENTSO-E A77 unavailability of generation units. Counts the worst case of each message's availability curve; only the highest revision per message is shown, withdrawn messages are hidden. PLANNED = scheduled maintenance, FORCED = unplanned trip — forced capacity loss is what moves prices intraday. Descriptive, not a price call."
+      info="ENTSO-E A77 unavailability of generation units + A78 unavailability of transmission infrastructure (interconnectors/lines). Counts the worst case of each message's availability curve; only the highest revision per message is shown, withdrawn messages are hidden. PLANNED = scheduled maintenance, FORCED = unplanned trip — forced capacity loss is what moves prices intraday. Descriptive, not a price call."
       collapsible
       headerRight={
-        data?.total_offline_mw != null && (
-          <span className="font-mono text-[10px] font-bold text-orange-400">
-            {fmtGw(data.total_offline_mw)} offline
-          </span>
-        )
+        view === 'transmission'
+          ? transRunning.length > 0 && (
+              <span className="font-mono text-[10px] font-bold text-orange-400">
+                {transRunning.length} running
+              </span>
+            )
+          : data?.total_offline_mw != null && (
+              <span className="font-mono text-[10px] font-bold text-orange-400">
+                {fmtGw(data.total_offline_mw)} offline
+              </span>
+            )
       }
     >
       {loading && !data ? (
         <div className="px-4 py-4 font-mono text-[10px] text-neutral-600 animate-pulse">Loading outages…</div>
       ) : (
         <>
-          <div className="px-4 py-3 border-b border-border/30">
-            <PanelTakeaway tone={forced > 1000 ? 'warn' : 'info'}>
-              {`${fmtGw(data.total_offline_mw)} of generation is offline right now` +
-                (forced > 0 ? ` — ${fmtGw(forced)} of it forced (unplanned).` : ', all of it planned maintenance.')}
-              {upcoming.length > 0 ? ` ${upcoming.length} more outage${upcoming.length === 1 ? '' : 's'} start within 30 days.` : ''}
-            </PanelTakeaway>
+          <div className="flex items-center gap-1.5 px-4 py-2 border-b border-border/30">
+            <ToggleBtn id="generation" label="GENERATION" view={view} setView={setView} />
+            <ToggleBtn id="transmission" label="TRANSMISSION" view={view} setView={setView} />
           </div>
-          <div className="px-2 py-2 overflow-x-auto">
-            <table className="w-full font-mono text-[11px]">
-              <thead>
-                <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
-                  <th className="text-left px-2 py-1">Unit</th>
-                  <th className="text-left px-2 py-1">Fuel</th>
-                  <th className="text-right px-2 py-1">Offline</th>
-                  <th className="text-left px-2 py-1">Kind</th>
-                  <th className="text-left px-2 py-1">Until</th>
-                </tr>
-              </thead>
-              <tbody>
-                {running.slice(0, 12).map((o) => (
-                  <tr key={o.mrid} className="border-t border-border/30">
-                    {/* The name comes from the message where it has one, else from the A71/A33
-                        unit registry via unit_eic — a key the outage table had been writing and
-                        nothing had ever read. Falling back to the mRID means we know neither. */}
-                    <td className="px-2 py-1.5 text-neutral-300 max-w-[180px] truncate"
-                        title={o.unit_name ? `${o.unit_name}${o.unit_eic ? ` · ${o.unit_eic}` : ''}` : o.unit_eic || o.mrid}>
-                      {o.unit_name || o.unit_eic || o.mrid}
-                    </td>
-                    <td className="px-2 py-1.5 text-neutral-500">{o.fuel || '—'}</td>
-                    <td className="px-2 py-1.5 text-right font-bold text-neutral-200">{fmtGw(o.offline_mw)}</td>
-                    <td className="px-2 py-1.5">
-                      <span className={`text-[9px] tracking-wide border rounded px-1.5 py-0.5 ${
-                        o.kind === 'forced'
-                          ? 'text-orange-400 border-orange-500/30'
-                          : 'text-neutral-500 border-border'
-                      }`}>
-                        {o.kind === 'forced' ? 'FORCED' : 'PLANNED'}
-                      </span>
-                    </td>
-                    <td className="px-2 py-1.5 text-neutral-500">{fmtEnd(o.end_utc)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            {running.length > 12 && (
-              <div className="font-mono text-[9px] text-neutral-600 px-2 pt-1">
-                + {running.length - 12} smaller outages running
+
+          {view === 'generation' ? (
+            <>
+              <div className="px-4 py-3 border-b border-border/30">
+                <PanelTakeaway tone={forced > 1000 ? 'warn' : 'info'}>
+                  {`${fmtGw(data.total_offline_mw)} of generation is offline right now` +
+                    (forced > 0 ? ` — ${fmtGw(forced)} of it forced (unplanned).` : ', all of it planned maintenance.')}
+                  {upcoming.length > 0 ? ` ${upcoming.length} more outage${upcoming.length === 1 ? '' : 's'} start within 30 days.` : ''}
+                </PanelTakeaway>
               </div>
-            )}
+              <div className="px-2 py-2 overflow-x-auto">
+                <table className="w-full font-mono text-[11px]">
+                  <thead>
+                    <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                      <th className="text-left px-2 py-1">Unit</th>
+                      <th className="text-left px-2 py-1">Fuel</th>
+                      <th className="text-right px-2 py-1">Offline</th>
+                      <th className="text-left px-2 py-1">Kind</th>
+                      <th className="text-left px-2 py-1">Until</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {running.slice(0, 12).map((o) => (
+                      <tr key={o.mrid} className="border-t border-border/30">
+                        {/* The name comes from the message where it has one, else from the A71/A33
+                            unit registry via unit_eic — a key the outage table had been writing and
+                            nothing had ever read. Falling back to the mRID means we know neither. */}
+                        <td className="px-2 py-1.5 text-neutral-300 max-w-[180px] truncate"
+                            title={o.unit_name ? `${o.unit_name}${o.unit_eic ? ` · ${o.unit_eic}` : ''}` : o.unit_eic || o.mrid}>
+                          {o.unit_name || o.unit_eic || o.mrid}
+                        </td>
+                        <td className="px-2 py-1.5 text-neutral-500">{o.fuel || '—'}</td>
+                        <td className="px-2 py-1.5 text-right font-bold text-neutral-200">{fmtGw(o.offline_mw)}</td>
+                        <td className="px-2 py-1.5">
+                          <span className={`text-[9px] tracking-wide border rounded px-1.5 py-0.5 ${
+                            o.kind === 'forced'
+                              ? 'text-orange-400 border-orange-500/30'
+                              : 'text-neutral-500 border-border'
+                          }`}>
+                            {o.kind === 'forced' ? 'FORCED' : 'PLANNED'}
+                          </span>
+                        </td>
+                        <td className="px-2 py-1.5 text-neutral-500">{fmtEnd(o.end_utc)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                {running.length === 0 && (
+                  <div className="font-mono text-[10px] text-neutral-600 px-2 py-2">
+                    No generation outages running right now.
+                  </div>
+                )}
+                {running.length > 12 && (
+                  <div className="font-mono text-[9px] text-neutral-600 px-2 pt-1">
+                    + {running.length - 12} smaller outages running
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="px-4 py-3 border-b border-border/30">
+                <PanelTakeaway tone="info">
+                  {transRunning.length > 0
+                    ? `${transRunning.length} interconnector/line outage${transRunning.length === 1 ? '' : 's'} affecting ${zoneLabel} right now.`
+                    : `No transmission (interconnector/line) outages affecting ${zoneLabel} right now.`}
+                  {transUpcoming.length > 0 ? ` ${transUpcoming.length} more start within 30 days.` : ''}
+                </PanelTakeaway>
+              </div>
+              <div className="px-2 py-2 overflow-x-auto">
+                <table className="w-full font-mono text-[11px]">
+                  <thead>
+                    <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                      <th className="text-left px-2 py-1">Asset</th>
+                      <th className="text-left px-2 py-1">Counterparty</th>
+                      <th className="text-right px-2 py-1">Available</th>
+                      <th className="text-left px-2 py-1">Kind</th>
+                      <th className="text-left px-2 py-1">Until</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {transRunning.slice(0, 12).map((o) => (
+                      <tr key={o.mrid} className="border-t border-border/30">
+                        {/* No nominal capacity is ever published for a transmission asset (ENTSO-E
+                            A78 schema), so "Available" is the honest figure — there is no baseline
+                            to subtract it from for an "offline" number the way generation has. */}
+                        <td className="px-2 py-1.5 text-neutral-300 max-w-[180px] truncate"
+                            title={o.asset_name ? `${o.asset_name}${o.asset_eic ? ` · ${o.asset_eic}` : ''}` : o.asset_eic || o.mrid}>
+                          {o.asset_name || o.asset_eic || o.mrid}
+                        </td>
+                        <td className="px-2 py-1.5 text-neutral-500">{o.counterparty_zone || '—'}</td>
+                        <td className="px-2 py-1.5 text-right font-bold text-neutral-200">{fmtGw(o.available_mw)}</td>
+                        <td className="px-2 py-1.5">
+                          <span className={`text-[9px] tracking-wide border rounded px-1.5 py-0.5 ${
+                            o.kind === 'forced'
+                              ? 'text-orange-400 border-orange-500/30'
+                              : 'text-neutral-500 border-border'
+                          }`}>
+                            {o.kind === 'forced' ? 'FORCED' : 'PLANNED'}
+                          </span>
+                        </td>
+                        <td className="px-2 py-1.5 text-neutral-500">{fmtEnd(o.end_utc)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                {transRunning.length === 0 && (
+                  <div className="font-mono text-[10px] text-neutral-600 px-2 py-2">
+                    No transmission outages running right now.
+                  </div>
+                )}
+                {transRunning.length > 12 && (
+                  <div className="font-mono text-[9px] text-neutral-600 px-2 pt-1">
+                    + {transRunning.length - 12} smaller outages running
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {/* Nord Pool's UMM feed can't be re-displayed here without their written consent
+              (Clause 11.1, REMIT UMM Services General Terms) — per-message deep links need
+              no licence. See docs/findings/2026-07-20-umm-feasibility.md. */}
+          <div className="px-4 py-2 border-t border-border/30">
+            <a
+              href="https://umm.nordpoolgroup.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-[9px] text-neutral-500 hover:text-cyan-glow transition-colors"
+            >
+              Nordic/Baltic market messages: Nord Pool UMM ↗
+            </a>
+            <div className="font-mono text-[9px] text-neutral-700 mt-0.5">
+              Licensed for research/analysis, not re-display here — link out to read the originals.
+            </div>
           </div>
         </>
       )}

--- a/frontend/src/components/SeriesExplorer.jsx
+++ b/frontend/src/components/SeriesExplorer.jsx
@@ -1,121 +1,290 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
 import { InfoPopover } from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
+import useSeriesFrame, { MAX_SERIES_ROWS } from '../hooks/useSeriesFrame'
 import { useViewState } from '../context/ViewStateContext'
-import { rangeStart } from '../utils/ranges'
 import { CHART_TOOLTIP_PROPS } from '../utils/chart'
 
 const API = '/api'
-const COLOR_A = '#22d3ee'
-const COLOR_B = '#a78bfa'
+const DEFAULT_SERIES = 'price.dayahead'
+const DEFAULT_RESOLUTION = 'daily'
 
-// Friendly names for the canonical series the desk itself charts; everything
-// else (gen.<fuel>, flow.<zone>) gets a generated label so the raw-key dump
-// the catalog returns stays readable.
-const SERIES_LABELS = {
-  'price.dayahead': 'Day-ahead price · hourly',
-  'price.dayahead.qh': 'Day-ahead price · 15-min',
-  'imbalance.price': 'Imbalance price · hourly',
-  'imbalance.price.qh': 'Imbalance price · 15-min',
-  'load.actual': 'Load · actual',
-  'load.forecast': 'Load · TSO forecast',
-  'residual.actual': 'Residual load · actual',
-  'residual.forecast': 'Residual load · TSO forecast',
-  'generation.forecast': 'Generation · TSO forecast',
-  'hydro.reservoir': 'Hydro reservoir filling · weekly',
-  'wind.actual': 'Wind · actual',
-  'solar.actual': 'Solar · actual',
-}
+// Positional row colors — NOT per-series/per-zone, so a row keeps its color
+// when a sibling row is removed. Row 0/1 keep the original Explorer's
+// cyan/violet; the rest reuse ZoneCompareChart's pink/green/indigo plus the
+// old Δ-spread amber, so a hue already means something elsewhere on the desk.
+const ROW_COLORS = ['#22d3ee', '#a78bfa', '#f472b6', '#4ade80', '#fbbf24', '#818cf8']
 
-const GROUP_ORDER = ['price', 'imbalance', 'load', 'residual', 'generation', 'wind', 'solar', 'gen', 'flow', 'hydro']
-const GROUP_LABELS = {
-  price: 'Prices', imbalance: 'Imbalance', load: 'Load', residual: 'Residual load',
-  generation: 'Generation forecast', wind: 'Wind', solar: 'Solar',
-  gen: 'Generation mix (per fuel)', flow: 'Cross-border flows (hourly)', hydro: 'Hydro',
-}
+// Module-level (stable reference) fallbacks for before the catalog loads.
+const FALLBACK_SERIES = [{ key: DEFAULT_SERIES, unit: 'EUR/MWh', label: 'Day-ahead price · hourly', group: 'price' }]
+const FALLBACK_ZONES = [{ key: 'DE_LU', label: 'DE-LU' }]
+const FALLBACK_GROUPS = [{ key: 'price', label: 'Prices' }]
 
-function seriesLabel(s) {
-  if (SERIES_LABELS[s.key]) return SERIES_LABELS[s.key]
-  if (s.key.startsWith('flow.')) return `Flow ↔ ${s.key.slice(5).replace('_', '-')}`
-  if (s.key.startsWith('gen.')) return `Generation · ${s.key.slice(4)}`
-  return s.key
-}
-
-function groupedSeries(seriesList) {
-  const groups = new Map()
-  for (const s of seriesList) {
-    const prefix = s.key.split('.')[0]
-    if (!groups.has(prefix)) groups.set(prefix, [])
-    groups.get(prefix).push(s)
+// Subsequence fuzzy match (same idiom as CommandPalette.jsx's fuzzyScore):
+// every char of `q` appears in order in `text`. Lower score = better match.
+function fuzzyScore(text, q) {
+  if (!q) return 0
+  const t = text.toLowerCase()
+  let ti = 0
+  let score = 0
+  let last = -1
+  for (const ch of q.toLowerCase()) {
+    const idx = t.indexOf(ch, ti)
+    if (idx === -1) return null
+    score += idx - last - 1
+    if (last === -1) score += idx
+    last = idx
+    ti = idx + 1
   }
-  const order = [...GROUP_ORDER.filter((g) => groups.has(g)), ...[...groups.keys()].filter((g) => !GROUP_ORDER.includes(g))]
-  return order.map((g) => ({
-    group: GROUP_LABELS[g] || g,
-    items: groups.get(g).slice().sort((a, b) => a.key.localeCompare(b.key)),
-  }))
+  return score
 }
 
-// Explorer selection is shareable: s/vs/res live in the URL query (zone+range
-// already travel via the global ViewState spine). replaceState so browsing the
-// catalog doesn't spam the history stack.
+// Explorer/Builder selection is shareable: rows/res live in the URL query
+// (zone+range already travel via the global ViewState spine). replaceState so
+// editing the chart doesn't spam the history stack.
 function readParam(name, fallback) {
   if (typeof window === 'undefined') return fallback
   return new URLSearchParams(window.location.search).get(name) || fallback
 }
 
-export default function SeriesExplorer() {
-  const [series, setSeries] = useState(() => readParam('s', 'price.dayahead'))
-  const { zone, setZone, range } = useViewState()  // primary zone + range = the global spine
-  const [compareZone, setCompareZone] = useState(() => readParam('vs', ''))  // '' = off
-  const [spread, setSpread] = useState(false)  // Δ (A−B) instead of two lines
-  const [resolution, setResolution] = useState(() => readParam('res', 'daily'))
+// `?rows=series:zone,series:zone,...` — ':' is safe as a delimiter since
+// neither series keys (dot-namespaced) nor zone keys ever contain one.
+function parseRowsParam(raw) {
+  if (!raw) return null
+  const rows = raw.split(',').map((pair) => {
+    const i = pair.indexOf(':')
+    if (i === -1) return null
+    const series = pair.slice(0, i)
+    const zone = pair.slice(i + 1)
+    return series && zone ? { series, zone } : null
+  }).filter(Boolean)
+  return rows.length ? rows : null
+}
+
+function serializeRows(rows) {
+  return rows.map((r) => `${r.series}:${r.zone}`).join(',')
+}
+
+function rowLabel(row, seriesList, zoneList) {
+  if (!row) return ''
+  const s = seriesList.find((x) => x.key === row.series)
+  const z = zoneList.find((x) => x.key === row.zone)
+  return `${s?.label || row.series} · ${z?.label || row.zone}`
+}
+
+// Searchable series picker: text input + fuzzy-filtered, group-organized list
+// (groups/labels come from the v1 catalog, same data the plain <select> used
+// to render as <optgroup>s). Replaces the old <select> now that the catalog
+// can hold enough series that scrolling one flat list is the wrong UI.
+function SeriesPicker({ value, onChange, seriesList, groups }) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const ref = useRef(null)
 
   useEffect(() => {
+    if (!open) return
+    const handler = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false) }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const selected = seriesList.find((s) => s.key === value)
+
+  const filteredGroups = useMemo(() => {
+    if (!query) return groups
+    return groups
+      .map((g) => {
+        const scored = g.items
+          .map((s) => ({ s, score: fuzzyScore(`${s.label} ${s.key}`, query) }))
+          .filter((x) => x.score !== null)
+          .sort((a, b) => a.score - b.score)
+        return { ...g, items: scored.map((x) => x.s) }
+      })
+      .filter((g) => g.items.length > 0)
+  }, [groups, query])
+
+  const pick = (key) => { onChange(key); setOpen(false); setQuery('') }
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="font-mono text-[11px] bg-[#0a0a12] border border-border rounded px-2 py-1 text-neutral-300 max-w-[240px] truncate text-left hover:border-cyan-glow/40"
+        title={selected ? `${selected.label} (${selected.key})` : value}
+      >
+        {selected ? `${selected.label}${selected.unit ? ` (${selected.unit})` : ''}` : value}
+      </button>
+      {open && (
+        <div className="absolute z-30 mt-1 w-72 max-h-72 overflow-y-auto border border-border bg-surface rounded shadow-xl shadow-black/40">
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') { e.preventDefault(); setOpen(false) }
+              else if (e.key === 'Enter') {
+                e.preventDefault()
+                const first = filteredGroups[0]?.items[0]
+                if (first) pick(first.key)
+              }
+            }}
+            placeholder="Filter series…"
+            className="w-full border-b border-border px-2 py-1.5 font-mono text-[11px] text-neutral-200 placeholder:text-neutral-600 outline-none sticky top-0 bg-surface"
+          />
+          {filteredGroups.length === 0 && (
+            <div className="px-2 py-3 font-mono text-[10px] text-neutral-600">No matching series.</div>
+          )}
+          {filteredGroups.map((g) => (
+            <div key={g.group}>
+              <div className="px-2 pt-1.5 pb-0.5 font-mono text-[9px] tracking-wider text-neutral-600">{g.group}</div>
+              {g.items.map((s) => (
+                <button
+                  key={s.key}
+                  type="button"
+                  onClick={() => pick(s.key)}
+                  className={`w-full flex items-center justify-between gap-2 px-2 py-1 text-left font-mono text-[11px] hover:bg-white/[0.04] ${
+                    s.key === value ? 'bg-cyan-glow/10 text-cyan-glow' : 'text-neutral-300'
+                  }`}
+                >
+                  <span className="truncate">{s.label}</span>
+                  {s.unit && <span className="text-[9px] text-neutral-600 shrink-0">{s.unit}</span>}
+                </button>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function SeriesExplorer() {
+  const { zone, setZone, range } = useViewState()  // primary zone + range = the global spine
+
+  // Parsed ONCE at mount: either the current `rows=` format, or a legacy
+  // `s=`/`vs=` link (old shared Explorer URLs) — never both. `primaryZone` is
+  // only set from a `rows=` link (the legacy scheme never encoded row 0's
+  // zone; it always rode the global spine).
+  const initialRef = useRef(null)
+  if (initialRef.current === null) {
     const params = new URLSearchParams(window.location.search)
-    const setOrDelete = (k, v, def) => (v && v !== def ? params.set(k, v) : params.delete(k))
-    setOrDelete('s', series, 'price.dayahead')
-    setOrDelete('vs', compareZone, '')
-    setOrDelete('res', resolution, 'daily')
+    const rowsParam = parseRowsParam(params.get('rows'))
+    if (rowsParam) {
+      initialRef.current = {
+        primarySeries: rowsParam[0].series,
+        primaryZone: rowsParam[0].zone,
+        extra: rowsParam.slice(1, MAX_SERIES_ROWS),
+      }
+    } else {
+      const legacyS = params.get('s')
+      const legacyVs = params.get('vs')
+      initialRef.current = {
+        primarySeries: legacyS || DEFAULT_SERIES,
+        primaryZone: null,
+        extra: legacyVs ? [{ series: legacyS || DEFAULT_SERIES, zone: legacyVs }] : [],
+      }
+    }
+  }
+  const initial = initialRef.current
+
+  const [primarySeries, setPrimarySeries] = useState(initial.primarySeries)
+  const [extraRows, setExtraRows] = useState(initial.extra)  // [{series,zone}] — rows 1..5
+  const [resolution, setResolution] = useState(() => readParam('res', DEFAULT_RESOLUTION))
+  const [spread, setSpread] = useState(false)  // Δ (row0 − row1) instead of separate lines
+
+  // A `rows=` link may carry an explicit zone for row 0 (the legacy `s=`/`vs=`
+  // scheme never did — it always rode the global zone spine). Adopt it once.
+  useEffect(() => {
+    if (initial.primaryZone && initial.primaryZone !== zone) setZone(initial.primaryZone)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const rows = useMemo(
+    () => [{ series: primarySeries, zone }, ...extraRows],
+    [primarySeries, zone, extraRows]
+  )
+
+  // Rewrite the URL to the canonical `rows=`/`res=` form on every edit — this
+  // also erases any leftover legacy `s=`/`vs=` from the link that seeded us.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const isDefaultSingleRow = rows.length === 1 && primarySeries === DEFAULT_SERIES
+    if (isDefaultSingleRow) params.delete('rows')
+    else params.set('rows', serializeRows(rows))
+    if (resolution !== DEFAULT_RESOLUTION) params.set('res', resolution)
+    else params.delete('res')
+    params.delete('s')
+    params.delete('vs')
     const qs = params.toString()
     history.replaceState(null, '', `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`)
-  }, [series, compareZone, resolution])
+  }, [rows, resolution, primarySeries])
 
   const { data: catalog } = useFetchWithError(`${API}/v1/series/catalog`)
-  const start = rangeStart(range)
+  const seriesList = catalog?.series || FALLBACK_SERIES
+  const zoneList = catalog?.zones || FALLBACK_ZONES
+  // Grouped once from `catalog` alone (not the derived seriesList/groups
+  // fallbacks above, whose `||` literals would otherwise be a fresh array
+  // reference every render and defeat this memo).
+  const displayGroups = useMemo(() => {
+    const groups = catalog?.groups || FALLBACK_GROUPS
+    const list = catalog?.series || FALLBACK_SERIES
+    return groups.map((g) => ({ group: g.label, items: list.filter((s) => s.group === g.key) })).filter((g) => g.items.length > 0)
+  }, [catalog])
+  // coverage_by_series can lag `series` by up to an hour (server-cached) — its
+  // absence for a (series,zone) pair means "not yet reflected", never a hard
+  // block. Used only to dim zone options, never to disable them.
+  const coverageSet = useMemo(() => {
+    const set = new Set()
+    for (const c of catalog?.coverage_by_series || []) set.add(`${c.series}|${c.zone}`)
+    return set
+  }, [catalog])
 
-  const enc = encodeURIComponent(series)
-  const url = `${API}/v1/series?series=${enc}&zone=${zone}&start=${start}&resolution=${resolution}`
-  const { data: resp, loading, error } = useFetchWithError(url, { deps: [series, zone, start, resolution] })
+  const { frame, loading, error, perRow } = useSeriesFrame(rows, range, resolution)
 
-  const comparing = !!compareZone && compareZone !== zone
-  const cmpZoneEff = compareZone || zone  // when off, same URL as primary → served from SWR cache (no extra fetch)
-  const cmpUrl = `${API}/v1/series?series=${enc}&zone=${cmpZoneEff}&start=${start}&resolution=${resolution}`
-  const { data: cmpResp } = useFetchWithError(cmpUrl, { deps: [series, cmpZoneEff, start, resolution] })
-
-  const tkey = resolution === 'daily' ? 'date' : 'datetime_utc'
-  const data = useMemo(() => {
-    const base = (resp?.data || []).map((p) => ({ t: p[tkey], a: p.value }))
-    if (!comparing) return base
-    const bByT = new Map((cmpResp?.data || []).map((p) => [p[tkey], p.value]))
-    return base.map((row) => {
-      const b = bByT.get(row.t) ?? null
-      const d = row.a != null && b != null ? Math.round((row.a - b) * 100) / 100 : null
-      return { ...row, b, d }
+  // Dual-axis-by-unit assignment: row 0 defines the left axis; the first row
+  // with a genuinely different unit gets the right axis; a third distinct
+  // unit is rejected (2 axes max) rather than drawn on a meaningless scale.
+  const { assigned, rejected, rightUnit } = useMemo(() => {
+    const leftUnit = perRow[0]?.unit ?? null
+    let right = null
+    const bad = []
+    const out = perRow.map((r, i) => {
+      const color = ROW_COLORS[i % ROW_COLORS.length]
+      if (i === 0) return { ...r, axis: 'left', color }
+      if (r.unit == null || leftUnit == null || r.unit === leftUnit) return { ...r, axis: 'left', color }
+      if (right == null) { right = r.unit; return { ...r, axis: 'right', color } }
+      if (r.unit === right) return { ...r, axis: 'right', color }
+      bad.push({ ...r, color })
+      return { ...r, axis: null, color }
     })
-  }, [resp, cmpResp, comparing, tkey])
-  const showSpread = comparing && spread
-  // A daily point is a mean of the hours on record for that day; the last one is usually a stump
-  // (the hours that have elapsed). Say so rather than let it read as a settled day.
-  const lastDaily = resolution === 'daily' ? (resp?.data || []).at(-1) : null
-  const partialHours = lastDaily?.hours != null && lastDaily.hours < 24 ? lastDaily.hours : null
+    return { assigned: out, rejected: bad, leftUnit, rightUnit: right }
+  }, [perRow])
+  const visibleRows = assigned.filter((r) => r.axis)
 
-  const csvUrl = `${url}&format=csv`
-  const seriesList = catalog?.series || [{ key: 'price.dayahead', unit: 'EUR/MWh' }]
-  const zoneList = catalog?.zones || [{ key: 'DE_LU', label: 'DE-LU' }]
-  const zoneLabel = (k) => zoneList.find((z) => z.key === k)?.label || k
+  // Spread only makes sense for exactly two rows on the SAME unit (both units
+  // known and equal) — a superset of the original "comparing" toggle, which
+  // only ever had two same-series rows so units always matched by construction.
+  const canSpread = rows.length === 2 && perRow[0]?.unit != null && perRow[0].unit === perRow[1]?.unit
+  const showSpread = spread && canSpread
+  const spreadFrame = useMemo(
+    () => frame.map((p) => ({ t: p.t, d: p.v0 != null && p.v1 != null ? Math.round((p.v0 - p.v1) * 100) / 100 : null })),
+    [frame]
+  )
+
+  const canAddRow = rows.length < MAX_SERIES_ROWS
+  const addRow = () => {
+    if (!canAddRow) return
+    const used = new Set(rows.map((r) => r.zone))
+    const nextZone = zoneList.find((z) => !used.has(z.key))?.key || zone
+    setExtraRows((rs) => [...rs, { series: primarySeries, zone: nextZone }])
+  }
+  const removeExtraRow = (i) => setExtraRows((rs) => rs.filter((_, idx) => idx !== i))
+  const updateExtraRow = (i, patch) => setExtraRows((rs) => rs.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
+
   const fmtT = (t) => (resolution === 'daily' ? t : String(t).slice(5, 16).replace('T', ' '))
 
   return (
@@ -123,46 +292,76 @@ export default function SeriesExplorer() {
       <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-2.5 border-b border-border">
         <div className="flex items-center gap-2">
           <span className="font-mono text-xs text-neutral-500 tracking-wider">SERIES EXPLORER · /api/v1</span>
-          <InfoPopover text="Query any series for any zone over the canonical hourly store via the public data API (GET /api/v1/series). Pick a series, a zone (optionally a second zone to compare), a range and resolution; download the exact query as CSV. Free, official, redistributable data — descriptive, not a forecast." />
+          <InfoPopover text="Query any series for any zone over the canonical hourly store via the public data API (GET /api/v1/series). Add up to 6 series×zone rows; a second unit gets its own right-hand axis, and two same-unit rows can show their Δ spread instead. Download any row as CSV, or share the exact chart — it's all in the URL. Free, official, redistributable data — descriptive, not a forecast." />
         </div>
-        <a
-          href={csvUrl}
-          className="font-mono text-[10px] tracking-wider border border-border rounded px-2 py-1 text-neutral-400 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
-        >
-          ↓ CSV
-        </a>
+        <span className="font-mono text-[9px] text-neutral-700 tracking-wider">{rows.length}/{MAX_SERIES_ROWS} rows</span>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2 px-4 py-2.5 border-b border-border/50">
-        <select value={series} onChange={(e) => setSeries(e.target.value)}
-          className="font-mono text-[11px] bg-[#0a0a12] border border-border rounded px-2 py-1 text-neutral-300">
-          {groupedSeries(seriesList).map(({ group, items }) => (
-            <optgroup key={group} label={group}>
-              {items.map((s) => (
-                <option key={s.key} value={s.key}>
-                  {seriesLabel(s)}{s.unit ? ` (${s.unit})` : ''}
-                </option>
-              ))}
-            </optgroup>
-          ))}
-        </select>
-        <select value={zone} onChange={(e) => setZone(e.target.value)}
-          className="font-mono text-[11px] bg-[#0a0a12] border border-cyan-500/40 text-cyan-300 rounded px-2 py-1">
-          {zoneList.map((z) => <option key={z.key} value={z.key}>{z.label || z.key}</option>)}
-        </select>
-        <select value={compareZone} onChange={(e) => setCompareZone(e.target.value)}
-          className="font-mono text-[11px] bg-[#0a0a12] border border-violet-400/40 text-violet-300 rounded px-2 py-1">
-          <option value="">vs … compare</option>
-          {zoneList.filter((z) => z.key !== zone).map((z) => <option key={z.key} value={z.key}>vs {z.label || z.key}</option>)}
-        </select>
-        {comparing && (
+      <div className="px-4 py-2.5 border-b border-border/50 space-y-1.5">
+        {rows.map((row, i) => (
+          <div key={i} className="flex flex-wrap items-center gap-1.5">
+            <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ background: ROW_COLORS[i % ROW_COLORS.length] }} />
+            <SeriesPicker
+              value={row.series}
+              onChange={(key) => (i === 0 ? setPrimarySeries(key) : updateExtraRow(i - 1, { series: key }))}
+              seriesList={seriesList}
+              groups={displayGroups}
+            />
+            <select
+              value={row.zone}
+              onChange={(e) => (i === 0 ? setZone(e.target.value) : updateExtraRow(i - 1, { zone: e.target.value }))}
+              className={`font-mono text-[11px] bg-[#0a0a12] border rounded px-2 py-1 ${i === 0 ? 'border-cyan-500/40 text-cyan-300' : 'border-border text-neutral-300'}`}
+            >
+              {zoneList.map((z) => {
+                const covered = coverageSet.has(`${row.series}|${z.key}`)
+                return (
+                  <option key={z.key} value={z.key} style={covered ? undefined : { color: '#525252' }}>
+                    {z.label || z.key}{covered ? '' : ' · no data'}
+                  </option>
+                )
+              })}
+            </select>
+            <a
+              href={perRow[i]?.downloadUrl || '#'}
+              className="font-mono text-[9px] tracking-wider border border-border rounded px-1.5 py-0.5 text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+              title="Download this row's data as CSV"
+            >
+              ↓ CSV
+            </a>
+            {i > 0 && (
+              <button
+                onClick={() => removeExtraRow(i - 1)}
+                aria-label="Remove row"
+                title="Remove row"
+                className="font-mono text-[10px] px-1.5 py-0.5 rounded border border-border text-neutral-500 hover:text-red-400 hover:border-red-400/40"
+              >
+                ×
+              </button>
+            )}
+            {perRow[i]?.available === false && (
+              <span className="font-mono text-[9px] text-neutral-600">{perRow[i].reason || 'no data'}</span>
+            )}
+          </div>
+        ))}
+        {canAddRow && (
+          <button
+            onClick={addRow}
+            className="font-mono text-[10px] px-2 py-1 rounded border border-border text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+          >
+            + add series
+          </button>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-border/50">
+        {canSpread && (
           <button onClick={() => setSpread((s) => !s)}
             className={`font-mono text-[9px] px-2 py-0.5 rounded border ${spread ? 'text-amber-300 border-amber-400/40 bg-amber-400/10' : 'text-neutral-500 border-border hover:text-neutral-300'}`}
-            title="Show the A−B spread instead of two lines">
+            title="Show the row0 − row1 spread instead of two lines">
             Δ A−B
           </button>
         )}
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 ml-auto">
           {['hourly', 'daily'].map((rz) => (
             <button key={rz} onClick={() => setResolution(rz)}
               className={`font-mono text-[9px] px-2 py-0.5 rounded border ${resolution === rz ? 'text-violet-300 border-violet-400/40 bg-violet-400/10' : 'text-neutral-500 border-border hover:text-neutral-300'}`}>
@@ -172,51 +371,67 @@ export default function SeriesExplorer() {
         </div>
       </div>
 
+      {rejected.length > 0 && (
+        <div className="px-4 pt-2 font-mono text-[9px] text-amber-400">
+          Not charted (only two units per chart): {rejected.map((r) => `${rowLabel(r, seriesList, zoneList)} (${r.unit})`).join(', ')}.
+        </div>
+      )}
+
       <div className="px-2 pt-3 pb-1" style={{ minHeight: 240 }}>
-        {loading && <div className="px-4 py-10 text-center font-mono text-[10px] text-neutral-600 animate-pulse">Loading…</div>}
-        {!loading && error && !resp && (
+        {loading && frame.length === 0 && (
+          <div className="px-4 py-10 text-center font-mono text-[10px] text-neutral-600 animate-pulse">Loading…</div>
+        )}
+        {!loading && error && frame.length === 0 && (
           <div className="px-4 py-10 text-center font-mono text-[10px] text-red-400">Fetch error — retrying on next refresh.</div>
         )}
-        {!loading && resp && resp.available === false && (
-          <div className="px-4 py-10 text-center font-mono text-[10px] text-neutral-600">
-            {resp.reason || 'No data for this selection.'}
-          </div>
+        {!loading && !error && frame.length === 0 && (
+          <div className="px-4 py-10 text-center font-mono text-[10px] text-neutral-600">No data for this selection.</div>
         )}
-        {!loading && data.length > 0 && (
+        {frame.length > 0 && (
           <>
-            <div className="px-2 pb-2 flex items-center gap-3 font-mono text-[10px] text-neutral-500">
-              <span>{resp.count} points · {resp.unit || ''} · {resolution}</span>
-              {partialHours != null && (
-                <span className="text-neutral-600" title={`The last day averages ${partialHours} of 24 hours — it is still filling in.`}>
-                  last day {partialHours}/24 h
-                </span>
-              )}
+            <div className="px-2 pb-2 flex flex-wrap items-center gap-3 font-mono text-[10px] text-neutral-500">
               {showSpread ? (
-                <span className="flex items-center gap-1"><span className="inline-block w-2 h-0.5" style={{ background: '#fbbf24' }} />{zoneLabel(zone)} − {zoneLabel(compareZone)}</span>
+                <span className="flex items-center gap-1">
+                  <span className="inline-block w-2 h-0.5" style={{ background: '#fbbf24' }} />
+                  {rowLabel(assigned[0], seriesList, zoneList)} − {rowLabel(assigned[1], seriesList, zoneList)}
+                </span>
               ) : (
-                <>
-                  <span className="flex items-center gap-1"><span className="inline-block w-2 h-0.5" style={{ background: COLOR_A }} />{zoneLabel(zone)}</span>
-                  {comparing && <span className="flex items-center gap-1"><span className="inline-block w-2 h-0.5" style={{ background: COLOR_B }} />{zoneLabel(compareZone)}</span>}
-                </>
+                visibleRows.map((r) => (
+                  <span key={r.key} className="flex items-center gap-1">
+                    <span className="inline-block w-2 h-0.5" style={{ background: r.color }} />
+                    <span>{rowLabel(r, seriesList, zoneList)}{r.unit ? ` (${r.unit})` : ''}</span>
+                    {r.partialHours != null && (
+                      <span className="text-neutral-600" title={`The last day averages ${r.partialHours} of 24 hours — it is still filling in.`}>
+                        {r.partialHours}/24h
+                      </span>
+                    )}
+                  </span>
+                ))
               )}
             </div>
             <ResponsiveContainer width="100%" height={220}>
-              <LineChart data={data} margin={{ top: 5, right: 12, left: 0, bottom: 0 }}>
+              <LineChart data={showSpread ? spreadFrame : frame} margin={{ top: 5, right: 12, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
                 <XAxis dataKey="t" tickFormatter={fmtT} tick={{ fontSize: 8, fill: '#737373' }} minTickGap={40} />
-                <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={44} domain={['auto', 'auto']} />
+                <YAxis yAxisId="left" tick={{ fontSize: 8, fill: '#737373' }} width={44} domain={['auto', 'auto']} />
+                {!showSpread && rightUnit && (
+                  <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 8, fill: '#737373' }} width={44} domain={['auto', 'auto']} />
+                )}
                 <Tooltip {...CHART_TOOLTIP_PROPS} labelFormatter={fmtT}
-                  formatter={(v, n) => [v != null ? Number(v).toFixed(1) : '—', n === 'd' ? `${zoneLabel(zone)} − ${zoneLabel(compareZone)}` : n === 'a' ? zoneLabel(zone) : zoneLabel(compareZone)]} />
+                  formatter={(v, name) => {
+                    if (showSpread) return [v != null ? Number(v).toFixed(1) : '—', 'Δ']
+                    const r = visibleRows.find((x) => x.key === name)
+                    return [v != null ? Number(v).toFixed(1) : '—', r ? rowLabel(r, seriesList, zoneList) : name]
+                  }} />
                 {showSpread ? (
                   <>
-                    <ReferenceLine y={0} stroke="#444" />
-                    <Line type="monotone" dataKey="d" stroke="#fbbf24" dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />
+                    <ReferenceLine yAxisId="left" y={0} stroke="#444" />
+                    <Line yAxisId="left" type="monotone" dataKey="d" stroke="#fbbf24" dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />
                   </>
                 ) : (
-                  <>
-                    <Line type="monotone" dataKey="a" stroke={COLOR_A} dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />
-                    {comparing && <Line type="monotone" dataKey="b" stroke={COLOR_B} dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />}
-                  </>
+                  visibleRows.map((r) => (
+                    <Line key={r.key} yAxisId={r.axis} type="monotone" dataKey={r.key} stroke={r.color} dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />
+                  ))
                 )}
               </LineChart>
             </ResponsiveContainer>

--- a/frontend/src/components/SeriesExplorer.jsx
+++ b/frontend/src/components/SeriesExplorer.jsx
@@ -23,6 +23,17 @@ const FALLBACK_SERIES = [{ key: DEFAULT_SERIES, unit: 'EUR/MWh', label: 'Day-ahe
 const FALLBACK_ZONES = [{ key: 'DE_LU', label: 'DE-LU' }]
 const FALLBACK_GROUPS = [{ key: 'price', label: 'Prices' }]
 
+// Module-level (page-load-scoped, NOT per-mount) latch for the row-0-zone
+// adoption effect below. SeriesExplorer unmounts/remounts every time the
+// EXPLORE tab is switched away from and back, but the `rows=` URL param it
+// last wrote is never cleared on unmount — so a naive per-mount effect would
+// re-read that stale link on every remount and silently snap the global zone
+// back to it, even after the user picked a different zone elsewhere (e.g.
+// RegionPills) in between. Adoption must happen at most once per SPA session
+// (a genuine fresh page load, or a shared /builder link) — this flag is that
+// gate. `let` (not `const`) since exactly one mount flips it.
+let adoptedRowZone = false
+
 // Subsequence fuzzy match (same idiom as CommandPalette.jsx's fuzzyScore):
 // every char of `q` appears in order in `text`. Lower score = better match.
 function fuzzyScore(text, q) {
@@ -177,34 +188,43 @@ export default function SeriesExplorer() {
       initialRef.current = {
         primarySeries: rowsParam[0].series,
         primaryZone: rowsParam[0].zone,
-        extra: rowsParam.slice(1, MAX_SERIES_ROWS),
+        // Stable ids (not array position) so removing a middle row later
+        // doesn't reassign a sibling SeriesPicker's open/query state onto it.
+        extra: rowsParam.slice(1, MAX_SERIES_ROWS).map((r, idx) => ({ ...r, id: idx + 1 })),
       }
     } else {
       const legacyS = params.get('s')
       const legacyVs = params.get('vs')
-      initialRef.current = {
-        primarySeries: legacyS || DEFAULT_SERIES,
-        primaryZone: null,
-        extra: legacyVs ? [{ series: legacyS || DEFAULT_SERIES, zone: legacyVs }] : [],
-      }
+      // The old 2-line Explorer treated vs === the current zone as a no-op
+      // (`comparing = compareZone && compareZone !== zone`) — never a second
+      // line. Preserve that: don't manufacture a duplicate row for it.
+      const extra = legacyVs && legacyVs !== zone
+        ? [{ series: legacyS || DEFAULT_SERIES, zone: legacyVs, id: 1 }]
+        : []
+      initialRef.current = { primarySeries: legacyS || DEFAULT_SERIES, primaryZone: null, extra }
     }
   }
   const initial = initialRef.current
+  const nextRowId = useRef(initial.extra.length + 1)  // ids already used: 1..extra.length
 
   const [primarySeries, setPrimarySeries] = useState(initial.primarySeries)
-  const [extraRows, setExtraRows] = useState(initial.extra)  // [{series,zone}] — rows 1..5
+  const [extraRows, setExtraRows] = useState(initial.extra)  // [{id,series,zone}] — rows 1..5
   const [resolution, setResolution] = useState(() => readParam('res', DEFAULT_RESOLUTION))
   const [spread, setSpread] = useState(false)  // Δ (row0 − row1) instead of separate lines
 
   // A `rows=` link may carry an explicit zone for row 0 (the legacy `s=`/`vs=`
-  // scheme never did — it always rode the global zone spine). Adopt it once.
+  // scheme never did — it always rode the global zone spine). Adopt it AT
+  // MOST ONCE per page load (see `adoptedRowZone` above), never on a
+  // tab-switch remount.
   useEffect(() => {
+    if (adoptedRowZone) return
+    adoptedRowZone = true
     if (initial.primaryZone && initial.primaryZone !== zone) setZone(initial.primaryZone)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const rows = useMemo(
-    () => [{ series: primarySeries, zone }, ...extraRows],
+    () => [{ id: 'primary', series: primarySeries, zone }, ...extraRows],
     [primarySeries, zone, extraRows]
   )
 
@@ -280,7 +300,7 @@ export default function SeriesExplorer() {
     if (!canAddRow) return
     const used = new Set(rows.map((r) => r.zone))
     const nextZone = zoneList.find((z) => !used.has(z.key))?.key || zone
-    setExtraRows((rs) => [...rs, { series: primarySeries, zone: nextZone }])
+    setExtraRows((rs) => [...rs, { id: nextRowId.current++, series: primarySeries, zone: nextZone }])
   }
   const removeExtraRow = (i) => setExtraRows((rs) => rs.filter((_, idx) => idx !== i))
   const updateExtraRow = (i, patch) => setExtraRows((rs) => rs.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
@@ -299,7 +319,7 @@ export default function SeriesExplorer() {
 
       <div className="px-4 py-2.5 border-b border-border/50 space-y-1.5">
         {rows.map((row, i) => (
-          <div key={i} className="flex flex-wrap items-center gap-1.5">
+          <div key={row.id} className="flex flex-wrap items-center gap-1.5">
             <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ background: ROW_COLORS[i % ROW_COLORS.length] }} />
             <SeriesPicker
               value={row.series}
@@ -338,7 +358,9 @@ export default function SeriesExplorer() {
                 ×
               </button>
             )}
-            {perRow[i]?.available === false && (
+            {perRow[i]?.error ? (
+              <span className="font-mono text-[9px] text-red-400" title={perRow[i].error}>fetch error</span>
+            ) : perRow[i]?.available === false && (
               <span className="font-mono text-[9px] text-neutral-600">{perRow[i].reason || 'no data'}</span>
             )}
           </div>
@@ -400,6 +422,9 @@ export default function SeriesExplorer() {
                   <span key={r.key} className="flex items-center gap-1">
                     <span className="inline-block w-2 h-0.5" style={{ background: r.color }} />
                     <span>{rowLabel(r, seriesList, zoneList)}{r.unit ? ` (${r.unit})` : ''}</span>
+                    {r.error && (
+                      <span className="text-red-400" title={r.error}>fetch error</span>
+                    )}
                     {r.partialHours != null && (
                       <span className="text-neutral-600" title={`The last day averages ${r.partialHours} of 24 hours — it is still filling in.`}>
                         {r.partialHours}/24h

--- a/frontend/src/components/SeriesExplorer.jsx
+++ b/frontend/src/components/SeriesExplorer.jsx
@@ -79,6 +79,18 @@ function serializeRows(rows) {
   return rows.map((r) => `${r.series}:${r.zone}`).join(',')
 }
 
+// The `rows=`/`res=` pair for the canonical URL, omitting each when it's the
+// default (a lone default-series row / daily resolution) — shared by the
+// history.replaceState sync effect and the /builder "open full-screen" link,
+// so the two can never disagree on what counts as "default enough to omit".
+function rowsQueryParams(rows, resolution, primarySeries) {
+  const p = new URLSearchParams()
+  const isDefaultSingleRow = rows.length === 1 && primarySeries === DEFAULT_SERIES
+  if (!isDefaultSingleRow) p.set('rows', serializeRows(rows))
+  if (resolution !== DEFAULT_RESOLUTION) p.set('res', resolution)
+  return p
+}
+
 function rowLabel(row, seriesList, zoneList) {
   if (!row) return ''
   const s = seriesList.find((x) => x.key === row.series)
@@ -93,6 +105,7 @@ function rowLabel(row, seriesList, zoneList) {
 function SeriesPicker({ value, onChange, seriesList, groups }) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
+  const [sel, setSel] = useState(0)  // index into the FLATTENED filtered list
   const ref = useRef(null)
 
   useEffect(() => {
@@ -116,8 +129,21 @@ function SeriesPicker({ value, onChange, seriesList, groups }) {
       })
       .filter((g) => g.items.length > 0)
   }, [groups, query])
+  // Flattened for arrow-key navigation/highlighting — same idiom as
+  // CommandPalette's `results`/`sel` (a group boundary is just a render
+  // detail, the selection index doesn't know about groups).
+  const flatItems = useMemo(() => filteredGroups.flatMap((g) => g.items), [filteredGroups])
+  const indexByKey = useMemo(() => new Map(flatItems.map((s, i) => [s.key, i])), [flatItems])
+  const safeSel = Math.min(sel, Math.max(flatItems.length - 1, 0))
 
-  const pick = (key) => { onChange(key); setOpen(false); setQuery('') }
+  const pick = (key) => { onChange(key); setOpen(false); setQuery(''); setSel(0) }
+
+  const onKeyDown = (e) => {
+    if (e.key === 'Escape') { e.preventDefault(); setOpen(false) }
+    else if (e.key === 'ArrowDown') { e.preventDefault(); setSel((s) => Math.min(s + 1, flatItems.length - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setSel((s) => Math.max(s - 1, 0)) }
+    else if (e.key === 'Enter') { e.preventDefault(); if (flatItems[safeSel]) pick(flatItems[safeSel].key) }
+  }
 
   return (
     <div className="relative" ref={ref}>
@@ -134,15 +160,8 @@ function SeriesPicker({ value, onChange, seriesList, groups }) {
           <input
             autoFocus
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') { e.preventDefault(); setOpen(false) }
-              else if (e.key === 'Enter') {
-                e.preventDefault()
-                const first = filteredGroups[0]?.items[0]
-                if (first) pick(first.key)
-              }
-            }}
+            onChange={(e) => { setQuery(e.target.value); setSel(0) }}
+            onKeyDown={onKeyDown}
             placeholder="Filter series…"
             className="w-full border-b border-border px-2 py-1.5 font-mono text-[11px] text-neutral-200 placeholder:text-neutral-600 outline-none sticky top-0 bg-surface"
           />
@@ -152,19 +171,23 @@ function SeriesPicker({ value, onChange, seriesList, groups }) {
           {filteredGroups.map((g) => (
             <div key={g.group}>
               <div className="px-2 pt-1.5 pb-0.5 font-mono text-[9px] tracking-wider text-neutral-600">{g.group}</div>
-              {g.items.map((s) => (
-                <button
-                  key={s.key}
-                  type="button"
-                  onClick={() => pick(s.key)}
-                  className={`w-full flex items-center justify-between gap-2 px-2 py-1 text-left font-mono text-[11px] hover:bg-white/[0.04] ${
-                    s.key === value ? 'bg-cyan-glow/10 text-cyan-glow' : 'text-neutral-300'
-                  }`}
-                >
-                  <span className="truncate">{s.label}</span>
-                  {s.unit && <span className="text-[9px] text-neutral-600 shrink-0">{s.unit}</span>}
-                </button>
-              ))}
+              {g.items.map((s) => {
+                const idx = indexByKey.get(s.key)
+                return (
+                  <button
+                    key={s.key}
+                    type="button"
+                    onClick={() => pick(s.key)}
+                    onMouseEnter={() => setSel(idx)}
+                    className={`w-full flex items-center justify-between gap-2 px-2 py-1 text-left font-mono text-[11px] ${
+                      idx === safeSel ? 'bg-cyan-glow/10 text-cyan-glow' : s.key === value ? 'text-cyan-glow' : 'text-neutral-300 hover:bg-white/[0.04]'
+                    }`}
+                  >
+                    <span className="truncate">{s.label}</span>
+                    {s.unit && <span className="text-[9px] text-neutral-600 shrink-0">{s.unit}</span>}
+                  </button>
+                )
+              })}
             </div>
           ))}
         </div>
@@ -209,7 +232,14 @@ export default function SeriesExplorer() {
 
   const [primarySeries, setPrimarySeries] = useState(initial.primarySeries)
   const [extraRows, setExtraRows] = useState(initial.extra)  // [{id,series,zone}] — rows 1..5
-  const [resolution, setResolution] = useState(() => readParam('res', DEFAULT_RESOLUTION))
+  const [resolution, setResolution] = useState(() => {
+    // A mistyped/stale shared link (e.g. `?res=hour`) must fall back to the
+    // default instead of being sent straight to the API — `resolution` isn't
+    // validated server-side beyond a 422, and the bad value would just get
+    // re-persisted into the URL by the sync effect below.
+    const r = readParam('res', DEFAULT_RESOLUTION)
+    return r === 'hourly' || r === 'daily' ? r : DEFAULT_RESOLUTION
+  })
   const [spread, setSpread] = useState(false)  // Δ (row0 − row1) instead of separate lines
 
   // A `rows=` link may carry an explicit zone for row 0 (the legacy `s=`/`vs=`
@@ -232,16 +262,25 @@ export default function SeriesExplorer() {
   // also erases any leftover legacy `s=`/`vs=` from the link that seeded us.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
-    const isDefaultSingleRow = rows.length === 1 && primarySeries === DEFAULT_SERIES
-    if (isDefaultSingleRow) params.delete('rows')
-    else params.set('rows', serializeRows(rows))
-    if (resolution !== DEFAULT_RESOLUTION) params.set('res', resolution)
-    else params.delete('res')
+    const rq = rowsQueryParams(rows, resolution, primarySeries)
+    if (rq.has('rows')) params.set('rows', rq.get('rows')); else params.delete('rows')
+    if (rq.has('res')) params.set('res', rq.get('res')); else params.delete('res')
     params.delete('s')
     params.delete('vs')
     const qs = params.toString()
     history.replaceState(null, '', `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`)
   }, [rows, resolution, primarySeries])
+
+  // /builder discoverability: a link out of the EXPLORE tab (never shown ON
+  // /builder itself, which already IS the full-screen view) carrying the
+  // current chart + the zone/range spine, so the exact view travels.
+  const isBuilderRoute = typeof window !== 'undefined' && window.location.pathname === '/builder'
+  const builderHref = (() => {
+    const p = rowsQueryParams(rows, resolution, primarySeries)
+    p.set('zone', zone)
+    p.set('range', range)
+    return `/builder?${p.toString()}`
+  })()
 
   const { data: catalog } = useFetchWithError(`${API}/v1/series/catalog`)
   const seriesList = catalog?.series || FALLBACK_SERIES
@@ -256,7 +295,11 @@ export default function SeriesExplorer() {
   }, [catalog])
   // coverage_by_series can lag `series` by up to an hour (server-cached) — its
   // absence for a (series,zone) pair means "not yet reflected", never a hard
-  // block. Used only to dim zone options, never to disable them.
+  // block. Used only to dim zone options, never to disable them. A missing/
+  // empty coverage list (catalog not loaded yet, or itself failed) is NOT
+  // evidence of "no data anywhere" — dimming every zone in that case would be
+  // a lie, so dimming is gated on the catalog actually having coverage rows.
+  const hasCoverageData = (catalog?.coverage_by_series?.length ?? 0) > 0
   const coverageSet = useMemo(() => {
     const set = new Set()
     for (const c of catalog?.coverage_by_series || []) set.add(`${c.series}|${c.zone}`)
@@ -265,23 +308,25 @@ export default function SeriesExplorer() {
 
   const { frame, loading, error, perRow } = useSeriesFrame(rows, range, resolution)
 
-  // Dual-axis-by-unit assignment: row 0 defines the left axis; the first row
-  // with a genuinely different unit gets the right axis; a third distinct
-  // unit is rejected (2 axes max) rather than drawn on a meaningless scale.
+  // Dual-axis-by-unit assignment: the left axis anchors to the FIRST row with
+  // a known unit — not strictly row 0 — so a slow-to-load or errored row 0
+  // doesn't collapse every other (already-known, possibly different) unit
+  // onto one axis while it waits; the first genuinely different unit seen
+  // gets the right axis, and a third distinct unit is rejected (2 axes max)
+  // rather than drawn on a meaningless scale.
   const { assigned, rejected, rightUnit } = useMemo(() => {
-    const leftUnit = perRow[0]?.unit ?? null
+    const leftUnit = perRow.find((r) => r.unit != null)?.unit ?? null
     let right = null
     const bad = []
     const out = perRow.map((r, i) => {
       const color = ROW_COLORS[i % ROW_COLORS.length]
-      if (i === 0) return { ...r, axis: 'left', color }
       if (r.unit == null || leftUnit == null || r.unit === leftUnit) return { ...r, axis: 'left', color }
       if (right == null) { right = r.unit; return { ...r, axis: 'right', color } }
       if (r.unit === right) return { ...r, axis: 'right', color }
       bad.push({ ...r, color })
       return { ...r, axis: null, color }
     })
-    return { assigned: out, rejected: bad, leftUnit, rightUnit: right }
+    return { assigned: out, rejected: bad, rightUnit: right }
   }, [perRow])
   const visibleRows = assigned.filter((r) => r.axis)
 
@@ -314,7 +359,18 @@ export default function SeriesExplorer() {
           <span className="font-mono text-xs text-neutral-500 tracking-wider">SERIES EXPLORER · /api/v1</span>
           <InfoPopover text="Query any series for any zone over the canonical hourly store via the public data API (GET /api/v1/series). Add up to 6 series×zone rows; a second unit gets its own right-hand axis, and two same-unit rows can show their Δ spread instead. Download any row as CSV, or share the exact chart — it's all in the URL. Free, official, redistributable data — descriptive, not a forecast." />
         </div>
-        <span className="font-mono text-[9px] text-neutral-700 tracking-wider">{rows.length}/{MAX_SERIES_ROWS} rows</span>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[9px] text-neutral-700 tracking-wider">{rows.length}/{MAX_SERIES_ROWS} rows</span>
+          {!isBuilderRoute && (
+            <a
+              href={builderHref}
+              title="Open this chart full-screen at /builder"
+              className="font-mono text-[9px] tracking-wider border border-border rounded px-1.5 py-0.5 text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+            >
+              open full-screen ↗
+            </a>
+          )}
+        </div>
       </div>
 
       <div className="px-4 py-2.5 border-b border-border/50 space-y-1.5">
@@ -333,7 +389,7 @@ export default function SeriesExplorer() {
               className={`font-mono text-[11px] bg-[#0a0a12] border rounded px-2 py-1 ${i === 0 ? 'border-cyan-500/40 text-cyan-300' : 'border-border text-neutral-300'}`}
             >
               {zoneList.map((z) => {
-                const covered = coverageSet.has(`${row.series}|${z.key}`)
+                const covered = !hasCoverageData || coverageSet.has(`${row.series}|${z.key}`)
                 return (
                   <option key={z.key} value={z.key} style={covered ? undefined : { color: '#525252' }}>
                     {z.label || z.key}{covered ? '' : ' · no data'}

--- a/frontend/src/components/SparkCalculatorPanel.jsx
+++ b/frontend/src/components/SparkCalculatorPanel.jsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react'
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+import {
+  ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
+} from 'recharts'
+import { fmtDate, CHART_TOOLTIP_PROPS } from '../utils/chart'
+
+const API = '/api'
+
+// A drag fires dozens of onChange ticks; only the settled value is worth a network round trip.
+const DEBOUNCE_MS = 300
+const MIN_PCT = 35
+const MAX_PCT = 63
+// Shown only until the first response lands and echoes the real backend default — never sent
+// to the API (userPct/committedPct stay null until the user actually touches the slider).
+const FALLBACK_DISPLAY_PCT = 50
+
+/**
+ * PPA / asset-modelling knob on top of the desk's own spark spread: an owner's actual CCGT
+ * doesn't necessarily run at the desk's EU-fleet-average 50% efficiency assumption, and the
+ * heat rate moves the spread (and the break-even carbon price) linearly. This panel re-runs
+ * backend/routes/power.py::get_spark_spread server-side at whatever efficiency the slider is
+ * set to — the raw TTF gas price never reaches the browser either way (ICE Endex licensing);
+ * only the derived, efficiency-adjusted arithmetic does.
+ */
+export default function SparkCalculatorPanel({ zone = 'DE_LU' }) {
+  // null = the user hasn't touched the slider yet, so the request carries no override and the
+  // backend applies its own settings.gas_ccgt_efficiency — the slider's displayed position is
+  // then derived straight from that response (see `displayPct` below), never adopted via an
+  // effect: adjusting state to mirror a prop/response belongs in render, not in a setState-on-
+  // mount effect (that cascades an extra render for no benefit here).
+  const [userPct, setUserPct] = useState(null)
+  const [committedPct, setCommittedPct] = useState(null)
+
+  // Debounce the slider → fetch: don't refetch on every drag tick, only once it settles. This
+  // IS a legitimate effect (syncing a timer, not deriving state), and setState happens inside
+  // the timeout callback, not synchronously in the effect body.
+  useEffect(() => {
+    if (userPct == null) return
+    const t = setTimeout(() => setCommittedPct(userPct), DEBOUNCE_MS)
+    return () => clearTimeout(t)
+  }, [userPct])
+
+  const efficiency = committedPct != null ? (committedPct / 100).toFixed(2) : null
+  const url = `${API}/power/spark-spread?zone=${zone}&days=365${efficiency != null ? `&efficiency=${efficiency}` : ''}`
+  const { data, loading, error } = useFetchWithError(
+    url, { deps: [zone, efficiency], pollMs: POLL_SLOW_MS },
+  )
+
+  // The slider's displayed position: whatever the user chose, else the backend's own default
+  // once it's known, else a placeholder while the very first request is in flight.
+  const displayPct = userPct ?? (data?.efficiency != null ? Math.round(data.efficiency * 100) : FALLBACK_DISPLAY_PCT)
+
+  const zoneLabel = data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)
+
+  if (error && !data) {
+    return (
+      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-red-400">SPARK CALCULATOR // FETCH ERROR</div>
+      </div>
+    )
+  }
+  // Never vanish silently: an unavailable zone (no overlapping power/TTF price days — the
+  // spark route computes live per zone, but that overlap isn't guaranteed everywhere) still
+  // gets a calm explanation, not a blank space.
+  if (!loading && !data?.available) {
+    return (
+      <div className="border border-border bg-surface rounded px-4 py-3">
+        <div className="font-mono text-[10px] text-neutral-500">
+          SPARK CALCULATOR · {zoneLabel} — {data?.reason || 'no overlapping power/TTF price days yet.'}
+        </div>
+      </div>
+    )
+  }
+
+  const rows = data?.data ?? []
+  const latest = data?.latest
+
+  return (
+    <Panel
+      id="power-spark-calculator"
+      title={`SPARK CALCULATOR · ${zoneLabel}`}
+      info="Re-runs the dirty spark spread at a CCGT efficiency you choose, instead of the desk's fixed fleet-average assumption. Realised prices, not a forecast."
+      freshness={data}
+      collapsible
+      headerRight={
+        latest?.dirty_spark_spread != null && (
+          <div className="flex items-center gap-3 font-mono text-[10px]">
+            <span className="text-neutral-500">
+              Spread <span className="text-neutral-200">
+                {latest.dirty_spark_spread >= 0 ? '+' : ''}{latest.dirty_spark_spread.toFixed(1)} €/MWh
+              </span>
+            </span>
+            <span className="text-neutral-600">@ {displayPct}% eff.</span>
+          </div>
+        )
+      }
+    >
+      <div className="px-4 py-2.5 border-b border-border/30">
+        <label className="flex items-center gap-3 font-mono text-[10px] text-neutral-400">
+          <span className="shrink-0 w-40">CCGT efficiency: {displayPct}%</span>
+          <input
+            type="range"
+            min={MIN_PCT}
+            max={MAX_PCT}
+            step={1}
+            value={displayPct}
+            onChange={(e) => setUserPct(Number(e.target.value))}
+            className="flex-1 accent-cyan-500"
+          />
+          <span className="shrink-0 w-24 text-right text-neutral-600">
+            {MIN_PCT}–{MAX_PCT}%
+          </span>
+        </label>
+      </div>
+
+      {loading && !data ? (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">
+          Computing spark spread…
+        </div>
+      ) : (
+        <>
+          {latest && (
+            <div className="px-4 py-3 border-b border-border/30">
+              <div className="flex items-baseline gap-4 flex-wrap">
+                <div>
+                  <div className="font-mono text-2xl font-bold text-neutral-100">
+                    {latest.dirty_spark_spread >= 0 ? '+' : ''}{latest.dirty_spark_spread.toFixed(1)}
+                  </div>
+                  <div className="font-mono text-[9px] text-neutral-600">EUR/MWh dirty spark</div>
+                </div>
+                <div>
+                  <div className={`font-mono text-2xl font-bold ${latest.breakeven_eua_eur_t != null ? 'text-amber-400' : 'text-neutral-700'}`}>
+                    {latest.breakeven_eua_eur_t != null ? `€${latest.breakeven_eua_eur_t.toFixed(0)}` : '—'}
+                  </div>
+                  <div className="font-mono text-[9px] text-neutral-600">
+                    /t CO₂ break-even{latest.breakeven_eua_eur_t == null ? ' (already negative)' : ''}
+                  </div>
+                </div>
+                <div className="font-mono text-[10px] text-neutral-500">
+                  <span className="text-neutral-600">HEAT-RATE</span>{' '}
+                  <span className="text-neutral-300">{latest.heat_rate?.toFixed(3)}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {rows.length > 1 && (
+            <div className="px-2 py-2">
+              <ResponsiveContainer width="100%" height={160}>
+                <LineChart data={rows} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
+                  <XAxis dataKey="date" tick={{ fontSize: 8, fill: '#737373' }}
+                    tickFormatter={fmtDate} minTickGap={50} />
+                  <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={34} />
+                  <ReferenceLine y={0} stroke="#525252" strokeDasharray="4 4" />
+                  <Tooltip
+                    {...CHART_TOOLTIP_PROPS}
+                    labelFormatter={fmtDate}
+                    formatter={(v) => [`${Number(v) >= 0 ? '+' : ''}${Number(v).toFixed(1)} €/MWh`, 'Dirty spark']}
+                  />
+                  <Line type="monotone" dataKey="dirty_spark_spread" name="Dirty spark"
+                    stroke="#fb923c" strokeWidth={1.4} dot={false} isAnimationActive={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          <div className="px-4 pb-3 font-mono text-[9px] text-neutral-500 leading-relaxed">
+            Dirty spark (excl. CO₂) — EUA prices are licence-blocked; breakeven EUA shows what
+            CO₂ price would zero the spread. Realised day-ahead prices, not a forecast: moving the
+            slider re-derives the same historical record at a different heat rate, it does not
+            project anything forward.
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/embed/EmbedFrame.jsx
+++ b/frontend/src/components/embed/EmbedFrame.jsx
@@ -1,0 +1,79 @@
+import { EMBED_COLORS } from './embedUtils'
+
+// Minimal chrome around every /embed/<zone>/<metric> widget: a one-line header (zone +
+// metric title), the metric's own content, a freshness caption and the REQUIRED
+// attribution footer. Fills the iframe completely (100vw/100vh, no page margin — see
+// index.css: body already has margin:0, so nothing extra is needed there).
+//
+// `freshness` is optional: { label: string, stale: bool } — the caption text and
+// whether to render it in the warning color. Null renders no caption (e.g. while the
+// zone/metric hasn't resolved yet).
+
+const WRAP_STYLE = {
+  width: '100vw',
+  height: '100vh',
+  minHeight: 140,
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
+  background: EMBED_COLORS.bg,
+  color: EMBED_COLORS.text,
+  fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+  border: `1px solid ${EMBED_COLORS.panelBorder}`,
+  overflow: 'hidden',
+}
+
+const HEADER_STYLE = {
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: 8,
+  padding: '8px 10px 4px',
+  flexShrink: 0,
+}
+
+const ZONE_STYLE = { fontSize: 12, fontWeight: 700, color: EMBED_COLORS.text }
+const TITLE_STYLE = { fontSize: 10, color: EMBED_COLORS.muted, letterSpacing: '0.02em' }
+
+const BODY_STYLE = {
+  flex: 1,
+  minHeight: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '0 4px',
+}
+
+const FOOTER_STYLE = {
+  flexShrink: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
+  padding: '4px 10px 6px',
+  fontSize: 9,
+  borderTop: `1px solid ${EMBED_COLORS.panelBorder}`,
+}
+
+const LINK_STYLE = { color: EMBED_COLORS.accent, fontWeight: 700, textDecoration: 'none' }
+
+export default function EmbedFrame({ zoneLabel, metricTitle, freshness, children }) {
+  return (
+    <div style={WRAP_STYLE}>
+      <div style={HEADER_STYLE}>
+        <span style={ZONE_STYLE}>{zoneLabel}</span>
+        <span style={TITLE_STYLE}>{metricTitle}</span>
+      </div>
+      <div style={BODY_STYLE}>{children}</div>
+      <div style={FOOTER_STYLE}>
+        <span style={{ color: freshness?.stale ? EMBED_COLORS.warn : EMBED_COLORS.faint }}>
+          {freshness?.label ?? ' '}
+        </span>
+        <span style={{ color: EMBED_COLORS.faint, whiteSpace: 'nowrap' }}>
+          <a href="https://obsyd.dev" target="_blank" rel="noopener noreferrer" style={LINK_STYLE}>
+            OBSYD
+          </a>
+          {' · obsyd.dev — data: ENTSO-E'}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/embed/EmbedGenMixChart.jsx
+++ b/frontend/src/components/embed/EmbedGenMixChart.jsx
@@ -1,0 +1,115 @@
+import {
+  ResponsiveContainer, ComposedChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
+} from 'recharts'
+import useFetchWithError from '../../hooks/useFetchWithError'
+import { POLL_FAST_MS } from '../../utils/poll'
+import { fmtHour, fmtTs, CHART_TOOLTIP_PROPS } from '../../utils/chart'
+import { fuelColor, fuelLabel, sortFuels } from '../../utils/fuels'
+import EmbedFrame from './EmbedFrame'
+import EmbedUnknownCard from './EmbedUnknownCard'
+import { EMBED_COLORS, MSG_STYLE, zoneLabel, METRIC_TITLES } from './embedUtils'
+
+const API = '/api'
+const TITLE = METRIC_TITLES.genmix
+
+/**
+ * /embed/<zone>/genmix — today's (or yesterday's, honestly labeled) stacked
+ * generation mix by fuel, from GET /api/power/live?zone= — the same near-real-time
+ * read LiveNowPanel's GENERATION view uses, simplified to just the mix (no load
+ * lines; see EmbedLoadChart for those). `zone` is checked against the response's
+ * own `zones` list — the endpoint itself silently resolves an unknown zone to the
+ * default, so the embed layer is the one place that must not let that pass quietly.
+ */
+export default function EmbedGenMixChart({ zone }) {
+  const url = `${API}/power/live?zone=${encodeURIComponent(zone)}`
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone], pollMs: POLL_FAST_MS })
+  const zl = data?.zone_label ?? zoneLabel(zone)
+
+  const zoneKnown = !data || !Array.isArray(data.zones) || data.zones.includes(zone)
+  if (!zoneKnown) {
+    return (
+      <EmbedFrame zoneLabel={zoneLabel(zone)} metricTitle={TITLE}>
+        <EmbedUnknownCard message={`Unknown zone "${zone}".`} />
+      </EmbedFrame>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <EmbedFrame zoneLabel={zl} metricTitle={TITLE}>
+        <div style={MSG_STYLE}>Fetch error — try again shortly.</div>
+      </EmbedFrame>
+    )
+  }
+
+  if (!data?.available && !loading) {
+    return (
+      <EmbedFrame zoneLabel={zl} metricTitle={TITLE}>
+        <div style={MSG_STYLE}>{data?.reason || 'No live data yet for this zone.'}</div>
+      </EmbedFrame>
+    )
+  }
+
+  const hours = data?.hours ?? []
+  const showingToday = data?.showing === 'today'
+  const seenFuels = new Set()
+  for (const h of hours) for (const k of Object.keys(h.gen || {})) seenFuels.add(k)
+  const fuels = sortFuels([...seenFuels])
+  const rows = hours.map((h, i) => ({ hour: i, ...h.gen }))
+
+  const freshness = data?.available
+    ? {
+        label: showingToday
+          ? `Live · updated ${fmtTs(data.latest_actual_ts)} (${data.lag_minutes}m lag)`
+          : 'Showing yesterday — no actuals published yet today',
+        stale: !!data?.stale,
+      }
+    : null
+
+  return (
+    <EmbedFrame zoneLabel={zl} metricTitle={TITLE} freshness={freshness}>
+      {loading && !data ? (
+        <div style={MSG_STYLE}>Loading…</div>
+      ) : fuels.length === 0 ? (
+        <div style={MSG_STYLE}>No generation-mix data for this zone yet.</div>
+      ) : (
+        <ResponsiveContainer width="100%" height="100%" minHeight={80}>
+          <ComposedChart data={rows} margin={{ top: 8, right: 10, bottom: 2, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke={EMBED_COLORS.grid} />
+            <XAxis
+              dataKey="hour"
+              tickFormatter={fmtHour}
+              tick={{ fontSize: 9, fill: EMBED_COLORS.faint }}
+              interval={3}
+            />
+            <YAxis
+              tick={{ fontSize: 9, fill: EMBED_COLORS.faint }}
+              width={32}
+              tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
+            />
+            <Tooltip
+              {...CHART_TOOLTIP_PROPS}
+              formatter={(v, name) => [v == null ? '—' : `${Math.round(v).toLocaleString()} MW`, fuelLabel(name)]}
+              labelFormatter={(h) => `${fmtHour(h)} UTC`}
+            />
+            {fuels.map((fuel) => (
+              <Area
+                key={fuel}
+                type="monotone"
+                dataKey={fuel}
+                name={fuel}
+                stackId="gen"
+                stroke={fuelColor(fuel)}
+                fill={fuelColor(fuel)}
+                fillOpacity={0.4}
+                strokeWidth={1}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ))}
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </EmbedFrame>
+  )
+}

--- a/frontend/src/components/embed/EmbedLoadChart.jsx
+++ b/frontend/src/components/embed/EmbedLoadChart.jsx
@@ -1,0 +1,113 @@
+import {
+  ResponsiveContainer, ComposedChart, Line, XAxis, YAxis, Tooltip, CartesianGrid,
+} from 'recharts'
+import useFetchWithError from '../../hooks/useFetchWithError'
+import { POLL_FAST_MS } from '../../utils/poll'
+import { fmtHour, fmtTs, CHART_TOOLTIP_PROPS } from '../../utils/chart'
+import EmbedFrame from './EmbedFrame'
+import EmbedUnknownCard from './EmbedUnknownCard'
+import { EMBED_COLORS, MSG_STYLE, zoneLabel, METRIC_TITLES } from './embedUtils'
+
+const API = '/api'
+const TITLE = METRIC_TITLES.load
+
+/**
+ * /embed/<zone>/load — today's (or yesterday's) published load actual vs. the
+ * day-ahead load forecast for the same hours, from GET /api/power/live?zone= — the
+ * same source EmbedGenMixChart uses, just the load lines instead of the fuel stack
+ * (mirrors LiveNowPanel's two views, split into two dedicated embed widgets since
+ * each /embed page renders exactly one metric).
+ */
+export default function EmbedLoadChart({ zone }) {
+  const url = `${API}/power/live?zone=${encodeURIComponent(zone)}`
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone], pollMs: POLL_FAST_MS })
+  const zl = data?.zone_label ?? zoneLabel(zone)
+
+  const zoneKnown = !data || !Array.isArray(data.zones) || data.zones.includes(zone)
+  if (!zoneKnown) {
+    return (
+      <EmbedFrame zoneLabel={zoneLabel(zone)} metricTitle={TITLE}>
+        <EmbedUnknownCard message={`Unknown zone "${zone}".`} />
+      </EmbedFrame>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <EmbedFrame zoneLabel={zl} metricTitle={TITLE}>
+        <div style={MSG_STYLE}>Fetch error — try again shortly.</div>
+      </EmbedFrame>
+    )
+  }
+
+  if (!data?.available && !loading) {
+    return (
+      <EmbedFrame zoneLabel={zl} metricTitle={TITLE}>
+        <div style={MSG_STYLE}>{data?.reason || 'No live data yet for this zone.'}</div>
+      </EmbedFrame>
+    )
+  }
+
+  const hours = data?.hours ?? []
+  const showingToday = data?.showing === 'today'
+  const rows = hours.map((h, i) => ({ hour: i, load: h.load, load_fc: h.load_fc }))
+
+  const freshness = data?.available
+    ? {
+        label: showingToday
+          ? `Live · updated ${fmtTs(data.latest_actual_ts)} (${data.lag_minutes}m lag)`
+          : 'Showing yesterday — no actuals published yet today',
+        stale: !!data?.stale,
+      }
+    : null
+
+  return (
+    <EmbedFrame zoneLabel={zl} metricTitle={TITLE} freshness={freshness}>
+      {loading && !data ? (
+        <div style={MSG_STYLE}>Loading…</div>
+      ) : (
+        <ResponsiveContainer width="100%" height="100%" minHeight={80}>
+          <ComposedChart data={rows} margin={{ top: 8, right: 10, bottom: 2, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke={EMBED_COLORS.grid} />
+            <XAxis
+              dataKey="hour"
+              tickFormatter={fmtHour}
+              tick={{ fontSize: 9, fill: EMBED_COLORS.faint }}
+              interval={3}
+            />
+            <YAxis
+              tick={{ fontSize: 9, fill: EMBED_COLORS.faint }}
+              width={32}
+              tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
+            />
+            <Tooltip
+              {...CHART_TOOLTIP_PROPS}
+              formatter={(v, name) => [v == null ? '—' : `${Math.round(v).toLocaleString()} MW`, name]}
+              labelFormatter={(h) => `${fmtHour(h)} UTC`}
+            />
+            <Line
+              type="monotone"
+              dataKey="load"
+              name="load"
+              stroke={EMBED_COLORS.accent}
+              strokeWidth={1.5}
+              dot={false}
+              isAnimationActive={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="load_fc"
+              name="load forecast"
+              stroke={EMBED_COLORS.text}
+              strokeDasharray="4 3"
+              strokeWidth={1}
+              dot={false}
+              connectNulls
+              isAnimationActive={false}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </EmbedFrame>
+  )
+}

--- a/frontend/src/components/embed/EmbedPage.jsx
+++ b/frontend/src/components/embed/EmbedPage.jsx
@@ -26,6 +26,14 @@ export default function EmbedPage({ zone, metric }) {
     )
   }
 
+  if (!metric) {
+    return (
+      <EmbedFrame zoneLabel={zoneLabel(zone)} metricTitle="Unknown">
+        <EmbedUnknownCard message="No metric specified — use /embed/<ZONE>/<metric>." />
+      </EmbedFrame>
+    )
+  }
+
   if (!VALID_METRICS.includes(metric)) {
     return (
       <EmbedFrame zoneLabel={zoneLabel(zone)} metricTitle="Unknown">

--- a/frontend/src/components/embed/EmbedPage.jsx
+++ b/frontend/src/components/embed/EmbedPage.jsx
@@ -1,0 +1,40 @@
+import EmbedFrame from './EmbedFrame'
+import EmbedUnknownCard from './EmbedUnknownCard'
+import EmbedPriceChart from './EmbedPriceChart'
+import EmbedGenMixChart from './EmbedGenMixChart'
+import EmbedLoadChart from './EmbedLoadChart'
+import { VALID_METRICS, zoneLabel } from './embedUtils'
+
+/**
+ * /embed/<ZONE>/<metric> — top of the embeddable-widget tree (Task P10). Rendered
+ * OUTSIDE ViewStateProvider by App.jsx (no zone/range spine, no URL rewriting, no
+ * Dashboard boot fetches) — an iframe widget is a single fixed zone+metric, not a
+ * navigable desk.
+ *
+ * The metric is checked here (a closed, static set — no fetch needed). The zone is
+ * checked by whichever chart component ends up rendering, against ITS OWN fetch's
+ * `zones` list — the underlying /api/power/* endpoints silently resolve an unknown
+ * zone key to DE_LU, so per-metric validation against the real response is the only
+ * way to avoid ever showing a wrong zone under a confidently-labeled iframe.
+ */
+export default function EmbedPage({ zone, metric }) {
+  if (!zone) {
+    return (
+      <EmbedFrame zoneLabel="—" metricTitle="Unknown">
+        <EmbedUnknownCard message="No zone specified — use /embed/<ZONE>/<metric>." />
+      </EmbedFrame>
+    )
+  }
+
+  if (!VALID_METRICS.includes(metric)) {
+    return (
+      <EmbedFrame zoneLabel={zoneLabel(zone)} metricTitle="Unknown">
+        <EmbedUnknownCard message={`Unknown metric "${metric}".`} />
+      </EmbedFrame>
+    )
+  }
+
+  if (metric === 'price') return <EmbedPriceChart zone={zone} />
+  if (metric === 'genmix') return <EmbedGenMixChart zone={zone} />
+  return <EmbedLoadChart zone={zone} />
+}

--- a/frontend/src/components/embed/EmbedPriceChart.jsx
+++ b/frontend/src/components/embed/EmbedPriceChart.jsx
@@ -1,0 +1,108 @@
+import {
+  ResponsiveContainer, ComposedChart, Area, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
+} from 'recharts'
+import useFetchWithError from '../../hooks/useFetchWithError'
+import { POLL_FAST_MS } from '../../utils/poll'
+import { fmtHour, CHART_TOOLTIP_PROPS } from '../../utils/chart'
+import EmbedFrame from './EmbedFrame'
+import EmbedUnknownCard from './EmbedUnknownCard'
+import { EMBED_COLORS, MSG_STYLE, daysSince, zoneLabel, METRIC_TITLES } from './embedUtils'
+
+const API = '/api'
+const TITLE = METRIC_TITLES.price
+
+// Same idea as PowerDayAheadPanel's NegativeDot: a red marker on hours the auction
+// cleared below zero (renewable oversupply) — the one visual fact worth a mark here.
+function NegativeDot({ cx, cy, payload }) {
+  if (payload?.price == null || payload.price >= 0 || cx == null || cy == null) return null
+  return <circle cx={cx} cy={cy} r={2.5} fill={EMBED_COLORS.negative} stroke="none" />
+}
+
+/**
+ * /embed/<zone>/price — today's (or the latest published) day-ahead hourly curve.
+ * Reads GET /api/power/day-ahead/hourly?zone=, the same source PowerDayAheadPanel's
+ * HOURLY view uses. The endpoint silently falls back to DE_LU for an unknown zone
+ * key, so this checks the requested zone against the response's own `zones` list
+ * (always present) rather than trust `data.zone` — an embed must never quietly
+ * relabel itself onto a different zone than the URL asked for.
+ */
+export default function EmbedPriceChart({ zone }) {
+  const url = `${API}/power/day-ahead/hourly?zone=${encodeURIComponent(zone)}`
+  const { data, loading, error } = useFetchWithError(url, { deps: [zone], pollMs: POLL_FAST_MS })
+  const zl = zoneLabel(zone)
+
+  const zoneKnown = !data || !Array.isArray(data.zones) || data.zones.includes(zone)
+  if (!zoneKnown) {
+    return (
+      <EmbedFrame zoneLabel={zl} metricTitle={TITLE}>
+        <EmbedUnknownCard message={`Unknown zone "${zone}".`} />
+      </EmbedFrame>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <EmbedFrame zoneLabel={zl} metricTitle={TITLE}>
+        <div style={MSG_STYLE}>Fetch error — try again shortly.</div>
+      </EmbedFrame>
+    )
+  }
+
+  if (!data?.available && !loading) {
+    return (
+      <EmbedFrame zoneLabel={zl} metricTitle={TITLE}>
+        <div style={MSG_STYLE}>{data?.reason || 'No day-ahead data yet for this zone.'}</div>
+      </EmbedFrame>
+    )
+  }
+
+  const rows = data?.data ?? []
+  const age = daysSince(data?.date)
+  // Day-ahead is normally published ~1 day AHEAD of delivery (age can be negative) —
+  // only flag it once the shown day is itself more than a day old, i.e. the collector
+  // has stalled, not the ordinary "tomorrow's prices, published today" case.
+  const stale = age != null && age > 1
+  const freshness = data?.date ? { label: `Delivery day ${data.date} · UTC`, stale } : null
+  const todayUtc = new Date().toISOString().slice(0, 10)
+  const nowHour = data?.date === todayUtc ? new Date().getUTCHours() : null
+
+  return (
+    <EmbedFrame zoneLabel={zl} metricTitle={TITLE} freshness={freshness}>
+      {loading && !data ? (
+        <div style={MSG_STYLE}>Loading…</div>
+      ) : (
+        <ResponsiveContainer width="100%" height="100%" minHeight={80}>
+          <ComposedChart data={rows} margin={{ top: 8, right: 10, bottom: 2, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke={EMBED_COLORS.grid} />
+            <XAxis
+              dataKey="hour"
+              tickFormatter={fmtHour}
+              tick={{ fontSize: 9, fill: EMBED_COLORS.faint }}
+              interval={3}
+            />
+            <YAxis tick={{ fontSize: 9, fill: EMBED_COLORS.faint }} width={32} />
+            <ReferenceLine y={0} stroke="#2a2a3a" strokeDasharray="2 2" />
+            {nowHour != null && (
+              <ReferenceLine x={nowHour} stroke={EMBED_COLORS.accent} strokeDasharray="3 3" />
+            )}
+            <Tooltip
+              {...CHART_TOOLTIP_PROPS}
+              formatter={(v) => [v == null ? '—' : `${Number(v).toFixed(1)} €/MWh`, 'day-ahead']}
+              labelFormatter={(h) => `${fmtHour(h)} UTC`}
+            />
+            <Area
+              type="stepAfter"
+              dataKey="price"
+              stroke={EMBED_COLORS.accent}
+              fill={EMBED_COLORS.accent}
+              fillOpacity={0.14}
+              strokeWidth={1.5}
+              dot={<NegativeDot />}
+              isAnimationActive={false}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </EmbedFrame>
+  )
+}

--- a/frontend/src/components/embed/EmbedUnknownCard.jsx
+++ b/frontend/src/components/embed/EmbedUnknownCard.jsx
@@ -1,0 +1,20 @@
+import { EMBED_COLORS, VALID_METRICS } from './embedUtils'
+
+// Explicit "this embed URL is wrong" card — NEVER a silent DE_LU fallback. Shown for
+// an unrecognized zone or metric so a broken embed link fails loudly (to whoever
+// pasted it) instead of quietly always showing Germany.
+export default function EmbedUnknownCard({ message }) {
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center',
+      justifyContent: 'center', gap: 6, padding: '10px 14px', textAlign: 'center' }}>
+      <div style={{ fontSize: 11, color: EMBED_COLORS.text }}>{message}</div>
+      <div style={{ fontSize: 10, color: EMBED_COLORS.muted }}>
+        Valid metrics: {VALID_METRICS.join(', ')}
+      </div>
+      <a href="https://obsyd.dev" target="_blank" rel="noopener noreferrer"
+        style={{ fontSize: 10, color: EMBED_COLORS.accent, textDecoration: 'none', fontWeight: 700 }}>
+        See all zones at obsyd.dev →
+      </a>
+    </div>
+  )
+}

--- a/frontend/src/components/embed/embedUtils.js
+++ b/frontend/src/components/embed/embedUtils.js
@@ -1,0 +1,57 @@
+// Shared helpers for the /embed/<zone>/<metric> iframe widgets (Task P10).
+//
+// The embed pages intentionally do NOT reuse the desk's Tailwind color tokens
+// (bg-surface / border-border / text-cyan-glow / text-neutral-*): those tokens are
+// CSS custom properties (and a few hard utility overrides) that ThemeContext flips
+// via an `html.light` class — and light is the SITE'S actual default theme (see
+// index.html's pre-paint script). An embed dropped into a stranger's page must look
+// the same dark, compact widget regardless of what the top-level obsyd.dev document's
+// theme happens to be, so every embed component below uses plain hex values instead.
+
+export const VALID_METRICS = ['price', 'genmix', 'load']
+
+export const METRIC_TITLES = {
+  price: 'Day-ahead price',
+  genmix: 'Generation mix',
+  load: 'Load',
+}
+
+// The zone registry's full label (e.g. "IT-Nord") isn't known client-side without an
+// extra fetch; day-ahead/hourly doesn't return one at all. Mirrors the same shortcut
+// PowerDayAheadPanel/LiveNowPanel already use elsewhere on the desk.
+export function zoneLabel(zone) {
+  return zone === 'DE_LU' ? 'DE-LU' : zone
+}
+
+// Days between an ISO date string (UTC midnight) and now — negative for a future
+// delivery date (normal for day-ahead prices, which publish ~1 day ahead).
+export function daysSince(dateStr) {
+  if (!dateStr) return null
+  const d = new Date(dateStr + 'T00:00:00Z')
+  if (Number.isNaN(d.getTime())) return null
+  return Math.floor((Date.now() - d.getTime()) / 86_400_000)
+}
+
+// Dark palette shared by every embed component — deliberately plain hex, see above.
+export const EMBED_COLORS = {
+  bg: '#0b0d12',
+  panelBorder: '#20232b',
+  text: '#c9ccd6',
+  muted: '#7d8394',
+  faint: '#5b6070',
+  accent: '#2dd4bf',
+  negative: '#f87171',
+  warn: '#f59e0b',
+  grid: '#1e1e2e',
+}
+
+export const MSG_STYLE = {
+  flex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textAlign: 'center',
+  padding: '8px 12px',
+  fontSize: 11,
+  color: EMBED_COLORS.muted,
+}

--- a/frontend/src/hooks/useFetchWithError.js
+++ b/frontend/src/hooks/useFetchWithError.js
@@ -11,23 +11,27 @@ const swrCache = new Map() // url -> last successful (transformed) payload
 // instances at the identical url in the same render — each used to fire its
 // own GET, multiplying load against the backend's shared heavy_query_guard
 // semaphore (at the limit, one visitor's fixed-slot waste could transiently
-// 503 a different visitor's real request). The entry is removed the instant
-// its fetch settles, so this dedupes only genuinely CONCURRENT callers — a
-// later poll or refetch always starts a fresh request. Skipped entirely when
-// the caller passes custom `headers`, so a request under different
-// credentials never risks sharing another caller's response.
+// 503 a different visitor's real request). Skipped entirely when the caller
+// passes custom `headers`, so a request under different credentials never
+// risks sharing another caller's response.
 //
-// The physical fetch is wired to whichever caller happens to be first for a
-// given url (the "leader"); a follower just awaits that same promise. If the
-// leader's own component unmounts first, its AbortController cancels the
-// shared fetch and every follower sees an AbortError too — `run()` below
-// already treats AbortError as a silent no-op (same as the un-deduped path),
-// and a still-mounted follower gets fresh data on its own next natural
-// refetch. This only matters when two DIFFERENT components request the
-// exact same url at the exact same moment; the common single-caller path is
-// untouched — still tied to its own controller, still cancels on unmount
-// exactly as before this map existed.
-const inFlightRequests = new Map() // url -> Promise<rawJson>
+// Each entry owns its OWN AbortController (never any single caller's) plus a
+// subscriber count:
+//   - a caller's own unmount/abort only decrements the count and rejects
+//     THAT caller's returned promise with AbortError; the PHYSICAL fetch is
+//     aborted only once the LAST subscriber leaves — a solo caller's unmount
+//     still cancels its fetch exactly as before this map existed, and a
+//     leader's early unmount no longer strands a still-mounted follower.
+//   - reusing an entry is guarded by `entry.controller.signal.aborted`, so a
+//     StrictMode double-invoke (dev: setup→cleanup→setup runs synchronously,
+//     before the settled entry's removal microtask has a chance to run) or a
+//     genuinely quick unmount/remount never joins an already-doomed entry —
+//     it starts a fresh fetch instead of awaiting a promise that can only
+//     ever reject.
+//   - the entry is removed as soon as its fetch settles, on BOTH the resolve
+//     and the reject branch (never an unhandled rejection), so a later poll
+//     or refetch always starts against a clean slate.
+const inFlightRequests = new Map() // url -> { promise, controller, subscribers }
 
 function fetchRawJson(url, { headers, signal }) {
   return fetch(url, { credentials: 'include', headers, signal }).then((res) => {
@@ -38,14 +42,24 @@ function fetchRawJson(url, { headers, signal }) {
 
 function dedupedFetchRawJson(url, { headers, signal }) {
   if (headers) return fetchRawJson(url, { headers, signal }) // custom headers: never share
-  const existing = inFlightRequests.get(url)
-  if (existing) return existing
-  const p = fetchRawJson(url, { headers, signal })
-  inFlightRequests.set(url, p)
-  p.finally(() => {
-    if (inFlightRequests.get(url) === p) inFlightRequests.delete(url)
+  let entry = inFlightRequests.get(url)
+  if (!entry || entry.controller.signal.aborted) {   // never share a dead fetch (StrictMode / quick remount)
+    const controller = new AbortController()
+    const promise = fetchRawJson(url, { headers, signal: controller.signal })
+    entry = { promise, controller, subscribers: 0 }
+    inFlightRequests.set(url, entry)
+    const remove = () => { if (inFlightRequests.get(url) === entry) inFlightRequests.delete(url) }
+    promise.then(remove, remove)                     // both-ways handler: no unhandled rejection
+  }
+  entry.subscribers++
+  signal.addEventListener('abort', () => {           // abort the PHYSICAL fetch only when the LAST subscriber leaves
+    if (--entry.subscribers === 0) entry.controller.abort()
+  }, { once: true })
+  return new Promise((resolve, reject) => {          // each caller still gets ITS OWN AbortError on ITS OWN unmount
+    if (signal.aborted) return reject(new DOMException('aborted', 'AbortError'))
+    signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true })
+    entry.promise.then(resolve, reject)
   })
-  return p
 }
 
 /**

--- a/frontend/src/hooks/useFetchWithError.js
+++ b/frontend/src/hooks/useFetchWithError.js
@@ -5,6 +5,49 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 // the background — instead of flashing a skeleton and re-fetching cold.
 const swrCache = new Map() // url -> last successful (transformed) payload
 
+// Module-level in-flight-request map: concurrent callers for the SAME url
+// share ONE physical fetch's raw JSON. Fixed-slot components (ZoneCompareChart's
+// compare zones, useSeriesFrame's 6 series rows) point several sibling hook
+// instances at the identical url in the same render — each used to fire its
+// own GET, multiplying load against the backend's shared heavy_query_guard
+// semaphore (at the limit, one visitor's fixed-slot waste could transiently
+// 503 a different visitor's real request). The entry is removed the instant
+// its fetch settles, so this dedupes only genuinely CONCURRENT callers — a
+// later poll or refetch always starts a fresh request. Skipped entirely when
+// the caller passes custom `headers`, so a request under different
+// credentials never risks sharing another caller's response.
+//
+// The physical fetch is wired to whichever caller happens to be first for a
+// given url (the "leader"); a follower just awaits that same promise. If the
+// leader's own component unmounts first, its AbortController cancels the
+// shared fetch and every follower sees an AbortError too — `run()` below
+// already treats AbortError as a silent no-op (same as the un-deduped path),
+// and a still-mounted follower gets fresh data on its own next natural
+// refetch. This only matters when two DIFFERENT components request the
+// exact same url at the exact same moment; the common single-caller path is
+// untouched — still tied to its own controller, still cancels on unmount
+// exactly as before this map existed.
+const inFlightRequests = new Map() // url -> Promise<rawJson>
+
+function fetchRawJson(url, { headers, signal }) {
+  return fetch(url, { credentials: 'include', headers, signal }).then((res) => {
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    return res.json()
+  })
+}
+
+function dedupedFetchRawJson(url, { headers, signal }) {
+  if (headers) return fetchRawJson(url, { headers, signal }) // custom headers: never share
+  const existing = inFlightRequests.get(url)
+  if (existing) return existing
+  const p = fetchRawJson(url, { headers, signal })
+  inFlightRequests.set(url, p)
+  p.finally(() => {
+    if (inFlightRequests.get(url) === p) inFlightRequests.delete(url)
+  })
+  return p
+}
+
 /**
  * Tiny replacement for the `.catch(() => {})` pattern that hides
  * errors in many panels. Always returns the same shape and never
@@ -50,15 +93,7 @@ export default function useFetchWithError(url, opts = {}) {
       }
       setError(null)
       try {
-        const res = await fetch(url, {
-          credentials: 'include',
-          headers,
-          signal: controller.signal,
-        })
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}`)
-        }
-        const json = await res.json()
+        const json = await dedupedFetchRawJson(url, { headers, signal: controller.signal })
         if (myReq !== reqRef.current) return // a newer call superseded us
         const payload = transform ? transform(json) : json
         swrCache.set(url, payload)

--- a/frontend/src/hooks/useSeriesFrame.js
+++ b/frontend/src/hooks/useSeriesFrame.js
@@ -1,0 +1,113 @@
+import { useMemo } from 'react'
+import useFetchWithError from './useFetchWithError'
+import { rangeStart } from '../utils/ranges'
+
+const API = '/api'
+
+// Chart-Builder hard cap: also the number of fixed fetch slots below. Six keeps
+// a full chart well inside the v1 API's shared 120/min-per-IP rate bucket even
+// on a fast zone/series edit.
+export const MAX_SERIES_ROWS = 6
+
+function seriesUrl(row, start, resolution) {
+  return `${API}/v1/series?series=${encodeURIComponent(row.series)}&zone=${encodeURIComponent(row.zone)}&start=${start}&resolution=${resolution}`
+}
+
+/**
+ * Multi-series/multi-zone outer-join over GET /api/v1/series — the
+ * Chart-Builder's data layer. Generalizes SeriesExplorer's original 2-line
+ * (primary + one compare) join into up to MAX_SERIES_ROWS independent
+ * (series, zone) rows.
+ *
+ * `rows` is `[{series, zone, ...anything}]` (up to MAX_SERIES_ROWS; extra
+ * fields such as `label`/`color` are opaque to this hook and echoed back
+ * verbatim on the matching `perRow` entry, so a caller can carry UI-only
+ * metadata through the join without this hook knowing about it).
+ *
+ * React hooks cannot be called in a loop, so — exactly like
+ * ZoneCompareChart's MAX_COMPARE slots — there are always exactly
+ * MAX_SERIES_ROWS useFetchWithError calls. A slot beyond the real row count
+ * re-points at row 0's URL, which is already in the SWR cache: it costs no
+ * extra request, just a cache hit.
+ *
+ * Returns `{ frame, loading, error, perRow }`:
+ *   - `frame`: time-sorted outer join, one entry per distinct timestamp seen
+ *     across ANY active row: `{ t, v0, v1, ..., v<n-1> }`, null where a row
+ *     has no point at that `t`.
+ *   - `perRow`: one entry per active row (input order), each the input row
+ *     plus `{ key: 'v<i>', unit, count, available, reason, downloadUrl,
+ *     loading, error, partialHours }` — partialHours is set only in daily
+ *     resolution, when the last point on record averages < 24 hours (a day
+ *     still filling in).
+ *   - `loading`/`error`: whole-frame convenience flags (error mirrors row 0,
+ *     the row that gates the chart rendering anything at all).
+ */
+export default function useSeriesFrame(rows, range, resolution = 'daily') {
+  const start = rangeStart(range)
+  const activeRows = useMemo(
+    () => (rows || []).filter((r) => r?.series && r?.zone).slice(0, MAX_SERIES_ROWS),
+    [rows]
+  )
+  const primary = activeRows[0] || null
+  const slot = (i) => activeRows[i] || primary
+
+  // A completely empty `rows` list (no primary yet) still needs a URL for
+  // every hook call — fall back to a harmless constant so the hook count and
+  // order never change.
+  const FALLBACK_URL = `${API}/v1/series?series=price.dayahead&zone=DE_LU&start=${start}&resolution=${resolution}`
+  const urlOf = (i) => {
+    const r = slot(i)
+    return r ? seriesUrl(r, start, resolution) : FALLBACK_URL
+  }
+
+  const r0 = useFetchWithError(urlOf(0), { deps: [start, resolution] })
+  const r1 = useFetchWithError(urlOf(1), { deps: [start, resolution] })
+  const r2 = useFetchWithError(urlOf(2), { deps: [start, resolution] })
+  const r3 = useFetchWithError(urlOf(3), { deps: [start, resolution] })
+  const r4 = useFetchWithError(urlOf(4), { deps: [start, resolution] })
+  const r5 = useFetchWithError(urlOf(5), { deps: [start, resolution] })
+  const responses = [r0, r1, r2, r3, r4, r5]
+
+  const tkey = resolution === 'daily' ? 'date' : 'datetime_utc'
+  const rowSig = activeRows.map((r) => `${r.series}:${r.zone}`).join(',')
+
+  const { frame, perRow } = useMemo(() => {
+    const n = activeRows.length
+    const byT = new Map()
+    const perRowOut = []
+    for (let i = 0; i < n; i++) {
+      const row = activeRows[i]
+      const resp = responses[i].data
+      const points = resp?.data || []
+      const key = `v${i}`
+      for (const p of points) {
+        const t = p[tkey]
+        if (!byT.has(t)) byT.set(t, { t })
+        byT.get(t)[key] = p.value == null ? null : p.value
+      }
+      const last = resolution === 'daily' ? points.at(-1) : null
+      perRowOut.push({
+        ...row,
+        key,
+        unit: resp?.unit ?? null,
+        count: resp?.count ?? points.length,
+        available: resp ? resp.available !== false : null,
+        reason: resp?.reason ?? null,
+        downloadUrl: `${seriesUrl(row, start, resolution)}&format=csv`,
+        loading: responses[i].loading,
+        error: responses[i].error,
+        partialHours: last?.hours != null && last.hours < 24 ? last.hours : null,
+      })
+    }
+    const frameOut = [...byT.values()].sort((a, b) => (a.t < b.t ? -1 : a.t > b.t ? 1 : 0))
+    return { frame: frameOut, perRow: perRowOut }
+    // responses[i].data are the real per-row payloads; rowSig covers row identity/order,
+    // start/resolution/tkey cover the query window — together the full input surface.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [r0.data, r1.data, r2.data, r3.data, r4.data, r5.data, rowSig, tkey, resolution, start])
+
+  const loading = activeRows.length > 0 && responses.slice(0, activeRows.length).some((r) => r.loading)
+  const error = activeRows.length > 0 && responses[0].error && !responses[0].data ? responses[0].error : null
+
+  return { frame, loading, error, perRow }
+}

--- a/frontend/src/hooks/useSeriesFrame.js
+++ b/frontend/src/hooks/useSeriesFrame.js
@@ -82,7 +82,7 @@ export default function useSeriesFrame(rows, range, resolution = 'daily') {
   // deps, perRow[i].loading/error froze at whatever they were on the render
   // that last touched `data`, so a failed row stayed {loading:true,
   // error:null} forever instead of surfacing the failure.
-  const respSig = responses.map((r, i) => `${i}:${r.loading}:${!!r.error}`).join('|')
+  const respSig = responses.map((r) => `${r.loading}:${!!r.error}`).join('|')
 
   const { frame, perRow } = useMemo(() => {
     const n = activeRows.length

--- a/frontend/src/hooks/useSeriesFrame.js
+++ b/frontend/src/hooks/useSeriesFrame.js
@@ -27,8 +27,14 @@ function seriesUrl(row, start, resolution) {
  * React hooks cannot be called in a loop, so — exactly like
  * ZoneCompareChart's MAX_COMPARE slots — there are always exactly
  * MAX_SERIES_ROWS useFetchWithError calls. A slot beyond the real row count
- * re-points at row 0's URL, which is already in the SWR cache: it costs no
- * extra request, just a cache hit.
+ * re-points at row 0's URL. That does NOT skip a request — useFetchWithError
+ * revalidates in every hook instance it's called from, regardless of cache —
+ * but the URL matches an already-cached entry, so the unused slot renders
+ * row 0's data with no loading flash instead of a distinct fetch of its own.
+ * Net effect: a full chart is still bounded at <= MAX_SERIES_ROWS requests per
+ * change, never more. A real request-level dedupe for concurrent identical
+ * URLs (so an unused slot's revalidation doesn't even hit the network) would
+ * be a desk-wide improvement to useFetchWithError itself — out of scope here.
  *
  * Returns `{ frame, loading, error, perRow }`:
  *   - `frame`: time-sorted outer join, one entry per distinct timestamp seen
@@ -70,6 +76,13 @@ export default function useSeriesFrame(rows, range, resolution = 'daily') {
 
   const tkey = resolution === 'daily' ? 'date' : 'datetime_utc'
   const rowSig = activeRows.map((r) => `${r.series}:${r.zone}`).join(',')
+  // r{i}.data's referential identity already drives the memo below, but
+  // loading/error are separate state on the same hook instance and can flip
+  // (e.g. a slot 429s, or recovers) with no new `data` — without this in the
+  // deps, perRow[i].loading/error froze at whatever they were on the render
+  // that last touched `data`, so a failed row stayed {loading:true,
+  // error:null} forever instead of surfacing the failure.
+  const respSig = responses.map((r, i) => `${i}:${r.loading}:${!!r.error}`).join('|')
 
   const { frame, perRow } = useMemo(() => {
     const n = activeRows.length
@@ -101,10 +114,11 @@ export default function useSeriesFrame(rows, range, resolution = 'daily') {
     }
     const frameOut = [...byT.values()].sort((a, b) => (a.t < b.t ? -1 : a.t > b.t ? 1 : 0))
     return { frame: frameOut, perRow: perRowOut }
-    // responses[i].data are the real per-row payloads; rowSig covers row identity/order,
-    // start/resolution/tkey cover the query window — together the full input surface.
+    // responses[i].data are the real per-row payloads; respSig covers each
+    // slot's loading/error; rowSig covers row identity/order; start/
+    // resolution/tkey cover the query window — together the full input surface.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [r0.data, r1.data, r2.data, r3.data, r4.data, r5.data, rowSig, tkey, resolution, start])
+  }, [r0.data, r1.data, r2.data, r3.data, r4.data, r5.data, respSig, rowSig, tkey, resolution, start])
 
   const loading = activeRows.length > 0 && responses.slice(0, activeRows.length).some((r) => r.loading)
   const error = activeRows.length > 0 && responses[0].error && !responses[0].data ? responses[0].error : null

--- a/frontend/src/utils/fuels.js
+++ b/frontend/src/utils/fuels.js
@@ -106,6 +106,15 @@ export function fuelColor(key) {
   return CANONICAL[key] ?? CANONICAL[ALIASES[key]] ?? DEFAULT_FUEL_COLOR
 }
 
+// Friendly display name for a fuel key. Most panels (GenerationMixPanel, CapturePanel)
+// receive an already-canonical label from the backend and never need this — but
+// backend/power/live.py deliberately ships the RAW ENTSO-E code (`gen.<Bxx>` -> "B16")
+// and defers the mapping here, so a raw code is resolved through ALIASES; an
+// already-canonical name (or anything unknown) passes through unchanged.
+export function fuelLabel(key) {
+  return CANONICAL[key] ? key : (ALIASES[key] ?? key)
+}
+
 const ORDER_INDEX = new Map(STACK_ORDER.map((label, i) => [label, i]))
 
 function orderIndex(key) {

--- a/frontend/src/utils/poll.js
+++ b/frontend/src/utils/poll.js
@@ -1,4 +1,4 @@
 // Central poll cadences for the auto-refreshing views. The ENTSO-E ingest runs
 // every 30 minutes, so anything faster than these just re-reads the same data.
-export const POLL_FAST_MS = 5 * 60 * 1000 // situation views: hero, overview, narrative
+export const POLL_FAST_MS = 5 * 60 * 1000 // situation views: hero, overview, narrative, live-now
 export const POLL_SLOW_MS = 10 * 60 * 1000 // detail panels: grid, mix, flows, outages


### PR DESCRIPTION
## Summary

Closes the data-depth and tooling gap toward paid power desks (gridstatus-style), all on free, attribution-compliant sources (ENTSO-E):

- **Live today-view**: `GET /api/power/live` + a LiveNowPanel on the POWER tab — today's hourly actual load/generation/prices vs day-ahead expectation, with an honest publication-lag chip and yesterday-fallback semantics.
- **Activated balancing energy** (aFRR/mFRR prices, ENTSO-E A84): new collector, 8 canonical series, `/api/power/balancing`, BalancingPanel with honest non-activation gaps. A83 volumes are structurally unavailable on the public API today (documented; daily re-verify probe).
- **German balancing-capacity prices** (FCR/aFRR/mFRR via ENTSO-E A15, DE-LU LFC block): volume-weighted averages per 4h block normalized to EUR/MW/h, `/api/power/capacity-prices`, CapacityPricePanel.
- **Transmission outages** (A78) through the existing outage pipeline (directed border pairs, counterparty-aware zone matching), OutagePanel GENERATION|TRANSMISSION toggle, plus a Nord Pool UMM link-out (re-display is licence-blocked; see docs/findings).
- **Chart-Builder**: SeriesExplorer evolved to up to 6 series×zone rows, dual unit axes, fuzzy grouped picker fed by new server-side catalog labels/groups + per-(series,zone) coverage, shareable `/builder` route with legacy-link back-compat.
- **Embeds & badges**: `/embed/<zone>/<metric>` iframe widgets (price/genmix/load) with baked-in attribution, SVG status badges at `/api/v1/badge/{zone}/{metric}.svg`, Caddy `/embed/*` frame exception (X-Frame-Options stays DENY everywhere else), docs/API.md Embedding section.
- **PPA/capture tools**: `negative_hours` metric, PPA strike overlay on the capture panel, spark calculator with per-request CCGT-efficiency override (server-side; no licensed gas price ever leaves the API).
- Two feasibility spikes documented in `docs/findings/` (Nord Pool UMM: no-go without written consent; regelleistung.net: superseded by ENTSO-E A15).

## Test Plan

- [x] Backend suite: 1140 passed, 1 skipped (was 983 before the branch); ruff clean
- [x] Frontend `npm run build` + eslint clean on all touched files; bundle +9 kB, heavy chunks stay lazy
- [x] Live-API spikes pinned in module docstrings (A84/A83, A15 pagination, A78 directed pairs)
- [x] Security: badge SVG attribute-injection regression test; embeds validate zones against the response (no silent DE_LU fallback)
- [ ] Post-merge deploy: `npm run build` + `systemctl restart obsyd`, one-time `power_backfill --sources balancing` / `--sources capacity`, manual Caddy `@embed` edit (documented in `deploy/install-caddy-integration.sh`)
- [ ] Prod smoke: `/api/power/live?zone=DE_LU` fills over the day; `/embed/DE_LU/price` frameable; `verify-zone-coherence.mjs` against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)