### PR TITLE
Border flows on the map + structured borders legend (no more wall of text)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -258,6 +258,11 @@ function Dashboard() {
   // downstream consumers stay untouched. SparkSpreadHistory is DE-LU-only in-panel.
   const { zone: energyZone, setZone: setEnergyZone } = useViewState()
 
+  // Map arc click → border detail: the focus travels as a prop to BordersPanel
+  // (opens the row, expands + scrolls the panel). `ts` makes every click a NEW
+  // signal, so re-clicking the same border still scrolls/expands.
+  const [borderFocus, setBorderFocus] = useState(null)
+
   // URL hash sync — keep the default (POWER) tab off the URL so the bare
   // homepage stays clean (`/`); only non-default tabs get a shareable hash.
   useEffect(() => {
@@ -809,7 +814,7 @@ function Dashboard() {
               </ErrorBoundary>
               <ErrorBoundary name="power-map">
                 <Suspense fallback={MAP_FALLBACK}>
-                  <PowerMap />
+                  <PowerMap onBorderSelect={(a, b) => setBorderFocus({ a, b, ts: Date.now() })} />
                 </Suspense>
               </ErrorBoundary>
             </div>
@@ -819,7 +824,7 @@ function Dashboard() {
             {/* The border layer: prices × flows. A zone map shows WHERE power is
                 expensive; only the borders show whether the market is coupled. */}
             <ErrorBoundary name="borders">
-              <BordersPanel />
+              <BordersPanel focus={borderFocus} />
             </ErrorBoundary>
             <ErrorBoundary name="hydro">
               <HydroReservoirPanel />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, lazy, Suspense } from 'react'
+import { useState, useEffect, useCallback, lazy, Suspense } from 'react'
 import Sidebar from './components/Sidebar'
 import CompactView from './components/CompactView'
 import AlertsPanel from './components/AlertsPanel'
@@ -260,8 +260,10 @@ function Dashboard() {
 
   // Map arc click → border detail: the focus travels as a prop to BordersPanel
   // (opens the row, expands + scrolls the panel). `ts` makes every click a NEW
-  // signal, so re-clicking the same border still scrolls/expands.
+  // signal, so re-clicking the same border still scrolls/expands. Stable
+  // callback — PowerMap's layers memo depends on it.
   const [borderFocus, setBorderFocus] = useState(null)
+  const onBorderSelect = useCallback((a, b) => setBorderFocus({ a, b, ts: Date.now() }), [])
 
   // URL hash sync — keep the default (POWER) tab off the URL so the bare
   // homepage stays clean (`/`); only non-default tabs get a shareable hash.
@@ -814,7 +816,7 @@ function Dashboard() {
               </ErrorBoundary>
               <ErrorBoundary name="power-map">
                 <Suspense fallback={MAP_FALLBACK}>
-                  <PowerMap onBorderSelect={(a, b) => setBorderFocus({ a, b, ts: Date.now() })} />
+                  <PowerMap onBorderSelect={onBorderSelect} />
                 </Suspense>
               </ErrorBoundary>
             </div>

--- a/frontend/src/components/BordersPanel.jsx
+++ b/frontend/src/components/BordersPanel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { POLL_SLOW_MS } from '../utils/poll'
@@ -36,7 +36,9 @@ function Chip({ kind }) {
 // The full prose definitions live in HOW TO READ; the API keeps its note.
 function BordersLegend({ eps }) {
   const rows = [
-    ['Coupled', `share of hours the two zones cleared at the same price (within €${eps ?? 1}/MWh).`],
+    // Fallback mirrors backend COUPLED_EPS_EUR (0.5) — only shown in the brief
+    // window before /power/borders delivers the real value.
+    ['Coupled', `share of hours the two zones cleared at the same price (within €${eps ?? 0.5}/MWh).`],
     ['Ø spread', 'mean absolute day-ahead spread over the window (€/MWh).'],
     ['Now', 'the latest hour’s spread; the expensive side is named. “coupled” = below the threshold.'],
     ['At rail', 'share of hours the flow sat at or above this border’s own 95th percentile over the last year.'],
@@ -129,14 +131,17 @@ export default function BordersPanel({ focus }) {
   // Map arc click → this panel: open the border's row. Keys match by
   // construction — both sides use the canonically sorted zone pair. State is
   // adjusted during render (React's previous-renders pattern); only the DOM
-  // scroll stays in an effect.
-  const [seenFocus, setSeenFocus] = useState(null)
+  // scroll stays in an effect. Both trackers initialize to the INCOMING focus,
+  // so a remount with an old focus (tab switch and back) neither re-opens the
+  // row nor scrolls — only a focus that changes after mount does.
+  const [seenFocus, setSeenFocus] = useState(focus)
   if (focus && focus !== seenFocus) {
     setSeenFocus(focus)
     if (focus.a && focus.b) setOpen(`${focus.a}|${focus.b}`)
   }
+  const mountFocus = useRef(focus)
   useEffect(() => {
-    if (!focus?.a || !focus?.b) return
+    if (!focus?.a || !focus?.b || focus === mountFocus.current) return
     document.getElementById('panel-power-borders')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }, [focus])
 

--- a/frontend/src/components/BordersPanel.jsx
+++ b/frontend/src/components/BordersPanel.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { POLL_SLOW_MS } from '../utils/poll'
@@ -18,6 +18,52 @@ function convergenceColor(pct) {
   return 'text-orange-400'
 }
 
+// A small chip in the legend, matching the ones in the Util column.
+function Chip({ kind }) {
+  return (
+    <span
+      className={`text-[8px] px-1 py-px rounded border ${
+        kind === 'ntc' ? 'border-cyan-glow/40 text-cyan-glow/80' : 'border-border text-neutral-600'
+      }`}
+    >
+      {kind === 'ntc' ? 'NTC' : 'P95'}
+    </span>
+  )
+}
+
+// The structured replacement for the raw ~1100-char API note that used to be
+// dumped into a 256-px popover. One row per column, HowToRead's <dl> pattern.
+// The full prose definitions live in HOW TO READ; the API keeps its note.
+function BordersLegend({ eps }) {
+  const rows = [
+    ['Coupled', `share of hours the two zones cleared at the same price (within €${eps ?? 1}/MWh).`],
+    ['Ø spread', 'mean absolute day-ahead spread over the window (€/MWh).'],
+    ['Now', 'the latest hour’s spread; the expensive side is named. “coupled” = below the threshold.'],
+    ['At rail', 'share of hours the flow sat at or above this border’s own 95th percentile over the last year.'],
+    [<span key="util" className="inline-flex items-center gap-1">Util <Chip kind="ntc" /> <Chip kind="p95" /></span>,
+      'latest |flow| ÷ day-ahead NTC in the flow’s direction, where ENTSO-E publishes one (NTC chip) — offered capacity, can exceed 100%. P95 chip = no NTC published (flow-based Core / Nordics, by market design); “At rail” stands in.'],
+    ['Counter', 'share of split hours where power ran from the expensive zone to the cheap one.'],
+    ['Loop', 'physical flow minus scheduled exchange, where both grains exist — transit and loop together, not a claim about this interconnector.'],
+    ['SCHED', 'row read from ENTSO-E’s scheduled exchanges (bidding-zone resolved) instead of the physical country-level flow.'],
+  ]
+  return (
+    <div className="space-y-2">
+      <dl className="space-y-1.5">
+        {rows.map(([term, def], i) => (
+          <div key={i} className="grid grid-cols-[64px_1fr] gap-x-2">
+            <dt className="text-cyan-glow/90">{term}</dt>
+            <dd className="text-neutral-400 leading-snug">{def}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="pt-1 border-t border-border/40 text-neutral-500">
+        Descriptive statistics — a spread is not a claim this border was the binding
+        constraint. Full definitions: HOW TO READ, bottom of this tab.
+      </div>
+    </div>
+  )
+}
+
 function SpreadChart({ a, b }) {
   const { data, loading } = useFetchWithError(
     `${API}/power/spread?a=${a}&b=${b}&days=14`, { deps: [a, b] },
@@ -35,10 +81,12 @@ function SpreadChart({ a, b }) {
   const rows = (data.data ?? []).map((p) => ({
     x: p.ts_utc, spread: p.spread, flow: p.flow_mw != null ? p.flow_mw / 1000 : null,
   }))
+  // Compact caption; the full API note (utilization semantics etc.) rides on hover.
+  const [labelA, labelB] = (data.label ?? '').split('↔')
   return (
     <div className="px-2 pt-3 pb-1 border-t border-border/40">
-      <div className="px-2 pb-1 font-mono text-[9px] text-neutral-600">
-        {data.label} · spread (€/MWh, line) vs physical flow (GW, bars) · {data.note}
+      <div className="px-2 pb-1 font-mono text-[9px] text-neutral-600" title={data.note}>
+        {data.label} · spread = {labelA} − {labelB} (€/MWh, line) · flow &gt; 0 = {labelA} exports (GW, bars)
       </div>
       <ResponsiveContainer width="100%" height={180}>
         <ComposedChart data={rows} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
@@ -72,11 +120,25 @@ function SpreadChart({ a, b }) {
  * constraint is a network element inside the grid, not the border itself. The
  * backend caption says so and travels with the data.
  */
-export default function BordersPanel() {
+export default function BordersPanel({ focus }) {
   const [open, setOpen] = useState(null)  // "A|B" of the expanded border
   const { data, loading, error } = useFetchWithError(`${API}/power/borders?days=30`, {
     pollMs: POLL_SLOW_MS,
   })
+
+  // Map arc click → this panel: open the border's row. Keys match by
+  // construction — both sides use the canonically sorted zone pair. State is
+  // adjusted during render (React's previous-renders pattern); only the DOM
+  // scroll stays in an effect.
+  const [seenFocus, setSeenFocus] = useState(null)
+  if (focus && focus !== seenFocus) {
+    setSeenFocus(focus)
+    if (focus.a && focus.b) setOpen(`${focus.a}|${focus.b}`)
+  }
+  useEffect(() => {
+    if (!focus?.a || !focus?.b) return
+    document.getElementById('panel-power-borders')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [focus])
 
   if (error) {
     return (
@@ -103,7 +165,9 @@ export default function BordersPanel() {
     <Panel
       id="power-borders"
       title="BORDERS · PRICE CONVERGENCE & CONGESTION"
-      info={data?.note || 'Prices joined to physical flows, per border.'}
+      info={<BordersLegend eps={data?.coupled_eps_eur} />}
+      infoWide
+      expandSignal={focus?.ts}
       collapsible
       headerRight={
         borders.length > 0 && (
@@ -126,7 +190,7 @@ export default function BordersPanel() {
                   <th className="text-right px-2 py-1" title="Mean absolute day-ahead spread over the window">Ø spread</th>
                   <th className="text-right px-2 py-1" title="Latest spread; the expensive side is named">Now</th>
                   <th className="text-right px-2 py-1" title="Share of hours the flow reached this border's own 95th percentile — the honest proxy where no NTC is published (P95 chip)">At rail</th>
-                  <th className="text-right px-2 py-1" title="Latest |flow| ÷ day-ahead NTC in the flow's direction, where ENTSO-E publishes one (A61, NTC chip). Offered auction capacity, not a physical limit — can exceed 100% after intraday/countertrading. P95 chip = no NTC exists for this border (flow-based Core / Nordics), by market design.">Util</th>
+                  <th className="text-right px-2 py-1" title="Latest |flow| ÷ day-ahead NTC where one is published — offered capacity, can exceed 100% (chips: NTC = real denominator, P95 = own history stands in).">Util</th>
                   <th className="text-right px-2 py-1" title="Share of split hours where power ran from the expensive zone to the cheap one">Counter</th>
                   <th className="text-right px-2 py-1" title="Physical flow minus scheduled exchange, where both grains exist. Transit and loop flow together — not a claim about this interconnector.">Loop</th>
                 </tr>

--- a/frontend/src/components/CrossBorderFlowPanel.jsx
+++ b/frontend/src/components/CrossBorderFlowPanel.jsx
@@ -251,8 +251,8 @@ export default function CrossBorderFlowPanel({ zone = 'DE_LU' }) {
               xFormatter={fmtTs}
             />
           ))}
-          <div className="px-4 py-2 font-mono text-[9px] text-neutral-700">
-            hourly mean MW · last {data?.hours}h · {data?.note}
+          <div className="px-4 py-2 font-mono text-[9px] text-neutral-700" title={data?.note}>
+            hourly mean MW · last {data?.hours}h · net &gt; 0 = export
           </div>
         </>
       )}

--- a/frontend/src/components/HowToRead.jsx
+++ b/frontend/src/components/HowToRead.jsx
@@ -10,6 +10,12 @@ const TERMS = [
   ['Spark spread', 'the profit margin of a gas-fired power plant: power price − gas cost. Positive = worth running; negative = uneconomic.'],
   ['Dunkelflaute', 'a “dark lull”: wind + solar cover under 15% of demand AND that is unusually dark for this zone in this month (bottom 2% of its own record) — thermal plants carry the grid, prices tend to firm. A zone with no wind/solar fleet cannot have one; its 0% is its normal, not an event.'],
   ['Day-ahead price', 'tomorrow’s hourly electricity price, set at today’s auction (€/MWh).'],
+  ['Coupled border', 'two neighbouring zones cleared at (nearly) the same day-ahead price — the interconnector had room, so they traded as one market. A low coupled share means they clear apart, and the spread is the story.'],
+  ['At the rail', 'the physical flow sat at or above this border’s own 95th percentile of the last year — near the top of its observed range. A statement about its own history, not about a physical limit.'],
+  ['NTC utilization', 'latest |flow| ÷ the day-ahead NTC in the flow’s direction, where ENTSO-E publishes one. NTC is the capacity OFFERED to the auction, not a physical limit — utilization can exceed 100% after intraday trading and countertrading. The flow-based Core region and the Nordics publish none by market design → those borders show a P95 chip instead (their own 95th percentile stands in).'],
+  ['Counter-price flow', 'power ran from the expensive zone to the cheap one during hours the prices were split. Common under flow-based market coupling, where a border can be loaded to relieve a constraint elsewhere in the grid — noteworthy, not automatically wrong.'],
+  ['Loop flow', 'physical flow minus scheduled exchange, where both records exist — transit and loop flow together, not a claim about any single interconnector.'],
+  ['SCHED vs physical', 'which record a border is read from. SCHED = ENTSO-E’s scheduled commercial exchanges, resolved per bidding zone (the only grain that can see DK1 vs DK2); physical = the metered country-level flow.'],
 ]
 
 export default function HowToRead() {

--- a/frontend/src/components/Panel.jsx
+++ b/frontend/src/components/Panel.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 
 import FreshnessCaption from './FreshnessCaption'
 
-export function InfoPopover({ text }) {
+export function InfoPopover({ text, wide = false }) {
   const [open, setOpen] = useState(false)
   const ref = useRef(null)
 
@@ -25,7 +25,7 @@ export function InfoPopover({ text }) {
         i
       </button>
       {open && (
-        <div className="absolute top-5 left-0 z-50 w-64 max-w-[calc(100vw-2rem)] border border-border bg-surface rounded px-3 py-2.5 font-mono text-[10px] text-neutral-400 leading-relaxed shadow-xl shadow-black/20">
+        <div className={`absolute top-5 left-0 z-50 ${wide ? 'w-96' : 'w-64'} max-w-[calc(100vw-2rem)] max-h-[60vh] overflow-y-auto border border-border bg-surface rounded px-3 py-2.5 font-mono text-[10px] text-neutral-400 leading-relaxed shadow-xl shadow-black/20`}>
           {text}
         </div>
       )}
@@ -33,7 +33,7 @@ export function InfoPopover({ text }) {
   )
 }
 
-export default function Panel({ id, title, info, collapsible = false, defaultCollapsed = false, headerRight, downloadUrl, freshness, children }) {
+export default function Panel({ id, title, info, infoWide = false, collapsible = false, defaultCollapsed = false, expandSignal, headerRight, downloadUrl, freshness, children }) {
   const [collapsed, setCollapsed] = useState(() => {
     if (!collapsible) return false
     try {
@@ -52,6 +52,16 @@ export default function Panel({ id, title, info, collapsible = false, defaultCol
     } catch { /* localStorage unavailable */ }
   }, [collapsed, id, collapsible])
 
+  // External expand signal (e.g. a map click focusing this panel): any NEW
+  // non-null value un-collapses. It only ever expands — never re-collapses.
+  // Adjusted during render (React's "storing information from previous renders"
+  // pattern) instead of an effect, so the panel never paints collapsed first.
+  const [seenSignal, setSeenSignal] = useState(expandSignal)
+  if (expandSignal !== seenSignal) {
+    setSeenSignal(expandSignal)
+    if (expandSignal != null && collapsed) setCollapsed(false)
+  }
+
   return (
     <div id={id ? `panel-${id}` : undefined} className="border border-border bg-surface rounded overflow-hidden shadow-sm">
       <div
@@ -63,7 +73,7 @@ export default function Panel({ id, title, info, collapsible = false, defaultCol
           <span className="font-mono text-[11px] font-semibold text-neutral-300 truncate">
             {title}
           </span>
-          {info && <InfoPopover text={info} />}
+          {info && <InfoPopover text={info} wide={infoWide} />}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {freshness && <FreshnessCaption meta={freshness} />}

--- a/frontend/src/components/PowerMap.jsx
+++ b/frontend/src/components/PowerMap.jsx
@@ -127,6 +127,10 @@ const INITIAL_VIEW = { longitude: 9, latitude: 54, zoom: 3.1, minZoom: 2.5, maxZ
 // 1 px floor so thin borders stay hoverable.
 const FLOW_WIDTH_MAX_MW = 5000
 const ARC_MAX_PX = 8
+// NTC-utilization classing thresholds (%) — single source for the arc colors
+// AND the footer legend, so the two can never drift apart.
+const UTIL_MID = 70
+const UTIL_HIGH = 90
 const arcWidth = (mw) =>
   Math.max(1, ARC_MAX_PX * Math.sqrt(Math.min(Math.abs(mw), FLOW_WIDTH_MAX_MW) / FLOW_WIDTH_MAX_MW))
 const rgbCss = ([r, g, b]) => `rgb(${r},${g},${b})`
@@ -259,8 +263,8 @@ export default function PowerMap({ onBorderSelect }) {
       if (noFlow) rgb = pal.arc.none
       else if (b.capacity_source !== 'ntc') rgb = pal.arc.proxy
       else if (b.util_latest_pct == null) rgb = pal.arc.none
-      else if (b.util_latest_pct < 70) rgb = pal.arc.low
-      else if (b.util_latest_pct < 90) rgb = pal.arc.mid
+      else if (b.util_latest_pct < UTIL_MID) rgb = pal.arc.low
+      else if (b.util_latest_pct < UTIL_HIGH) rgb = pal.arc.mid
       else rgb = pal.arc.high
       out.push({
         ...b,
@@ -367,7 +371,8 @@ export default function PowerMap({ onBorderSelect }) {
   const getTooltip = ({ object }) => {
     if (!object) return null
     if (object.zone_a && object.zone_b) { // a border arc — richer, so {html}
-      const [la, lb] = (object.label || `${object.zone_a}↔${object.zone_b}`).split('↔')
+      const label = object.label || `${object.zone_a}↔${object.zone_b}`
+      const [la, lb] = label.split('↔')
       const mw = object.latest_flow_mw
       const dir = mw == null || mw === 0
         ? 'no current flow reading'
@@ -388,7 +393,7 @@ export default function PowerMap({ onBorderSelect }) {
         ? `coupled ${object.convergence_pct.toFixed(0)}% of hrs` : null
       // Only our own API values are interpolated — no user-controlled strings.
       const html = [
-        `<div style="font-weight:600">${object.label}</div>`,
+        `<div style="font-weight:600">${label}</div>`,
         `<div>${dir}</div>`,
         util && `<div>${util}</div>`,
         now && `<div>${now}</div>`,
@@ -487,15 +492,19 @@ export default function PowerMap({ onBorderSelect }) {
         </div>
       )}
 
-      {/* Flow-arc legend — swatches read straight from pal.arc, so they cannot
-          drift from the layer. Only shown while the arcs themselves are on. */}
+      {/* Flow-arc legend — swatches read straight from pal.arc (they cannot
+          drift from the layer) and thresholds from UTIL_MID/UTIL_HIGH. Only the
+          ■ carries the series color; the label text stays neutral ink (amber-600
+          text at 9px would sit at ~2.9:1 on the light surface). Only shown while
+          the arcs themselves are on. */}
       {showArcs && (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 px-4 py-1.5 border-t border-border font-mono text-[9px] text-neutral-600">
           <span>flows: width ∝ GW (√, caps at 5)</span>
-          <span style={{ color: rgbCss(pal.arc.low) }}>■ &lt;70%</span>
-          <span style={{ color: rgbCss(pal.arc.mid) }}>■ 70–90%</span>
-          <span style={{ color: rgbCss(pal.arc.high) }}>■ ≥90% of NTC</span>
-          <span style={{ color: rgbCss(pal.arc.proxy) }}>■ no NTC (p95)</span>
+          <span><span style={{ color: rgbCss(pal.arc.low) }}>■</span> &lt;{UTIL_MID}%</span>
+          <span><span style={{ color: rgbCss(pal.arc.mid) }}>■</span> {UTIL_MID}–{UTIL_HIGH}%</span>
+          <span><span style={{ color: rgbCss(pal.arc.high) }}>■</span> ≥{UTIL_HIGH}% of NTC</span>
+          <span><span style={{ color: rgbCss(pal.arc.proxy) }}>■</span> no NTC (p95)</span>
+          <span><span style={{ color: rgbCss(pal.arc.none) }}>■</span> no reading</span>
           <span>solid end = importer</span>
           {!atLatest && <span className="text-neutral-500">hidden while scrubbing — arcs show latest only</span>}
         </div>

--- a/frontend/src/components/PowerMap.jsx
+++ b/frontend/src/components/PowerMap.jsx
@@ -70,6 +70,9 @@ const PALETTES = {
     labelOutline: [255, 255, 255, 255],
     highlight: [8, 100, 124, 50],
     tooltip: { background: '#ffffff', border: '1px solid #d6dae0', color: '#1f2430' },
+    // low is cyan-600 [8,145,178], NOT cyan-700 [14,116,144]: validated better —
+    // 3.38:1 contrast on #f4f5f7 passes, and deutan ΔE vs the proxy gray is
+    // 15.6 (cyan-700 only manages 11.4).
     // mid is amber-600 [217,119,6], NOT amber-700: the validator showed
     // amber-700 vs orange-700 at deutan ΔE 0.1 / normal 4.1 on #f4f5f7 —
     // indistinguishable. amber-600 lifts the pair to deutan 11.3 / normal

--- a/frontend/src/components/PowerMap.jsx
+++ b/frontend/src/components/PowerMap.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import DeckGL from '@deck.gl/react'
-import { GeoJsonLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers'
+import { ArcLayer, GeoJsonLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers'
 import { InfoPopover } from './Panel'
 import { useTheme } from '../context/ThemeContext'
 
@@ -48,6 +48,13 @@ const PALETTES = {
     labelOutline: [6, 6, 10, 255],
     highlight: [103, 232, 249, 60],
     tooltip: { background: '#0a0a12', border: '1px solid #2a2a3a', color: '#d4d4d8' },
+    // Flow arcs: an ordinal load ramp (low/mid/high vs NTC) + two deliberate
+    // no-signal grays (proxy = no NTC published, none = no flow reading).
+    // Validator (dataviz skill) vs #06060a: trio contrast all ≥3:1, CVD ΔE 8.2
+    // (≥8 target); amber↔orange normal ΔE 11.2 is adjacent-ordinal-step
+    // territory and is relieved by the worded legend + exact util % in the
+    // tooltip. The grays are MEANT to read gray.
+    arc: { low: [34, 211, 238], mid: [251, 191, 36], high: [251, 146, 60], proxy: [148, 163, 184], none: [100, 116, 139] },
   },
   light: {
     surface: '#f4f5f7',
@@ -63,6 +70,11 @@ const PALETTES = {
     labelOutline: [255, 255, 255, 255],
     highlight: [8, 100, 124, 50],
     tooltip: { background: '#ffffff', border: '1px solid #d6dae0', color: '#1f2430' },
+    // mid is amber-600 [217,119,6], NOT amber-700: the validator showed
+    // amber-700 vs orange-700 at deutan ΔE 0.1 / normal 4.1 on #f4f5f7 —
+    // indistinguishable. amber-600 lifts the pair to deutan 11.3 / normal
+    // 12.7 (CVD target met; adjacent ordinal steps, legend + tooltip relieve).
+    arc: { low: [8, 145, 178], mid: [217, 119, 6], high: [194, 65, 12], proxy: [100, 116, 139], none: [148, 163, 184] },
   },
 }
 
@@ -106,6 +118,16 @@ function percentile(sorted, p) {
 
 const INITIAL_VIEW = { longitude: 9, latitude: 54, zoom: 3.1, minZoom: 2.5, maxZoom: 6 }
 
+// ── Cross-border flow arcs ────────────────────────────────────────────────────
+// Width encodes |latest flow|: √ scale (a 4× flow reads 2× wide — GW differences
+// stay legible without 5-GW borders drowning 300-MW ones), capped at 5 GW / 8 px,
+// 1 px floor so thin borders stay hoverable.
+const FLOW_WIDTH_MAX_MW = 5000
+const ARC_MAX_PX = 8
+const arcWidth = (mw) =>
+  Math.max(1, ARC_MAX_PX * Math.sqrt(Math.min(Math.abs(mw), FLOW_WIDTH_MAX_MW) / FLOW_WIDTH_MAX_MW))
+const rgbCss = ([r, g, b]) => `rgb(${r},${g},${b})`
+
 const METRICS = [
   { key: 'price', label: 'DAY-AHEAD €/MWh' },
   { key: 'state', label: 'GRID STATE' },
@@ -118,7 +140,7 @@ function fmtTs(iso) {
   })
 }
 
-export default function PowerMap() {
+export default function PowerMap({ onBorderSelect }) {
   const { theme } = useTheme()
   const pal = PALETTES[theme] || PALETTES.dark
   const [geo, setGeo] = useState(null)
@@ -127,6 +149,8 @@ export default function PowerMap() {
   const [view, setView] = useState('zones') // 'zones' choropleth | 'points' per-zone dots
   const [snap, setSnap] = useState(null) // hourly day-ahead price matrix (scrubber)
   const [idx, setIdx] = useState(null)   // selected hour index; null = latest/live
+  const [borders, setBorders] = useState(null) // /power/borders rows → flow arcs
+  const [showArcs, setShowArcs] = useState(true)
 
   useEffect(() => {
     fetch('/geo/eu-zones.geojson').then((r) => r.json()).then(setGeo).catch((e) => console.error('PowerMap geo:', e))
@@ -147,9 +171,23 @@ export default function PowerMap() {
       .catch(() => {})
     return () => { alive = false }
   }, [])
+  useEffect(() => {
+    // Deliberately duplicates BordersPanel's GET (server caches the computation);
+    // one request at mount, no polling — the arcs say "latest", not "live".
+    let alive = true
+    fetch(`${API}/power/borders?days=30`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (alive && d?.available) setBorders(d.borders || []) })
+      .catch((e) => console.error('PowerMap borders:', e))
+    return () => { alive = false }
+  }, [])
 
   const ts = snap?.timestamps || []
   const effIdx = idx == null ? ts.length - 1 : idx
+  // Arcs always show the LATEST flow. While the scrubber sits on a past hour the
+  // choropleth shows that hour — latest arcs on top of it would lie, so they hide.
+  // (The scrubber only exists for the price metric; grid state is always live.)
+  const atLatest = metric !== 'price' || ts.length === 0 || effIdx === ts.length - 1
 
   // When scrubbing (price metric + snapshot loaded), override each zone's price with
   // the day-ahead price at the selected hour; otherwise use the live overview.
@@ -197,15 +235,78 @@ export default function PowerMap() {
     return pts
   }, [effRows])
 
-  const zoneFill = (zone) => {
-    const z = byZone.get(zone)
-    if (!z) return pal.contextFill
-    if (metric === 'state') return [...(pal.state[z.state] || pal.mid), 215]
-    return [...priceColor(z.price_close, lo, hi, pal), 235]
-  }
+  // One arc per border, carrying the WHOLE border object (the tooltip reads its
+  // stats). Direction is static: faint end = exporter, solid end = importer.
+  const arcs = useMemo(() => {
+    const out = [];
+    (borders || []).forEach((b, i) => {
+      const ca = ZONE_COORDS[b.zone_a]
+      const cb = ZONE_COORDS[b.zone_b]
+      if (!ca || !cb) {
+        console.warn(`PowerMap arcs: no coordinates for border ${b.zone_a}-${b.zone_b}`)
+        return
+      }
+      const mw = b.latest_flow_mw
+      const noFlow = mw == null || mw === 0
+      // API sign convention: positive = zone_a → zone_b (canonical sorted pair).
+      const flip = !noFlow && mw < 0
+      // Color = how loaded the border is; the grays are states, not magnitudes:
+      // proxy = no NTC published (flow-based Core / Nordics), none = no reading.
+      let rgb
+      if (noFlow) rgb = pal.arc.none
+      else if (b.capacity_source !== 'ntc') rgb = pal.arc.proxy
+      else if (b.util_latest_pct == null) rgb = pal.arc.none
+      else if (b.util_latest_pct < 70) rgb = pal.arc.low
+      else if (b.util_latest_pct < 90) rgb = pal.arc.mid
+      else rgb = pal.arc.high
+      out.push({
+        ...b,
+        source: flip ? cb : ca,
+        target: flip ? ca : cb,
+        width: noFlow ? 1 : arcWidth(mw),
+        // No reading → uniform faint alpha at both ends: a gradient would claim
+        // a direction we do not have. Still pickable/clickable.
+        sourceColor: [...rgb, noFlow ? 90 : 70],
+        targetColor: [...rgb, noFlow ? 90 : 235],
+        // Deterministic ±8° fan so parallel Benelux/Nordic arcs do not stack.
+        tilt: ((i % 3) - 1) * 8,
+      })
+    })
+    return out
+  }, [borders, pal])
 
   const layers = useMemo(() => {
     if (!geo) return []
+    const zoneFill = (zone) => {
+      const z = byZone.get(zone)
+      if (!z) return pal.contextFill
+      if (metric === 'state') return [...(pal.state[z.state] || pal.mid), 215]
+      return [...priceColor(z.price_close, lo, hi, pal), 235]
+    }
+    const arcLayer = showArcs && atLatest && arcs.length > 0
+      ? new ArcLayer({
+        id: 'border-arcs',
+        data: arcs,
+        pickable: true,
+        autoHighlight: true,
+        highlightColor: pal.highlight,
+        getSourcePosition: (d) => d.source,
+        getTargetPosition: (d) => d.target,
+        getSourceColor: (d) => d.sourceColor,
+        getTargetColor: (d) => d.targetColor,
+        getWidth: (d) => d.width,
+        widthUnits: 'pixels',
+        widthMinPixels: 1,
+        widthMaxPixels: ARC_MAX_PX,
+        getHeight: 0.4,
+        getTilt: (d) => d.tilt,
+        onClick: ({ object }) => { if (object) onBorderSelect?.(object.zone_a, object.zone_b) },
+        updateTriggers: {
+          getSourceColor: [arcs], getTargetColor: [arcs], getWidth: [arcs],
+          getTilt: [arcs], getSourcePosition: [arcs], getTargetPosition: [arcs],
+        },
+      })
+      : null
     const zonesLayer = new GeoJsonLayer({
       id: 'eu-zones',
       data: geo,
@@ -226,6 +327,7 @@ export default function PowerMap() {
       }
       return [
         zonesLayer.clone({ pickable: false, autoHighlight: false, getFillColor: pal.contextFill, updateTriggers: { getFillColor: [theme] } }),
+        ...(arcLayer ? [arcLayer] : []),
         new ScatterplotLayer({
           id: 'power-points', data: points, pickable: true,
           getPosition: (d) => d.position, getFillColor: pointFill,
@@ -254,12 +356,44 @@ export default function PowerMap() {
       pickable: false,
       updateTriggers: { getText: [effRows], getPosition: [effRows], getColor: [theme] },
     })
-    return metric === 'price' ? [zonesLayer, labels] : [zonesLayer]
-  }, [geo, view, metric, effRows, byZone, lo, hi, points, theme])
+    const base = metric === 'price' ? [zonesLayer, labels] : [zonesLayer]
+    return arcLayer ? [...base, arcLayer] : base
+  }, [geo, view, metric, effRows, byZone, lo, hi, points, theme, arcs, showArcs, atLatest, onBorderSelect, pal])
 
   const TIP_STYLE = { ...pal.tooltip, fontFamily: 'monospace', fontSize: '11px', padding: '6px 8px' }
   const getTooltip = ({ object }) => {
     if (!object) return null
+    if (object.zone_a && object.zone_b) { // a border arc — richer, so {html}
+      const [la, lb] = (object.label || `${object.zone_a}↔${object.zone_b}`).split('↔')
+      const mw = object.latest_flow_mw
+      const dir = mw == null || mw === 0
+        ? 'no current flow reading'
+        : `${mw > 0 ? la : lb} → ${mw > 0 ? lb : la} · ${(Math.abs(mw) / 1000).toFixed(1)} GW`
+      const util = object.capacity_source === 'ntc'
+        ? (object.util_latest_pct != null
+          ? `util ${object.util_latest_pct.toFixed(0)}% of NTC (offered capacity — can exceed 100%)`
+          : null)
+        : (object.at_rail_pct != null
+          ? `at rail ${object.at_rail_pct.toFixed(0)}% (no NTC published — own p95)`
+          : null)
+      const now = object.latest_spread == null
+        ? null
+        : object.expensive_side == null
+          ? 'now: coupled'
+          : `now: €${Math.abs(object.latest_spread).toFixed(0)} · ${object.expensive_side === object.zone_a ? la : lb} dearer`
+      const coupled = object.convergence_pct != null
+        ? `coupled ${object.convergence_pct.toFixed(0)}% of hrs` : null
+      // Only our own API values are interpolated — no user-controlled strings.
+      const html = [
+        `<div style="font-weight:600">${object.label}</div>`,
+        `<div>${dir}</div>`,
+        util && `<div>${util}</div>`,
+        now && `<div>${now}</div>`,
+        coupled && `<div>${coupled}</div>`,
+        '<div style="opacity:.55">click → border detail</div>',
+      ].filter(Boolean).join('')
+      return { html, style: TIP_STYLE }
+    }
     if (object.position && object.zone) { // a scatter point
       const price = object.price != null ? `${object.price.toFixed(1)} €/MWh` : 'n/a'
       return { text: `${object.label} · ${object.state || ''}\nDay-ahead: ${price}`, style: TIP_STYLE }
@@ -282,7 +416,7 @@ export default function PowerMap() {
       <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-2.5 border-b border-border">
         <div className="flex items-center gap-2 min-w-0">
           <span className="font-mono text-[12px] font-semibold text-neutral-300">Europe · power map</span>
-          <InfoPopover text="Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by the day-ahead price — or by grid state. IMPORTANT: it shades ONE HOUR at a time (the hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the all-zones table shows a positive daily mean. Drag the slider to move through the hours. Fixed colour scale across the shown week: violet = negative prices (a distinct state, not just cheap), brighter cyan = more expensive. Dark shapes = neighbouring countries, no data by design. Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast." />
+          <InfoPopover text="Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by the day-ahead price — or by grid state. IMPORTANT: it shades ONE HOUR at a time (the hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the all-zones table shows a positive daily mean. Drag the slider to move through the hours. Fixed colour scale across the shown week: violet = negative prices (a distinct state, not just cheap), brighter cyan = more expensive. Dark shapes = neighbouring countries, no data by design. FLOWS arcs = the latest cross-border flow per border: the faint end exports, the solid end imports; width ∝ GW, colour = how loaded the border is vs its offered day-ahead capacity (grey = no NTC published or no reading); they always show the latest hour and hide while you scrub the past — click one for the border detail below. Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast." />
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex items-center gap-1">
@@ -313,6 +447,15 @@ export default function PowerMap() {
               </button>
             ))}
           </div>
+          <button
+            onClick={() => setShowArcs(!showArcs)}
+            className={`font-mono text-[9px] px-2 py-0.5 rounded border ${
+              showArcs ? 'text-cyan-glow border-cyan-glow/40 bg-cyan-glow/10' : 'text-neutral-500 border-border hover:text-neutral-300'
+            }`}
+            title="Cross-border flow arcs (latest hour)"
+          >
+            FLOWS
+          </button>
         </div>
       </div>
 
@@ -338,6 +481,20 @@ export default function PowerMap() {
           {effIdx !== ts.length - 1 && (
             <button onClick={() => setIdx(null)} className="font-mono text-[9px] text-neutral-500 hover:text-cyan-glow shrink-0">↺ live</button>
           )}
+        </div>
+      )}
+
+      {/* Flow-arc legend — swatches read straight from pal.arc, so they cannot
+          drift from the layer. Only shown while the arcs themselves are on. */}
+      {showArcs && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 px-4 py-1.5 border-t border-border font-mono text-[9px] text-neutral-600">
+          <span>flows: width ∝ GW (√, caps at 5)</span>
+          <span style={{ color: rgbCss(pal.arc.low) }}>■ &lt;70%</span>
+          <span style={{ color: rgbCss(pal.arc.mid) }}>■ 70–90%</span>
+          <span style={{ color: rgbCss(pal.arc.high) }}>■ ≥90% of NTC</span>
+          <span style={{ color: rgbCss(pal.arc.proxy) }}>■ no NTC (p95)</span>
+          <span>solid end = importer</span>
+          {!atLatest && <span className="text-neutral-500">hidden while scrubbing — arcs show latest only</span>}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Owner feedback: the BordersPanel info popover rendered the raw ~1100-char API note as a wall of text ("wirkt unfertig"), and border info belonged on the map (the Electricity-Maps/gridstatus pattern: short tooltips at the element, long form in a glossary, data on the map).

- **Map arcs (PowerMap):** deck.gl ArcLayer over `/api/power/borders` — one arc per border, width ∝ √flow (caps 5 GW), color = NTC utilization (<70/70–90/≥90%) or proxy-gray where no NTC is published (flow-based Core/Nordics, by market design); direction reads statically via faint-exporter → solid-importer gradient; unclamped >100% honesty preserved. HTML hover tooltip (direction + GW, util or at-rail with caveats, now-spread + dearer side, coupled %). Click → scrolls to BordersPanel and opens that border's spread chart (works when collapsed). FLOWS toggle default on; arcs hide while the scrubber is off the latest hour (they always show latest). 5-state footer legend with swatches read from the palette. Both themes dataviz-validated (light mid = amber-600 after a contrast check; rationale in comments).
- **Structured legend (BordersPanel):** the raw note is no longer rendered anywhere — replaced by an 8-row term/definition legend (HowToRead pattern, rendered NTC/P95 chips, honesty disclaimer footer); InfoPopover gains a `wide` variant + global max-height guard; SpreadChart + CrossBorderFlowPanel captions condensed with the full note on `title=`. HowToRead gains six border terms (the long-form home). The API `note` itself is untouched for API consumers.
- Frontend-only; zero backend changes; no new dependency (ArcLayer ships with the installed @deck.gl/layers).

## Test plan

- [x] `npm run build` clean; eslint on all changed files clean (repo-wide count improved 36 → 25, all remaining pre-existing in untouched files)
- [x] Spec review + quality review passed (direction-semantics chain API→flip→alpha→tooltip verified end-to-end; 55 existing info= callers unaffected)
- [x] Headless visual smoke (playwright + dev server): arcs render in both themes with correct NTC/proxy coloring, structured legend popover, 5-state map legend, FLOWS toggle, LATEST gate
- [ ] After merge: VPS `git pull` + `npm run build` (frontend-only — no restart needed, Caddy serves dist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)