### PR TITLE
Zone labels with collision culling + flow-arc visual rework

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@deck.gl/core": "^9.2.10",
+        "@deck.gl/extensions": "^9.2.10",
         "@deck.gl/layers": "^9.2.10",
         "@deck.gl/react": "^9.2.10",
         "@tailwindcss/vite": "^4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@deck.gl/core": "^9.2.10",
+    "@deck.gl/extensions": "^9.2.10",
     "@deck.gl/layers": "^9.2.10",
     "@deck.gl/react": "^9.2.10",
     "@tailwindcss/vite": "^4.2.1",

--- a/frontend/src/components/powermap/Legend.jsx
+++ b/frontend/src/components/powermap/Legend.jsx
@@ -15,6 +15,7 @@ export function FlowArcLegend({ pal, atLatest }) {
       <span><span style={{ color: rgbCss(pal.arc.high) }}>■</span> ≥{UTIL_HIGH}% of NTC</span>
       <span><span style={{ color: rgbCss(pal.arc.proxy) }}>■</span> no NTC (p95)</span>
       <span><span style={{ color: rgbCss(pal.arc.none) }}>■</span> no reading</span>
+      <span>· grey = context (thin)</span>
       <span>solid end = importer</span>
       {!atLatest && <span className="text-neutral-500">hidden while scrubbing — arcs show latest only</span>}
     </div>

--- a/frontend/src/components/powermap/Legend.jsx
+++ b/frontend/src/components/powermap/Legend.jsx
@@ -15,7 +15,7 @@ export function FlowArcLegend({ pal, atLatest }) {
       <span><span style={{ color: rgbCss(pal.arc.high) }}>■</span> ≥{UTIL_HIGH}% of NTC</span>
       <span><span style={{ color: rgbCss(pal.arc.proxy) }}>■</span> no NTC (p95)</span>
       <span><span style={{ color: rgbCss(pal.arc.none) }}>■</span> no reading</span>
-      <span>· grey = context (thin)</span>
+      <span>grey = context (thin)</span>
       <span>solid end = importer</span>
       {!atLatest && <span className="text-neutral-500">hidden while scrubbing — arcs show latest only</span>}
     </div>

--- a/frontend/src/components/powermap/constants.js
+++ b/frontend/src/components/powermap/constants.js
@@ -18,10 +18,14 @@ export const INITIAL_VIEW = { longitude: 9, latitude: 54, zoom: 3.1, minZoom: 2.
 
 // ── Cross-border flow arcs ────────────────────────────────────────────────────
 // Width encodes |latest flow|: √ scale (a 4× flow reads 2× wide — GW differences
-// stay legible without 5-GW borders drowning 300-MW ones), capped at 5 GW / 8 px,
+// stay legible without 5-GW borders drowning 300-MW ones), capped at 5 GW / 6 px,
 // 1 px floor so thin borders stay hoverable.
 export const FLOW_WIDTH_MAX_MW = 5000
-export const ARC_MAX_PX = 8
+export const ARC_MAX_PX = 6
+// Gray context arcs (no NTC / no reading) cap here instead: they carry no load
+// signal, so they must not out-shout the informative NTC-colored arcs — see
+// buildArcs in layers/flowArcsLayer.js.
+export const ARC_CONTEXT_MAX_PX = 2
 // NTC-utilization classing thresholds (%) — single source for the arc colors
 // AND the footer legend, so the two can never drift apart.
 export const UTIL_MID = 70

--- a/frontend/src/components/powermap/fills.js
+++ b/frontend/src/components/powermap/fills.js
@@ -7,10 +7,12 @@ import { PriceScaleLegend, StateLegend } from './Legend'
 //   scrub          — whether the time scrubber applies (grid state is always live)
 //   hasLabels      — whether the ZONES view offers the per-zone TextLayer
 //                    (+ the LABELS toggle in the header)
-//   labelText(pt)  — label string for one point row; null = no label for this
-//                    point (price fill skips zones without a price)
-//   labelPriority(pt) — collision-cull rank: when labels overlap, the HIGHER
-//                    value survives. Must stay within deck.gl's −1000..1000.
+//   labelText(pt, ctx) — label string for one point row, ctx as in getColor;
+//                    null = no label for this point (price fill skips zones
+//                    without a price)
+//   labelPriority(pt, ctx) — collision-cull rank: when labels overlap, the
+//                    HIGHER value survives. Must stay within deck.gl's
+//                    −1000..1000.
 //   getColor(zoneKey, ctx) — base RGB for one zone, ctx = {byZone, scale, pal};
 //                    null = zone has no data (index falls back to pal.contextFill)
 //   alpha          — layer opacities: .zone (choropleth) / .point (dots)

--- a/frontend/src/components/powermap/fills.js
+++ b/frontend/src/components/powermap/fills.js
@@ -5,7 +5,12 @@ import { PriceScaleLegend, StateLegend } from './Legend'
 // index.jsx never branches on a fill key:
 //   key/label      — header toggle button
 //   scrub          — whether the time scrubber applies (grid state is always live)
-//   hasLabels      — whether the ZONES view draws the per-zone value TextLayer
+//   hasLabels      — whether the ZONES view offers the per-zone TextLayer
+//                    (+ the LABELS toggle in the header)
+//   labelText(pt)  — label string for one point row; null = no label for this
+//                    point (price fill skips zones without a price)
+//   labelPriority(pt) — collision-cull rank: when labels overlap, the HIGHER
+//                    value survives. Must stay within deck.gl's −1000..1000.
 //   getColor(zoneKey, ctx) — base RGB for one zone, ctx = {byZone, scale, pal};
 //                    null = zone has no data (index falls back to pal.contextFill)
 //   alpha          — layer opacities: .zone (choropleth) / .point (dots)
@@ -18,6 +23,12 @@ export const FILLS = [
     label: 'DAY-AHEAD €/MWh',
     scrub: true,
     hasLabels: true,
+    labelText: (p) => (p.price == null ? null : `${p.label} ${Math.round(p.price)}`),
+    // |price| so the EXTREME zones survive the collision cull — a €300 spike or
+    // a €−40 solar dump is exactly the label you want in the dense Benelux
+    // cluster, not whichever zone happens to draw first. Clamped: spike hours
+    // exceed 1000 €/MWh and deck.gl's priority range ends there.
+    labelPriority: (p) => Math.min(Math.abs(p.price ?? 0), 1000),
     getColor: (zone, { byZone, scale }) => {
       const z = byZone.get(zone)
       if (!z) return null
@@ -33,7 +44,12 @@ export const FILLS = [
     key: 'state',
     label: 'GRID STATE',
     scrub: false,
-    hasLabels: false,
+    hasLabels: true,
+    // State is already the color — the label only answers "which zone is that",
+    // so it's the bare zone code. Cull priority = severity: a STRESSED zone's
+    // name must not lose the overlap fight to a CALM neighbour.
+    labelText: (p) => p.label,
+    labelPriority: (p) => ({ CALM: 0, ELEVATED: 1, STRESSED: 2 })[p.state] ?? 0,
     getColor: (zone, { byZone, pal }) => {
       const z = byZone.get(zone)
       if (!z) return null

--- a/frontend/src/components/powermap/index.jsx
+++ b/frontend/src/components/powermap/index.jsx
@@ -116,7 +116,7 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
       ]
     }
     const labels = overlays.labels && fillDef.hasLabels
-      ? makeLabelsLayer({ points, pal, theme, effRows, fill, fillDef })
+      ? makeLabelsLayer({ points, pal, theme, effRows, fill, fillDef, fillCtx })
       : null
     const base = labels ? [zonesLayer, labels] : [zonesLayer]
     return arcLayer ? [...base, arcLayer] : base
@@ -151,7 +151,7 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
           >
             FLOWS
           </ToggleButton>
-          {fillDef.hasLabels && (
+          {view === 'zones' && fillDef.hasLabels && (
             <ToggleButton
               active={overlays.labels}
               onClick={() => setOverlays((o) => ({ ...o, labels: !o.labels }))}
@@ -167,7 +167,9 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
         className={`relative ${tall ? 'h-[60vh] lg:h-[min(75vh,calc(100vh-230px))]' : ''}`}
         style={tall ? { background: pal.surface } : { height: 460, background: pal.surface }}
       >
-        <DeckGL initialViewState={INITIAL_VIEW} controller={true} layers={layers} getTooltip={getTooltip} />
+        {/* pickingRadius: the demoted 2 px context arcs stay clickable without
+            pixel-hunting — widens hit-testing only, no visual change. */}
+        <DeckGL initialViewState={INITIAL_VIEW} controller={true} layers={layers} getTooltip={getTooltip} pickingRadius={4} />
       </div>
 
       {fillDef.scrub && ts.length > 1 && <Scrubber ts={ts} effIdx={effIdx} setIdx={setIdx} />}

--- a/frontend/src/components/powermap/index.jsx
+++ b/frontend/src/components/powermap/index.jsx
@@ -43,7 +43,8 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
   const { geo, rows, snap, borders } = useMapData(fill)
   const [view, setView] = useState('zones') // 'zones' choropleth | 'points' per-zone dots
   const [idx, setIdx] = useState(null) // selected hour index; null = latest/live
-  const [overlays, setOverlays] = useState({ flows: true }) // map overlays; flows = cross-border arcs
+  // Map overlays: flows = cross-border arcs, labels = per-zone TextLayer.
+  const [overlays, setOverlays] = useState({ flows: true, labels: true })
 
   const fillDef = FILLS.find((f) => f.key === fill) || FILLS[0]
 
@@ -114,8 +115,10 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
         makePointsLayer({ points, pointFill, pal, theme, fillColorTriggers, onZoneClick: onZoneSelect }),
       ]
     }
-    const labels = makeLabelsLayer({ points, pal, theme, effRows })
-    const base = fillDef.hasLabels ? [zonesLayer, labels] : [zonesLayer]
+    const labels = overlays.labels && fillDef.hasLabels
+      ? makeLabelsLayer({ points, pal, theme, effRows, fill, fillDef })
+      : null
+    const base = labels ? [zonesLayer, labels] : [zonesLayer]
     return arcLayer ? [...base, arcLayer] : base
   }, [geo, view, fill, fillDef, effRows, byZone, scale, points, theme, arcs, overlays, atLatest, onBorderSelect, onZoneSelect, selectedZone, pal])
 
@@ -128,7 +131,7 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
       <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-2.5 border-b border-border">
         <div className="flex items-center gap-2 min-w-0">
           <span className="font-mono text-[12px] font-semibold text-neutral-300">Europe · power map</span>
-          <InfoPopover text="Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by the day-ahead price — or by grid state. IMPORTANT: it shades ONE HOUR at a time (the hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the all-zones table shows a positive daily mean. Drag the slider to move through the hours. Fixed equal-frequency colour scale across the shown week: colours spread by rank among the week's all-zone hours, not by € distance (tooltips carry exact €) — violet = negative prices (a distinct state, not just cheap), brighter cyan = more expensive. Dark shapes = neighbouring countries, no data by design. FLOWS arcs = the latest cross-border flow per border: the faint end exports, the solid end imports; width ∝ GW, colour = how loaded the border is vs its offered day-ahead capacity (grey = no NTC published or no reading); they always show the latest hour and hide while you scrub the past — click one for the border detail below. Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast." />
+          <InfoPopover text="Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by the day-ahead price — or by grid state. IMPORTANT: it shades ONE HOUR at a time (the hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the all-zones table shows a positive daily mean. Drag the slider to move through the hours. Fixed equal-frequency colour scale across the shown week: colours spread by rank among the week's all-zone hours, not by € distance (tooltips carry exact €) — violet = negative prices (a distinct state, not just cheap), brighter cyan = more expensive. Dark shapes = neighbouring countries, no data by design. FLOWS arcs = the latest cross-border flow per border: the faint end exports, the solid end imports; width ∝ GW, colour = how loaded the border is vs its offered day-ahead capacity (grey = no NTC published or no reading — drawn thin and faint as context); they always show the latest hour and hide while you scrub the past — click one for the border detail below. Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast." />
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex items-center gap-1">
@@ -148,6 +151,15 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
           >
             FLOWS
           </ToggleButton>
+          {fillDef.hasLabels && (
+            <ToggleButton
+              active={overlays.labels}
+              onClick={() => setOverlays((o) => ({ ...o, labels: !o.labels }))}
+              title="Per-zone labels (overlapping labels hide — zoom in to reveal)"
+            >
+              LABELS
+            </ToggleButton>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/powermap/layers/flowArcsLayer.js
+++ b/frontend/src/components/powermap/layers/flowArcsLayer.js
@@ -1,5 +1,5 @@
 import { ArcLayer } from '@deck.gl/layers'
-import { ZONE_COORDS, ARC_MAX_PX, UTIL_MID, UTIL_HIGH, arcWidth } from '../constants'
+import { ZONE_COORDS, ARC_MAX_PX, ARC_CONTEXT_MAX_PX, UTIL_MID, UTIL_HIGH, arcWidth } from '../constants'
 
 // One arc per border, carrying the WHOLE border object (the tooltip reads its
 // stats). Direction is static: faint end = exporter, solid end = importer.
@@ -18,22 +18,35 @@ export function buildArcs(borders, pal) {
     const flip = !noFlow && mw < 0
     // Color = how loaded the border is; the grays are states, not magnitudes:
     // proxy = no NTC published (flow-based Core / Nordics), none = no reading.
+    // `informative` = the arc carries a real NTC-utilization reading. The gray
+    // arcs are demoted to quiet context (2 px cap, lower alpha): 40 of 63
+    // borders are gray by MARKET DESIGN, not data failure, and at full √ width
+    // they drowned the handful of arcs that actually say something.
     let rgb
+    let informative = false
     if (noFlow) rgb = pal.arc.none
     else if (b.capacity_source !== 'ntc') rgb = pal.arc.proxy
     else if (b.util_latest_pct == null) rgb = pal.arc.none
-    else if (b.util_latest_pct < UTIL_MID) rgb = pal.arc.low
-    else if (b.util_latest_pct < UTIL_HIGH) rgb = pal.arc.mid
-    else rgb = pal.arc.high
+    else {
+      informative = true
+      if (b.util_latest_pct < UTIL_MID) rgb = pal.arc.low
+      else if (b.util_latest_pct < UTIL_HIGH) rgb = pal.arc.mid
+      else rgb = pal.arc.high
+    }
+    // No reading → uniform faint alpha at both ends: a gradient would claim
+    // a direction we do not have. Still pickable/clickable (widthMinPixels 1).
+    let sourceAlpha, targetAlpha
+    if (noFlow) { sourceAlpha = 60; targetAlpha = 60 }
+    else if (informative) { sourceAlpha = 70; targetAlpha = 235 }
+    else { sourceAlpha = 40; targetAlpha = 110 }
     out.push({
       ...b,
+      informative,
       source: flip ? cb : ca,
       target: flip ? ca : cb,
-      width: noFlow ? 1 : arcWidth(mw),
-      // No reading → uniform faint alpha at both ends: a gradient would claim
-      // a direction we do not have. Still pickable/clickable.
-      sourceColor: [...rgb, noFlow ? 90 : 70],
-      targetColor: [...rgb, noFlow ? 90 : 235],
+      width: noFlow ? 1 : informative ? arcWidth(mw) : Math.min(arcWidth(mw), ARC_CONTEXT_MAX_PX),
+      sourceColor: [...rgb, sourceAlpha],
+      targetColor: [...rgb, targetAlpha],
       // Deterministic ±8° fan so parallel Benelux/Nordic arcs do not stack.
       tilt: ((i % 3) - 1) * 8,
     })

--- a/frontend/src/components/powermap/layers/flowArcsLayer.js
+++ b/frontend/src/components/powermap/layers/flowArcsLayer.js
@@ -41,7 +41,6 @@ export function buildArcs(borders, pal) {
     else { sourceAlpha = 40; targetAlpha = 110 }
     out.push({
       ...b,
-      informative,
       source: flip ? cb : ca,
       target: flip ? ca : cb,
       width: noFlow ? 1 : informative ? arcWidth(mw) : Math.min(arcWidth(mw), ARC_CONTEXT_MAX_PX),

--- a/frontend/src/components/powermap/layers/labelsLayer.js
+++ b/frontend/src/components/powermap/layers/labelsLayer.js
@@ -1,12 +1,15 @@
 import { TextLayer } from '@deck.gl/layers'
+import { CollisionFilterExtension } from '@deck.gl/extensions'
 
-// Per-zone price labels for the ZONES view (price fill only).
-export function makeLabelsLayer({ points, pal, theme, effRows }) {
+// Per-zone labels for the ZONES view — "DE-LU 74" on the price fill, bare zone
+// code on the state fill. Text + cull priority are dispatched through the fill
+// registry (fills.js), so this factory never branches on a fill key.
+export function makeLabelsLayer({ points, pal, theme, effRows, fill, fillDef }) {
   return new TextLayer({
-    id: 'zone-price-labels',
-    data: points.filter((p) => p.price != null),
+    id: 'zone-labels',
+    data: points.filter((p) => fillDef.labelText(p) != null),
     getPosition: (d) => d.position,
-    getText: (d) => `${Math.round(d.price)}`,
+    getText: (d) => fillDef.labelText(d),
     getColor: pal.label,
     outlineColor: pal.labelOutline,
     outlineWidth: 2,
@@ -19,6 +22,20 @@ export function makeLabelsLayer({ points, pal, theme, effRows }) {
     sizeMaxPixels: 13,
     billboard: true,
     pickable: false,
-    updateTriggers: { getText: [effRows], getPosition: [effRows], getColor: [theme] },
+    // Collision cull: overlapping labels hide instead of overprinting (they
+    // reappear on zoom — that's the extension's behavior, no code needed).
+    // Which one survives is the fill's call — see labelPriority in fills.js.
+    // sizeScale 1.2 tests a slightly fatter footprint, buying breathing room
+    // between labels that would otherwise kiss.
+    extensions: [new CollisionFilterExtension()],
+    collisionGroup: 'zone-labels',
+    getCollisionPriority: (d) => fillDef.labelPriority(d),
+    collisionTestProps: { sizeScale: 1.2 },
+    updateTriggers: {
+      getText: [effRows, fill],
+      getPosition: [effRows],
+      getColor: [theme],
+      getCollisionPriority: [effRows, fill],
+    },
   })
 }

--- a/frontend/src/components/powermap/layers/labelsLayer.js
+++ b/frontend/src/components/powermap/layers/labelsLayer.js
@@ -3,13 +3,14 @@ import { CollisionFilterExtension } from '@deck.gl/extensions'
 
 // Per-zone labels for the ZONES view — "DE-LU 74" on the price fill, bare zone
 // code on the state fill. Text + cull priority are dispatched through the fill
-// registry (fills.js), so this factory never branches on a fill key.
-export function makeLabelsLayer({ points, pal, theme, effRows, fill, fillDef }) {
+// registry (fills.js) with the same ctx getColor sees, so this factory never
+// branches on a fill key and a future fill can label from per-zone data.
+export function makeLabelsLayer({ points, pal, theme, effRows, fill, fillDef, fillCtx }) {
   return new TextLayer({
     id: 'zone-labels',
-    data: points.filter((p) => fillDef.labelText(p) != null),
+    data: points.filter((p) => fillDef.labelText(p, fillCtx) != null),
     getPosition: (d) => d.position,
-    getText: (d) => fillDef.labelText(d),
+    getText: (d) => fillDef.labelText(d, fillCtx),
     getColor: pal.label,
     outlineColor: pal.labelOutline,
     outlineWidth: 2,
@@ -26,11 +27,12 @@ export function makeLabelsLayer({ points, pal, theme, effRows, fill, fillDef }) 
     // reappear on zoom — that's the extension's behavior, no code needed).
     // Which one survives is the fill's call — see labelPriority in fills.js.
     // sizeScale 1.2 tests a slightly fatter footprint, buying breathing room
-    // between labels that would otherwise kiss.
+    // between labels that would otherwise kiss; sizeMaxPixels lifted in step
+    // so the padding survives once labels hit the 13 px render cap.
     extensions: [new CollisionFilterExtension()],
     collisionGroup: 'zone-labels',
-    getCollisionPriority: (d) => fillDef.labelPriority(d),
-    collisionTestProps: { sizeScale: 1.2 },
+    getCollisionPriority: (d) => fillDef.labelPriority(d, fillCtx),
+    collisionTestProps: { sizeScale: 1.2, sizeMaxPixels: 16 },
     updateTriggers: {
       getText: [effRows, fill],
       getPosition: [effRows],


### PR DESCRIPTION
## Was
PR 5/9 des Map-Redesign-Plans: Labels werden lesbar („DE-LU 74" statt nackter Zahl, State-Fill bekommt Zonen-Code-Labels), Kollisionen werden per deck.gl `CollisionFilterExtension` gecullt (Priorität |Preis|, geclampt auf den Shader-Bereich ±1000; State: Severity-Rang), plus LABELS-Toggle (nur ZONES-View). Die Flow-Arcs hören auf, die Karte zu dominieren: Pixel-Cap 8→6, die 40/63 grauen No-Signal-Arcs (kein NTC per Marktdesign) werden auf ≤2px + reduziertes Alpha demotet — leiser Kontext statt lautester Layer; `pickingRadius=4` hält sie klickbar.

## Wie
- Label-API im Fill-Registry-Vertrag: `labelText(pt, ctx)` / `labelPriority(pt, ctx)` — symmetrisch zu `getColor`, PR 6 erreicht per-Zone-Daten ohne Umbau.
- Ehrlichkeits-Semantik unangetastet: >100 % NTC nie geclampt, No-Reading-Arcs behalten uniformes Alpha (kein erfundener Richtungs-Gradient), Legende + ⓘ sagen die Demotion dazu („grey = context (thin)").
- `@deck.gl/extensions` von Phantom- zu deklarierter Dependency (^9.2.10, Lockfile-kohärent, kein Dual-Install).

## Verifikation
Build + Modul-Lint grün; Bundle-Grep bestätigt Collision-Shader; Spec-Review verifizierte Shader-Range, Layer-ID-Scoping (VesselMap = eigene Deck-Instanz) und npm-Auflösung; Qualitäts-Re-Review bestätigt Picking-Präzedenz (Zone unterm Cursor gewinnt immer gegen Arc). Visueller Smoke folgt vor dem Deploy über PRs 3–5 gemeinsam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)