### PR TITLE
Name B25 (Energy Storage) — BE's mix drew a raw code slice

### DIFF
--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -296,8 +296,9 @@ class ProductionUnit(Base):
     psr_type stores the RAW B-CODE, deliberately. This table exists to join PowerOutage.unit_eic,
     and PowerOutage.psr_type is a raw code (labelled at read time), while InstalledCapacity and
     PowerGenMix store the readable LABEL. Choosing the label here would mean joining a labelled
-    table to a coded one — and PSR_LABELS has real gaps (A71/A33 returns B03; the store already
-    holds gen.B25), so PSR_LABELS.get(code, code) is not injective in the way a join needs.
+    table to a coded one — and PSR_LABELS grows gaps whenever ENTSO-E extends the codelist (B03
+    was missing until 2026-07, B25 until 2026-08), so PSR_LABELS.get(code, code) is not
+    injective in the way a join needs.
     """
 
     __tablename__ = "production_unit"

--- a/backend/power/entsoe_grid.py
+++ b/backend/power/entsoe_grid.py
@@ -73,7 +73,8 @@ PSR_LABELS: dict[str, str] = {
     "B02": "Lignite",
     # B03/B07/B08/B13 were missing, so the mix legend read "gen.B03" — the raw code, between
     # "Fossil Gas" and "Hard Coal". B03 is coal-derived gas and DE-LU burns it. Every generation
-    # code in the ENTSO-E list (B01-B20) belongs here; B21-B24 are network elements, not fuels.
+    # code in the ENTSO-E list (B01-B20, plus the later-added B25) belongs here; B21-B24 are
+    # network elements, not fuels.
     "B03": "Fossil Coal-derived gas",
     "B04": "Fossil Gas",
     "B05": "Hard Coal",
@@ -92,6 +93,9 @@ PSR_LABELS: dict[str, str] = {
     "B18": "Wind Offshore",
     "B19": "Wind Onshore",
     "B20": "Other",
+    # B25 = "Energy storage" in the ENTSO-E codelist: battery discharge. BE reports ~100 MW
+    # under it; without the label the BE mix drew a raw "B25" slice.
+    "B25": "Energy Storage",
 }
 
 _RESOLUTION_HOURS = {"PT60M": 1.0, "PT30M": 0.5, "PT15M": 0.25}

--- a/backend/power/entsoe_units.py
+++ b/backend/power/entsoe_units.py
@@ -91,7 +91,7 @@ def parse_production_units(xml_text: str) -> list[dict]:
             "unit_eic": eic,
             "name": next((e.text for e in ts.iter()
                           if _localname(e.tag) == "registeredResource.name"), None),
-            # RAW code. B03 is real and is NOT in PSR_LABELS — label at read time, never here.
+            # RAW code, deliberately — label at read time, never here (ProductionUnit docstring).
             "psr_type": next((e.text for e in ts.iter()
                               if _localname(e.tag) == "psrType"), None),
             "nominal_mw": _float(nominal),

--- a/backend/tests/test_power_psr_labels.py
+++ b/backend/tests/test_power_psr_labels.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 from backend.power.entsoe_grid import PSR_LABELS
 
 # The generation types in the ENTSO-E codelist (A75/A68/A71 report these). B21-B24 are network
-# elements (AC/DC link, substation, transformer) — never generation, never in a mix.
-GENERATION_CODES = [f"B{i:02d}" for i in range(1, 21)]
+# elements (AC/DC link, substation, transformer) — never generation, never in a mix. B25 (Energy
+# storage, added to the codelist later) IS generation: BE reports its batteries under it.
+GENERATION_CODES = [f"B{i:02d}" for i in range(1, 21)] + ["B25"]
 
 
 def test_every_generation_psr_code_has_a_label():
@@ -20,6 +21,27 @@ def test_every_generation_psr_code_has_a_label():
 
 def test_the_coal_derived_gas_that_leaked_is_named():
     assert PSR_LABELS["B03"] == "Fossil Coal-derived gas"
+
+
+def test_the_battery_storage_that_leaked_is_named():
+    """BE's mix showed a raw "B25" slice (~100 MW of batteries) next to named fuels."""
+    assert PSR_LABELS["B25"] == "Energy Storage"
+
+
+def test_the_migration_renames_stored_b25_rows(db_session, monkeypatch):
+    import backend.migrations as migrations
+    from backend.models.energy import PowerGenMix
+
+    db_session.add(PowerGenMix(date="2026-07-31", zone="BE", psr_type="B25", gen_mw=102.8))
+    db_session.commit()
+
+    monkeypatch.setattr(migrations, "engine", db_session.get_bind())
+    applied: list[str] = []
+    migrations._relabel_raw_psr_codes(applied)
+    db_session.expire_all()
+
+    types = {r.psr_type for r in db_session.query(PowerGenMix).all()}
+    assert types == {"Energy Storage"}
 
 
 def test_the_migration_renames_rows_stored_under_the_raw_code(db_session, monkeypatch):

