### PR TITLE
Record the Zenodo DOI in CITATION.cff and README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,9 +11,10 @@ authors:
 repository-code: "https://github.com/jo20ow/Obsyd"
 url: "https://obsyd.dev"
 license: AGPL-3.0
-version: 1.0.0
-date-released: 2026-07-29
-# doi: 10.5281/zenodo.XXXXXXX  # Zenodo DOI — added after the first archived release
+version: 1.0.1
+date-released: 2026-07-30
+# Concept DOI (resolves to the latest archived version; version DOIs listed on Zenodo).
+doi: 10.5281/zenodo.21699869
 keywords:
   - electricity
   - energy

--- a/README.md
+++ b/README.md
@@ -145,16 +145,17 @@ The React frontend renders the bidding-zone map with deck.gl (real zone geometry
 
 ## Citing OBSYD
 
-If OBSYD's data or code feeds into published work, cite the archived Zenodo release once it is available — the DOI will be added to [CITATION.cff](CITATION.cff) after the first archived release. Until then:
+If OBSYD's data or code feeds into published work, cite the archived Zenodo release ([DOI 10.5281/zenodo.21699869](https://doi.org/10.5281/zenodo.21699869) — the concept DOI, resolving to the latest archived version; GitHub's "Cite this repository" button uses [CITATION.cff](CITATION.cff)):
 
 ```bibtex
 @software{weisser_obsyd_2026,
   author  = {Weisser, Johannes},
   title   = {OBSYD --- European Power Desk},
   year    = {2026},
+  doi     = {10.5281/zenodo.21699869},
   url     = {https://obsyd.dev},
-  version = {1.0.0},
-  note    = {Source: https://github.com/jo20ow/Obsyd. DOI via Zenodo forthcoming.}
+  version = {1.0.1},
+  note    = {Source code: https://github.com/jo20ow/Obsyd}
 }
 ```
 


### PR DESCRIPTION
Concept DOI 10.5281/zenodo.21699869 (latest archived version), minted from the v1.0.1 GitHub release via the Zenodo webhook. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)