### PR TITLE
Bulk price-setting-tech endpoint for the power map

### DIFF
--- a/backend/power/marginal.py
+++ b/backend/power/marginal.py
@@ -51,6 +51,7 @@ the number is there to let them do.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
@@ -58,6 +59,8 @@ from sqlalchemy.orm import Session
 from backend.models.energy import SeriesDim
 from backend.power.hourly_store import read_hourly
 from backend.power.zones import POWER_ZONES
+
+logger = logging.getLogger(__name__)
 
 PRICE_SERIES = "price.dayahead"
 
@@ -339,19 +342,30 @@ def compute_marginal(
 
 
 def compute_marginal_overview(
-    db: Session, hours: int = 72, *, now: datetime | None = None
+    db: Session, hours: int = 168, *, now: datetime | None = None
 ) -> dict:
     """Latest price-setting attribution for EVERY enabled zone — one map read.
 
     Compute-on-read like compute_marginal, which it calls per zone and reduces
     to each zone's newest attributed hour (`hourly[-1]`). A zone with no
     attributable hour in the window goes into `missing` — shown as no-data,
-    never painted with an invented value.
+    never painted with an invented value — and a zone whose compute RAISES
+    goes into `errors`, kept apart from `missing` so a failure can never pass
+    itself off as an honest data gap. The 168 h default is compute_marginal's
+    own, and deliberately wider than the 3-day stale threshold: a shorter
+    window would age a zone into `missing` before `stale` could ever fire,
+    making painted-but-stale unrepresentable.
     """
     zones: list[dict] = []
     missing: list[str] = []
+    errors: list[str] = []
     for zone in POWER_ZONES:
-        result = compute_marginal(db, zone, hours=hours, now=now)
+        try:
+            result = compute_marginal(db, zone, hours=hours, now=now)
+        except Exception:
+            logger.exception("marginal overview: compute failed for zone %s", zone)
+            errors.append(zone)
+            continue
         hourly = result.get("hourly") if result.get("available") else None
         if not hourly:
             missing.append(zone)
@@ -373,6 +387,7 @@ def compute_marginal_overview(
         "hours": hours,
         "zones": zones,
         "missing": missing,
+        "errors": errors,
         "method": METHOD,
         "note": NOTE,
     }

--- a/backend/power/marginal.py
+++ b/backend/power/marginal.py
@@ -128,6 +128,31 @@ TECH_LABELS = {
     "hydro_flex": "Flexible hydro (opportunity cost)",
 }
 
+#: The honesty strings, shared verbatim by compute_marginal and
+#: compute_marginal_overview — module constants so the two responses can never
+#: drift apart.
+METHOD = (
+    "Technology-level estimate from a FIXED conventional merit order "
+    "(must-run renewables → nuclear → lignite → hard coal → gas → oil): "
+    "per hour, the most expensive band that meaningfully dispatches "
+    f"(≥{MIN_SHARE_PCT}% of generation and ≥{MIN_MW:.0f} MW) is taken to "
+    "have set the price. The order is assumed, not computed — no fuel, CO2 "
+    "or per-plant efficiency data exists here "
+    "(docs/findings/2026-06-24-eua-coal-data-source.md)."
+)
+NOTE = (
+    "A descriptive attribution heuristic, not a model of the SDAC auction "
+    "and not a forecast. A fixed order cannot see coal↔gas fuel switching; "
+    "pumped storage and reservoir hydro bid opportunity cost and can set "
+    "the price at any level (hours where flexible hydro meaningfully "
+    "dispatches and out-runs every qualifying thermal band are attributed "
+    "'hydro_flex', with that caveat); imports can set the price with no "
+    "domestic technology "
+    "marginal at all. 'tension' hours sit outside the technology's coarse "
+    "expected price band and are reported, never reclassified — "
+    "consistent_pct is the canary that the static order is off."
+)
+
 
 def _consistency(tech: str, price: float) -> str:
     """"ok" when the price sits in the attributed technology's coarse band.
@@ -308,25 +333,46 @@ def compute_marginal(
             "attributed_hours": n,
         },
         "as_of": hourly[-1]["ts_utc"],
-        "method": (
-            "Technology-level estimate from a FIXED conventional merit order "
-            "(must-run renewables → nuclear → lignite → hard coal → gas → oil): "
-            "per hour, the most expensive band that meaningfully dispatches "
-            f"(≥{MIN_SHARE_PCT}% of generation and ≥{MIN_MW:.0f} MW) is taken to "
-            "have set the price. The order is assumed, not computed — no fuel, CO2 "
-            "or per-plant efficiency data exists here "
-            "(docs/findings/2026-06-24-eua-coal-data-source.md)."
-        ),
-        "note": (
-            "A descriptive attribution heuristic, not a model of the SDAC auction "
-            "and not a forecast. A fixed order cannot see coal↔gas fuel switching; "
-            "pumped storage and reservoir hydro bid opportunity cost and can set "
-            "the price at any level (hours where flexible hydro meaningfully "
-            "dispatches and out-runs every qualifying thermal band are attributed "
-            "'hydro_flex', with that caveat); imports can set the price with no "
-            "domestic technology "
-            "marginal at all. 'tension' hours sit outside the technology's coarse "
-            "expected price band and are reported, never reclassified — "
-            "consistent_pct is the canary that the static order is off."
-        ),
+        "method": METHOD,
+        "note": NOTE,
+    }
+
+
+def compute_marginal_overview(
+    db: Session, hours: int = 72, *, now: datetime | None = None
+) -> dict:
+    """Latest price-setting attribution for EVERY enabled zone — one map read.
+
+    Compute-on-read like compute_marginal, which it calls per zone and reduces
+    to each zone's newest attributed hour (`hourly[-1]`). A zone with no
+    attributable hour in the window goes into `missing` — shown as no-data,
+    never painted with an invented value.
+    """
+    zones: list[dict] = []
+    missing: list[str] = []
+    for zone in POWER_ZONES:
+        result = compute_marginal(db, zone, hours=hours, now=now)
+        hourly = result.get("hourly") if result.get("available") else None
+        if not hourly:
+            missing.append(zone)
+            continue
+        latest = hourly[-1]
+        zones.append({
+            "zone": zone,
+            "zone_label": POWER_ZONES[zone]["label"],
+            "tech": latest["tech"],
+            "tech_label": latest["tech_label"],
+            "share_pct": latest["share_pct"],
+            "mw": latest["mw"],
+            "consistency": latest["consistency"],
+            "price": latest["price"],
+            "ts_utc": latest["ts_utc"],
+        })
+    return {
+        "available": bool(zones),
+        "hours": hours,
+        "zones": zones,
+        "missing": missing,
+        "method": METHOD,
+        "note": NOTE,
     }

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -35,7 +35,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from backend.api_guard import heavy_query_guard
+from backend.api_guard import cached_value, heavy_query_guard
 from backend.config import settings
 from backend.database import get_db
 from backend.models.energy import (
@@ -1703,6 +1703,44 @@ def get_marginal(
         **data,
         **_freshness(as_of[:10] if as_of else None, datetime.utcnow().date(),
                      PANEL_MAX_AGE_DAYS["marginal"]),
+    }
+
+
+# No shadowing risk from /marginal above: it takes no path parameter, so
+# Starlette full-path matching keeps both routes reachable in either order.
+@router.get("/marginal/overview")
+def get_marginal_overview(
+    db: Session = Depends(get_db),
+    _guard: None = Depends(heavy_query_guard),
+):
+    """Latest price-setting technology for EVERY enabled zone — the map fill.
+
+    One compute walks all zones (~1-3 s cold across 37 zones in prod), so the
+    payload is cached for 30 minutes and the cold compute sits behind
+    heavy_query_guard. Freshness is derived per REQUEST, outside the cache —
+    a warm cache must not freeze age_days — and the cached dict is never
+    mutated: the response is rebuilt around it.
+    """
+    from backend.power.marginal import compute_marginal_overview
+
+    data = cached_value(
+        "marginal_overview", lambda: compute_marginal_overview(db), ttl=1800.0
+    )
+    if not data.get("available"):
+        # No freshness triple on an unavailable body, matching /marginal.
+        # Copied, so no caller can ever mutate the cached dict.
+        return {**data}
+    today = datetime.utcnow().date()
+    zones = [
+        {**z, "stale": _freshness(z["ts_utc"][:10], today,
+                                  PANEL_MAX_AGE_DAYS["marginal"])["stale"]}
+        for z in data["zones"]
+    ]
+    newest = max(z["ts_utc"] for z in data["zones"])
+    return {
+        **data,
+        "zones": zones,
+        **_freshness(newest[:10], today, PANEL_MAX_AGE_DAYS["marginal"]),
     }
 
 

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -1728,7 +1728,10 @@ def get_marginal_overview(
     )
     if not data.get("available"):
         # No freshness triple on an unavailable body, matching /marginal.
-        # Copied, so no caller can ever mutate the cached dict.
+        # Top-level copy only; the nested lists stay shared but are never
+        # mutated. (An unavailable body is cached for the full TTL too —
+        # accepted: 30 min of no-data on a cold deploy beats a herd of
+        # all-zone recomputes.)
         return {**data}
     today = datetime.utcnow().date()
     zones = [
@@ -1736,6 +1739,8 @@ def get_marginal_overview(
                                   PANEL_MAX_AGE_DAYS["marginal"])["stale"]}
         for z in data["zones"]
     ]
+    # Best-of across zones is honest here: every zone rides the same A75
+    # ingest, and the per-zone `stale` above carries each zone's own signal.
     newest = max(z["ts_utc"] for z in data["zones"])
     return {
         **data,

--- a/backend/tests/test_marginal_overview.py
+++ b/backend/tests/test_marginal_overview.py
@@ -3,11 +3,12 @@
 /api/power/marginal/overview returns the LATEST price-setting attribution per
 enabled zone for a map fill. These tests pin the honesty rules the map
 inherits from the single-zone endpoint: a zone with no attributable hour is
-`missing` (no-data), never painted with an invented value; a "tension" hour
-crosses into the bulk payload unreclassified; the method/note strings are the
-SAME objects both endpoints serve (no drift); and the 30-minute payload cache
-never freezes freshness (derived per request) and is never mutated by the
-per-request stale stamping.
+`missing` (no-data), never painted with an invented value; a zone whose
+compute FAILS lands in `errors`, visibly distinct from no-data and never
+silently dropped; a "tension" hour crosses into the bulk payload
+unreclassified; the method/note strings are the SAME objects both endpoints
+serve (no drift); and the 30-minute payload cache never freezes freshness
+(derived per request) and is never mutated by the per-request stale stamping.
 """
 from __future__ import annotations
 
@@ -91,6 +92,7 @@ def test_empty_db_route_answers_available_false_with_all_zones_missing(db_sessio
     assert body["available"] is False
     assert body["zones"] == []
     assert body["missing"] == list(POWER_ZONES)
+    assert body["errors"] == []
     # No freshness triple on an unavailable body — matching /marginal's shape.
     assert "as_of" not in body and "age_days" not in body and "stale" not in body
 
@@ -109,7 +111,11 @@ def test_one_entry_per_seeded_zone_and_the_latest_hour_wins(db_session, monkeypa
 
     out = compute_marginal_overview(db_session, now=_NOW)
     assert out["available"] is True
-    assert out["hours"] == 72
+    assert out["hours"] == 168, (
+        "compute_marginal's own default window: anything shorter than 4 days "
+        "would age a zone into `missing` before `stale` (threshold 3d) could "
+        "ever fire — painted-but-stale must be representable"
+    )
     by_zone = {z["zone"]: z for z in out["zones"]}
     assert set(by_zone) == {"DE_LU", "NO2"}
     de = by_zone["DE_LU"]
@@ -124,6 +130,7 @@ def test_one_entry_per_seeded_zone_and_the_latest_hour_wins(db_session, monkeypa
     assert no2["tech"] == "hydro_flex"
     assert no2["zone_label"] == "NO2"
     assert out["missing"] == ["FR", "NL"]
+    assert out["errors"] == []
 
 
 def test_tension_crosses_into_the_bulk_payload_unreclassified(db_session):
@@ -134,6 +141,27 @@ def test_tension_crosses_into_the_bulk_payload_unreclassified(db_session):
     (entry,) = out["zones"]
     assert entry["tech"] == "lignite"
     assert entry["consistency"] == "tension"
+
+
+def test_a_zone_compute_failure_is_isolated_and_visible(db_session, monkeypatch):
+    """One zone blowing up must not blank the whole map — and must not vanish
+    silently either: compute-failure (`errors`) is not no-data (`missing`)."""
+    real = compute_marginal
+
+    def failing(db, zone, **kw):
+        if zone == "FR":
+            raise RuntimeError("boom")
+        return real(db, zone, **kw)
+
+    monkeypatch.setattr(marginal_mod, "compute_marginal", failing)
+    _seed_days_ago(db_session, 0)
+    r = _client(db_session).get("/api/power/marginal/overview")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert [z["zone"] for z in body["zones"]] == ["DE_LU"]
+    assert body["errors"] == ["FR"]
+    assert body["missing"] == ["NL"]
 
 
 def test_method_and_note_are_shared_with_the_single_zone_compute(db_session):
@@ -150,14 +178,11 @@ def test_method_and_note_are_shared_with_the_single_zone_compute(db_session):
 # ─── route: freshness outside the cache, cache never mutated ──────────────────
 
 
-def test_stale_seed_flags_zone_and_top_level(db_session, monkeypatch):
-    # A 5-day-old hour sits OUTSIDE the default 72 h compute window, so widen
-    # the window the route computes with: present-but-old (`stale`), not
-    # absent (`missing`), is what this test pins. Threshold is
-    # PANEL_MAX_AGE_DAYS["marginal"] = 3.
-    real = compute_marginal_overview
-    monkeypatch.setattr(marginal_mod, "compute_marginal_overview",
-                        lambda db, **kw: real(db, hours=240, **kw))
+def test_stale_seed_flags_zone_and_top_level(db_session):
+    # A 5-day-old hour sits INSIDE the 168 h compute window but past the 3-day
+    # threshold (PANEL_MAX_AGE_DAYS["marginal"]): painted-but-stale, the state
+    # the map must distinguish from `missing` — no window tricks, this is the
+    # route's real production behavior.
     _seed_days_ago(db_session, 5)
     body = _client(db_session).get("/api/power/marginal/overview").json()
     assert body["available"] is True
@@ -208,3 +233,19 @@ def test_response_is_built_around_the_cache_never_from_it(db_session):
     assert "as_of" not in cached and "age_days" not in cached and "stale" not in cached
     assert all("stale" not in z for z in cached["zones"])
     assert all(z["stale"] is False for z in body["zones"])
+
+
+def test_route_is_behind_the_heavy_query_guard(db_session):
+    """Cold, this compute walks every zone — it must hold a heavy slot, so a
+    drained semaphore means fail-fast 503, never a queued threadpool thread."""
+    import backend.api_guard as guard
+
+    c = _client(db_session)
+    acquired = [guard._heavy_sem.acquire(blocking=False)
+                for _ in range(guard.HEAVY_QUERY_SLOTS)]
+    try:
+        assert all(acquired)
+        assert c.get("/api/power/marginal/overview").status_code == 503
+    finally:
+        for _ in acquired:
+            guard._heavy_sem.release()

--- a/backend/tests/test_marginal_overview.py
+++ b/backend/tests/test_marginal_overview.py
@@ -1,0 +1,210 @@
+"""Bulk marginal overview: one read colours the whole map, honestly.
+
+/api/power/marginal/overview returns the LATEST price-setting attribution per
+enabled zone for a map fill. These tests pin the honesty rules the map
+inherits from the single-zone endpoint: a zone with no attributable hour is
+`missing` (no-data), never painted with an invented value; a "tension" hour
+crosses into the bulk payload unreclassified; the method/note strings are the
+SAME objects both endpoints serve (no drift); and the 30-minute payload cache
+never freezes freshness (derived per request) and is never mutated by the
+per-request stale stamping.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.power.marginal as marginal_mod
+from backend.api_guard import _reset_coverage_cache, cached_value
+from backend.power.hourly_store import upsert_hourly
+from backend.power.marginal import (
+    METHOD,
+    NOTE,
+    compute_marginal,
+    compute_marginal_overview,
+)
+from backend.power.zones import POWER_ZONES, ZONE_REGISTRY
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    _reset_coverage_cache()  # process-global keyed cache; would leak the overview between tests
+    yield
+    _reset_coverage_cache()
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    from backend.main import app
+
+    app.dependency_overrides.clear()
+
+
+def _client(db):
+    from backend.database import get_db
+    from backend.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+#: Fixed anchor at top of hour — the window math must never depend on the wall clock.
+_NOW = datetime(2026, 3, 10, 12, tzinfo=timezone.utc)
+
+
+def _ts(hours_ago: int) -> int:
+    return int((_NOW - timedelta(hours=hours_ago)).timestamp())
+
+
+def _seed_hour(db, hours_ago: int, price: float | None, gens: dict[str, float],
+               zone: str = "DE_LU") -> None:
+    """One zone-hour: an optional day-ahead price plus MW per gen.<Bxx> series."""
+    t = _ts(hours_ago)
+    if price is not None:
+        upsert_hourly(db, "price.dayahead", zone, [(t, price)], unit="EUR/MWh")
+    for code, mw in gens.items():
+        upsert_hourly(db, f"gen.{code}", zone, [(t, mw)], unit="MW")
+
+
+def _seed_days_ago(db, days: int, zone: str = "DE_LU") -> None:
+    """A gas-marginal hour exactly `days` whole days before the CURRENT
+    top-of-hour: the route reads the real clock, and a whole-day offset keeps
+    the seeded DATE exactly `days` behind today at any wall-clock time (the
+    UTC-midnight flake fixed repo-wide in #111)."""
+    t = int(datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+            .timestamp()) - days * 86400
+    upsert_hourly(db, "price.dayahead", zone, [(t, 80.0)], unit="EUR/MWh")
+    upsert_hourly(db, "gen.B19", zone, [(t, 10_000.0)], unit="MW")
+    upsert_hourly(db, "gen.B04", zone, [(t, 5_000.0)], unit="MW")
+
+
+# ─── the bulk compute ─────────────────────────────────────────────────────────
+
+
+def test_empty_db_route_answers_available_false_with_all_zones_missing(db_session):
+    r = _client(db_session).get("/api/power/marginal/overview")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["zones"] == []
+    assert body["missing"] == list(POWER_ZONES)
+    # No freshness triple on an unavailable body — matching /marginal's shape.
+    assert "as_of" not in body and "age_days" not in body and "stale" not in body
+
+
+def test_one_entry_per_seeded_zone_and_the_latest_hour_wins(db_session, monkeypatch):
+    # NO2 is not in the test env's ENABLED_ZONES (DE_LU/FR/NL) — widen the
+    # module's zone view so the Nordic hydro_flex case runs under its real key.
+    monkeypatch.setattr(marginal_mod, "POWER_ZONES",
+                        {**POWER_ZONES, "NO2": ZONE_REGISTRY["NO2"]})
+    # DE_LU: an older lignite hour then a newer gas hour — the map shows hourly[-1].
+    _seed_hour(db_session, 5, 60.0, {"B19": 4_000, "B02": 4_000})
+    _seed_hour(db_session, 2, 80.0, {"B19": 10_000, "B04": 5_000})
+    # NO2: the Nordic reservoir hour — hydro_flex, never "must-run".
+    _seed_hour(db_session, 2, 45.0, {"B12": 9_500, "B11": 300, "B19": 200},
+               zone="NO2")
+
+    out = compute_marginal_overview(db_session, now=_NOW)
+    assert out["available"] is True
+    assert out["hours"] == 72
+    by_zone = {z["zone"]: z for z in out["zones"]}
+    assert set(by_zone) == {"DE_LU", "NO2"}
+    de = by_zone["DE_LU"]
+    assert de["tech"] == "gas" and de["tech_label"] == "Gas"
+    assert de["price"] == 80.0
+    assert de["mw"] == 5_000.0
+    assert de["share_pct"] == pytest.approx(33.3)
+    assert de["consistency"] == "ok"
+    assert de["zone_label"] == "DE-LU"
+    assert de["ts_utc"] == datetime.fromtimestamp(_ts(2), tz=timezone.utc).isoformat()
+    no2 = by_zone["NO2"]
+    assert no2["tech"] == "hydro_flex"
+    assert no2["zone_label"] == "NO2"
+    assert out["missing"] == ["FR", "NL"]
+
+
+def test_tension_crosses_into_the_bulk_payload_unreclassified(db_session):
+    """Lignite at €300 contradicts the assumed order; the map payload SAYS so —
+    reclassifying in the bulk view would hide exactly what the canary shows."""
+    _seed_hour(db_session, 2, 300.0, {"B19": 4_000, "B02": 4_000})
+    out = compute_marginal_overview(db_session, now=_NOW)
+    (entry,) = out["zones"]
+    assert entry["tech"] == "lignite"
+    assert entry["consistency"] == "tension"
+
+
+def test_method_and_note_are_shared_with_the_single_zone_compute(db_session):
+    """One pair of strings, two endpoints: the module constants ARE the values
+    both computes serve, so the honesty wording can never drift apart."""
+    _seed_hour(db_session, 2, 80.0, {"B19": 10_000, "B04": 5_000})
+    single = compute_marginal(db_session, "DE_LU", hours=72, now=_NOW)
+    out = compute_marginal_overview(db_session, now=_NOW)
+    assert out["method"] is METHOD and single["method"] is METHOD
+    assert out["note"] is NOTE and single["note"] is NOTE
+    assert "estimate" in METHOD and "not a forecast" in NOTE
+
+
+# ─── route: freshness outside the cache, cache never mutated ──────────────────
+
+
+def test_stale_seed_flags_zone_and_top_level(db_session, monkeypatch):
+    # A 5-day-old hour sits OUTSIDE the default 72 h compute window, so widen
+    # the window the route computes with: present-but-old (`stale`), not
+    # absent (`missing`), is what this test pins. Threshold is
+    # PANEL_MAX_AGE_DAYS["marginal"] = 3.
+    real = compute_marginal_overview
+    monkeypatch.setattr(marginal_mod, "compute_marginal_overview",
+                        lambda db, **kw: real(db, hours=240, **kw))
+    _seed_days_ago(db_session, 5)
+    body = _client(db_session).get("/api/power/marginal/overview").json()
+    assert body["available"] is True
+    (entry,) = body["zones"]
+    assert entry["stale"] is True
+    assert body["stale"] is True and body["age_days"] == 5
+    assert body["as_of"] == entry["ts_utc"][:10]
+
+
+def test_fresh_seed_is_not_stale(db_session):
+    _seed_days_ago(db_session, 0)
+    body = _client(db_session).get("/api/power/marginal/overview").json()
+    (entry,) = body["zones"]
+    assert entry["stale"] is False
+    assert body["stale"] is False and body["age_days"] == 0
+    assert body["as_of"] == datetime.now(timezone.utc).date().isoformat()
+
+
+def test_route_computes_once_and_serves_the_warm_cache(db_session, monkeypatch):
+    calls = {"n": 0}
+    real = compute_marginal_overview
+
+    def counting(db, **kw):
+        calls["n"] += 1
+        return real(db, **kw)
+
+    monkeypatch.setattr(marginal_mod, "compute_marginal_overview", counting)
+    _seed_days_ago(db_session, 0)
+    client = _client(db_session)
+    first = client.get("/api/power/marginal/overview").json()
+    second = client.get("/api/power/marginal/overview").json()
+    assert calls["n"] == 1, "the second request must be served from the warm cache"
+    assert first == second
+
+
+def test_response_is_built_around_the_cache_never_from_it(db_session):
+    """The stale/freshness stamps are per-request; stamping the cached dict
+    would freeze the first request's clock for every reader after it."""
+    from backend.routes.power import get_marginal_overview
+
+    _seed_days_ago(db_session, 0)
+    body = get_marginal_overview(db=db_session, _guard=None)
+    cached = cached_value("marginal_overview",
+                          lambda: pytest.fail("cache must be warm here"))
+    assert body is not cached
+    assert body["zones"] is not cached["zones"]
+    # The per-request stamps must never have leaked INTO the cached payload.
+    assert "as_of" not in cached and "age_days" not in cached and "stale" not in cached
+    assert all("stale" not in z for z in cached["zones"])
+    assert all(z["stale"] is False for z in body["zones"])


### PR DESCRIPTION
## Was
Neuer Bulk-Endpoint `GET /api/power/marginal/overview` (PR 1/9 des Map-Redesign-Plans): liefert die zuletzt preissetzende Technologie ALLER enabled Zonen in einem Request — Futter für das kommende Karten-Fill „Price-setting tech". Bisher war `/marginal` one-zone-per-request (37 Requests für eine Europa-Karte).

## Wie
- `compute_marginal_overview(db, hours=168)` in `backend/power/marginal.py`: pure, loopt `POWER_ZONES` über das bestehende `compute_marginal`, nimmt `hourly[-1]`; Zonen ohne attributierbare Stunde → `missing`, Compute-Fehler pro Zone isoliert → sichtbares `errors`-Bucket (`logger.exception`, nichts verschwindet stumm, ein Store-Bug einer Zone killt nicht mehr die ganze Karte).
- `METHOD`/`NOTE` auf Modul-Konstanten gehoben — beide Endpoints teilen wortgleiche Honesty-Strings (identity-gepinnt im Test).
- Route: sync `def`, `Depends(heavy_query_guard)`, `cached_value("marginal_overview", ttl=1800)`; Freshness (Triple + per-Zone `stale`) pro Request AUSSERHALB des Cache, gecachtes Dict wird nie mutiert. Fenster 168h > 96h-Grenze, damit `stale` (Schwelle 3d) erreichbar ist statt strukturell tot.

## Tests (TDD, rot gesehen)
10 neue Tests in `test_marginal_overview.py`: leer→unavailable, DE_LU-Gas+NO2-hydro_flex, tension bleibt tension, stale im echten Fenster (ohne Monkeypatch-Wrapper), fresh→not stale, Cache=1 Compute, Response≠Cache-Identität, Fehler-Isolation (FR raist → 200, errors=["FR"]), 503 bei erschöpftem Guard, METHOD/NOTE-Identität. Suite: **1255 passed, 1 skipped**. Zwei-stufiges Review (Spec + Qualität) bestanden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)