### PR TITLE
Backfill sources for balancing/capacity + daily backup snapshot + heartbeat

### DIFF
--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -374,6 +374,14 @@ def main(argv: list[str]) -> int:
     end = datetime.strptime(args.end, "%Y-%m-%d").date()
     zones = _resolve_zones(args.zones)
     sources = {s.strip() for s in args.sources.split(",") if s.strip()}
+    # Unknown tokens must be a hard error, not a silent no-op: run_backfill simply
+    # skips sources it doesn't recognise, so a typo like "balancin" would otherwise
+    # sleep through the plan, exit 0 and log "complete" while fetching nothing.
+    known = set(ALL_SOURCES) | {"capacity", "units_gen"}  # opt-ins are valid, just not defaults
+    unknown = sources - known
+    if unknown:
+        logger.error("unknown --sources token(s) %s (valid: %s)", sorted(unknown), sorted(known))
+        return 2
     if not zones:
         logger.error("no valid zones resolved from %r (enabled: %s)", args.zones, list(POWER_ZONES))
         return 2

--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -186,9 +186,13 @@ async def run_backfill(
     # drag the price/grid/forecast/imbalance machinery through the throttle for nothing.
     # Pre-availability years (2019–2020 answer empty for many zones) are absorbed by the
     # collector: ENTSO-E's two documented "genuinely nothing here" 400 phrases are cached as
-    # emptiness, ONLY those (a 401/429/5xx raises → retried here, never cached), so each
-    # empty zone-month costs one request, once. See the module docstring for why this — at
-    # 2 requests per zone-month — stays in ALL_SOURCES while capacity/units_gen do not.
+    # emptiness, ONLY those — so each empty zone-month costs one request, once. A 401/429/5xx
+    # is never cached, but note it is also never retried HERE: ingest_balancing swallows
+    # httpx.HTTPError internally (log-and-skip per month, the sibling per-step-isolation
+    # convention), so the _with_retry wrapper below effectively guards the SQLite-lock/
+    # OSError cases only; an HTTP-failed month simply stays uncached and is re-fetched by
+    # the next run. See the module docstring for why this — at 2 requests per zone-month —
+    # stays in ALL_SOURCES while capacity/units_gen do not.
     balancing_months = 0
     if "balancing" in sources:
         balancing_plan = len(zones) * len(windows)

--- a/backend/scripts/power_backfill.py
+++ b/backend/scripts/power_backfill.py
@@ -13,9 +13,20 @@ from cache for free. Meant to run in the ingest process (never the API worker) �
 a mass backfill is a throttled, multi-day marathon against ENTSO-E's rate limit.
 
 Border-level sources (zone-independent, run AFTER the zone loop): "flows" (Energy-Charts
-/cbpf), "scheduled" (A09), "netpos" (A25), "capacity" (A15) and "ntc" (A61 day-ahead NTC —
-NTC-allocated borders only, both directions per pair; the flow-based Core region and the
-Nordics publish none, so a full-history run stays cheap).
+/cbpf), "scheduled" (A09), "netpos" (A25) and "ntc" (A61 day-ahead NTC — NTC-allocated
+borders only, both directions per pair; the flow-based Core region and the Nordics publish
+none, so a full-history run stays cheap).
+
+"balancing" (activated balancing energy, A83/A84) ALSO runs after the zone loop, but it is
+per-zone: ingest_balancing fetches whole control-area MONTHS (one A84 + one A83 request per
+zone-month, raw-cached), so it gets its own zone×month sweep with its own counter instead of
+piggybacking on the per-day sibling sources above. It stays in ALL_SOURCES because that
+volume — 2 requests per zone-month — is the same order as the siblings' 1, unlike the two
+opt-outs below. Pre-availability years (2019–2020 answer empty for many zones) and zones
+without a balancing publication return ENTSO-E's two documented "genuinely nothing here"
+400 phrases, which the collector caches as emptiness (entsoe_balancing.py — ONLY those
+phrases; a 401/429/5xx raises and is never cached), so a deep run pays for each empty
+zone-month exactly once.
 
 "units_gen" (A73 per-unit generation) also runs after the zone loop — it iterates its own
 A73_ZONES config (currently DE_LU = 4 German control areas), not the enabled zones. It is
@@ -25,9 +36,19 @@ fast against the shared ENTSO-E token (the lesson every deep multi-source run he
 re-taught). Recommended --start 2025-01-01; deeper history is possible but each extra year
 is another ~240 requests for a per-plant drill-down whose product value is recent.
 
+"capacity" (procured balancing-capacity prices, A15, DE-LU LFC block only) is likewise
+deliberately NOT in ALL_SOURCES — it is BY FAR the heaviest source per calendar day: 3
+processTypes/day, each offset-paginated in steps of 100 TimeSeries (~69 pages observed for
+a single busy aFRR day → ~200+ requests/day, i.e. thousands of times a sibling source's
+volume), all against the shared ENTSO-E token. Run it EXPLICITLY, LAST and ALONE
+(`--sources capacity --start 2024-01-01`), NEVER bundled with other sources. The German
+daily-tender history barely predates ~2018/2019 and the product value is recent —
+--start 2024-01-01 is the recommended floor; every extra year is ~70k more requests.
+
 FIRST DEPLOY of the balancing/capacity/ntc/units_gen collectors: right after the
-service restart that ships them, run `--sources balancing`, `--sources capacity`,
-`--sources ntc` and `--sources units_gen --start 2025-01-01` once each. Not a launch
+service restart that ships them, run `--sources balancing`, `--sources ntc`,
+`--sources units_gen --start 2025-01-01` and — last and alone, per the warning above —
+`--sources capacity --start 2024-01-01` once each. Not a launch
 blocker if skipped — the 09:00 UTC collector watchdog will email a stale alert
 (balancing_energy/capacity_prices/ntc_dayahead; unit_generation can flag once because
 the 09:40 UTC job has not yet had its first run) until the daily jobs fill the series
@@ -58,7 +79,10 @@ BACKFILL_START = date(2015, 1, 1)  # ENTSO-E Transparency era; override with --s
 # "flows" is zone-independent (one /cbpf sweep covers every border) and runs once
 # per month after the zone loop. Moderate history is the point (--start 2024-01-01
 # per roadmap Block 2.4) — deep flow history adds little over the daily means.
-ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "balancing", "flows", "scheduled", "netpos", "capacity", "ntc")
+# "capacity" and "units_gen" are deliberately NOT here (see module docstring): both are
+# explicit-opt-in sources whose request volume per default run is far beyond the siblings'
+# (~200+ paginated requests per DAY for A15 vs. 1–2 per zone-MONTH for everything below).
+ALL_SOURCES = ("price", "grid", "forecast", "imbalance", "balancing", "flows", "scheduled", "netpos", "ntc")
 # Small pause between zone-months to stay under ENTSO-E's ~400 req/min token limit.
 THROTTLE_SECONDS = 1.0
 
