### PR TITLE
Bump obsyd client to 0.2.1 (gridstatus-free metadata)

### DIFF
--- a/clients/python/obsyd.py
+++ b/clients/python/obsyd.py
@@ -28,7 +28,7 @@ from typing import Sequence
 import pandas as pd
 import requests
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 _RETRY_STATUSES = {429, 502, 503, 504}
 


### PR DESCRIPTION
Metadata-only release picking up the description/keyword/docstring cleanup from #134. Merge, then tag `client-v0.2.1` to publish to PyPI via Trusted Publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)