### PR TITLE
Europe-wide A78 transmission-outage endpoint for the power map

### DIFF
--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -2314,6 +2314,135 @@ def get_outages(
     }
 
 
+# No shadowing risk from /outages above: it takes no path parameter (zone is a
+# QUERY param), so Starlette full-path matching keeps both routes reachable in
+# either order — same situation as /marginal vs /marginal/overview.
+@router.get("/outages/transmission")
+def get_transmission_outages_europe(
+    horizon_days: int = Query(30, ge=1, le=400,
+                              description="Include outages starting up to this many days out"),
+    db: Session = Depends(get_db),
+):
+    """All current/upcoming transmission-infrastructure outages (ENTSO-E A78)
+    Europe-wide, deduped to one event per physical asset — the map overlay's
+    "which lines are gone" feed. Free tier.
+
+    One request instead of one per zone: /outages?kind=transmission keeps the
+    same physical event once per queried direction (two DISJOINT mRIDs — live
+    spike 2026-07-21). Here the directions collapse into ONE event keyed on
+    (asset_eic, start_utc, end_utc) — falling back to asset_name when the EIC
+    is missing, and to the mRID (no dedupe) when both are — keeping the LOWEST
+    available_mw (most-constrained side, matching the per-zone sort convention)
+    and the union of filing zones in `reported_by`.
+
+    `zone_a`/`zone_b` = sorted canonical pair (the /borders convention). When
+    the counterparty EIC is outside ZONE_REGISTRY the event is STILL included
+    (never vanish silently): the real zone stays in `zone_a`, the raw EIC rides
+    in `zone_b`, and `counterparty_mapped: false` tells the frontend to skip
+    the coordinate lookup for it.
+
+    Withdrawn latest revisions hide the event (ranking before filtering — see
+    latest_outage_revisions). Events sort deterministically: running_now first,
+    then available_mw ascending nulls-last, then start_utc. nominal_mw/
+    offline_mw are deliberately OMITTED — always null for A78, no capacity
+    baseline is ever published (see the PowerOutage docstring). No cache and no
+    heavy_query_guard: the A78 population is small (hundreds of rows);
+    `cached_value` with ttl=300 is the follow-up if prod latency ever says so.
+    """
+    from backend.models.energy import PowerOutage
+    from backend.power.entsoe_outages import ASSET_TYPE_LABELS
+    from backend.power.zones import ZONE_REGISTRY
+    from backend.signals.detectors.power import latest_outage_revisions
+
+    now = datetime.utcnow()
+    now_iso = now.strftime("%Y-%m-%dT%H:%MZ")
+    horizon_iso = (now + timedelta(days=horizon_days)).strftime("%Y-%m-%dT%H:%MZ")
+
+    rows = latest_outage_revisions(db, zone=None, doc_type="A78")
+    if not rows:
+        return {
+            "available": False,
+            "reason": "No transmission outage messages ingested yet — check back shortly.",
+        }
+
+    merged: dict[tuple, dict] = {}
+    for r in rows:
+        if r.status != "active":
+            continue
+        if r.end_utc < now_iso or r.start_utc > horizon_iso:
+            continue
+        mapped = r.counterparty_zone in ZONE_REGISTRY
+        if mapped:
+            zone_a, zone_b = sorted([r.zone, r.counterparty_zone])
+        else:
+            # Raw-EIC (or missing) counterparty: keep the real zone in zone_a —
+            # naive sorted() would push it to zone_b ("1..." < "DE_LU") and
+            # break the frontend's mapped-side coordinate lookup.
+            zone_a, zone_b = r.zone, r.counterparty_zone
+        if r.unit_eic:
+            key = ("eic", r.unit_eic, r.start_utc, r.end_utc)
+        elif r.unit_name:
+            key = ("name", r.unit_name, r.start_utc, r.end_utc)
+        else:
+            key = ("mrid", r.mrid)  # no asset identity at all → nothing to dedupe on
+        event = {
+            "mrid": r.mrid,
+            "asset_name": r.unit_name or r.unit_eic,
+            "asset_eic": r.unit_eic,
+            "zone_a": zone_a,
+            "zone_b": zone_b,
+            "counterparty_mapped": mapped,
+            "reported_by": [r.zone],
+            "asset_type": ASSET_TYPE_LABELS.get(r.psr_type, r.psr_type),
+            "kind": _OUTAGE_KIND.get(r.business_type, r.business_type),
+            "available_mw": r.available_mw,
+            "start_utc": r.start_utc,
+            "end_utc": r.end_utc,
+            "running_now": r.start_utc <= now_iso <= r.end_utc,
+        }
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = event
+            continue
+        # Same physical event, other direction: keep the most-constrained row
+        # (lowest available_mw; a null figure loses to a real one), remember
+        # every filing zone.
+        reported_by = sorted(set(existing["reported_by"]) | {r.zone})
+        keep = existing
+        if event["available_mw"] is not None and (
+            existing["available_mw"] is None
+            or event["available_mw"] < existing["available_mw"]
+        ):
+            keep = event
+        keep["reported_by"] = reported_by
+        merged[key] = keep
+
+    events = sorted(
+        merged.values(),
+        key=lambda e: (
+            not e["running_now"],
+            e["available_mw"] if e["available_mw"] is not None else float("inf"),
+            e["start_utc"],
+        ),
+    )
+    # Freshness = newest A78 message we EVER ingested (any revision, any zone) —
+    # a superseded revision still proves the collector is alive.
+    newest_msg = (
+        db.query(func.max(PowerOutage.created_at))
+        .filter(PowerOutage.doc_type == "A78")
+        .scalar()
+    )
+    return {
+        "available": True,
+        "unit": "MW",
+        "horizon_days": horizon_days,
+        "events": events,
+        "count": len(events),
+        **_freshness(newest_msg.strftime("%Y-%m-%d") if newest_msg else None,
+                     now.date(), 2),
+    }
+
+
 # ─── Per-unit generation (free) ───────────────────────────────────────────────
 
 #: The honest wording everywhere this data appears. A73's population is the

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -2332,8 +2332,8 @@ def get_transmission_outages_europe(
     spike 2026-07-21). Here the directions collapse into ONE event keyed on
     (asset_eic, start_utc, end_utc) — falling back to asset_name when the EIC
     is missing, and to the mRID (no dedupe) when both are — keeping the LOWEST
