### PR TITLE
Equal-frequency price scale for the power map

### DIFF
--- a/frontend/src/components/powermap/Legend.jsx
+++ b/frontend/src/components/powermap/Legend.jsx
@@ -1,6 +1,5 @@
 import { rgbCss } from './palettes'
 import { UTIL_MID, UTIL_HIGH } from './constants'
-import { legendGradient } from './scales'
 
 /* Flow-arc legend — swatches read straight from pal.arc (they cannot
    drift from the layer) and thresholds from UTIL_MID/UTIL_HIGH. Only the
@@ -22,23 +21,49 @@ export function FlowArcLegend({ pal, atLatest }) {
   )
 }
 
-// Price gradient row: the fixed weekly p2/p98 domain, generated FROM priceColor
-// via legendGradient — it cannot drift from the map.
-export function PriceScaleLegend({ lo, hi, pal }) {
+// Price scale row. The bar is the week's CDF axis (left = cheapest observed
+// hour, right = most expensive): equal bar length = equal share of the week's
+// all-zone hours — that IS the equal-frequency contract. Every stop and tick
+// comes from the scale object itself, so the legend cannot drift from the map.
+// Ticks under the bar name the p10/p25/p50/p75/p90 prices; endpoints are the
+// observed min/max (no clamp — ranks are outlier-robust by construction). The
+// zero marker sits at 0 €'s share of the population.
+export function PriceScaleLegend({ scale }) {
+  const stops = scale.stops(12)
+  const gradient = `linear-gradient(90deg, ${stops
+    .map((c, i) => `${rgbCss(c)} ${(i / (stops.length - 1)) * 100}%`)
+    .join(', ')})`
+  const q = scale.quantiles
+  const ticks = q ? [[10, q.p10], [25, q.p25], [50, q.p50], [75, q.p75], [90, q.p90]] : []
   return (
-    <span className="flex items-center gap-1" title="Fixed scale across the shown week (2nd–98th percentile); the tooltip has exact values.">
-      <span className="text-neutral-500">{lo < 0 ? `≤${lo.toFixed(0)}` : lo.toFixed(0)}</span>
-      <span className="relative inline-block h-2 w-28 rounded overflow-hidden" style={{ background: legendGradient(lo, hi, pal) }}>
-        {lo < 0 && (
-          <span
-            className="absolute top-0 h-2 w-px bg-neutral-400"
-            style={{ left: `${((0 - lo) / (hi - lo)) * 100}%` }}
-            title="0 €/MWh"
-          />
+    <span
+      className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5"
+      title="Fixed equal-frequency scale across the shown week: colors spread by rank among all zones × hours, not by € distance — tooltips carry exact €. Ticks mark the p10/p25/median/p75/p90 prices."
+    >
+      <span className="text-neutral-500">{scale.lo.toFixed(0)}</span>
+      <span className="flex flex-col gap-px">
+        <span className="relative block h-2 w-36 rounded overflow-hidden" style={{ background: gradient }}>
+          {scale.hasNegatives && (
+            <span
+              className="absolute top-0 h-2 w-px bg-neutral-400"
+              style={{ left: `${scale.negShare * 100}%` }}
+              title="0 €/MWh"
+            />
+          )}
+        </span>
+        {ticks.length > 0 && (
+          <span className="relative block h-2.5 w-36 text-[8px] leading-none text-neutral-500">
+            {ticks.map(([p, v]) => (
+              <span key={p} className="absolute -translate-x-1/2" style={{ left: `${p}%` }} title={`p${p}`}>
+                {v.toFixed(0)}
+              </span>
+            ))}
+          </span>
         )}
       </span>
-      <span className="text-neutral-500">≥{hi.toFixed(0)} €/MWh</span>
-      {lo < 0 && <span className="ml-1 text-violet-300/70">violet = negative</span>}
+      <span className="text-neutral-500">{scale.hi.toFixed(0)} €/MWh</span>
+      <span className="text-neutral-600">equal-frequency scale · week&apos;s all-zone hours</span>
+      {scale.hasNegatives && <span className="text-violet-300/70">violet = negative</span>}
     </span>
   )
 }

--- a/frontend/src/components/powermap/Legend.jsx
+++ b/frontend/src/components/powermap/Legend.jsx
@@ -29,12 +29,22 @@ export function FlowArcLegend({ pal, atLatest }) {
 // observed min/max (no clamp — ranks are outlier-robust by construction). The
 // zero marker sits at 0 €'s share of the population.
 export function PriceScaleLegend({ scale }) {
-  const stops = scale.stops(12)
-  const gradient = `linear-gradient(90deg, ${stops
-    .map((c, i) => `${rgbCss(c)} ${(i / (stops.length - 1)) * 100}%`)
+  // Stops carry their own CDF position (the doubled stop at the zero share
+  // renders as a CSS hard edge — see makeQuantileScale.stops).
+  const gradient = `linear-gradient(90deg, ${scale
+    .stops(12)
+    .map(({ pos, rgb }) => `${rgbCss(rgb)} ${(pos * 100).toFixed(2)}%`)
     .join(', ')})`
   const q = scale.quantiles
-  const ticks = q ? [[10, q.p10], [25, q.p25], [50, q.p50], [75, q.p75], [90, q.p90]] : []
+  // Flat weeks collapse neighbouring quantiles onto the same rounded label —
+  // render each label once (first position wins) instead of stacking "82 82".
+  const ticks = []
+  if (q) {
+    for (const [p, v] of [[10, q.p10], [25, q.p25], [50, q.p50], [75, q.p75], [90, q.p90]]) {
+      const label = v.toFixed(0)
+      if (!ticks.length || ticks[ticks.length - 1].label !== label) ticks.push({ p, label })
+    }
+  }
   return (
     <span
       className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5"
@@ -42,8 +52,8 @@ export function PriceScaleLegend({ scale }) {
     >
       <span className="text-neutral-500">{scale.lo.toFixed(0)}</span>
       <span className="flex flex-col gap-px">
-        <span className="relative block h-2 w-36 rounded overflow-hidden" style={{ background: gradient }}>
-          {scale.hasNegatives && (
+        <span className="relative block h-2 w-40 rounded overflow-hidden" style={{ background: gradient }}>
+          {scale.negShare > 0 && (
             <span
               className="absolute top-0 h-2 w-px bg-neutral-400"
               style={{ left: `${scale.negShare * 100}%` }}
@@ -52,10 +62,10 @@ export function PriceScaleLegend({ scale }) {
           )}
         </span>
         {ticks.length > 0 && (
-          <span className="relative block h-2.5 w-36 text-[8px] leading-none text-neutral-500">
-            {ticks.map(([p, v]) => (
+          <span className="relative block h-2.5 w-40 text-[8px] leading-none text-neutral-500">
+            {ticks.map(({ p, label }) => (
               <span key={p} className="absolute -translate-x-1/2" style={{ left: `${p}%` }} title={`p${p}`}>
-                {v.toFixed(0)}
+                {label}
               </span>
             ))}
           </span>
@@ -63,7 +73,7 @@ export function PriceScaleLegend({ scale }) {
       </span>
       <span className="text-neutral-500">{scale.hi.toFixed(0)} €/MWh</span>
       <span className="text-neutral-600">equal-frequency scale · week&apos;s all-zone hours</span>
-      {scale.hasNegatives && <span className="text-violet-300/70">violet = negative</span>}
+      {scale.negShare > 0 && <span className="text-violet-300">violet = negative</span>}
     </span>
   )
 }

--- a/frontend/src/components/powermap/fills.js
+++ b/frontend/src/components/powermap/fills.js
@@ -1,4 +1,3 @@
-import { priceColor } from './scales'
 import { PriceScaleLegend, StateLegend } from './Legend'
 
 // Fill registry — one entry per choropleth fill mode, carrying the FULL
@@ -7,10 +6,10 @@ import { PriceScaleLegend, StateLegend } from './Legend'
 //   key/label      — header toggle button
 //   scrub          — whether the time scrubber applies (grid state is always live)
 //   hasLabels      — whether the ZONES view draws the per-zone value TextLayer
-//   getColor(zoneKey, ctx) — base RGB for one zone, ctx = {byZone, lo, hi, pal};
+//   getColor(zoneKey, ctx) — base RGB for one zone, ctx = {byZone, scale, pal};
 //                    null = zone has no data (index falls back to pal.contextFill)
 //   alpha          — layer opacities: .zone (choropleth) / .point (dots)
-//   Legend         — footer legend row component; always receives {lo, hi, pal}
+//   Legend         — footer legend row component; always receives {scale, pal}
 //   triggers(ctx)  — updateTriggers tail: the identities THIS fill's colors
 //                    depend on beyond the shared [fill, effRows, theme]
 export const FILLS = [
@@ -19,14 +18,16 @@ export const FILLS = [
     label: 'DAY-AHEAD €/MWh',
     scrub: true,
     hasLabels: true,
-    getColor: (zone, { byZone, lo, hi, pal }) => {
+    getColor: (zone, { byZone, scale }) => {
       const z = byZone.get(zone)
       if (!z) return null
-      return priceColor(z.price_close, lo, hi, pal)
+      return scale.color(z.price_close)
     },
     alpha: { zone: 235, point: 240 },
     Legend: PriceScaleLegend,
-    triggers: ({ lo, hi }) => [lo, hi],
+    // The scale object is memoized on [snap, rows, pal] in index.jsx — its
+    // identity IS the domain version, so a new week population repaints.
+    triggers: ({ scale }) => [scale],
   },
   {
     key: 'state',

--- a/frontend/src/components/powermap/index.jsx
+++ b/frontend/src/components/powermap/index.jsx
@@ -4,7 +4,7 @@ import { InfoPopover } from '../Panel'
 import { useTheme } from '../../context/ThemeContext'
 import { PALETTES } from './palettes'
 import { ZONE_COORDS, INITIAL_VIEW } from './constants'
-import { weekDomain } from './scales'
+import { collectWeekValues, makeQuantileScale } from './scales'
 import { FILLS } from './fills'
 import useMapData from './useMapData'
 import { makeTooltip } from './tooltip'
@@ -71,9 +71,11 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
     return m
   }, [effRows])
 
-  // Fixed weekly color domain — see weekDomain in scales.js (p2/p98 over all
-  // zones × all snapshot hours + the live rows).
-  const { lo, hi } = useMemo(() => weekDomain(snap, rows), [snap, rows])
+  // Week-fixed equal-frequency color scale, built ONCE from the whole window's
+  // population (all zones × all hours + live rows) so scrubbing repaints hours
+  // against the same mapping — see makeQuantileScale in scales.js. Its object
+  // identity doubles as the repaint trigger for the price fill.
+  const scale = useMemo(() => makeQuantileScale(collectWeekValues(snap, rows), pal), [snap, rows, pal])
 
   const points = useMemo(() => {
     const pts = []
@@ -89,12 +91,12 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
 
   const layers = useMemo(() => {
     if (!geo) return []
-    const fillCtx = { byZone, lo, hi, pal }
+    const fillCtx = { byZone, scale, pal }
     const zoneFill = (zone) => {
       const rgb = fillDef.getColor(zone, fillCtx)
       return rgb ? [...rgb, fillDef.alpha.zone] : pal.contextFill
     }
-    // Shared identity inputs + the active fill's own tail (e.g. lo/hi for price).
+    // Shared identity inputs + the active fill's own tail (e.g. the scale for price).
     const fillColorTriggers = [fill, effRows, ...fillDef.triggers(fillCtx), theme]
     const arcLayer = overlays.flows && atLatest && arcs.length > 0
       ? makeFlowArcsLayer({ arcs, pal, onBorderSelect })
@@ -115,7 +117,7 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
     const labels = makeLabelsLayer({ points, pal, theme, effRows })
     const base = fillDef.hasLabels ? [zonesLayer, labels] : [zonesLayer]
     return arcLayer ? [...base, arcLayer] : base
-  }, [geo, view, fill, fillDef, effRows, byZone, lo, hi, points, theme, arcs, overlays, atLatest, onBorderSelect, onZoneSelect, selectedZone, pal])
+  }, [geo, view, fill, fillDef, effRows, byZone, scale, points, theme, arcs, overlays, atLatest, onBorderSelect, onZoneSelect, selectedZone, pal])
 
   const getTooltip = useMemo(() => makeTooltip(byZone, pal), [byZone, pal])
 
@@ -126,7 +128,7 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
       <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-2.5 border-b border-border">
         <div className="flex items-center gap-2 min-w-0">
           <span className="font-mono text-[12px] font-semibold text-neutral-300">Europe · power map</span>
-          <InfoPopover text="Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by the day-ahead price — or by grid state. IMPORTANT: it shades ONE HOUR at a time (the hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the all-zones table shows a positive daily mean. Drag the slider to move through the hours. Fixed colour scale across the shown week: violet = negative prices (a distinct state, not just cheap), brighter cyan = more expensive. Dark shapes = neighbouring countries, no data by design. FLOWS arcs = the latest cross-border flow per border: the faint end exports, the solid end imports; width ∝ GW, colour = how loaded the border is vs its offered day-ahead capacity (grey = no NTC published or no reading); they always show the latest hour and hide while you scrub the past — click one for the border detail below. Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast." />
+          <InfoPopover text="Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by the day-ahead price — or by grid state. IMPORTANT: it shades ONE HOUR at a time (the hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the all-zones table shows a positive daily mean. Drag the slider to move through the hours. Fixed equal-frequency colour scale across the shown week: colours spread by rank among the week's all-zone hours, not by € distance (tooltips carry exact €) — violet = negative prices (a distinct state, not just cheap), brighter cyan = more expensive. Dark shapes = neighbouring countries, no data by design. FLOWS arcs = the latest cross-border flow per border: the faint end exports, the solid end imports; width ∝ GW, colour = how loaded the border is vs its offered day-ahead capacity (grey = no NTC published or no reading); they always show the latest hour and hide while you scrub the past — click one for the border detail below. Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast." />
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex items-center gap-1">
@@ -161,7 +163,7 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
       {overlays.flows && <FlowArcLegend pal={pal} atLatest={atLatest} />}
 
       <div className="flex items-center justify-between gap-2 px-4 py-2 border-t border-border font-mono text-[9px] text-neutral-600">
-        <fillDef.Legend lo={lo} hi={hi} pal={pal} />
+        <fillDef.Legend scale={scale} pal={pal} />
         <span>{zoneCount} zones · ENTSO-E · zones © Electricity Maps</span>
       </div>
     </div>

--- a/frontend/src/components/powermap/scales.js
+++ b/frontend/src/components/powermap/scales.js
@@ -1,4 +1,4 @@
-export function lerp(a, b, t) {
+function lerp(a, b, t) {
   return [
     Math.round(a[0] + (b[0] - a[0]) * t),
     Math.round(a[1] + (b[1] - a[1]) * t),
@@ -6,39 +6,37 @@ export function lerp(a, b, t) {
   ]
 }
 
-// v → RGB for the diverging price scale on the fixed domain [lo, hi] (lo may be ≥0,
-// then only the positive pole is in play). Values are clamped to the domain.
-export function priceColor(v, lo, hi, pal) {
-  if (v == null) return pal.mid
-  if (v >= 0) {
-    const span = Math.max(hi, 1e-6)
-    return lerp(pal.mid, pal.posPole, Math.min(Math.max(v / span, 0), 1))
-  }
-  const span = Math.max(-lo, 1e-6)
-  return lerp(pal.mid, pal.negPole, Math.min(Math.max(-v / span, 0), 1))
-}
-
-// The legend is GENERATED from priceColor — it cannot drift from the map.
-export function legendGradient(lo, hi, pal) {
-  const stops = []
-  for (let i = 0; i <= 12; i++) {
-    const v = lo + ((hi - lo) * i) / 12
-    const [r, g, b] = priceColor(v, lo, hi, pal)
-    stops.push(`rgb(${r},${g},${b}) ${(i / 12) * 100}%`)
-  }
-  return `linear-gradient(90deg, ${stops.join(', ')})`
-}
-
-export function percentile(sorted, p) {
+function percentile(sorted, p) {
   if (sorted.length === 0) return 0
   const i = (sorted.length - 1) * p
   const f = Math.floor(i)
   return sorted[f] + (sorted[Math.min(f + 1, sorted.length - 1)] - sorted[f]) * (i - f)
 }
 
+// Interpolated empirical CDF: where does v sit among the sorted observed
+// values, as a fraction in [0, 1]? Binary search + linear interpolation
+// between neighbours (the inverse of `percentile`) — smooth, monotone, and
+// clamped for values outside the observed range. Runs of duplicates are fine:
+// the search lands past the run, so the interpolation denominator stays > 0.
+function cdfRank(sorted, v) {
+  const n = sorted.length
+  if (n === 0 || v <= sorted[0]) return 0
+  if (v >= sorted[n - 1]) return 1
+  let lo = 0
+  let hi = n - 1
+  while (lo < hi) {
+    const m = (lo + hi) >> 1
+    if (sorted[m] > v) hi = m
+    else lo = m + 1
+  }
+  // sorted[lo-1] <= v < sorted[lo]
+  const frac = (v - sorted[lo - 1]) / (sorted[lo] - sorted[lo - 1])
+  return (lo - 1 + frac) / (n - 1)
+}
+
 // All price values in the shown window — every zone × every snapshot hour,
-// plus the live overview rows. This is the population behind the fixed weekly
-// color domain (and the population a quantile scale would classify).
+// plus the live overview rows. This is the population the quantile scale
+// classifies against.
 export function collectWeekValues(snap, rows) {
   const vals = []
   if (snap?.zones) {
@@ -50,17 +48,64 @@ export function collectWeekValues(snap, rows) {
   return vals
 }
 
-// FIXED color domain over the whole 7-day window (all zones × all hours), so
-// scrubbing compares hours honestly — a per-frame min/max would repaint every
-// zone each step and make yesterday incomparable to today. p2/p98 clamp keeps
-// one spike hour from crushing the rest of the scale; the legend says so.
-// Carries the sorted `vals` population so scale construction stays a
-// scales.js-only concern.
-export function weekDomain(snap, rows) {
-  const vals = collectWeekValues(snap, rows)
-  if (!vals.length) return { lo: 0, hi: 1, vals }
-  vals.sort((a, b) => a - b)
-  const p2 = percentile(vals, 0.02)
-  const p95 = percentile(vals, 0.95)
-  return { lo: Math.min(p2, 0), hi: Math.max(p95, 1), vals }
+// Equal-frequency (quantile) color scale over the week population.
+//
+// WHY not linear: in expensive evening hours nearly every zone sits in the top
+// tenth of a week-fixed linear domain and the continent flattens into one blue.
+// Ranks spread the colors by how a price sits WITHIN the week's distribution,
+// so differentiation survives by construction (and outliers can't crush the
+// scale — no p2/p98 clamp needed); the tooltip keeps the exact €.
+//
+// The domain is FIXED across the whole window: the scale is built ONCE from
+// the full week population (all zones × all hours), so scrubbing repaints
+// every hour against the SAME mapping — 20:00 yesterday stays honestly
+// comparable to 20:00 today. Never rebuild it per frame.
+//
+// Negatives keep the violet pole and rank only among THEMSELVES (most-negative
+// → full violet, closest-to-zero → ~mid): a negative price is a distinct
+// market state and must never blend into "cheap".
+export function makeQuantileScale(vals, pal) {
+  const sorted = [...vals].sort((a, b) => a - b)
+  const n = sorted.length
+  let split = 0 // size of the negative slice
+  while (split < n && sorted[split] < 0) split++
+  const neg = sorted.slice(0, split)
+  const pos = sorted.slice(split)
+
+  const color = (v) => {
+    if (v == null || n === 0) return pal.mid
+    if (v < 0) {
+      // A negative outside the observed range — or with no negatives in the
+      // population at all — clamps to FULL violet: it is more extreme than
+      // anything seen, never "cheap".
+      return lerp(pal.mid, pal.negPole, neg.length ? 1 - cdfRank(neg, v) : 1)
+    }
+    return lerp(pal.mid, pal.posPole, pos.length ? cdfRank(pos, v) : 0)
+  }
+
+  return {
+    color,
+    // Legend samples on the CDF axis: stop i sits at population fraction
+    // i/nStops and is colored by the price found there — equal bar length =
+    // equal share of the week's hours, and because every stop goes through
+    // color() the legend cannot drift from the map.
+    stops(nStops) {
+      const out = []
+      for (let i = 0; i <= nStops; i++) out.push(color(n ? percentile(sorted, i / nStops) : null))
+      return out
+    },
+    quantiles: n
+      ? {
+          p10: percentile(sorted, 0.1),
+          p25: percentile(sorted, 0.25),
+          p50: percentile(sorted, 0.5),
+          p75: percentile(sorted, 0.75),
+          p90: percentile(sorted, 0.9),
+        }
+      : null,
+    lo: n ? sorted[0] : 0, // observed extremes — legend endpoints only
+    hi: n ? sorted[n - 1] : 0,
+    hasNegatives: split > 0,
+    negShare: n ? split / n : 0, // CDF position of 0 € — the legend's zero marker
+  }
 }

--- a/frontend/src/components/powermap/scales.js
+++ b/frontend/src/components/powermap/scales.js
@@ -70,7 +70,8 @@ export function makeQuantileScale(vals, pal) {
   let split = 0 // size of the negative slice
   while (split < n && sorted[split] < 0) split++
   const neg = sorted.slice(0, split)
-  const pos = sorted.slice(split)
+  const nonNeg = sorted.slice(split)
+  const negShare = n ? split / n : 0
 
   const color = (v) => {
     if (v == null || n === 0) return pal.mid
@@ -80,18 +81,33 @@ export function makeQuantileScale(vals, pal) {
       // anything seen, never "cheap".
       return lerp(pal.mid, pal.negPole, neg.length ? 1 - cdfRank(neg, v) : 1)
     }
-    return lerp(pal.mid, pal.posPole, pos.length ? cdfRank(pos, v) : 0)
+    return lerp(pal.mid, pal.posPole, nonNeg.length ? cdfRank(nonNeg, v) : 0)
   }
 
   return {
     color,
-    // Legend samples on the CDF axis: stop i sits at population fraction
-    // i/nStops and is colored by the price found there — equal bar length =
-    // equal share of the week's hours, and because every stop goes through
-    // color() the legend cannot drift from the map.
+    // Legend stops, POSITIONED on the CDF axis: [{pos, rgb}] with pos in
+    // [0, 1]. The two sides of 0 are sampled SEPARATELY, with a doubled stop
+    // at pos = negShare (violet side, then cyan side) pinning the handoff as
+    // a hard edge — uniform sampling would smooth the violet→mid pinch away
+    // whenever negatives are sparse (negShare < 1/nStops, the common live
+    // case) and let prices just above zero render violet-ish. Every stop
+    // still goes through color(), so the legend cannot drift from the map.
     stops(nStops) {
+      if (n === 0) return [{ pos: 0, rgb: pal.mid }, { pos: 1, rgb: pal.mid }]
       const out = []
-      for (let i = 0; i <= nStops; i++) out.push(color(n ? percentile(sorted, i / nStops) : null))
+      if (neg.length) {
+        const k = Math.max(2, Math.round(nStops * negShare))
+        for (let i = 0; i <= k; i++) {
+          out.push({ pos: (i / k) * negShare, rgb: color(percentile(neg, i / k)) })
+        }
+      }
+      if (nonNeg.length) {
+        const k = Math.max(2, nStops - Math.round(nStops * negShare))
+        for (let i = 0; i <= k; i++) {
+          out.push({ pos: negShare + (i / k) * (1 - negShare), rgb: color(percentile(nonNeg, i / k)) })
+        }
+      }
       return out
     },
     quantiles: n
@@ -105,7 +121,6 @@ export function makeQuantileScale(vals, pal) {
       : null,
     lo: n ? sorted[0] : 0, // observed extremes — legend endpoints only
     hi: n ? sorted[n - 1] : 0,
-    hasNegatives: split > 0,
-    negShare: n ? split / n : 0, // CDF position of 0 € — the legend's zero marker
+    negShare, // CDF position of 0 € — the legend's zero marker; > 0 ⇔ negatives exist
   }
 }


### PR DESCRIPTION
## Was
PR 4/9 des Map-Redesign-Plans: Die lineare Preis-Farbskala wird durch eine **equal-frequency-(Quantil-)Skala** ersetzt — Fix für das „Einheitsblau" (in teuren Abendstunden saß fast der ganze Kontinent am oberen Ende der wochen-fixen linearen Skala und nichts differenzierte mehr).

## Wie
- `makeQuantileScale(vals, pal)` in `scales.js`: Farben nach Rang (empirische CDF, Binary Search auf der einmal sortierten Wochen-Population ~37 Zonen × 168 h), Domain bleibt **wochen-fix** — Scrubbing vergleicht Stunden weiterhin ehrlich gegen dieselbe Abbildung.
- **Negativ bleibt der Violett-Pol** (eigener Marktzustand, mischt nie in „billig"): Negative ranken unter sich Richtung Violett, `color(0)` = exakt Mid. `stops()` liefert **positionierte** `{pos, rgb}`-Stops mit Doppel-Stop bei `negShare` — die Violett→Mid-Kante übersteht auch sparse-negative Wochen (uniforme Stops hätten sie glattgelerpt).
- Legende = CDF-Achse, AUS der Skala generiert (anti-drift): Preis-Ticks bei p10/p25/p50/p75/p90 (mit Kollisions-Guard), Null-Marker bei `negShare`, Caption „equal-frequency scale · week's all-zone hours"; p2/p98-Clamp-Semantik entfernt (Quantile sind robust); InfoPopover-Wording nachgezogen; Light-Theme-Fix der Violett-Note (`/70`-Modifier umging den `html.light`-Override).
- Toter Linear-Code (`priceColor`/`legendGradient`/`weekDomain`) gelöscht.

## Verifikation
Build + Modul-Lint grün; Skalen-Mathematik von zwei unabhängigen Reviewern mit eigenen Simulationsskripten geprüft (Monotonie, Duplikat-Runs, Grenzfälle, sparse-negative Gradient); zwei-stufiges Review bestanden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)