### PR TITLE
Per-unit freshness for the plant-output board + 6h A73 polling

### DIFF
--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -484,19 +484,23 @@ async def _run_capacity_prices():
 
 
 async def _run_unit_generation():
-    """Daily per-unit generation refresh (ENTSO-E A73 — backend/power/
-    entsoe_unit_generation.py). days_back=12 with overwrite=True: the source
-    publishes ~6 days behind (probe 2026-07-28 — D-1/D-3 answer a clean 200-ACK,
-    D-7 delivers), so the rolling window re-asks the still-filling frontier until
-    each day lands; without overwrite the write-once raw cache would freeze the
-    first (empty) answer forever. Daily, NOT hourly: an hourly cadence would spend
-    the shared ENTSO-E token re-asking a source that moves once a day at most."""
+    """Per-unit generation refresh (ENTSO-E A73 — backend/power/
+    entsoe_unit_generation.py), four times a day. days_back=12 with overwrite=True:
+    the source publishes days behind (probe 2026-07-28 — D-1/D-3 answer a clean
+    200-ACK, D-7 delivers), so the rolling window re-asks the still-filling
+    frontier until each day lands; without overwrite the write-once raw cache
+    would freeze the first (empty) answer forever. Every 6 h, NOT hourly: each of
+    the four German TSOs publishes on its own once-a-day rhythm (smoke: TenneT
+    ~D-2, the others ~D-5), so a 6-hour cadence catches each TSO's publication
+    moment within ~6 h instead of up to 24 h late — at 4 runs/day x ~8 ENTSO-E
+    requests that is trivial, while hourly would spend the shared token re-asking
+    a source that moves a few times a day at most."""
     from backend.power.entsoe_unit_generation import ingest_unit_generation
 
     db = SessionLocal()
     try:
         result = await ingest_unit_generation(db, days_back=12, overwrite=True)
-        logger.info("unit generation daily: %s", result)
+        logger.info("unit generation 6h: %s", result)
     except Exception as exc:
         db.rollback()
         logger.error("_run_unit_generation failed: %s", exc)
@@ -562,10 +566,12 @@ def start_scheduler():
     # after all three TSO publication windows (FCR ~08:30, aFRR ~09:30, mFRR ~11:00
     # Europe/Berlin, i.e. UTC+1/+2 — see docs/findings/2026-07-20-regelleistung-capacity-prices.md).
     scheduler.add_job(_run_capacity_prices, CronTrigger(hour=11, minute=30), id="capacity_prices_daily", **JOB_DEFAULTS)
-    # Per-unit generation (A73): daily 09:40 UTC — after the morning publication
-    # updates, offset from the 09:00 watchdog and the 10:00 gas job. Daily on
-    # purpose: the source lags ~6 days, hourly polling would waste the shared token.
-    scheduler.add_job(_run_unit_generation, CronTrigger(hour=9, minute=40), id="unit_generation_daily", **JOB_DEFAULTS)
+    # Per-unit generation (A73): every 6 h at 03/09/15/21:40 UTC — the four German
+    # TSOs each publish once a day at different moments (TenneT ~D-2, the others
+    # ~D-5), so this catches each TSO's publication within ~6 h instead of up to
+    # 24 h late. minute=40 stays clear of the :20 balancing and :45 outage-snapshot
+    # jobs; 4 runs/day x ~8 ENTSO-E requests is trivial on the shared token.
+    scheduler.add_job(_run_unit_generation, CronTrigger(hour="3,9,15,21", minute=40), id="unit_generation_6h", **JOB_DEFAULTS)
     # All-time records: nightly at 23:45, after the 22:30 power ingest.
     scheduler.add_job(_run_records_nightly, CronTrigger(hour=23, minute=45), id="records_nightly", **JOB_DEFAULTS)
     # Episodes: 23:50, right after the records — same doctrine (full recompute from the canonical

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -362,7 +362,8 @@ class UnitGeneration(Base):
     # WITHOUT ROWID: the composite PK becomes the table's clustering key (PowerHourly's
     # convention — the per-unit /units/history range scan rides it directly).
     # The (zone, ts_utc) composite serves the OTHER access pattern — the board's
-    # three zone+hour-range queries (max ts, latest-day rows, trailing population),
+    # three zone+hour-range queries (zone max ts, per-unit GROUP-BY latest over the
+    # trailing window, the latest-days span scan),
     # which would otherwise degrade to full-zone scans on a public endpoint. It also
     # covers plain zone lookups, so `zone` carries no redundant single-column index.
     # Existing DBs get the index via migrations.py (create_all never retro-fits).

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -333,9 +333,9 @@ class UnitGeneration(Base):
     and simply out of merit; availability is what the A77 outage feed says, not this.
     Publication lags DAYS, and unevenly per control area (probe: D-1/D-3 empty, D-7
     full; smoke: TenneT at D-2 while the other German CTAs sat at D-5) — so the newest
-    hour trails the wall clock by days AND most units trail the newest hour. "Latest
-    published day", never "live"; readers must keep unpublished units visible as
-    "not reporting".
+    hour trails the wall clock by days AND most units trail the newest hour. Never
+    "live"; readers must surface each unit's OWN latest published hour with its own
+    lag (sampling everyone at the zone-wide newest hour nulls most of the board).
 
     DELIBERATELY NOT power_hourly. Per-unit output's natural key is the UNIT, not the
     (series, zone) pair; 85+ EIC-named series keys would pollute the series catalog

--- a/backend/power/entsoe_unit_generation.py
+++ b/backend/power/entsoe_unit_generation.py
@@ -49,9 +49,11 @@ published data end (e.g. Thursday 14:00 mid-window), so the expansion never
 fabricates beyond publication.
 
 PER-CTA LAG SKEW (same smoke): TenneT published to D-2 while 50Hertz/Amprion/