--- a/backend/tests/test_production_units.py
+++ b/backend/tests/test_production_units.py
@@ -105,16 +105,15 @@ def test_units_carry_the_eic_the_outage_table_has_been_writing_all_along():
 def test_an_unknown_psr_code_survives_instead_of_raising():
     """A KeyError on an unrecognised code would take out the whole registry for a zone.
 
-    This used to use B03 as its example of an unknown code — which was true, and was exactly the
-    bug: B03 is Fossil Coal-derived gas, DE-LU burns it, and the mix legend read "gen.B03" at the
-    user. It is named now. The graceful degradation this test guards is unchanged: B25 is not a
-    generation type at all, yet it sits in the store as gen.B25."""
+    Real codes make bad examples of "unknown": B03 was this test's example until DE-LU's mix
+    leaked it, B25 until BE's batteries leaked it — both are named now. B99 does not exist in
+    any ENTSO-E codelist, so the graceful-degradation guard cannot rot into a label again."""
     from backend.power.entsoe_grid import PSR_LABELS
 
-    assert "B25" not in PSR_LABELS
-    units = parse_production_units(_unit_xml(("X1", "Mystery Plant", "B25", 200.0)))
-    assert units[0]["psr_type"] == "B25"
-    assert PSR_LABELS.get("B25", "B25") == "B25", "labelled at read time, degrading gracefully"
+    assert "B99" not in PSR_LABELS
+    units = parse_production_units(_unit_xml(("X1", "Mystery Plant", "B99", 200.0)))
+    assert units[0]["psr_type"] == "B99"
+    assert PSR_LABELS.get("B99", "B99") == "B99", "labelled at read time, degrading gracefully"
 
 
 def test_the_psr_type_is_the_RAW_code_not_the_label():

--- a/frontend/src/utils/fuels.js
+++ b/frontend/src/utils/fuels.js
@@ -37,6 +37,7 @@ export const STACK_ORDER = [
   'Hydro Reservoir',
   'Hydro Run-of-river',
   'Hydro Pumped Storage',
+  'Energy Storage',
   'Other Renewable',
   'Wind Offshore',
   'Wind Onshore',
@@ -59,7 +60,11 @@ const CANONICAL = {
   'Marine': '#2dd4bf',
   'Hydro Reservoir': '#2563eb',
   'Hydro Run-of-river': '#60a5fa',
+  // Battery discharge (B25) joins pumped storage in the indigo family — same hue,
+  // big lightness step; both new adjacencies clear the palette's CVD worst-pair on
+  // lightness alone (L* 74 vs 50 indigo, vs 58 green).
   'Hydro Pumped Storage': '#6366f1',
+  'Energy Storage': '#a5b4fc',
   'Other Renewable': '#16a34a',
   'Wind Offshore': '#0891b2',
   'Wind Onshore': '#67e8f9',
@@ -90,6 +95,7 @@ const ALIASES = {
   B18: 'Wind Offshore',
   B19: 'Wind Onshore',
   B20: 'Other',
+  B25: 'Energy Storage',
   'Fossil Brown coal/Lignite': 'Lignite',
   'Fossil Hard coal': 'Hard Coal',
   'Fossil Oil': 'Oil',


### PR DESCRIPTION
## Was
BE meldet ~100 MW Batterie-Entladung unter psrType **B25** (der nach B01–B20 ergänzte ENTSO-E-Code „Energy storage"). B25 fehlte in `PSR_LABELS`, daher speicherte der Ingest den Rohcode und die BE-Mix-Legende zeigte „B25" zwischen benannten Fuels. Gefunden beim Live-Daten-Audit (Energy-Charts zeigt dieselben MW als „Battery" — Daten korrekt, nur das Label fehlte).

## Wie
- `PSR_LABELS` bekommt `B25 → "Energy Storage"`. Die bestehende idempotente `_relabel_raw_psr_codes`-Migration benennt die gespeicherten `power_gen_mix`-/`installed_capacity`-Zeilen beim nächsten Deploy automatisch um (gleicher Mechanismus wie der B03/B07/B08/B13-Pass vom 2026-07-14). `series_catalog`/Read-Time-Lookups (`gen.B25` → „Generation · Energy Storage") ziehen automatisch nach.
- `fuels.js`: Alias `B25`, kanonische Farbe `#a5b4fc` (Indigo-Familie neben Hydro Pumped Storage, großer Helligkeitsschritt gemäß Paletten-Regeln; beide neuen Nachbarpaare liegen allein über Lightness über dem bisherigen CVD-Worst-Pair), Stack-Position bei den dispatchbaren Speichern.
- `test_production_units` benutzte B25 als „unbekannter Code"-Beispiel und assertete, dass es unbenannt bleibt — umgestellt auf B99 (existiert in keiner Codelist, kann nicht wie B03 und B25 zum Label rotten).
- Veraltete Docstring-Verweise auf „B25 ist keine Generation" bzw. „B03 fehlt in PSR_LABELS" nachgezogen.

## Tests
- Neu: `test_the_battery_storage_that_leaked_is_named`, `test_the_migration_renames_stored_b25_rows`; `GENERATION_CODES` deckt B25 mit ab (TDD, rot gesehen).
- Suite: **1245 passed, 1 skipped**; Frontend-Build grün.

## Deploy-Hinweis
Backend-Änderung → `git pull` + `npm run build` + `systemctl restart obsyd` (der Restart fährt die Relabel-Migration über die bestehenden B25-Zeilen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)