-    available_mw (most-constrained side, matching the per-zone sort convention)
-    and the union of filing zones in `reported_by`.
+    available_mw (most-constrained side, matching the per-zone sort convention;
+    ties keep the smaller mrid) and the union of filing zones in `reported_by`.
 
     `zone_a`/`zone_b` = sorted canonical pair (the /borders convention). When
     the counterparty EIC is outside ZONE_REGISTRY the event is STILL included
@@ -2343,7 +2343,7 @@ def get_transmission_outages_europe(
 
     Withdrawn latest revisions hide the event (ranking before filtering — see
     latest_outage_revisions). Events sort deterministically: running_now first,
-    then available_mw ascending nulls-last, then start_utc. nominal_mw/
+    then available_mw ascending nulls-last, then start_utc, then mrid. nominal_mw/
     offline_mw are deliberately OMITTED — always null for A78, no capacity
     baseline is ever published (see the PowerOutage docstring). No cache and no
     heavy_query_guard: the A78 population is small (hundreds of rows);
@@ -2358,8 +2358,23 @@ def get_transmission_outages_europe(
     now_iso = now.strftime("%Y-%m-%dT%H:%MZ")
     horizon_iso = (now + timedelta(days=horizon_days)).strftime("%Y-%m-%dT%H:%MZ")
 
-    rows = latest_outage_revisions(db, zone=None, doc_type="A78")
-    if not rows:
+    # ending_after prunes already-ended events in SQL instead of hydrating every
+    # A78 mRID ever ingested (the Python-side window filter below still applies:
+    # the prune is per-mRID, the winning revision can still end in the past).
+    rows = latest_outage_revisions(db, zone=None, doc_type="A78",
+                                   ending_after=now_iso)
+
+    # Freshness probe doubles as the table-level availability check: with the
+    # SQL prune, an empty `rows` no longer distinguishes "nothing ever
+    # ingested" from "history only, nothing current" — the latter must stay
+    # available:True with an empty feed. Newest A78 message EVER (any revision,
+    # any zone): a superseded revision still proves the collector is alive.
+    newest_msg = (
+        db.query(func.max(PowerOutage.created_at))
+        .filter(PowerOutage.doc_type == "A78")
+        .scalar()
+    )
+    if newest_msg is None:
         return {
             "available": False,
             "reason": "No transmission outage messages ingested yet — check back shortly.",
@@ -2406,7 +2421,10 @@ def get_transmission_outages_europe(
             continue
         # Same physical event, other direction: keep the most-constrained row
         # (lowest available_mw; a null figure loses to a real one), remember
-        # every filing zone.
+        # every filing zone. Ties — equal figures or both null — go to the
+        # smaller mrid, so the surfaced mrid is stable across requests and
+        # databases (row order from the ranked query is not guaranteed, and
+        # PR 7 keys the map arcs on mrid).
         reported_by = sorted(set(existing["reported_by"]) | {r.zone})
         keep = existing
         if event["available_mw"] is not None and (
@@ -2414,23 +2432,22 @@ def get_transmission_outages_europe(
             or event["available_mw"] < existing["available_mw"]
         ):
             keep = event
+        elif (event["available_mw"] == existing["available_mw"]
+              and event["mrid"] < existing["mrid"]):
+            keep = event
         keep["reported_by"] = reported_by
         merged[key] = keep
 
+    # mrid as the final key makes the order fully deterministic even between
+    # events with identical constraint and start.
     events = sorted(
         merged.values(),
         key=lambda e: (
             not e["running_now"],
             e["available_mw"] if e["available_mw"] is not None else float("inf"),
             e["start_utc"],
+            e["mrid"],
         ),
-    )
-    # Freshness = newest A78 message we EVER ingested (any revision, any zone) —
-    # a superseded revision still proves the collector is alive.
-    newest_msg = (
-        db.query(func.max(PowerOutage.created_at))
-        .filter(PowerOutage.doc_type == "A78")
-        .scalar()
     )
     return {
         "available": True,

--- a/backend/tests/test_transmission_outages.py
+++ b/backend/tests/test_transmission_outages.py
@@ -784,6 +784,65 @@ def test_europe_route_no_identity_means_no_dedupe(db_session):
     assert body["count"] == 2
 
 
+def test_europe_route_merge_tie_keeps_smaller_mrid(db_session):
+    """Equal available_mw on both directions (the common case — both TSOs report
+    the same figure): the kept row must be deterministic across requests and
+    databases, because PR 7 keys the map arcs on mrid. Smaller mrid wins.
+    The smaller mrid sits on the LATER-sorting zone (FR): the ranked query
+    happens to return rows in zone-partition order, so first-encountered-wins
+    would keep tb2 and cannot fake a pass here."""
+    _seed_transmission(db_session, mrid="tb2", zone="DE_LU", counterparty_zone="FR",
+                       available_mw=1000.0)
+    _seed_transmission(db_session, mrid="tb1", zone="FR", counterparty_zone="DE_LU",
+                       available_mw=1000.0)
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["count"] == 1
+    assert body["events"][0]["mrid"] == "tb1"
+
+
+def test_europe_route_none_counterparty_included_not_drawn(db_session):
+    """counterparty_zone can be null (message without an out_Domain we could
+    read). Same contract as a raw EIC: still listed, real zone in zone_a,
+    counterparty_mapped false so the frontend skips the coordinate lookup."""
+    _seed_transmission(db_session, mrid="nc1", zone="DE_LU", counterparty_zone=None)
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["count"] == 1
+    ev = body["events"][0]
+    assert ev["zone_a"] == "DE_LU"
+    assert ev["zone_b"] is None
+    assert ev["counterparty_mapped"] is False
+
+
+def test_europe_route_historical_only_table_is_available_but_empty(db_session):
+    """A table holding ONLY fully-past A78 events is a live feed with nothing
+    current — available:True with an empty list, NOT the 'nothing ingested yet'
+    unavailable body. Guards the ending_after SQL prune: an empty ranked set no
+    longer proves the table is empty."""
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    _seed_transmission(db_session, mrid="hist",
+                       start_utc=(now - timedelta(days=30)).strftime(fmt),
+                       end_utc=(now - timedelta(days=20)).strftime(fmt))
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["available"] is True
+    assert body["events"] == []
+    assert body["count"] == 0
+    assert body["as_of"] is not None  # freshness still reports the ingest
+
+
+def test_europe_route_fresh_a77_does_not_mask_stale_a78(db_session):
+    """The freshness triple is scoped to doc_type A78: a fresh A77 (generation)
+    message must never keep the map feed looking alive while the A78 collector
+    is dead. (get_outages deliberately differs — its per-zone triple spans both
+    doc types.)"""
+    _seed_generation(db_session)  # created_at defaults to now — fresh
+    _seed_transmission(db_session, created_at=datetime.utcnow() - timedelta(days=5))
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["available"] is True
+    assert body["age_days"] == 5
+    assert body["stale"] is True
+
+
 def test_europe_route_empty_table_is_unavailable(db_session):
     # An A77-only table must not count — the feed is scoped to doc_type A78.
     _seed_generation(db_session)

--- a/backend/tests/test_transmission_outages.py
+++ b/backend/tests/test_transmission_outages.py
@@ -668,6 +668,139 @@ def test_route_transmission_a77_generation_list_unaffected_by_reversed_direction
     assert body["total_offline_mw"] == pytest.approx(1000.0)
 
 
+# ─── route: /api/power/outages/transmission (Europe-wide map feed) ───────────
+#
+# One request returns every current/upcoming A78 event Europe-wide with a
+# CANONICAL zone pair, so the map can draw dashed zone-to-zone connections.
+# Unlike the per-zone panel (which keeps both directions, see
+# test_route_transmission_both_directions_of_a_border_both_appear), the map
+# feed dedupes the two directions of one physical event on
+# (asset_eic, start, end) — name-based when the EIC is missing, mRID (no
+# dedupe) when both are.
+
+
+def test_europe_route_dedupes_two_directions_into_one_event(db_session):
+    """Two directions = disjoint mRIDs, same physical asset. The map feed must
+    collapse them into ONE event: lowest available_mw (most-constrained side),
+    sorted canonical pair, union of filing zones in reported_by."""
+    _seed_transmission(db_session, mrid="d1", zone="DE_LU", counterparty_zone="FR",
+                       available_mw=1150.0)
+    _seed_transmission(db_session, mrid="d2", zone="FR", counterparty_zone="DE_LU",
+                       available_mw=900.0)
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["available"] is True
+    assert body["unit"] == "MW"
+    assert body["horizon_days"] == 30
+    assert body["count"] == 1
+    assert len(body["events"]) == 1
+    ev = body["events"][0]
+    assert ev["zone_a"] == "DE_LU"
+    assert ev["zone_b"] == "FR"
+    assert ev["counterparty_mapped"] is True
+    assert ev["available_mw"] == 900.0  # most-constrained direction wins
+    assert ev["reported_by"] == ["DE_LU", "FR"]
+    assert ev["asset_eic"] == "10T-DE-FR-00003E"
+    assert ev["asset_name"] == "Eichstetten-Vogelgrun"
+    assert ev["asset_type"] == "AC Line"
+    assert ev["kind"] == "planned"
+    assert ev["running_now"] is True
+    # nominal_mw/offline_mw deliberately omitted — always null for A78.
+    assert "nominal_mw" not in ev
+    assert "offline_mw" not in ev
+
+
+def test_europe_route_withdrawn_latest_revision_hides_event(db_session):
+    """Ranking before filtering, Europe-wide: the older ACTIVE revision must not
+    resurrect an event whose latest revision is withdrawn."""
+    _seed_transmission(db_session, mrid="w1", revision=1)
+    _seed_transmission(db_session, mrid="w1", revision=3, status="withdrawn")
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["available"] is True  # rows exist — the FEED is alive, just quiet
+    assert body["events"] == []
+    assert body["count"] == 0
+
+
+def test_europe_route_raw_eic_counterparty_included_not_drawn(db_session):
+    """An unmapped counterparty EIC must not vanish silently. The real zone must
+    stay in zone_a — naive sorted() would push it to zone_b ('1' < 'D')."""
+    _seed_transmission(db_session, mrid="raw1", zone="DE_LU",
+                       counterparty_zone="10Y-UNMAPPED-EIC-X")
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["count"] == 1
+    ev = body["events"][0]
+    assert ev["counterparty_mapped"] is False
+    assert ev["zone_a"] == "DE_LU"
+    assert ev["zone_b"] == "10Y-UNMAPPED-EIC-X"
+
+
+def test_europe_route_window_and_running_now(db_session):
+    now = datetime.now(timezone.utc)
+    fmt = "%Y-%m-%dT%H:%MZ"
+    _seed_transmission(db_session, mrid="past", unit_eic="E-PAST",
+                       start_utc=(now - timedelta(days=10)).strftime(fmt),
+                       end_utc=(now - timedelta(days=2)).strftime(fmt))
+    _seed_transmission(db_session, mrid="far", unit_eic="E-FAR",
+                       start_utc=(now + timedelta(days=40)).strftime(fmt),
+                       end_utc=(now + timedelta(days=50)).strftime(fmt))
+    _seed_transmission(db_session, mrid="soon", unit_eic="E-SOON",
+                       start_utc=(now + timedelta(days=3)).strftime(fmt),
+                       end_utc=(now + timedelta(days=6)).strftime(fmt))
+    _seed_transmission(db_session, mrid="run", unit_eic="E-RUN")
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    by_mrid = {e["mrid"]: e for e in body["events"]}
+    assert set(by_mrid) == {"soon", "run"}  # fully-past + beyond-horizon excluded
+    assert by_mrid["soon"]["running_now"] is False
+    assert by_mrid["run"]["running_now"] is True
+    # Deterministic order: running events first.
+    assert body["events"][0]["mrid"] == "run"
+    # A wider horizon admits the far-future event.
+    wide = _client(db_session).get(
+        "/api/power/outages/transmission?horizon_days=60").json()
+    assert "far" in {e["mrid"] for e in wide["events"]}
+
+
+def test_europe_route_null_eic_falls_back_to_name_dedupe(db_session):
+    _seed_transmission(db_session, mrid="n1", zone="DE_LU", counterparty_zone="FR",
+                       unit_eic=None, unit_name="Line X", available_mw=800.0)
+    _seed_transmission(db_session, mrid="n2", zone="FR", counterparty_zone="DE_LU",
+                       unit_eic=None, unit_name="Line X", available_mw=500.0)
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["count"] == 1
+    ev = body["events"][0]
+    assert ev["asset_eic"] is None
+    assert ev["asset_name"] == "Line X"
+    assert ev["available_mw"] == 500.0
+    assert ev["reported_by"] == ["DE_LU", "FR"]
+
+
+def test_europe_route_no_identity_means_no_dedupe(db_session):
+    """Both asset_eic AND asset_name null → mRID key: nothing to merge on, so
+    both rows stay visible rather than being guessed together."""
+    _seed_transmission(db_session, mrid="x1", zone="DE_LU", counterparty_zone="FR",
+                       unit_eic=None, unit_name=None)
+    _seed_transmission(db_session, mrid="x2", zone="FR", counterparty_zone="DE_LU",
+                       unit_eic=None, unit_name=None)
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["count"] == 2
+
+
+def test_europe_route_empty_table_is_unavailable(db_session):
+    # An A77-only table must not count — the feed is scoped to doc_type A78.
+    _seed_generation(db_session)
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["available"] is False
+    assert body.get("reason")
+
+
+def test_europe_route_carries_freshness_triple(db_session):
+    _seed_transmission(db_session)
+    body = _client(db_session).get("/api/power/outages/transmission").json()
+    assert body["available"] is True
+    assert body["as_of"] is not None
+    assert body["age_days"] == 0
+    assert body["stale"] is False
+
+
 # ─── review fix #2: the shared scheduler session must survive a mid-pass error ──
 
 


### PR DESCRIPTION
## Was
Neuer Endpoint `GET /api/power/outages/transmission` (PR 2/9 des Map-Redesign-Plans): alle laufenden/anstehenden ENTSO-E-A78-Leitungs-/Interconnector-Ausfälle Europa-weit in einem Request, mit Zonen-Paar-Identität — Futter für das kommende Karten-Overlay „welche Leitungen sind weg". Bisher one-zone-per-request.

## Wie
- Kern: vorhandenes `latest_outage_revisions(db, zone=None, doc_type="A78", ending_after=now)` — Revisions-Ranking vor Status-Filter (Withdrawals versteckten), SQL-Pruning vergangener Events statt Full-History-Hydration.
- Dedupe der Richtungs-Duplikate: Key `(asset_eic, start, end)` → Name-Fallback → mrid; niedrigste `available_mw` gewinnt, Ties → kleinere mrid (assoziativ, DB-Order-unabhängig); `reported_by` = Union der meldenden Zonen.
- Kanonisches sorted pair `zone_a/zone_b`; unmapped Counterparty (Raw-EIC/None) → Event bleibt drin mit `counterparty_mapped:false`, echte Zone in `zone_a`.
- `newest_msg`-Probe (A78-scoped) = Verfügbarkeits-Check UND Freshness-Quelle — frische A77 maskieren nie einen toten A78-Collector; History-only-Tabelle → `available:true, events:[]`.
- `nominal_mw`/`offline_mw` bewusst weg (bei A78 immer null) — `available_mw` as-is, nichts erfunden.

## Tests (TDD, rot gesehen)
12 neue Tests: Richtungs-Dedupe (min-MW/pair/reported_by), Europa-weites Withdrawal-Hiding, Raw-EIC + None-Counterparty, Fenster+running_now+horizon, Name-/mrid-Fallback, History-only, Freshness-Scoping (A77 maskiert nicht), deterministische Ties, leer→unavailable. Suite: **1267 passed, 1 skipped**. Zwei-stufiges Review bestanden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)