-TransnetBW stopped at D-5 — the zone's "latest published hour" is therefore the
-FASTEST CTA's frontier, and most units legitimately have no data there. The read
-side must carry the not-yet-published units as "not reporting", never drop them.
+TransnetBW stopped at D-5 (the regulation allows up to D+5) — the zone's "latest
+published hour" is therefore the FASTEST CTA's frontier, and most units
+legitimately have no data there. The read side must surface each unit at ITS OWN
+latest published hour with its own lag (per-unit freshness) — sampling everyone
+at the zone frontier nulls most of the board — and never drop a trailing unit.
 
 CONSUMPTION TimeSeries (outBiddingZone_Domain — pumped-storage pumping) are
 EXCLUDED, mirroring the A75 discrimination in backend/gas/entsoe.py::

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -2399,14 +2399,19 @@ def get_units_generation(
 
     registry = _unit_registry_for(db, list(latest_by_unit))
 
+    # ONE clock read per request — now_iso, today_utc, lag_days and every
+    # unit_lag_days derive from the same instant, so a request straddling UTC
+    # midnight cannot mix two different "today"s.
+    now = datetime.now(timezone.utc)
+    now_iso = now.strftime("%Y-%m-%dT%H:%MZ")
+    today_utc = now.date()
+
     # Outage status NOW, per unit — not at the (days-old) data hour: A77 outage
     # messages are near-real-time, so "in outage now" is honest and more useful
     # next to a last-published output reading. Highest revision per mRID wins and
     # withdrawn events hide (latest_outage_revisions — the same semantics the
     # outage board uses); ending_after prunes events already over. Same
     # fixed-width UTC-string comparison idiom as before, against now.
-    now = datetime.utcnow()
-    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
     latest_hour_dt = datetime.fromtimestamp(latest_ts, tz=timezone.utc)
     latest_hour_iso = latest_hour_dt.strftime("%Y-%m-%dT%H:%MZ")
     outage_by_eic: dict[str, dict] = {}
@@ -2426,7 +2431,6 @@ def get_units_generation(
             ),
         }
 
-    today_utc = datetime.now(timezone.utc).date()
     units: list[dict] = []
     for eic, unit_latest_ts in latest_by_unit.items():
         reg = registry.get(eic)