@@ -129,7 +153,7 @@ async def run_backfill(
     done = 0
     # A flows-only run must not walk the zone×month loop — it would do nothing
     # but sleep through the throttle (37 zones × months × 1 s on prod).
-    zone_sources = sources & {"price", "grid", "forecast", "imbalance", "balancing"}
+    zone_sources = sources & {"price", "grid", "forecast", "imbalance"}
     for zone in zones if zone_sources else []:
         cfg = POWER_ZONES[zone]
         eic = cfg["eic"]
@@ -150,12 +174,39 @@ async def run_backfill(
                 await _with_retry(lambda d=days: ingest_load_forecast(db, d, eic=eic, zone=zone, overwrite=overwrite), f"forecast {tag}")
             if "imbalance" in sources:
                 await _with_retry(lambda d=days: ingest_imbalance(db, d, zone=zone, overwrite=overwrite), f"imbalance {tag}")
-            if "balancing" in sources:
-                await _with_retry(lambda d=days: ingest_balancing(db, d, zone=zone, overwrite=overwrite), f"balancing {tag}")
             done += 1
             logger.info("power_backfill: %s done (%d/%d)", tag, done, plan)
             if throttle:
                 await asyncio.sleep(throttle)
+
+    # Activated balancing energy (A83/A84) is per-zone but runs AFTER the main zone loop:
+    # ingest_balancing fetches whole control-area MONTHS (one A84 + one A83 request per
+    # zone-month, raw-cached), so it gets its own zone×month sweep and counter instead of
+    # piggybacking on the per-day sibling sources above — and a balancing-only run does not
+    # drag the price/grid/forecast/imbalance machinery through the throttle for nothing.
+    # Pre-availability years (2019–2020 answer empty for many zones) are absorbed by the
+    # collector: ENTSO-E's two documented "genuinely nothing here" 400 phrases are cached as
+    # emptiness, ONLY those (a 401/429/5xx raises → retried here, never cached), so each
+    # empty zone-month costs one request, once. See the module docstring for why this — at
+    # 2 requests per zone-month — stays in ALL_SOURCES while capacity/units_gen do not.
+    balancing_months = 0
+    if "balancing" in sources:
+        balancing_plan = len(zones) * len(windows)
+        for zone in zones:
+            for m_start, m_end in windows:
+                if dry_run:
+                    balancing_months += 1
+                    continue
+                days = _daterange(m_start, m_end)
+                await _with_retry(
+                    lambda d=days, z=zone: ingest_balancing(db, d, zone=z, overwrite=overwrite),
+                    f"balancing {zone} {m_start:%Y-%m}",
+                )
+                balancing_months += 1
+                logger.info("power_backfill: balancing %s %s done (%d/%d)",
+                            zone, f"{m_start:%Y-%m}", balancing_months, balancing_plan)
+                if throttle:
+                    await asyncio.sleep(throttle)
 
     # Cross-border flows are zone-independent — one month-chunked, raw-cached
     # /cbpf sweep per month covers every enabled border (daily + hourly grain).
@@ -231,12 +282,18 @@ async def run_backfill(
             logger.info("power_backfill: ntc %s done (%d/%d)",
                         f"{m_start:%Y-%m}", ntc_months, len(windows))
 
-    # Balancing-capacity prices (FCR/aFRR/mFRR, A15) are DE_LU-only and zone-independent —
-    # one sweep per month covers the whole German market, like flows/scheduled/netpos above.
-    # NOTE: each day fetches 3 processTypes, each individually offset-paginated (see
-    # backend/power/entsoe_reserves.py) — a deep multi-year --start on this source alone is a
-    # much heavier pull than the other zone-independent sources; pass a narrower --start
-    # (the market's daily-tender history only goes back to ~2018/2019) when backfilling it.
+    # Balancing-capacity prices (FCR/aFRR/mFRR, A15) are DE_LU-only (AREA_DOMAIN in
+    # backend/power/entsoe_reserves.py — the DE-LU LFC block, the one domain that answers)
+    # and zone-independent — one sweep per month covers the whole German market.
+    # ⚠ NOT in ALL_SOURCES, and that must never change casually: each day fetches 3
+    # processTypes, each individually offset-paginated in steps of 100 TimeSeries (~69 pages
+    # observed for one busy aFRR day → ~200+ requests/day against the shared ENTSO-E token —
+    # thousands of times a sibling source's per-day volume). Run it EXPLICITLY, LAST and
+    # ALONE, never bundled with other sources, and with a tight --start (recommended
+    # `--sources capacity --start 2024-01-01`; the daily-tender history barely predates
+    # ~2018/2019 anyway). The month-window calls below are only the retry/log granularity:
+    # the ingest itself fetches DAY by DAY per processType with a per-day raw_cache entry,
+    # so the actual ENTSO-E windows are single days and a crashed month resumes from cache.
     capacity_months = 0
     if "capacity" in sources:
         from backend.power.entsoe_reserves import ingest_capacity_prices
@@ -276,6 +333,7 @@ async def run_backfill(
                         f"{m_start:%Y-%m}", units_gen_months, len(windows))
 
     return {"zone_months": done, "zones": zones, "months": len(windows),
+            "balancing_months": balancing_months,
             "flow_months": flow_months, "scheduled_months": sched_months,
             "netpos_months": netpos_months, "ntc_months": ntc_months,
             "capacity_months": capacity_months,
@@ -300,7 +358,9 @@ def main(argv: list[str]) -> int:
     p.add_argument("--start", default=BACKFILL_START.isoformat())
     p.add_argument("--end", default=date.today().isoformat())
     p.add_argument("--zones", default=None, help="comma list of zone keys (default: all enabled)")
-    p.add_argument("--sources", default=",".join(ALL_SOURCES), help="comma list: price,grid,forecast")
+    p.add_argument("--sources", default=",".join(ALL_SOURCES),
+                   help="comma list (default: every standard source; 'capacity' and "
+                        "'units_gen' are explicit opt-ins — see module docstring)")
     p.add_argument("--overwrite", action="store_true", help="re-fetch cached months")
     p.add_argument("--dry-run", action="store_true", help="print the plan without fetching")
     p.add_argument("--throttle", type=float, default=THROTTLE_SECONDS, help="seconds between zone-months")

--- a/backend/tests/test_capacity_prices.py
+++ b/backend/tests/test_capacity_prices.py
@@ -566,10 +566,16 @@ def test_panel_max_age_mirrors_freshness_spec():
 # ─── backfill registration ──────────────────────────────────────────────────────
 
 
-def test_backfill_source_registered():
+def test_backfill_source_is_explicit_opt_in_only():
+    """"capacity" must stay OUT of ALL_SOURCES (like units_gen): 3 processTypes per day,
+    each offset-paginated in 100-TimeSeries steps (~69 pages observed for one busy aFRR
+    day → ~200+ requests/day against the shared ENTSO-E token). Bundling it into an
+    unfiltered run would multiply the default backfill's request volume by orders of
+    magnitude. Explicit opt-in only: `--sources capacity --start 2024-01-01`, run last
+    and alone — see power_backfill's module docstring."""
     from backend.scripts import power_backfill as pb
 
-    assert "capacity" in pb.ALL_SOURCES
+    assert "capacity" not in pb.ALL_SOURCES
 
 
 async def test_backfill_capacity_runs_once_per_month_not_per_zone(monkeypatch):

--- a/backend/tests/test_power_backfill.py
+++ b/backend/tests/test_power_backfill.py
@@ -113,3 +113,94 @@ async def test_flows_dry_run_counts_without_fetching(monkeypatch):
         overwrite=False, dry_run=True, throttle=0,
     )
     assert res["flow_months"] == 3
+
+
+# ─── source registry: what a default (unfiltered) run may and may not pull ─────
+
+
+def test_all_sources_membership():
+    """"balancing" IS a default source: 2 requests per zone-month (one A84 + one A83,
+    with empty months cached by the collector) — the same order as the 1 request per
+    zone-month of price/grid/forecast/imbalance. "capacity" (A15, ~200+ paginated
+    requests per DAY) and "units_gen" (A73, per-CTA drill-down) are explicit opt-ins
+    and must never ride along in an unfiltered run — see the module docstring."""
+    assert "balancing" in pb.ALL_SOURCES
+    assert "capacity" not in pb.ALL_SOURCES
+    assert "units_gen" not in pb.ALL_SOURCES
+
+
+def test_sources_cli_default_round_trips():
+    """main() joins ALL_SOURCES into the --sources default and splits it back on commas —
+    every token must survive that round trip (no commas/blanks inside a token)."""
+    tokens = {s.strip() for s in ",".join(pb.ALL_SOURCES).split(",") if s.strip()}
+    assert tokens == set(pb.ALL_SOURCES)
+
+
+# ─── balancing: per-zone, but its own post-zone-loop sweep ──────────────────────
+
+
+async def test_balancing_dispatches_per_zone_month_outside_zone_loop(monkeypatch):
+    """balancing runs AFTER the main zone loop with its own counter: a balancing-only
+    run must not walk the price/grid/forecast/imbalance machinery, and each call gets
+    the month's day list plus the zone (ingest_balancing groups the days into
+    control-area month fetches itself)."""
+    calls = []
+
+    async def _balancing(db, days, **kwargs):
+        calls.append((days[0], days[-1], kwargs))
+
+    async def _boom(*a, **k):
+        raise AssertionError("zone-loop source called during a balancing-only run")
+
+    monkeypatch.setattr(pb, "ingest_balancing", _balancing)
+    monkeypatch.setattr(pb, "ingest_day_ahead", _boom)
+    monkeypatch.setattr(pb, "ingest_grid", _boom)
+
+    res = await pb.run_backfill(
+        db=None, start=date(2026, 1, 1), end=date(2026, 2, 28),
+        zones=["DE_LU", "FR"], sources={"balancing"},
+        overwrite=True, dry_run=False, throttle=0,
+    )
+    assert res["balancing_months"] == 4  # 2 zones × 2 months
+    assert res["zone_months"] == 0       # the main zone loop must not have run
+    assert [(c[0], c[1]) for c in calls] == [
+        ("2026-01-01", "2026-01-31"), ("2026-02-01", "2026-02-28"),
+        ("2026-01-01", "2026-01-31"), ("2026-02-01", "2026-02-28"),
+    ]
+    assert [c[2]["zone"] for c in calls] == ["DE_LU", "DE_LU", "FR", "FR"]
+    assert all(c[2]["overwrite"] is True for c in calls)
+
+
+async def test_balancing_dry_run_counts_zone_months_without_fetching(monkeypatch):
+    async def _boom(*a, **k):
+        raise AssertionError("ingest called during dry run")
+
+    monkeypatch.setattr(pb, "ingest_balancing", _boom)
+    res = await pb.run_backfill(
+        db=None, start=date(2026, 1, 1), end=date(2026, 3, 31),
+        zones=["DE_LU", "FR"], sources={"balancing"},
+        overwrite=False, dry_run=True, throttle=0,
+    )
+    assert res["balancing_months"] == 6  # 2 zones × 3 months
+
+
+# ─── capacity: opt-in only, dry-run still plans it ──────────────────────────────
+
+
+async def test_capacity_dry_run_counts_months_without_fetching(monkeypatch):
+    """The dedicated block still dispatches when asked for explicitly — and a dry run
+    plans its months without touching the network. Patched on the SOURCE module because
+    run_backfill imports ingest_capacity_prices locally (see test_capacity_prices.py's
+    dispatch test for the same reason)."""
+    from backend.power import entsoe_reserves as cap
+
+    async def _boom(*a, **k):
+        raise AssertionError("ingest called during dry run")
+
+    monkeypatch.setattr(cap, "ingest_capacity_prices", _boom)
+    res = await pb.run_backfill(
+        db=None, start=date(2026, 1, 1), end=date(2026, 3, 31),
+        zones=["DE_LU"], sources={"capacity"},
+        overwrite=False, dry_run=True, throttle=0,
+    )
+    assert res["capacity_months"] == 3

--- a/backend/tests/test_power_backfill.py
+++ b/backend/tests/test_power_backfill.py
@@ -136,6 +136,29 @@ def test_sources_cli_default_round_trips():
     assert tokens == set(pb.ALL_SOURCES)
 
 
+def test_main_rejects_unknown_source_tokens(monkeypatch):
+    """A typo like "balancin" must exit 2 BEFORE touching the DB — run_backfill skips
+    unrecognised sources, so without the guard a typo'd run sleeps through the plan,
+    exits 0 and logs "complete" while fetching nothing."""
+    def _boom():
+        raise AssertionError("DB opened despite an invalid --sources token")
+
+    monkeypatch.setattr(pb, "SessionLocal", _boom)
+    assert pb.main(["power_backfill", "--sources", "balancin", "--dry-run"]) == 2
+    assert pb.main(["power_backfill", "--sources", "price,balancin", "--dry-run"]) == 2
+
+
+def test_main_accepts_opt_in_source_tokens(monkeypatch):
+    """"capacity" and "units_gen" are valid tokens (explicit opt-ins), just not defaults —
+    the unknown-token guard must not reject them."""
+    class _Session:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(pb, "SessionLocal", lambda: _Session())
+    assert pb.main(["power_backfill", "--sources", "capacity,units_gen", "--dry-run"]) == 0
+
+
 # ─── balancing: per-zone, but its own post-zone-loop sweep ──────────────────────
 
 

--- a/deploy/OPS.md
+++ b/deploy/OPS.md
@@ -1,0 +1,110 @@
+# OBSYD ops runbook — backups, heartbeat, deep-history backfill
+
+Companion to the scripts in this directory. Everything here runs on the VPS as the
+`obsyd` user with the repo at `/home/obsyd/obsyd` (override paths via the env vars
+documented in each script's header).
+
+## 1. Cron lines (obsyd user's crontab)
+
+```cron
+# Daily consistent DB snapshot + .env copy + rotation (04:10 UTC — after the
+# nightly 23:45/23:50 recompute jobs, before the 09:00 UTC watchdog):
+10 4 * * * /home/obsyd/obsyd/deploy/backup-obsyd.sh >> /home/obsyd/obsyd/logs/backup-obsyd.log 2>&1
+
+# Liveness dead-man ping every 10 minutes (probes https://obsyd.dev/api/v1/meta,
+# pings healthchecks ONLY on HTTP 2xx — so one check catches VPS death AND service death):
+*/10 * * * * /home/obsyd/obsyd/deploy/heartbeat.sh
+```
+
+Both lines are safe to install BEFORE the healthchecks.io account exists: an unset
+ping URL means "no ping, exit 0" (heartbeat) / "back up anyway, skip the ping"
+(backup). Do NOT also cron the old `deploy/backup-db.sh` — `backup-obsyd.sh`
+supersedes it (sqlite3.backup() API instead of the sqlite3 CLI, plus rotation).
+
+## 2. Owner TODO — healthchecks.io
+
+1. Create a free https://healthchecks.io account and TWO checks:
+   * **obsyd-backup** — period 1 day, grace ~2 h (the 04:10 UTC cron).
+   * **obsyd-live** — period 10 min, grace ~15 min (the heartbeat cron).
+2. Put both ping URLs into the prod `.env` (`/home/obsyd/obsyd/.env`):
+
+   ```
+   HEALTHCHECKS_BACKUP_URL=https://hc-ping.com/<uuid-of-obsyd-backup>
+   HEALTHCHECKS_LIVE_URL=https://hc-ping.com/<uuid-of-obsyd-live>
+   ```
+
+   The scripts read them from the environment first, then from that `.env` —
+   no service restart needed (cron re-reads the file every run).
+3. Offsite: the snapshots in `/home/obsyd/backups/` are LOCAL. Pull the newest
+   one to a workstation regularly (the first line of the restore recipe below
+   doubles as the offsite copy) — a dead disk takes the backups with it otherwise.
+
+## 3. Restore recipe
+
+```sh
+# workstation: fetch + sanity-check a snapshot (also your offsite copy)
+scp <admin>@<vps>:/home/obsyd/backups/obsyd-YYYYMMDD.db.gz .
+gunzip -k obsyd-YYYYMMDD.db.gz     # keep the .gz; inspect the .db locally if in doubt
+
+# VPS: stop, swap, start
+sudo systemctl stop obsyd
+sudo -u obsyd gunzip -kc /home/obsyd/backups/obsyd-YYYYMMDD.db.gz \
+    > /home/obsyd/obsyd/obsyd.db.restored
+sudo -u obsyd mv /home/obsyd/obsyd/obsyd.db.restored /home/obsyd/obsyd/obsyd.db
+sudo -u obsyd rm -f /home/obsyd/obsyd/obsyd.db-wal /home/obsyd/obsyd/obsyd.db-shm
+sudo systemctl start obsyd
+# verify: https://obsyd.dev/api/v1/status
+```
+
+The matching `env-YYYYMMDD` file in the backup dir is the day's `.env` (chmod 600)
+— restore it alongside if the secrets were lost too.
+
+## 4. Uniform-2019 deep-history backfill (one-time, per series family)
+
+Goal: pull every lagging series back to a uniform 2019-01-01 line. ENTSO-E history
+is immutable — fetch once (raw-cached), keep forever. `price`/`grid`/`forecast`
+already carry deep history from earlier runs; the laggards are the sources below.
+
+Run SEQUENTIALLY (one source at a time — they all share the one ENTSO-E token and
+the one SQLite writer), as the `obsyd` user, from `/home/obsyd/obsyd`. Sanity-check
+the plan first with `--dry-run`. Every write is an upsert and every payload is
+disk-cached, so a crashed run resumes from cache for free.
+
+```sh
+cd /home/obsyd/obsyd
+nohup bash -c 'for s in flows scheduled netpos ntc units_gen imbalance balancing; do
+  .venv/bin/python -m backend.scripts.power_backfill --sources "$s" --start 2019-01-01 || exit 1
+done' >> logs/backfill-2019.log 2>&1 &
+tail -f logs/backfill-2019.log
+```
+
+Then — LAST and ALONE, only after the loop above has finished — capacity prices
+(A15 paginates extremely heavily, ~200+ requests per calendar DAY; never bundle it,
+and keep its tighter start):
+
+```sh
+nohup .venv/bin/python -m backend.scripts.power_backfill --sources capacity --start 2024-01-01 \
+    >> logs/backfill-capacity.log 2>&1 &
+```
+
+Notes:
+
+* Order rationale: cheap zone-independent sweeps first (`flows`, `scheduled`,
+  `netpos`, `ntc`), then the bounded per-CTA drill-down (`units_gen`, ~240
+  requests/extra year — acceptable sequentially for the uniform 2019 line, which
+  is why this runbook overrides the module docstring's 2025 floor), then the
+  per-zone month sweeps (`imbalance`, `balancing`). `balancing` absorbs
+  pre-availability years cheaply: the collector caches ENTSO-E's documented
+  "genuinely nothing here" 400 phrases as emptiness, so each empty zone-month
+  costs one request, once.
+* `--sources capacity --start 2024-01-01` is a hard recommendation, not a
+  default: it is deliberately NOT in `ALL_SOURCES` (see
+  `backend/scripts/power_backfill.py`'s module docstring), and every extra year
+  is ~70k more requests.
+* No recompute step needed afterwards: the all-time records (23:45 UTC) and
+  grid-stress episodes (23:50 UTC) jobs are full nightly recomputes over the
+  canonical series — the new history folds into records/episodes on its own
+  within a day.
+* The backfill can collide with the live scheduler on SQLite's single writer;
+  `_with_retry` in the backfill absorbs transient "database is locked" errors,
+  so just let it run.

--- a/deploy/OPS.md
+++ b/deploy/OPS.md
@@ -12,8 +12,10 @@ documented in each script's header).
 10 4 * * * /home/obsyd/obsyd/deploy/backup-obsyd.sh >> /home/obsyd/obsyd/logs/backup-obsyd.log 2>&1
 
 # Liveness dead-man ping every 10 minutes (probes https://obsyd.dev/api/v1/meta,
-# pings healthchecks ONLY on HTTP 2xx — so one check catches VPS death AND service death):
-*/10 * * * * /home/obsyd/obsyd/deploy/heartbeat.sh
+# pings healthchecks ONLY on HTTP 2xx — so one check catches VPS death AND service
+# death). Success is silent, so the log only grows on failures — and without the
+# redirect those diagnostics would die in cron's mail on this MTA-less VPS:
+*/10 * * * * /home/obsyd/obsyd/deploy/heartbeat.sh >> /home/obsyd/obsyd/logs/heartbeat.log 2>&1
 ```
 
 Both lines are safe to install BEFORE the healthchecks.io account exists: an unset
@@ -46,10 +48,12 @@ supersedes it (sqlite3.backup() API instead of the sqlite3 CLI, plus rotation).
 scp <admin>@<vps>:/home/obsyd/backups/obsyd-YYYYMMDD.db.gz .
 gunzip -k obsyd-YYYYMMDD.db.gz     # keep the .gz; inspect the .db locally if in doubt
 
-# VPS: stop, swap, start
+# VPS: stop, swap, start. NOTE the sh -c: a bare `sudo -u obsyd gunzip … > file`
+# runs the REDIRECT in the invoking shell (EACCES as the admin user; a
+# root-owned obsyd.db as root — the service then breaks on its first write
+# after an apparently successful restore).
 sudo systemctl stop obsyd
-sudo -u obsyd gunzip -kc /home/obsyd/backups/obsyd-YYYYMMDD.db.gz \
-    > /home/obsyd/obsyd/obsyd.db.restored
+sudo -u obsyd sh -c 'gunzip -kc /home/obsyd/backups/obsyd-YYYYMMDD.db.gz > /home/obsyd/obsyd/obsyd.db.restored'
 sudo -u obsyd mv /home/obsyd/obsyd/obsyd.db.restored /home/obsyd/obsyd/obsyd.db
 sudo -u obsyd rm -f /home/obsyd/obsyd/obsyd.db-wal /home/obsyd/obsyd/obsyd.db-shm
 sudo systemctl start obsyd
@@ -90,13 +94,18 @@ nohup .venv/bin/python -m backend.scripts.power_backfill --sources capacity --st
 Notes:
 
 * Order rationale: cheap zone-independent sweeps first (`flows`, `scheduled`,
-  `netpos`, `ntc`), then the bounded per-CTA drill-down (`units_gen`, ~240
-  requests/extra year — acceptable sequentially for the uniform 2019 line, which
-  is why this runbook overrides the module docstring's 2025 floor), then the
+  `netpos`, `ntc`), then the bounded per-CTA drill-down (`units_gen`), then the
   per-zone month sweeps (`imbalance`, `balancing`). `balancing` absorbs
   pre-availability years cheaply: the collector caches ENTSO-E's documented
   "genuinely nothing here" 400 phrases as emptiness, so each empty zone-month
   costs one request, once.
+* This runbook DELIBERATELY overrides the in-code start guidance for two
+  sources, both for the sake of the uniform 2019 line: `flows` (the in-code
+  comment recommends `--start 2024-01-01` per roadmap Block 2.4 — but one
+  cached /cbpf sweep per extra month is cheap, ~60 extra requests for the five
+  extra years) and `units_gen` (module-docstring floor is 2025; ~240 requests
+  per extra year — acceptable run sequentially). `capacity`'s 2024 floor is NOT
+  overridden — see below.
 * `--sources capacity --start 2024-01-01` is a hard recommendation, not a
   default: it is deliberately NOT in `ALL_SOURCES` (see
   `backend/scripts/power_backfill.py`'s module docstring), and every extra year

--- a/deploy/backup-obsyd.sh
+++ b/deploy/backup-obsyd.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# OBSYD daily DB snapshot + secrets copy, with a healthchecks.io dead-man ping.
+#
+# Install (obsyd user's crontab; 04:10 UTC — after the nightly jobs, before the
+# 09:00 UTC watchdog):
+#
+#   10 4 * * * /home/obsyd/obsyd/deploy/backup-obsyd.sh >> /home/obsyd/obsyd/logs/backup-obsyd.log 2>&1
+#
+# What it does, in order — ANY failure exits non-zero WITHOUT pinging, because the
+# missed ping IS the alarm (healthchecks.io fires when the daily ping goes missing):
+#   1. Online-consistent snapshot of obsyd.db via the venv Python's sqlite3.backup()
+#      API (safe mid-write, no `sqlite3` CLI required — unlike deploy/backup-db.sh,
+#      which this script supersedes for the power-only desk; do NOT cron both, they
+#      would double the disk footprint) + PRAGMA quick_check on the copy.
+#   2. gzip + gzip -t verification.
+#   3. Copy .env alongside as env-YYYYMMDD (chmod 600) — the API tokens are as
+#      unrecoverable as the data in a disaster.
+#   4. Rotation: keep the last 7 dailies (+ their env copies) and the last 4
+#      Sunday snapshots; delete older. Only files matching THIS script's naming
+#      (obsyd-YYYYMMDD.db.gz / sunday-obsyd-YYYYMMDD.db.gz / env-YYYYMMDD) are
+#      touched — backup-db.sh leftovers (obsyd-YYYY-MM-DD.db.gz) are left alone.
+#   5. Only after ALL of the above: ping HEALTHCHECKS_BACKUP_URL (from the
+#      environment, else read from the prod .env). Unset URL = no ping, still
+#      exit 0 — the cron is safe to install before the healthchecks account exists.
+#
+# RESTORE (offsite copy → workstation → VPS; see deploy/OPS.md for the full runbook):
+#   scp <admin>@<vps>:/home/obsyd/backups/obsyd-YYYYMMDD.db.gz .   # pick a date
+#   gunzip obsyd-YYYYMMDD.db.gz                                    # sanity-check locally
+#   # on the VPS:
+#   sudo systemctl stop obsyd
+#   sudo -u obsyd gunzip -kc /home/obsyd/backups/obsyd-YYYYMMDD.db.gz \
+#       > /home/obsyd/obsyd/obsyd.db.restored
+#   sudo -u obsyd mv /home/obsyd/obsyd/obsyd.db.restored /home/obsyd/obsyd/obsyd.db
+#   sudo -u obsyd rm -f /home/obsyd/obsyd/obsyd.db-wal /home/obsyd/obsyd/obsyd.db-shm
+#   sudo systemctl start obsyd
+#   # then check https://obsyd.dev/api/v1/status
+#
+# Paths/retention are overridable via environment (defaults below). No secrets are
+# ever echoed — the ping URL and the .env contents stay out of stdout/stderr.
+
+set -euo pipefail
+umask 077  # backups carry the .env — nothing this script writes may be group/world-readable
+
+APP_DIR="${OBSYD_APP_DIR:-/home/obsyd/obsyd}"
+DB_PATH="${OBSYD_DB_PATH:-$APP_DIR/obsyd.db}"
+ENV_FILE="${OBSYD_ENV_FILE:-$APP_DIR/.env}"
+BACKUP_DIR="${OBSYD_BACKUP_DIR:-/home/obsyd/backups}"
+VENV_PY="${OBSYD_VENV_PY:-$APP_DIR/.venv/bin/python}"
+KEEP_DAILY="${OBSYD_BACKUP_KEEP_DAILY:-7}"
+KEEP_SUNDAY="${OBSYD_BACKUP_KEEP_SUNDAY:-4}"
+
+STAMP=$(date -u +%Y%m%d)
+DOW=$(date -u +%u)  # 7 = Sunday
+OUT="$BACKUP_DIR/obsyd-$STAMP.db"
+
+fail() {
+    echo "[backup-obsyd] FAIL: $1" >&2
+    # never leave today's partial artifacts behind (an uncompressed .db once
+    # filled the disk and took the site down — see backup-db.sh's war story)
+    rm -f "$OUT" "$OUT-journal" "$OUT-wal" "$OUT-shm" "$OUT.gz" \
+        "$BACKUP_DIR/sunday-obsyd-$STAMP.db.gz" "$BACKUP_DIR/env-$STAMP"
+    exit 1
+}
+trap 'fail "unexpected error on line $LINENO"' ERR
+
+[ -f "$DB_PATH" ] || fail "database not found: $DB_PATH"
+[ -x "$VENV_PY" ] || fail "venv python not found: $VENV_PY"
+mkdir -p "$BACKUP_DIR"
+
+# ── 1. online-consistent snapshot + integrity check (sqlite3.backup API) ──────
+rm -f "$OUT" "$OUT.gz"
+"$VENV_PY" - "$DB_PATH" "$OUT" <<'PY' || fail "sqlite3.backup() snapshot failed"
+import sqlite3, sys
+
+src = sqlite3.connect(sys.argv[1])
+dst = sqlite3.connect(sys.argv[2])
+try:
+    with dst:
+        src.backup(dst)  # page-consistent even while the app is writing
+    verdict = dst.execute("PRAGMA quick_check(1)").fetchone()[0]
+    if verdict != "ok":
+        raise SystemExit(f"quick_check on the snapshot failed: {verdict}")
+finally:
+    dst.close()
+    src.close()
+PY
+rm -f "$OUT-journal" "$OUT-wal" "$OUT-shm"  # sidecars materialised by the check
+[ -s "$OUT" ] || fail "snapshot is empty"
+
+# ── 2. compress + verify ──────────────────────────────────────────────────────
+gzip -f "$OUT" || fail "gzip failed"
+gzip -t "$OUT.gz" || fail "gzip verification failed"
+
+# ── 3. Sunday copy (kept on a longer leash by the rotation below) ─────────────
+if [ "$DOW" = "7" ]; then
+    cp "$OUT.gz" "$BACKUP_DIR/sunday-obsyd-$STAMP.db.gz" || fail "sunday copy failed"
+fi
+
+# ── 4. secrets copy — set OBSYD_ENV_FILE="" to opt out explicitly ─────────────
+if [ -n "$ENV_FILE" ]; then
+    [ -f "$ENV_FILE" ] || fail ".env not found: $ENV_FILE (set OBSYD_ENV_FILE=\"\" to skip)"
+    install -m 600 "$ENV_FILE" "$BACKUP_DIR/env-$STAMP" || fail "env copy failed"
+fi
+
+# ── 5. rotation (count-based on the datestamped names, newest kept) ───────────
+prune() {  # $1 = anchored filename regex, $2 = how many newest to keep
+    ls -1 "$BACKUP_DIR" | { grep -E "$1" || true; } | sort -r | tail -n +"$(($2 + 1))" \
+        | while IFS= read -r f; do
+            echo "[backup-obsyd] pruning $f"
+            rm -f -- "$BACKUP_DIR/$f"
+        done
+}
+prune '^obsyd-[0-9]{8}\.db\.gz$' "$KEEP_DAILY"
+prune '^sunday-obsyd-[0-9]{8}\.db\.gz$' "$KEEP_SUNDAY"
+prune '^env-[0-9]{8}$' "$KEEP_DAILY"
+
+echo "[backup-obsyd] OK: $(basename "$OUT").gz ($(du -h "$OUT.gz" | cut -f1)), $(ls -1 "$BACKUP_DIR" | wc -l | tr -d ' ') files retained"
+
+# ── 6. dead-man ping — ONLY on full success, never on failure ─────────────────
+# The backup is complete and verified from here on: a ping failure must still exit
+# non-zero (so the cron log shows it), but must NOT delete the good snapshot.
+trap - ERR
+if [ -z "${HEALTHCHECKS_BACKUP_URL:-}" ] && [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+    HEALTHCHECKS_BACKUP_URL=$(grep -E '^HEALTHCHECKS_BACKUP_URL=' "$ENV_FILE" | tail -n 1 \
+        | cut -d= -f2- | sed -e 's/^["'\'']//' -e 's/["'\'']$//' || true)
+fi
+if [ -n "${HEALTHCHECKS_BACKUP_URL:-}" ]; then
+    if ! curl -fsS -m 10 --retry 3 -o /dev/null "$HEALTHCHECKS_BACKUP_URL"; then
+        echo "[backup-obsyd] FAIL: healthchecks ping failed (snapshot itself is on disk and intact)" >&2
+        exit 1
+    fi
+    echo "[backup-obsyd] healthchecks pinged"
+fi

--- a/deploy/backup-obsyd.sh
+++ b/deploy/backup-obsyd.sh
@@ -12,7 +12,11 @@
 #      API (safe mid-write, no `sqlite3` CLI required — unlike deploy/backup-db.sh,
 #      which this script supersedes for the power-only desk; do NOT cron both, they
 #      would double the disk footprint) + PRAGMA quick_check on the copy.
-#   2. gzip + gzip -t verification.
+#   2. gzip + gzip -t verification — all on a scratch `.part` name, then one atomic
+#      mv into the real obsyd-YYYYMMDD.db.gz. Today's published snapshot is never
+#      pre-cleaned and never deleted by a later failure: a failed same-day re-run
+#      only ever touches its own .part scratch, so it cannot clobber the morning's
+#      good artifact, and a verified snapshot survives any later cosmetic failure.
 #   3. Copy .env alongside as env-YYYYMMDD (chmod 600) — the API tokens are as
 #      unrecoverable as the data in a disaster.
 #   4. Rotation: keep the last 7 dailies (+ their env copies) and the last 4
@@ -25,11 +29,12 @@
 #
 # RESTORE (offsite copy → workstation → VPS; see deploy/OPS.md for the full runbook):
 #   scp <admin>@<vps>:/home/obsyd/backups/obsyd-YYYYMMDD.db.gz .   # pick a date
-#   gunzip obsyd-YYYYMMDD.db.gz                                    # sanity-check locally
-#   # on the VPS:
+#   gunzip -k obsyd-YYYYMMDD.db.gz                                 # sanity-check locally
+#   # on the VPS — NOTE the sh -c: a bare `sudo -u obsyd gunzip … > file` runs the
+#   # REDIRECT in the invoking shell (EACCES as the admin user; a root-owned
+#   # obsyd.db as root, breaking the service on its first write):
 #   sudo systemctl stop obsyd
-#   sudo -u obsyd gunzip -kc /home/obsyd/backups/obsyd-YYYYMMDD.db.gz \
-#       > /home/obsyd/obsyd/obsyd.db.restored
+#   sudo -u obsyd sh -c 'gunzip -kc /home/obsyd/backups/obsyd-YYYYMMDD.db.gz > /home/obsyd/obsyd/obsyd.db.restored'
 #   sudo -u obsyd mv /home/obsyd/obsyd/obsyd.db.restored /home/obsyd/obsyd/obsyd.db
 #   sudo -u obsyd rm -f /home/obsyd/obsyd/obsyd.db-wal /home/obsyd/obsyd/obsyd.db-shm
 #   sudo systemctl start obsyd
@@ -51,7 +56,8 @@ KEEP_SUNDAY="${OBSYD_BACKUP_KEEP_SUNDAY:-4}"
 
 STAMP=$(date -u +%Y%m%d)
 DOW=$(date -u +%u)  # 7 = Sunday
-OUT="$BACKUP_DIR/obsyd-$STAMP.db"
+OUT="$BACKUP_DIR/obsyd-$STAMP.db"  # published artifact is $OUT.gz — written ONLY by the atomic mv below
+PART="$OUT.part"                   # this run's scratch names ($PART, $PART.gz) — all it may pre-clean
 
 # Every file THIS run creates is appended here right before it is created, and
 # fail() removes ONLY these. A fixed cleanup list keyed on today's datestamp
@@ -75,9 +81,12 @@ trap 'fail "unexpected error on line $LINENO"' ERR
 mkdir -p "$BACKUP_DIR"
 
 # ── 1. online-consistent snapshot + integrity check (sqlite3.backup API) ──────
-rm -f "$OUT" "$OUT.gz"  # a re-run REPLACES today's snapshot — deliberate, past the guards above
-CREATED+=("$OUT" "$OUT-journal" "$OUT-wal" "$OUT-shm")
-"$VENV_PY" - "$DB_PATH" "$OUT" <<'PY' || fail "sqlite3.backup() snapshot failed"
+# Scratch-only pre-clean: stale .part leftovers from any crashed run (kill -9
+# never reaches the ERR trap) are unpublished by definition and safe to drop —
+# today's REAL $OUT.gz is deliberately not touched here.
+rm -f "$BACKUP_DIR"/obsyd-*.db.part "$BACKUP_DIR"/obsyd-*.db.part.gz
+CREATED+=("$PART" "$PART-journal" "$PART-wal" "$PART-shm")
+"$VENV_PY" - "$DB_PATH" "$PART" <<'PY' || fail "sqlite3.backup() snapshot failed"
 import sqlite3, sys
 
 src = sqlite3.connect(sys.argv[1])
@@ -92,13 +101,17 @@ finally:
     dst.close()
     src.close()
 PY
-rm -f "$OUT-journal" "$OUT-wal" "$OUT-shm"  # sidecars materialised by the check
-[ -s "$OUT" ] || fail "snapshot is empty"
+rm -f "$PART-journal" "$PART-wal" "$PART-shm"  # sidecars materialised by the check
+[ -s "$PART" ] || fail "snapshot is empty"
 
-# ── 2. compress + verify ──────────────────────────────────────────────────────
-CREATED+=("$OUT.gz")
-gzip -f "$OUT" || fail "gzip failed"
-gzip -t "$OUT.gz" || fail "gzip verification failed"
+# ── 2. compress + verify on the scratch name, then publish ATOMICALLY ─────────
+CREATED+=("$PART.gz")
+gzip -f "$PART" || fail "gzip failed"          # $PART → $PART.gz
+gzip -t "$PART.gz" || fail "gzip verification failed"
+# Verified good — publish with one same-filesystem rename. $OUT.gz is NOT added
+# to CREATED: from here on the daily snapshot is immune to any later failure
+# (fail() removes only this run's scratch + its own Sunday/env copies).
+mv -f "$PART.gz" "$OUT.gz" || fail "atomic publish (mv) failed"
 
 # ── 3. Sunday copy (kept on a longer leash by the rotation below) ─────────────
 if [ "$DOW" = "7" ]; then

--- a/deploy/backup-obsyd.sh
+++ b/deploy/backup-obsyd.sh
@@ -53,12 +53,19 @@ STAMP=$(date -u +%Y%m%d)
 DOW=$(date -u +%u)  # 7 = Sunday
 OUT="$BACKUP_DIR/obsyd-$STAMP.db"
 
+# Every file THIS run creates is appended here right before it is created, and
+# fail() removes ONLY these. A fixed cleanup list keyed on today's datestamp
+# would let a failed MANUAL re-run later the same day delete the morning's GOOD
+# snapshot/env/Sunday copy — files that run never touched.
+CREATED=()
+
 fail() {
     echo "[backup-obsyd] FAIL: $1" >&2
-    # never leave today's partial artifacts behind (an uncompressed .db once
+    # never leave THIS run's partial artifacts behind (an uncompressed .db once
     # filled the disk and took the site down — see backup-db.sh's war story)
-    rm -f "$OUT" "$OUT-journal" "$OUT-wal" "$OUT-shm" "$OUT.gz" \
-        "$BACKUP_DIR/sunday-obsyd-$STAMP.db.gz" "$BACKUP_DIR/env-$STAMP"
+    if [ "${#CREATED[@]}" -gt 0 ]; then
+        rm -f -- "${CREATED[@]}"
+    fi
     exit 1
 }
 trap 'fail "unexpected error on line $LINENO"' ERR
@@ -68,7 +75,8 @@ trap 'fail "unexpected error on line $LINENO"' ERR
 mkdir -p "$BACKUP_DIR"
 
 # ── 1. online-consistent snapshot + integrity check (sqlite3.backup API) ──────
-rm -f "$OUT" "$OUT.gz"
+rm -f "$OUT" "$OUT.gz"  # a re-run REPLACES today's snapshot — deliberate, past the guards above
+CREATED+=("$OUT" "$OUT-journal" "$OUT-wal" "$OUT-shm")
 "$VENV_PY" - "$DB_PATH" "$OUT" <<'PY' || fail "sqlite3.backup() snapshot failed"
 import sqlite3, sys
 
@@ -88,17 +96,20 @@ rm -f "$OUT-journal" "$OUT-wal" "$OUT-shm"  # sidecars materialised by the check
 [ -s "$OUT" ] || fail "snapshot is empty"
 
 # ── 2. compress + verify ──────────────────────────────────────────────────────
+CREATED+=("$OUT.gz")
 gzip -f "$OUT" || fail "gzip failed"
 gzip -t "$OUT.gz" || fail "gzip verification failed"
 
 # ── 3. Sunday copy (kept on a longer leash by the rotation below) ─────────────
 if [ "$DOW" = "7" ]; then
+    CREATED+=("$BACKUP_DIR/sunday-obsyd-$STAMP.db.gz")
     cp "$OUT.gz" "$BACKUP_DIR/sunday-obsyd-$STAMP.db.gz" || fail "sunday copy failed"
 fi
 
 # ── 4. secrets copy — set OBSYD_ENV_FILE="" to opt out explicitly ─────────────
 if [ -n "$ENV_FILE" ]; then
     [ -f "$ENV_FILE" ] || fail ".env not found: $ENV_FILE (set OBSYD_ENV_FILE=\"\" to skip)"
+    CREATED+=("$BACKUP_DIR/env-$STAMP")
     install -m 600 "$ENV_FILE" "$BACKUP_DIR/env-$STAMP" || fail "env copy failed"
 fi
 

--- a/deploy/heartbeat.sh
+++ b/deploy/heartbeat.sh
@@ -11,8 +11,9 @@
 #   * VPS death / cron death / network partition → this script never runs → no
 #     ping → healthchecks fires after its grace period.
 #   * Service death with the VPS alive (uvicorn crashed, Caddy/TLS/DNS broken,
-#     Docker ate the bridge again) → the probe fails (`curl -f`) → the script
-#     exits non-zero WITHOUT pinging → healthchecks fires just the same.
+#     Docker ate the bridge again) → the probe's status code is not 2xx (or the
+#     request itself fails) → the script exits non-zero WITHOUT pinging →
+#     healthchecks fires just the same.
 # A design that pinged unconditionally would only ever catch the first mode.
 #
 # The probe goes through https://obsyd.dev (public URL, not localhost:8000) on
@@ -37,8 +38,18 @@ if [ -z "${HEALTHCHECKS_LIVE_URL:-}" ] && [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE"
 fi
 [ -n "${HEALTHCHECKS_LIVE_URL:-}" ] || exit 0  # no check configured yet — do nothing
 
-# Probe first: any non-2xx / timeout / TLS error makes curl -f fail, set -e ends
-# the script here with a non-zero exit, and the ping below never happens.
-curl -fsS -m 10 -o /dev/null "$PROBE_URL"
+# Probe first, gating STRICTLY on 2xx. Deliberately no `curl -f` here: -f only
+# fails at >=400, so a 3xx (misconfigured Caddy redirect, parked domain) would
+# count as "alive". Instead capture the status code (no redirect following) and
+# accept 2xx only; a timeout/TLS/connect failure yields curl's "000", which the
+# same check rejects. The ping below never happens unless this passes.
+status=$(curl -sS -m 10 -o /dev/null -w '%{http_code}' "$PROBE_URL" || true)
+case "$status" in
+    2??) ;;  # genuinely alive — fall through to the healthchecks ping
+    *)
+        echo "[heartbeat] probe failed: HTTP $status from $PROBE_URL" >&2
+        exit 1
+        ;;
+esac
 
 curl -fsS -m 10 --retry 3 -o /dev/null "$HEALTHCHECKS_LIVE_URL"

--- a/deploy/heartbeat.sh
+++ b/deploy/heartbeat.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # OBSYD liveness heartbeat — a dead-man ping to healthchecks.io every 10 minutes.
 #
-# Install (obsyd user's crontab):
+# Install (obsyd user's crontab — the redirect matters: success is silent, but
+# failure diagnostics would otherwise die in cron's mail on this MTA-less VPS):
 #
-#   */10 * * * * /home/obsyd/obsyd/deploy/heartbeat.sh
+#   */10 * * * * /home/obsyd/obsyd/deploy/heartbeat.sh >> /home/obsyd/obsyd/logs/heartbeat.log 2>&1
 #
 # Design: probe the PUBLIC site first, and ping healthchecks ONLY when the probe
 # returns HTTP 2xx. That ping-only-on-200 rule is what makes one check catch BOTH

--- a/deploy/heartbeat.sh
+++ b/deploy/heartbeat.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# OBSYD liveness heartbeat — a dead-man ping to healthchecks.io every 10 minutes.
+#
+# Install (obsyd user's crontab):
+#
+#   */10 * * * * /home/obsyd/obsyd/deploy/heartbeat.sh
+#
+# Design: probe the PUBLIC site first, and ping healthchecks ONLY when the probe
+# returns HTTP 2xx. That ping-only-on-200 rule is what makes one check catch BOTH
+# failure modes:
+#   * VPS death / cron death / network partition → this script never runs → no
+#     ping → healthchecks fires after its grace period.
+#   * Service death with the VPS alive (uvicorn crashed, Caddy/TLS/DNS broken,
+#     Docker ate the bridge again) → the probe fails (`curl -f`) → the script
+#     exits non-zero WITHOUT pinging → healthchecks fires just the same.
+# A design that pinged unconditionally would only ever catch the first mode.
+#
+# The probe goes through https://obsyd.dev (public URL, not localhost:8000) on
+# purpose: it exercises DNS + certificate + Caddy + uvicorn — the whole path a
+# real visitor takes. /api/v1/meta is the cheapest real endpoint: it reads only
+# the tiny series-catalog dimension table (no power_hourly scan, no
+# heavy_query_guard), and 144 hits/day is noise against its 120 req/min limit.
+#
+# HEALTHCHECKS_LIVE_URL comes from the environment, else from the prod .env.
+# If it is set nowhere, the script silently exits 0 — the cron line is safe to
+# install BEFORE the healthchecks.io account/check exists. No secrets are echoed.
+
+set -euo pipefail
+
+APP_DIR="${OBSYD_APP_DIR:-/home/obsyd/obsyd}"
+ENV_FILE="${OBSYD_ENV_FILE:-$APP_DIR/.env}"
+PROBE_URL="${OBSYD_HEARTBEAT_PROBE_URL:-https://obsyd.dev/api/v1/meta}"
+
+if [ -z "${HEALTHCHECKS_LIVE_URL:-}" ] && [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+    HEALTHCHECKS_LIVE_URL=$(grep -E '^HEALTHCHECKS_LIVE_URL=' "$ENV_FILE" | tail -n 1 \
+        | cut -d= -f2- | sed -e 's/^["'\'']//' -e 's/["'\'']$//' || true)
+fi
+[ -n "${HEALTHCHECKS_LIVE_URL:-}" ] || exit 0  # no check configured yet — do nothing
+
+# Probe first: any non-2xx / timeout / TLS error makes curl -f fail, set -e ends
+# the script here with a non-zero exit, and the ping below never happens.
+curl -fsS -m 10 -o /dev/null "$PROBE_URL"
+
+curl -fsS -m 10 --retry 3 -o /dev/null "$HEALTHCHECKS_LIVE_URL"

--- a/deploy/install-caddy-integration.sh
+++ b/deploy/install-caddy-integration.sh
@@ -25,7 +25,8 @@
 # First deploy of the balancing/capacity collectors (activated balancing energy +
 # procured balancing-capacity prices): right after step [4/7]'s `systemctl restart
 # obsyd`, manually run `python -m backend.scripts.power_backfill --sources balancing`
-# and `python -m backend.scripts.power_backfill --sources capacity` once. Skipping
+# and — last and alone, A15 paginates extremely heavily — `python -m
+# backend.scripts.power_backfill --sources capacity --start 2024-01-01` once. Skipping
 # this is not a launch blocker — the 09:00 UTC collector watchdog will email a
 # capacity_prices/balancing_energy stale alert until the 11:30 UTC daily job fills the
 # series in on its own (self-heals within 24h) — but running the backfill closes the


### PR DESCRIPTION
## Summary

Prep for academic outreach: pull the young series back to a uniform 2019-01-01 history line (ENTSO-E history is immutable — fetch once, keep forever) and close the two smallest reliability gaps.

- **power_backfill gains `balancing` (A84/A83)** — in ALL_SOURCES (2 requests/zone-month, sibling-scale) — **and `capacity` (A15)** — opt-in only, loud warnings (extremely heavy pagination; recommend `--start 2024-01-01`, run last and alone). Unknown `--sources` tokens now fail with exit 2 instead of silently no-opping.
- **`deploy/backup-obsyd.sh`**: daily consistent SQLite snapshot (venv-python `sqlite3.backup()`, `PRAGMA quick_check`, gzip -t, atomic `.part` → publish), .env copy (0600), 7-daily/4-Sunday rotation, healthchecks ping only on full success.
- **`deploy/heartbeat.sh`**: */10 liveness probe of `/api/v1/meta` (verified cheap), pings healthchecks only on explicit 2xx; safe to install before the healthchecks account exists (silent no-op without URL).
- **`deploy/OPS.md`**: cron lines, owner TODO (healthchecks URLs), sudo-safe restore recipe, and the 2019 backfill runbook (flows → scheduled → netpos → ntc → units_gen → imbalance → balancing, then capacity 2024 alone).

## Test plan

- [x] Suite **1230 passed, 1 skipped** (+7); ruff + bash -n clean
- [x] Both scripts sandbox-executed by two independent reviewers: hostile-.env injection test, rotation live-test, atomic-publish failure paths (published snapshot survives byte-identical), heartbeat 200/302/500/000/unset matrix
- [ ] After merge: deploy, install crons, run the 2019 backfill chain overnight (sequential, throttled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)