@@ -2470,8 +2474,8 @@ def get_units_generation(
         "units": units,
         "totals": {
             "units": len(units),
-            # Units with any rows in the window — now usually equal to `units`;
-            # kept because it still distinguishes registry silence.
+            # Kept for payload-shape compatibility (always equals `units` unless
+            # a null-mw guard ever triggers).
             "reporting": len(reporting),
             "nominal_mw": round(sum(u["nominal_mw"] or 0.0 for u in units), 1),
             # Mixed timestamps by design (each unit's own latest reading) — NOT a
@@ -2482,9 +2486,9 @@ def get_units_generation(
         # CALENDAR days, deliberately — the freshness triple below counts calendar
         # days, and a whole-24h floor would disagree with it by one just after UTC
         # midnight (caption saying "5 days behind" beside an age_days of 6).
-        "lag_days": (datetime.now(timezone.utc).date() - latest_hour_dt.date()).days,
+        "lag_days": (today_utc - latest_hour_dt.date()).days,
         "note": _UNITS_GENERATION_NOTE,
-        **_freshness(latest_hour_dt.strftime("%Y-%m-%d"), now.date(),
+        **_freshness(latest_hour_dt.strftime("%Y-%m-%d"), today_utc,
                      PANEL_MAX_AGE_DAYS["units_generation"]),
     }
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -2282,10 +2282,12 @@ _UNITS_GENERATION_NOTE = (
     "threshold, dispatchable fuels only (no wind/solar) — i.e. the A71/A33 registry "
     "population, NOT the installed fleet. utilization_pct is output vs nameplate "
     "nominal capacity, not availability (a unit at 0% may simply be out of merit — "
-    "see the outage field for what is actually unavailable). ENTSO-E publishes this "
-    "days behind, per control area at different lags: 'latest published day' is the "
-    "fastest TSO's frontier, and units whose TSO has not published it yet appear "
-    "with current_mw = null (not reporting), never silently dropped. Not live."
+    "see the outage field for what is actually unavailable now; the outage badge is "
+    "joined at the current time, while the output value is the last published "
+    "reading). Per-unit timestamps vary because the four TSOs publish at different "
+    "speeds (up to the regulation's D+5); each row carries its own timestamp. "
+    "latest_readings_mw is the sum of each unit's latest published reading — mixed "
+    "timestamps, not a snapshot. Not live."
 )
 
 
@@ -2312,14 +2314,19 @@ def get_units_generation(
     zone: str = Query(DEFAULT_ZONE, description="Bidding zone key"),
     db: Session = Depends(get_db),
 ):
-    """Per-plant output and utilization for the LATEST PUBLISHED day (ENTSO-E A73).
+    """Per-plant output at each unit's OWN latest published hour (ENTSO-E A73).
 
-    Deliberately NOT called "live": A73 publishes ~6 days behind (probe 2026-07-28
-    — D-1/D-3 answer empty, D-7 delivers), and `lag_days` carries that honestly.
+    Deliberately NOT called "live": A73 publishes days behind, and the four German
+    TSOs publish at different speeds (smoke: TenneT ~D-2, the others ~D-5; the
+    regulation allows up to D+5). Pinning every unit to the zone-wide newest hour
+    showed only the fastest TSO's plants and nulled the rest, so each unit now
+    carries its own latest reading with its own timestamp and lag — which makes
+    latest_readings_mw a mixed-timestamp sum, not a snapshot (the note says so).
     Joins the A71/A33 unit registry for names/fuels/nameplate and the A77 outage
-    feed (highest-revision, withdrawn-hidden semantics) for what is off at the
-    latest hour. DE-LU only so far — the ingest zone list (A73_ZONES) is
-    config-extensible. Descriptive: which plants ran and how hard, not a price call.
+    feed (highest-revision, withdrawn-hidden semantics) for what is off NOW —
+    outage messages are near-real-time, unlike the output readings. DE-LU only so
+    far — the ingest zone list (A73_ZONES) is config-extensible. Descriptive:
+    which plants ran and how hard, not a price call.
     """
     from backend.models.energy import UnitGeneration
     from backend.power.entsoe_unit_generation import A73_ZONES
@@ -2350,54 +2357,64 @@ def get_units_generation(
             "reason": f"No per-unit generation ingested for {POWER_ZONES[resolved_zone]['label']} yet.",
         }
 
-    # The UTC day containing the newest hour — the latest PUBLISHED day.
+    # The POPULATION: every unit with any rows in the trailing 14-day window
+    # (anchored at the UTC day of the zone-wide newest hour — same window as
+    # before). The CTAs publish at different lags (smoke 2026-07-28 — TenneT was
+    # at D-2 while the other three German CTAs stopped at D-5), so instead of
+    # sampling everyone at the fastest TSO's frontier hour (which nulled 74 of 85
+    # units), each unit carries ITS OWN latest published hour. One GROUP BY over
+    # the (zone, ts_utc) index — never 85 single-unit queries.
     day_start = latest_ts - (latest_ts % 86_400)
-    rows = (
-        db.query(UnitGeneration)
+    window_start = day_start - 14 * 86_400
+    latest_by_unit: dict[str, int] = dict(
+        db.query(UnitGeneration.unit_eic, func.max(UnitGeneration.ts_utc))
         .filter(
             UnitGeneration.zone == resolved_zone,
-            UnitGeneration.ts_utc >= day_start,
-            UnitGeneration.ts_utc < day_start + 86_400,
+            UnitGeneration.ts_utc >= window_start,
         )
+        .group_by(UnitGeneration.unit_eic)
         .all()
     )
-    by_unit: dict[str, dict[int, float]] = {}
-    for r in rows:
-        by_unit.setdefault(r.unit_eic, {})[r.ts_utc] = r.mw
 
-    # The POPULATION is wider than the latest day: the CTAs publish at different
-    # lags (smoke 2026-07-28 — TenneT was at D-2 while the other three German CTAs
-    # stopped at D-5), so on the frontier day most units legitimately have no rows
-    # yet. Dropping them would present a 13-unit TenneT board as "DE-LU". Every
-    # unit seen in the trailing window is listed; the not-yet-published ones carry
-    # current_mw/day_avg_mw = null ("not reporting"), which the totals count.
-    population_window = day_start - 14 * 86_400
-    for (eic,) in (
-        db.query(UnitGeneration.unit_eic)
-        .filter(
-            UnitGeneration.zone == resolved_zone,
-            UnitGeneration.ts_utc >= population_window,
-            UnitGeneration.ts_utc < day_start,
-        )
-        .distinct()
-        .all()
-    ):
-        by_unit.setdefault(eic, {})
+    # Rows for current_mw + day_avg_mw: one index-friendly range scan spanning
+    # the units' latest UTC days (typically a 3–4 day band given the D-2…D-5
+    # TSO skew), then filtered per unit in Python to ITS OWN latest day.
+    unit_day_start = {eic: ts - (ts % 86_400) for eic, ts in latest_by_unit.items()}
+    hours_by_unit: dict[str, dict[int, float]] = {}
+    if unit_day_start:
+        span_start = min(unit_day_start.values())
+        span_end = max(unit_day_start.values()) + 86_400
+        for eic, ts, mw in (
+            db.query(UnitGeneration.unit_eic, UnitGeneration.ts_utc, UnitGeneration.mw)
+            .filter(
+                UnitGeneration.zone == resolved_zone,
+                UnitGeneration.ts_utc >= span_start,
+                UnitGeneration.ts_utc < span_end,
+            )
+            .all()
+        ):
+            ds = unit_day_start.get(eic)
+            if ds is not None and ds <= ts < ds + 86_400:
+                hours_by_unit.setdefault(eic, {})[ts] = mw
 
-    registry = _unit_registry_for(db, list(by_unit))
+    registry = _unit_registry_for(db, list(latest_by_unit))
 
-    # Outage status AT the latest hour, per unit. Highest revision per mRID wins and
-    # withdrawn events hide (latest_outage_revisions — the same semantics the outage
-    # board uses); ending_after prunes events that ended before the hour.
+    # Outage status NOW, per unit — not at the (days-old) data hour: A77 outage
+    # messages are near-real-time, so "in outage now" is honest and more useful
+    # next to a last-published output reading. Highest revision per mRID wins and
+    # withdrawn events hide (latest_outage_revisions — the same semantics the
+    # outage board uses); ending_after prunes events already over. Same
+    # fixed-width UTC-string comparison idiom as before, against now.
     now = datetime.utcnow()
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
     latest_hour_dt = datetime.fromtimestamp(latest_ts, tz=timezone.utc)
     latest_hour_iso = latest_hour_dt.strftime("%Y-%m-%dT%H:%MZ")
     outage_by_eic: dict[str, dict] = {}
     for o in latest_outage_revisions(db, resolved_zone,
-                                     ending_after=latest_hour_iso, doc_type="A77"):
+                                     ending_after=now_iso, doc_type="A77"):
         if o.status != "active" or not o.unit_eic:
             continue
-        if not (o.start_utc <= latest_hour_iso <= o.end_utc):
+        if not (o.start_utc <= now_iso <= o.end_utc):
             continue
         if outage_by_eic.get(o.unit_eic, {}).get("kind") == "forced":
             continue  # a forced outage is the more newsworthy label — keep it
@@ -2409,22 +2426,28 @@ def get_units_generation(
             ),
         }
 
+    today_utc = datetime.now(timezone.utc).date()
     units: list[dict] = []
-    for eic, hours in by_unit.items():
+    for eic, unit_latest_ts in latest_by_unit.items():
         reg = registry.get(eic)
         nominal = reg.nominal_mw if reg else None
         psr = reg.psr_type if reg else None
-        current = hours.get(latest_ts)
+        hours = hours_by_unit.get(eic, {})
+        # The unit's newest row is inside its own latest day by construction, so
+        # `current` is always present — ingest never writes null mw.
+        current = hours.get(unit_latest_ts)
+        unit_latest_dt = datetime.fromtimestamp(unit_latest_ts, tz=timezone.utc)
         units.append({
             "unit_eic": eic,
             "name": reg.name if reg else None,
             "psr_type": psr,
             "fuel": PSR_LABELS.get(psr, psr) if psr else None,
             "nominal_mw": nominal,
-            # null = the unit published nothing for the latest hour (not "0 MW" —
-            # zeros ARE published and mean the unit stood still). With the per-CTA
-            # lag skew this is COMMON at the frontier, not an edge case.
+            "unit_latest_hour_utc": unit_latest_dt.strftime("%Y-%m-%dT%H:%MZ"),
+            # CALENDAR days, same convention as the top-level lag_days below.
+            "unit_lag_days": (today_utc - unit_latest_dt.date()).days,
             "current_mw": round(current, 1) if current is not None else None,
+            # Mean over the UTC day containing the unit's OWN latest hour.
             "day_avg_mw": round(sum(hours.values()) / len(hours), 1) if hours else None,
             "utilization_pct": (
                 round(100.0 * current / nominal, 1)
@@ -2432,9 +2455,11 @@ def get_units_generation(
             ),
             "outage": outage_by_eic.get(eic),
         })
-    units.sort(key=lambda u: (u["current_mw"] is None,
-                              -(u["current_mw"] or 0.0),
-                              -(u["nominal_mw"] or 0.0)))
+    # current_mw is never None here — a unit enters the population by owning at
+    # least one row in the window, and its newest row IS its current reading. The
+    # old "not reporting, nulls last" sort branch is dead; `or 0.0` only guards a
+    # hypothetical null-mw row, it is not a sort tier.
+    units.sort(key=lambda u: (-(u["current_mw"] or 0.0), -(u["nominal_mw"] or 0.0)))
 
     reporting = [u for u in units if u["current_mw"] is not None]
     return {
@@ -2445,9 +2470,13 @@ def get_units_generation(
         "units": units,
         "totals": {
             "units": len(units),
+            # Units with any rows in the window — now usually equal to `units`;
+            # kept because it still distinguishes registry silence.
             "reporting": len(reporting),
             "nominal_mw": round(sum(u["nominal_mw"] or 0.0 for u in units), 1),
-            "generating_mw": round(sum(u["current_mw"] for u in reporting), 1),
+            # Mixed timestamps by design (each unit's own latest reading) — NOT a
+            # same-instant snapshot; the note says so verbatim.
+            "latest_readings_mw": round(sum(u["current_mw"] or 0.0 for u in reporting), 1),
         },
         "latest_hour_utc": latest_hour_iso,
         # CALENDAR days, deliberately — the freshness triple below counts calendar

--- a/backend/tests/test_unit_generation.py
+++ b/backend/tests/test_unit_generation.py
@@ -18,9 +18,11 @@ The probe/smoke-anchored facts worth pinning (2026-07-28):
 * Multiple TimeSeries cover one unit (68 TS / 35 units at Amprion): per-TS hourly
   means are averaged per unit-hour, so a PT60M and a PT15M series weigh equally
   (mean-of-means, not a raw-point average that weights one series 4:1).
-* Control areas publish at DIFFERENT lags (smoke: TenneT D-2, the rest D-5) — the
-  board must list a unit whose TSO has not reached the frontier yet as
-  "not reporting" (null), never drop it.
+* Control areas publish at DIFFERENT lags (smoke: TenneT D-2, the rest D-5; the
+  regulation allows up to D+5) — the board gives every unit ITS OWN latest
+  published hour, value and lag. Sampling everyone at the zone-wide newest hour
+  nulled 74 of 85 live units; a unit whose TSO trails the frontier must carry its
+  own reading, never a null row, and never be dropped.
 """
 from __future__ import annotations
 
@@ -376,8 +378,8 @@ def _seed_board(db):
     * 11WB GAS-1     — registry WITHOUT nominal → utilization null
     * 11WNOREG       — no registry row at all → name/fuel null
     * 11WLAG COAL-1  — rows only 3 days BEFORE the latest day (its CTA has not
-      published the frontier yet — the smoke's lag-skew case) → listed as
-      "not reporting", null current/day-avg, still in totals.units
+      published the frontier yet — the smoke's lag-skew case) → carries its OWN
+      D-9 reading and lag instead of a null "not reporting" row
     """
     latest = _latest_hour_epoch()
     day_start = latest - (latest % 86_400)
@@ -412,31 +414,86 @@ def test_generation_route_joins_registry_and_computes_utilization(db_session):
     assert a["nominal_mw"] == 800.0
     assert a["current_mw"] == 400.0
     assert a["utilization_pct"] == 50.0
+    latest_dt = datetime.fromtimestamp(latest, tz=timezone.utc)
+    assert a["unit_latest_hour_utc"] == latest_dt.strftime("%Y-%m-%dT%H:%MZ")
+    assert a["unit_lag_days"] == 6
     if prev is not None:
         assert a["day_avg_mw"] == 300.0  # mean over the day's reported hours
 
     assert by_eic["11WB"]["utilization_pct"] is None, "null nominal → no ratio"
     assert by_eic["11WNOREG"]["name"] is None and by_eic["11WNOREG"]["fuel"] is None
 
-    # Sorted by current_mw desc, not-reporting units last.
-    assert [u["unit_eic"] for u in body["units"]] == ["11WA", "11WB", "11WNOREG", "11WLAG"]
-    assert body["totals"] == {"units": 4, "reporting": 3,
-                              "nominal_mw": 1400.0, "generating_mw": 550.0}
+    # Sorted by current_mw desc — every listed unit carries its own reading now.
+    assert [u["unit_eic"] for u in body["units"]] == ["11WLAG", "11WA", "11WB", "11WNOREG"]
+    assert body["totals"] == {"units": 4, "reporting": 4,
+                              "nominal_mw": 1400.0, "latest_readings_mw": 1100.0}
 
 
-def test_generation_route_keeps_lagging_units_visible_as_not_reporting(db_session):
+def test_generation_route_gives_lagging_units_their_own_latest_reading(db_session):
     """The smoke's per-CTA lag skew: TenneT published D-2 while the others sat at
-    D-5 — a unit whose TSO has not reached the frontier day must stay LISTED with
-    null output, or the board silently presents one TSO's plants as the zone."""
-    _seed_board(db_session)
+    D-5 — a unit whose TSO trails the zone frontier now carries ITS OWN latest
+    published value and lag instead of a null "not reporting" row (which was 74
+    of 85 units on the live board when everyone was sampled at the fastest TSO's
+    hour)."""
+    latest, _prev = _seed_board(db_session)
     body = _client(db_session).get("/api/power/units/generation?zone=DE_LU").json()
 
     lag = {u["unit_eic"]: u for u in body["units"]}["11WLAG"]
     assert lag["name"] == "COAL-1", "registry join still applies"
-    assert lag["current_mw"] is None
-    assert lag["day_avg_mw"] is None, "no rows on the latest day — no fabricated mean"
-    assert lag["utilization_pct"] is None
-    assert body["totals"]["units"] == 4 and body["totals"]["reporting"] == 3
+    assert lag["current_mw"] == 550.0
+    assert lag["day_avg_mw"] == 550.0, "mean over ITS OWN latest day"
+    assert lag["utilization_pct"] == 91.7  # 550 / 600 nameplate
+    lag_dt = datetime.fromtimestamp(latest - 3 * 86_400, tz=timezone.utc)
+    assert lag["unit_latest_hour_utc"] == lag_dt.strftime("%Y-%m-%dT%H:%MZ")
+    assert lag["unit_lag_days"] == 9, "the zone frontier's 6 days + its own 3 more"
+    assert body["totals"]["units"] == 4 and body["totals"]["reporting"] == 4
+
+
+def _day_anchor(days_back: int) -> int:
+    """00:00 UTC exactly `days_back` calendar days ago — rows placed inside that
+    day give a deterministic unit_lag_days regardless of the wall-clock hour."""
+    d = datetime.now(timezone.utc).date() - timedelta(days=days_back)
+    return int(datetime(d.year, d.month, d.day, tzinfo=timezone.utc).timestamp())
+
+
+def test_generation_route_each_unit_carries_its_own_latest_hour(db_session):
+    """Two units at DIFFERENT lags (D-2 vs D-5 — the smoke's TSO skew): both carry
+    values at their OWN latest published hour with their own lag, day_avg is over
+    each unit's OWN latest day, the top level follows the fresher one, and
+    latest_readings_mw is the mixed-timestamp sum with both units reporting."""
+    db_session.add(ProductionUnit(unit_eic="11WF", zone="DE_LU", year=2026,
+                                  name="FRESH-1", psr_type="B04", nominal_mw=500.0))
+    db_session.add(ProductionUnit(unit_eic="11WS", zone="DE_LU", year=2026,
+                                  name="SLOW-1", psr_type="B05", nominal_mw=1000.0))
+    d2, d5, d6 = _day_anchor(2), _day_anchor(5), _day_anchor(6)
+    db_session.add(UnitGeneration(unit_eic="11WF", ts_utc=d2 + 10 * 3600, mw=300.0, zone="DE_LU"))
+    db_session.add(UnitGeneration(unit_eic="11WF", ts_utc=d2 + 11 * 3600, mw=500.0, zone="DE_LU"))
+    db_session.add(UnitGeneration(unit_eic="11WS", ts_utc=d5 + 8 * 3600, mw=100.0, zone="DE_LU"))
+    db_session.add(UnitGeneration(unit_eic="11WS", ts_utc=d5 + 9 * 3600, mw=200.0, zone="DE_LU"))
+    # A D-6 row must NOT leak into 11WS's day_avg — the mean is over the unit's
+    # OWN latest day, not over everything it published in the window.
+    db_session.add(UnitGeneration(unit_eic="11WS", ts_utc=d6 + 9 * 3600, mw=900.0, zone="DE_LU"))
+    db_session.commit()
+
+    body = _client(db_session).get("/api/power/units/generation?zone=DE_LU").json()
+    by_eic = {u["unit_eic"]: u for u in body["units"]}
+
+    fresh, slow = by_eic["11WF"], by_eic["11WS"]
+    assert fresh["current_mw"] == 500.0 and fresh["unit_lag_days"] == 2
+    assert fresh["unit_latest_hour_utc"] == datetime.fromtimestamp(
+        d2 + 11 * 3600, tz=timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    assert fresh["day_avg_mw"] == 400.0
+    assert slow["current_mw"] == 200.0 and slow["unit_lag_days"] == 5
+    assert slow["unit_latest_hour_utc"] == datetime.fromtimestamp(
+        d5 + 9 * 3600, tz=timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    assert slow["day_avg_mw"] == 150.0, "own latest day only — the D-6 row stays out"
+
+    # Top level follows the FRESHER unit; totals sum the mixed-timestamp readings.
+    assert body["latest_hour_utc"] == fresh["unit_latest_hour_utc"]
+    assert body["lag_days"] == 2
+    assert body["totals"] == {"units": 2, "reporting": 2,
+                              "nominal_mw": 1500.0, "latest_readings_mw": 700.0}
+    assert [u["unit_eic"] for u in body["units"]] == ["11WF", "11WS"]
 
 
 def test_generation_route_reports_the_honest_lag(db_session):
@@ -452,6 +509,12 @@ def test_generation_route_reports_the_honest_lag(db_session):
     assert body["as_of"] == latest_dt.strftime("%Y-%m-%d")
     assert body["stale"] is False, "6 days behind is A73's NORMAL lag, not staleness"
     assert "Not live" in body["note"] and "NOT the installed fleet" in body["note"]
+    # The honesty strings ARE the spec: the totals sum mixes per-unit timestamps
+    # and the note must say so verbatim, plus why the timestamps differ.
+    assert ("sum of each unit's latest published reading — mixed timestamps, "
+            "not a snapshot") in body["note"]
+    assert "publish at different speeds" in body["note"]
+    assert "D+5" in body["note"]
 
 
 def _seed_outage(db, eic, *, mrid, revision=1, bt="A54", status="active",
@@ -471,15 +534,15 @@ def _seed_outage(db, eic, *, mrid, revision=1, bt="A54", status="active",
 def test_generation_route_attaches_outages_with_revision_semantics(db_session):
     """The outage join must ride the same highest-revision/withdrawn-hidden rules
     as the outage board: a withdrawn latest revision hides the event even though
-    an older active revision exists, and an event overlapping the latest hour
-    attaches {kind, offline_mw}."""
+    an older active revision exists, and an event active NOW attaches
+    {kind, offline_mw}."""
     latest, _prev = _seed_board(db_session)
-    # 11WA: rev1 active AND covering the latest hour, rev2 WITHDRAWN → only the
-    # withdrawal (not the window) may be what hides it.
+    # 11WA: rev1 active AND spanning now, rev2 WITHDRAWN → only the withdrawal
+    # (not the window) may be what hides it.
     _seed_outage(db_session, "11WA", mrid="mA", revision=1, start_off_h=-24 * 8)
     _seed_outage(db_session, "11WA", mrid="mA", revision=2, status="withdrawn",
                  start_off_h=-24 * 8)
-    # 11WB: active forced outage spanning the latest hour (start 8 days ago).
+    # 11WB: active forced outage spanning now (start 8 days ago, end in 2 days).
     _seed_outage(db_session, "11WB", mrid="mB", start_off_h=-24 * 8)
 
     body = _client(db_session).get("/api/power/units/generation?zone=DE_LU").json()
@@ -488,9 +551,33 @@ def test_generation_route_attaches_outages_with_revision_semantics(db_session):
     assert by_eic["11WB"]["outage"] == {"kind": "forced", "offline_mw": 800.0}
 
 
-def test_generation_route_ignores_outages_not_covering_the_latest_hour(db_session):
-    """The board's hour is ~6 days in the past — an outage that starts tomorrow
-    (running_now for the outage panel's wall clock!) must NOT badge it."""
+def test_generation_route_outage_badge_is_joined_at_now_not_the_data_hour(db_session):
+    """A77 messages are near-real-time while the output readings lag days — the
+    badge answers "is this unit in outage NOW". An outage that covers only the
+    wall clock (NOT 11WA's D-6 data hour) must still attach: next to a days-old
+    reading, the current outage state is the honest and useful join."""
+    _seed_board(db_session)  # 11WA's own latest hour is D-6
+    _seed_outage(db_session, "11WA", mrid="mNOW", start_off_h=-24, end_off_h=24)
+
+    body = _client(db_session).get("/api/power/units/generation?zone=DE_LU").json()
+    by_eic = {u["unit_eic"]: u for u in body["units"]}
+    assert by_eic["11WA"]["outage"] == {"kind": "forced", "offline_mw": 800.0}
+
+
+def test_generation_route_outage_that_ended_yesterday_does_not_badge(db_session):
+    """The inverse: an outage that DID cover 11WA's (D-6) data hour but ended
+    yesterday is history — badging it would claim a running outage that is over."""
+    _seed_board(db_session)
+    _seed_outage(db_session, "11WA", mrid="mOLD", start_off_h=-24 * 7, end_off_h=-24)
+
+    body = _client(db_session).get("/api/power/units/generation?zone=DE_LU").json()
+    by_eic = {u["unit_eic"]: u for u in body["units"]}
+    assert by_eic["11WA"]["outage"] is None
+
+
+def test_generation_route_ignores_an_outage_that_starts_tomorrow(db_session):
+    """Upcoming is not "now": an outage starting tomorrow must not badge, even
+    though the outage panel lists it as upcoming."""
     _seed_board(db_session)
     _seed_outage(db_session, "11WA", mrid="mF", start_off_h=24, end_off_h=72)
 

--- a/backend/tests/test_unit_generation.py
+++ b/backend/tests/test_unit_generation.py
@@ -460,35 +460,53 @@ def test_generation_route_each_unit_carries_its_own_latest_hour(db_session):
     """Two units at DIFFERENT lags (D-2 vs D-5 — the smoke's TSO skew): both carry
     values at their OWN latest published hour with their own lag, day_avg is over
     each unit's OWN latest day, the top level follows the fresher one, and
-    latest_readings_mw is the mixed-timestamp sum with both units reporting."""
+    latest_readings_mw is the mixed-timestamp sum with both units reporting.
+    Guard rows kill three mutants: dropping the own-day filter, or the zone
+    filter on either the GROUP BY or the span scan, each corrupts an assertion."""
     db_session.add(ProductionUnit(unit_eic="11WF", zone="DE_LU", year=2026,
                                   name="FRESH-1", psr_type="B04", nominal_mw=500.0))
     db_session.add(ProductionUnit(unit_eic="11WS", zone="DE_LU", year=2026,
                                   name="SLOW-1", psr_type="B05", nominal_mw=1000.0))
-    d2, d5, d6 = _day_anchor(2), _day_anchor(5), _day_anchor(6)
-    db_session.add(UnitGeneration(unit_eic="11WF", ts_utc=d2 + 10 * 3600, mw=300.0, zone="DE_LU"))
-    db_session.add(UnitGeneration(unit_eic="11WF", ts_utc=d2 + 11 * 3600, mw=500.0, zone="DE_LU"))
-    db_session.add(UnitGeneration(unit_eic="11WS", ts_utc=d5 + 8 * 3600, mw=100.0, zone="DE_LU"))
-    db_session.add(UnitGeneration(unit_eic="11WS", ts_utc=d5 + 9 * 3600, mw=200.0, zone="DE_LU"))
-    # A D-6 row must NOT leak into 11WS's day_avg — the mean is over the unit's
-    # OWN latest day, not over everything it published in the window.
+    d2, d3, d5, d6 = _day_anchor(2), _day_anchor(3), _day_anchor(5), _day_anchor(6)
+    # Late-in-day hours ON PURPOSE (21–23 h UTC): an implementation flooring
+    # (now − ts) into 24-hour blocks would call D-2 23:00 "1 day behind" for most
+    # of the day — the calendar-day lag assertions below kill that mutant.
+    db_session.add(UnitGeneration(unit_eic="11WF", ts_utc=d2 + 22 * 3600, mw=300.0, zone="DE_LU"))
+    db_session.add(UnitGeneration(unit_eic="11WF", ts_utc=d2 + 23 * 3600, mw=500.0, zone="DE_LU"))
+    db_session.add(UnitGeneration(unit_eic="11WS", ts_utc=d5 + 21 * 3600, mw=100.0, zone="DE_LU"))
+    db_session.add(UnitGeneration(unit_eic="11WS", ts_utc=d5 + 22 * 3600, mw=200.0, zone="DE_LU"))
+    # IN-SPAN own-day guard: a D-3 row for the D-2 unit sits inside the span
+    # scan's SQL range but outside 11WF's own latest day — deleting the
+    # ds <= ts < ds+86400 filter absorbs it into day_avg and fails below.
+    db_session.add(UnitGeneration(unit_eic="11WF", ts_utc=d3 + 9 * 3600, mw=900.0, zone="DE_LU"))
+    # OUT-OF-SPAN guard: a D-6 row (before the span's SQL range) must not leak
+    # into 11WS's day_avg either.
     db_session.add(UnitGeneration(unit_eic="11WS", ts_utc=d6 + 9 * 3600, mw=900.0, zone="DE_LU"))
+    # CROSS-ZONE-BLEED guards, both inside the window: a foreign zone's unit must
+    # not enter the population (distinct EIC — kills a zone-filterless GROUP BY),
+    # and a foreign zone's row for a LISTED unit inside its own latest day must
+    # not enter its day_avg (kills a zone-filterless span scan).
+    db_session.add(UnitGeneration(unit_eic="11WXX", ts_utc=d2 + 23 * 3600, mw=999.0, zone="XX"))
+    db_session.add(UnitGeneration(unit_eic="11WF", ts_utc=d2 + 9 * 3600, mw=999.0, zone="XX"))
     db_session.commit()
 
     body = _client(db_session).get("/api/power/units/generation?zone=DE_LU").json()
     by_eic = {u["unit_eic"]: u for u in body["units"]}
+    assert "11WXX" not in by_eic, "foreign zone's unit must not bleed onto the board"
 
     fresh, slow = by_eic["11WF"], by_eic["11WS"]
     assert fresh["current_mw"] == 500.0 and fresh["unit_lag_days"] == 2
     assert fresh["unit_latest_hour_utc"] == datetime.fromtimestamp(
-        d2 + 11 * 3600, tz=timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
-    assert fresh["day_avg_mw"] == 400.0
+        d2 + 23 * 3600, tz=timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    assert fresh["day_avg_mw"] == 400.0, \
+        "own latest day, own zone only — neither the D-3 row nor XX's row counts"
     assert slow["current_mw"] == 200.0 and slow["unit_lag_days"] == 5
     assert slow["unit_latest_hour_utc"] == datetime.fromtimestamp(
-        d5 + 9 * 3600, tz=timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+        d5 + 22 * 3600, tz=timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
     assert slow["day_avg_mw"] == 150.0, "own latest day only — the D-6 row stays out"
 
-    # Top level follows the FRESHER unit; totals sum the mixed-timestamp readings.
+    # Top level follows the FRESHER unit; totals sum the mixed-timestamp readings
+    # (and would flag any cross-zone bleed too).
     assert body["latest_hour_utc"] == fresh["unit_latest_hour_utc"]
     assert body["lag_days"] == 2
     assert body["totals"] == {"units": 2, "reporting": 2,

--- a/docs/API.md
+++ b/docs/API.md
@@ -68,8 +68,10 @@ is the *published* unit list, not the full installed fleet.
 
 Per-unit hourly *output* (ENTSO-E A73; DE-LU so far) is deliberately **not** a
 `/api/v1/series` key — 85+ EIC-named series would drown the catalog. It lives on
-`GET /api/power/units/generation?zone=` (latest published day, ~6-day publication
-lag stated as `lag_days`) and `GET /api/power/units/history?zone=&unit=<EIC>&hours=`
+`GET /api/power/units/generation?zone=` (each unit's own latest published reading —
+the TSOs publish at different speeds, up to the regulation's D+5, so every row
+carries its own `unit_latest_hour_utc`/`unit_lag_days` and the summed total mixes
+timestamps, not a snapshot) and `GET /api/power/units/history?zone=&unit=<EIC>&hours=`
 (capped at 744 hours per request).
 
 ### `GET /api/v1/series/catalog`

--- a/frontend/src/components/UnitGenerationPanel.jsx
+++ b/frontend/src/components/UnitGenerationPanel.jsx
@@ -19,10 +19,11 @@ function fmtDay(iso) {
 }
 
 // Compact per-row age stamp: "today" for lag 0, else "D-2" — the full UTC
-// timestamp rides in the title tooltip next to it.
+// timestamp rides in the title tooltip next to it. <= 0, not === 0: a
+// future-dated row from a corrupt document must not render "D--1".
 function lagStamp(days) {
   if (days == null) return null
-  return days === 0 ? 'today' : `D-${days}`
+  return days <= 0 ? 'today' : `D-${days}`
 }
 
 /**

--- a/frontend/src/components/UnitGenerationPanel.jsx
+++ b/frontend/src/components/UnitGenerationPanel.jsx
@@ -18,15 +18,27 @@ function fmtDay(iso) {
   return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
 }
 
+// Compact per-row age stamp: "today" for lag 0, else "D-2" — the full UTC
+// timestamp rides in the title tooltip next to it.
+function lagStamp(days) {
+  if (days == null) return null
+  return days === 0 ? 'today' : `D-${days}`
+}
+
 /**
- * Per-plant output for the LATEST PUBLISHED day (ENTSO-E A73) — which named
- * plants ran, how hard against nameplate, and whether an outage explains a gap.
+ * Per-plant output at each unit's OWN latest published hour (ENTSO-E A73) —
+ * which named plants ran, how hard against nameplate, and whether an outage
+ * explains a gap.
  *
- * The honesty IS the feature: A73 publishes ~6 days behind, so the caption says
- * "published <day> · N days behind" instead of pretending to be live; the bar
- * is output vs NAMEPLATE (utilization, not availability); and the population is
- * only the published >=100 MW dispatchable units, not the fleet (the API note
- * carries the full caveat into the info popover).
+ * The honesty IS the feature: the four TSOs publish at different speeds (up to
+ * the regulation's D+5), so every row carries its own quiet age stamp, the
+ * caption shows the actual lag range instead of pretending one shared hour
+ * exists, and the totals line says "mixed timestamps, not a snapshot". The bar
+ * is output vs NAMEPLATE (utilization, not availability); the outage badge is
+ * joined at the CURRENT time (near-real-time A77) while the output value is the
+ * last published reading; and the population is only the published >=100 MW
+ * dispatchable units, not the fleet (the API note carries the full caveat into
+ * the info popover).
  */
 export default function UnitGenerationPanel({ zone = 'DE_LU' }) {
   const { data, loading, error } = useFetchWithError(`${API}/power/units/generation?zone=${zone}`, { deps: [zone], pollMs: POLL_SLOW_MS })
@@ -53,18 +65,28 @@ export default function UnitGenerationPanel({ zone = 'DE_LU' }) {
   const shown = units.slice(0, ROW_CAP)
   const totals = data?.totals
 
+  // The caption's lag range is DERIVED from the payload, not hardcoded — the
+  // TSOs' actual skew (e.g. D-2…D-5) is the honest thing to show.
+  const lags = units.map((u) => u.unit_lag_days).filter((d) => d != null)
+  const minLag = lags.length ? Math.min(...lags) : null
+  const maxLag = lags.length ? Math.max(...lags) : null
+
   return (
     <Panel
       id="unit-generation"
-      title="PLANT OUTPUT · LATEST PUBLISHED DAY"
+      title="PLANT OUTPUT · LATEST PUBLISHED READINGS"
       freshness={data}
       info={data?.note}
       collapsible
       headerRight={
         data?.latest_hour_utc && (
           <span className="font-mono text-[10px] text-neutral-500">
-            published {fmtDay(data.latest_hour_utc)}
-            {data.lag_days != null ? ` · ${data.lag_days} day${data.lag_days === 1 ? '' : 's'} behind` : ''}
+            freshest {fmtDay(data.latest_hour_utc)}
+            {minLag != null && (
+              maxLag > minLag
+                ? ` · per-plant timestamps vary (${lagStamp(minLag)}…${lagStamp(maxLag)} — TSOs publish at different speeds)`
+                : ` · all plants ${lagStamp(minLag)}`
+            )}
           </span>
         )
       }
@@ -76,8 +98,8 @@ export default function UnitGenerationPanel({ zone = 'DE_LU' }) {
           <div className="px-4 py-3 border-b border-border/30">
             <PanelTakeaway tone="info">
               {totals
-                ? `${totals.reporting} of ${totals.units} published units reporting at the latest hour — ${fmtMw(totals.generating_mw)} generating against ${fmtMw(totals.nominal_mw)} of nameplate.`
-                : 'Per-unit output for the latest published day.'}
+                ? `${totals.reporting} of ${totals.units} published units with readings — ${fmtMw(totals.latest_readings_mw)} summed from each plant's latest published reading (mixed timestamps, not a snapshot) against ${fmtMw(totals.nominal_mw)} of nameplate.`
+                : "Per-unit output at each plant's latest published hour."}
               {' '}Published units only (≥100 MW, dispatchable fuels) — not the fleet.
             </PanelTakeaway>
           </div>
@@ -88,9 +110,9 @@ export default function UnitGenerationPanel({ zone = 'DE_LU' }) {
                   <th className="text-left px-2 py-1">Unit</th>
                   <th className="text-left px-2 py-1">Fuel</th>
                   <th className="text-right px-2 py-1">Nominal</th>
-                  <th className="text-right px-2 py-1">Now</th>
+                  <th className="text-right px-2 py-1">Last</th>
                   <th className="text-left px-2 py-1 min-w-[110px]">Utilization</th>
-                  <th className="text-left px-2 py-1">Outage</th>
+                  <th className="text-left px-2 py-1">Outage now</th>
                 </tr>
               </thead>
               <tbody>
@@ -109,7 +131,16 @@ export default function UnitGenerationPanel({ zone = 'DE_LU' }) {
                       ) : '—'}
                     </td>
                     <td className="px-2 py-1.5 text-right text-neutral-500">{fmtMw(u.nominal_mw)}</td>
-                    <td className="px-2 py-1.5 text-right font-bold text-neutral-200">{fmtMw(u.current_mw)}</td>
+                    <td className="px-2 py-1.5 text-right">
+                      <span className="font-bold text-neutral-200">{fmtMw(u.current_mw)}</span>
+                      {/* Quiet per-unit age stamp — the TSOs publish at different
+                          speeds, so each reading carries its own timestamp. */}
+                      {u.unit_lag_days != null && (
+                        <div className="text-[9px] text-neutral-600 leading-tight" title={u.unit_latest_hour_utc}>
+                          {lagStamp(u.unit_lag_days)}
+                        </div>
+                      )}
+                    </td>
                     <td className="px-2 py-1.5">
                       {u.utilization_pct != null ? (
                         <div className="flex items-center gap-1.5">
@@ -124,16 +155,22 @@ export default function UnitGenerationPanel({ zone = 'DE_LU' }) {
                           <span className="text-[9px] text-neutral-500 w-9 text-right shrink-0">{u.utilization_pct}%</span>
                         </div>
                       ) : (
-                        <span className="text-[9px] text-neutral-600">{u.current_mw == null ? 'not reporting' : '—'}</span>
+                        // current_mw is never null anymore (every listed unit
+                        // carries its own latest reading) — a dash here means
+                        // the registry has no nameplate to divide by.
+                        <span className="text-[9px] text-neutral-600">—</span>
                       )}
                     </td>
                     <td className="px-2 py-1.5">
                       {u.outage ? (
-                        <span className={`text-[9px] tracking-wide border rounded px-1.5 py-0.5 ${
-                          u.outage.kind === 'forced'
-                            ? 'text-orange-400 border-orange-500/30'
-                            : 'text-neutral-500 border-border'
-                        }`}>
+                        <span
+                          className={`text-[9px] tracking-wide border rounded px-1.5 py-0.5 ${
+                            u.outage.kind === 'forced'
+                              ? 'text-orange-400 border-orange-500/30'
+                              : 'text-neutral-500 border-border'
+                          }`}
+                          title={`${u.outage.kind === 'forced' ? 'Forced' : 'Planned'} outage active NOW (near-real-time A77) — the output value is the plant's last published reading${u.outage.offline_mw != null ? ` · ~${Math.round(u.outage.offline_mw)} MW offline` : ''}`}
+                        >
                           {u.outage.kind === 'forced' ? 'FORCED' : 'PLANNED'}
                         </span>
                       ) : ''}


### PR DESCRIPTION
## Summary

Follow-up to #136 — the board was pinned to one zone-wide "latest published day", so the fastest TSO defined the date and 74 of 85 units showed as "not reporting" (the four German TSOs publish between ~D-2 and ~D-5; the regulation allows D+5).

- **Each unit now carries its own latest published reading**: `unit_latest_hour_utc`, `unit_lag_days`, `current_mw`/`day_avg_mw` over the unit's own latest day, with a quiet per-row age stamp ("D-2"/"today") in the panel and a caption deriving the actual lag range from the payload.
- **Outage badge is now anchored at NOW** (A77 is near-real-time) — "in outage now" next to a days-old output reading, honestly labeled.
- **Totals renamed honestly**: `generating_mw` → `latest_readings_mw` (mixed timestamps, not a snapshot — stated in the note).
- **A73 polling 4× daily** (03/09/15/21:40 UTC, job `unit_generation_6h`) instead of daily — catches each TSO's publication within ~6 h instead of up to 24 h late. ~32 ENTSO-E requests/day.

Read path stays three index-backed queries (zone max, per-unit GROUP BY, span scan) — benchmarked ~53 ms worst case.

## Test plan

- [x] Full suite: **1223 passed, 1 skipped**; build + ruff clean
- [x] Mutation-verified guards: zone filter off either query, own-day filter deleted, hours-floor lag — all four fail tests now
- [ ] After merge: VPS `git pull` + `npm run build` + `systemctl restart obsyd` — no backfill needed (data already ingested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)