### PR TITLE
Map-first desk split for the EUROPE tab

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback, lazy, Suspense } from 'react'
+import { useState, useEffect, lazy, Suspense } from 'react'
 import Sidebar from './components/Sidebar'
 import CompactView from './components/CompactView'
 import AlertsPanel from './components/AlertsPanel'
 import SeriesExplorer from './components/SeriesExplorer'
 import CoveragePanel from './components/CoveragePanel'
+import EuropeDesk from './components/EuropeDesk'
 import DurationCurvePanel from './components/DurationCurvePanel'
 import MeritOrderScatter from './components/MeritOrderScatter'
 import MarginalTechPanel from './components/MarginalTechPanel'
@@ -24,9 +25,6 @@ import SparkSpreadPanel from './components/SparkSpreadPanel'
 import GenerationMixPanel from './components/GenerationMixPanel'
 import CrossBorderFlowPanel from './components/CrossBorderFlowPanel'
 import RegionPills from './components/RegionPills'
-import LiveCharts from './components/LiveCharts'
-import InsightsStrip from './components/InsightsStrip'
-import NarrativeHero from './components/NarrativeHero'
 import RangeSelector from './components/RangeSelector'
 import PowerSituationHeader from './components/PowerSituationHeader'
 import LiveNowPanel from './components/LiveNowPanel'
@@ -41,11 +39,8 @@ import RecordsPanel from './components/RecordsPanel'
 import EpisodeArchivePanel from './components/EpisodeArchivePanel'
 import CapturePanel from './components/CapturePanel'
 import SparkCalculatorPanel from './components/SparkCalculatorPanel'
-import BordersPanel from './components/BordersPanel'
 import DriversPanel from './components/DriversPanel'
 import ProductsPanel from './components/ProductsPanel'
-import PowerOverviewMatrix from './components/PowerOverviewMatrix'
-import HowToRead from './components/HowToRead'
 import Landing from './components/Landing'
 import LegalPage from './components/LegalPage'
 import CommandPalette from './components/CommandPalette'
@@ -57,7 +52,6 @@ import { ViewStateProvider, useViewState } from './context/ViewStateContext'
 // tabs — lazy-load them so the default POWER desk doesn't ship the mapping stack.
 const VesselMap = lazy(() => import('./components/VesselMap'))
 const AtlasMap = lazy(() => import('./components/AtlasMap'))
-const PowerMap = lazy(() => import('./components/powermap'))
 
 // Dormant non-power verticals (oil/maritime/metals/news/atlas/sentiment): their
 // tabs left with the 2026-07-03 refocus, so these render blocks are unreachable —
@@ -257,13 +251,6 @@ function Dashboard() {
   // the URL (?zone=) and persists. Aliased to the old local names so the ~14
   // downstream consumers stay untouched. SparkSpreadHistory is DE-LU-only in-panel.
   const { zone: energyZone, setZone: setEnergyZone } = useViewState()
-
-  // Map arc click → border detail: the focus travels as a prop to BordersPanel
-  // (opens the row, expands + scrolls the panel). `ts` makes every click a NEW
-  // signal, so re-clicking the same border still scrolls/expands. Stable
-  // callback — PowerMap's layers memo depends on it.
-  const [borderFocus, setBorderFocus] = useState(null)
-  const onBorderSelect = useCallback((a, b) => setBorderFocus({ a, b, ts: Date.now() }), [])
 
   // URL hash sync — keep the default (POWER) tab off the URL so the bare
   // homepage stays clean (`/`); only non-default tabs get a shareable hash.
@@ -799,45 +786,12 @@ function Dashboard() {
           </>
         )}
 
-        {/* LIVE (default front door) — the all-zones overview: sortable table BESIDE
-            the choropleth map, then the anomaly radar + orientation. */}
+        {/* EUROPE (default front door) — map-first desk split; the whole tab
+            lives in EuropeDesk, which owns its own layout + selection state. */}
         {activeTab === 'europe' && (
-          <div className="space-y-3">
-            <ErrorBoundary name="narrative">
-              <NarrativeHero />
-            </ErrorBoundary>
-            <h2 className="font-mono text-[15px] font-semibold text-neutral-200">European power desk · all zones</h2>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 items-start">
-              <ErrorBoundary name="power-overview">
-                <PowerOverviewMatrix
-                  selectedZone={energyZone}
-                  onSelect={(z) => { setEnergyZone(z); goToTab('energy') }}
-                />
-              </ErrorBoundary>
-              <ErrorBoundary name="power-map">
-                <Suspense fallback={MAP_FALLBACK}>
-                  <PowerMap onBorderSelect={onBorderSelect} />
-                </Suspense>
-              </ErrorBoundary>
-            </div>
-            <ErrorBoundary name="insights">
-              <InsightsStrip onMore={() => goToTab('alerts')} />
-            </ErrorBoundary>
-            {/* The border layer: prices × flows. A zone map shows WHERE power is
-                expensive; only the borders show whether the market is coupled. */}
-            <ErrorBoundary name="borders">
-              <BordersPanel focus={borderFocus} />
-            </ErrorBoundary>
-            <ErrorBoundary name="hydro">
-              <HydroReservoirPanel />
-            </ErrorBoundary>
-            <ErrorBoundary name="live-charts">
-              <LiveCharts />
-            </ErrorBoundary>
-            <ErrorBoundary name="how-to-read">
-              <HowToRead />
-            </ErrorBoundary>
-          </div>
+          <ErrorBoundary name="europe-desk">
+            <EuropeDesk energyZone={energyZone} setEnergyZone={setEnergyZone} goToTab={goToTab} />
+          </ErrorBoundary>
         )}
 
         {/* EXPLORE TAB — interactive query over the public data API (/api/v1/series) */}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import AlertsPanel from './components/AlertsPanel'
 import SeriesExplorer from './components/SeriesExplorer'
 import CoveragePanel from './components/CoveragePanel'
 import EuropeDesk from './components/EuropeDesk'
+import { MAP_FALLBACK } from './components/MapFallback'
 import DurationCurvePanel from './components/DurationCurvePanel'
 import MeritOrderScatter from './components/MeritOrderScatter'
 import MarginalTechPanel from './components/MarginalTechPanel'
@@ -85,12 +86,6 @@ const CopperPanel = lazy(() => import('./components/CopperPanel'))
 const NewsPanel = lazy(() => import('./components/NewsPanel'))
 const EIAPredictionPanel = lazy(() => import('./components/EIAPredictionPanel'))
 const EIAPredictionMini = lazy(() => import('./components/EIAPredictionPanel').then((m) => ({ default: m.EIAPredictionMini })))
-
-const MAP_FALLBACK = (
-  <div className="border border-border bg-surface rounded px-4 py-8 text-center font-mono text-xs text-neutral-500">
-    Loading map…
-  </div>
-)
 
 const API = '/api'
 

--- a/frontend/src/components/EuropeDesk.jsx
+++ b/frontend/src/components/EuropeDesk.jsx
@@ -8,25 +8,27 @@ import BordersPanel from './BordersPanel'
 import HydroReservoirPanel from './HydroReservoirPanel'
 import LiveCharts from './LiveCharts'
 import HowToRead from './HowToRead'
+import { MAP_FALLBACK } from './MapFallback'
+import { DESK_COLUMN_H } from './powermap/constants'
 
 // The EUROPE tab — the desk's front door, lifted out of App.jsx so the layout
 // that makes it a *map-first desk* lives in one file instead of inline in the
 // 900-line tab switch.
 //
 // THE SPLIT: the map is the subject, not a sidecar. It takes the RIGHT column
-// (2fr, tall, and sticky on lg so it stays in view while you read past it); the
-// all-zones matrix rides a narrow LEFT rail (compact variant) and is the map's
-// index. Below lg the split collapses and the MAP COMES FIRST (order-1) —
-// on a phone the map is still the thing you came for, and nothing sticks.
+// (2fr); the all-zones matrix rides a narrow LEFT rail (compact variant) and is
+// the map's index. BOTH columns are exactly DESK_COLUMN_H tall and are flex
+// columns, so the row has ONE height and neither column invents its own: the
+// map's canvas and the rail's table are both `flex-1 min-h-0` and simply take
+// what is left after their own chrome. That is why there is no sticky here —
+// equal columns mean a sticky one could never travel — and why the rail shows
+// ~30 of 37 zones instead of inner-scrolling at 14 beside 400 px of dead space.
+// PR 9's detail card inherits the same budget instead of picking another vh.
+// Below lg the split collapses, NOTHING is force-fitted to the viewport, and the
+// MAP COMES FIRST (order-1) — on a phone it is still the thing you came for.
 // Everything below the grid (radar, borders, hydro, charts, orientation) stays
 // full width: they are the drill-down, read in sequence, not beside the map.
 const PowerMap = lazy(() => import('./powermap'))
-
-const MAP_FALLBACK = (
-  <div className="border border-border bg-surface rounded px-4 py-8 text-center font-mono text-xs text-neutral-500">
-    Loading map…
-  </div>
-)
 
 export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
   // Map arc / outage chord click → border detail: the focus travels as a prop to
@@ -60,35 +62,27 @@ export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
       <ErrorBoundary name="narrative">
         <NarrativeHero />
       </ErrorBoundary>
-      <h2 className="font-mono text-[15px] font-semibold text-neutral-200">European power desk · all zones</h2>
-
       <div className="grid grid-cols-1 lg:grid-cols-[minmax(340px,1fr)_2fr] gap-3 items-start">
-        <div className="order-2 lg:order-1 min-w-0 space-y-3">
+        {/* The rail is a flex COLUMN of the same height as the map card: the
+            table takes the space (flex-1 min-h-0 — see PowerOverviewMatrix's
+            `compact`), the button stays parked at the bottom. `gap-3` rather
+            than space-y so the button keeps its spacing as a flex item. */}
+        <div className={`order-2 lg:order-1 min-w-0 flex flex-col gap-3 ${DESK_COLUMN_H}`}>
           <ErrorBoundary name="power-overview">
             <PowerOverviewMatrix compact selectedZone={focusZone} onSelect={setFocusZone} />
           </ErrorBoundary>
           {/* Temporary until PR 9's zone detail card: a row click no longer
               jumps tabs, so the jump needs a door of its own — otherwise the
-              only way from "that zone looks odd" to its desk is the pills. */}
+              only way from "that zone looks odd" to its desk is the pills.
+              shrink-0: the button is chrome, the table is what yields. */}
           <button
             onClick={() => { setEnergyZone(focusZone); goToTab('energy') }}
-            className="w-full border border-border bg-surface rounded px-3 py-2 font-mono text-[11px] text-neutral-400 hover:text-cyan-glow hover:border-cyan-glow/40 text-left"
+            className="shrink-0 w-full border border-border bg-surface rounded px-3 py-2 font-mono text-[11px] text-neutral-400 hover:text-cyan-glow hover:border-cyan-glow/40 text-left"
           >
             Open zone <span className="text-neutral-200">{focusLabel}</span> <span className="text-cyan-glow">→</span>
           </button>
         </div>
-        {/* Sticky against the WINDOW: <main> has no inner scroll container, and
-            body's overflow-x:hidden propagates to the viewport (so body itself
-            stays `visible` and clips nothing) — verified, nothing here clips.
-            HONEST CAVEAT: this pins NOTHING today. A sticky grid item travels
-            inside its grid AREA, and the map is the TALLER column (976 px vs
-            the rail's 549 at 1500×1000), so the row is exactly the map's own
-            height and there is no room to move. Measured, not assumed. It is
-            left in because it is free and self-activating: the day the rail
-            outgrows the map, the map pins for the difference. Making it pin for
-            real would mean putting the panels below INTO the left column (a
-            true two-pane desk) — a different layout, not this one. */}
-        <div className="order-1 lg:order-2 min-w-0 lg:sticky lg:top-3">
+        <div className="order-1 lg:order-2 min-w-0">
           <ErrorBoundary name="power-map">
             <Suspense fallback={MAP_FALLBACK}>
               <PowerMap

--- a/frontend/src/components/EuropeDesk.jsx
+++ b/frontend/src/components/EuropeDesk.jsx
@@ -1,0 +1,124 @@
+import { useState, useCallback, lazy, Suspense } from 'react'
+import useZones from '../hooks/useZones'
+import ErrorBoundary from './ErrorBoundary'
+import NarrativeHero from './NarrativeHero'
+import PowerOverviewMatrix from './PowerOverviewMatrix'
+import InsightsStrip from './InsightsStrip'
+import BordersPanel from './BordersPanel'
+import HydroReservoirPanel from './HydroReservoirPanel'
+import LiveCharts from './LiveCharts'
+import HowToRead from './HowToRead'
+
+// The EUROPE tab — the desk's front door, lifted out of App.jsx so the layout
+// that makes it a *map-first desk* lives in one file instead of inline in the
+// 900-line tab switch.
+//
+// THE SPLIT: the map is the subject, not a sidecar. It takes the RIGHT column
+// (2fr, tall, and sticky on lg so it stays in view while you read past it); the
+// all-zones matrix rides a narrow LEFT rail (compact variant) and is the map's
+// index. Below lg the split collapses and the MAP COMES FIRST (order-1) —
+// on a phone the map is still the thing you came for, and nothing sticks.
+// Everything below the grid (radar, borders, hydro, charts, orientation) stays
+// full width: they are the drill-down, read in sequence, not beside the map.
+const PowerMap = lazy(() => import('./powermap'))
+
+const MAP_FALLBACK = (
+  <div className="border border-border bg-surface rounded px-4 py-8 text-center font-mono text-xs text-neutral-500">
+    Loading map…
+  </div>
+)
+
+export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
+  // Map arc / outage chord click → border detail: the focus travels as a prop to
+  // BordersPanel (opens the row, expands + scrolls the panel). `ts` makes every
+  // click a NEW signal, so re-clicking the same border still scrolls/expands.
+  // Stable callback — PowerMap's layers memo depends on it. Lives here, not in
+  // App: the EUROPE tab is the only place a border can be clicked.
+  const [borderFocus, setBorderFocus] = useState(null)
+  const onBorderSelect = useCallback((a, b) => setBorderFocus({ a, b, ts: Date.now() }), [])
+
+  // The zone the SPLIT is looking at — table row ⇄ map outline, both ways.
+  // Deliberately NOT the global `energyZone`: selecting here is "show me this
+  // zone on the map", a look, not a navigation. It FOLLOWS the global zone
+  // (so it is never empty on arrival, and picks up the async server default),
+  // but a look here never writes back. Jumping the whole desk is the explicit
+  // "Open zone →" button below (PR 9 grows it into a detail card).
+  // Render-phase sync, the repo's derive-from-props pattern (cf. Panel's
+  // expandSignal) — no effect, so the rail never paints the wrong zone first.
+  const [focusZone, setFocusZone] = useState(energyZone)
+  const [seenZone, setSeenZone] = useState(energyZone)
+  if (energyZone !== seenZone) {
+    setSeenZone(energyZone)
+    setFocusZone(energyZone)
+  }
+
+  const { zones } = useZones()
+  const focusLabel = zones.find((z) => z.key === focusZone)?.label || focusZone
+
+  return (
+    <div className="space-y-3">
+      <ErrorBoundary name="narrative">
+        <NarrativeHero />
+      </ErrorBoundary>
+      <h2 className="font-mono text-[15px] font-semibold text-neutral-200">European power desk · all zones</h2>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(340px,1fr)_2fr] gap-3 items-start">
+        <div className="order-2 lg:order-1 min-w-0 space-y-3">
+          <ErrorBoundary name="power-overview">
+            <PowerOverviewMatrix compact selectedZone={focusZone} onSelect={setFocusZone} />
+          </ErrorBoundary>
+          {/* Temporary until PR 9's zone detail card: a row click no longer
+              jumps tabs, so the jump needs a door of its own — otherwise the
+              only way from "that zone looks odd" to its desk is the pills. */}
+          <button
+            onClick={() => { setEnergyZone(focusZone); goToTab('energy') }}
+            className="w-full border border-border bg-surface rounded px-3 py-2 font-mono text-[11px] text-neutral-400 hover:text-cyan-glow hover:border-cyan-glow/40 text-left"
+          >
+            Open zone <span className="text-neutral-200">{focusLabel}</span> <span className="text-cyan-glow">→</span>
+          </button>
+        </div>
+        {/* Sticky against the WINDOW: <main> has no inner scroll container, and
+            body's overflow-x:hidden propagates to the viewport (so body itself
+            stays `visible` and clips nothing) — verified, nothing here clips.
+            HONEST CAVEAT: this pins NOTHING today. A sticky grid item travels
+            inside its grid AREA, and the map is the TALLER column (976 px vs
+            the rail's 549 at 1500×1000), so the row is exactly the map's own
+            height and there is no room to move. Measured, not assumed. It is
+            left in because it is free and self-activating: the day the rail
+            outgrows the map, the map pins for the difference. Making it pin for
+            real would mean putting the panels below INTO the left column (a
+            true two-pane desk) — a different layout, not this one. */}
+        <div className="order-1 lg:order-2 min-w-0 lg:sticky lg:top-3">
+          <ErrorBoundary name="power-map">
+            <Suspense fallback={MAP_FALLBACK}>
+              <PowerMap
+                tall
+                onBorderSelect={onBorderSelect}
+                selectedZone={focusZone}
+                onZoneSelect={setFocusZone}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        </div>
+      </div>
+
+      <ErrorBoundary name="insights">
+        <InsightsStrip onMore={() => goToTab('alerts')} />
+      </ErrorBoundary>
+      {/* The border layer: prices × flows. A zone map shows WHERE power is
+          expensive; only the borders show whether the market is coupled. */}
+      <ErrorBoundary name="borders">
+        <BordersPanel focus={borderFocus} />
+      </ErrorBoundary>
+      <ErrorBoundary name="hydro">
+        <HydroReservoirPanel />
+      </ErrorBoundary>
+      <ErrorBoundary name="live-charts">
+        <LiveCharts />
+      </ErrorBoundary>
+      <ErrorBoundary name="how-to-read">
+        <HowToRead />
+      </ErrorBoundary>
+    </div>
+  )
+}

--- a/frontend/src/components/MapFallback.jsx
+++ b/frontend/src/components/MapFallback.jsx
@@ -1,0 +1,9 @@
+// The Suspense fallback for every lazily-loaded map (PowerMap, VesselMap,
+// AtlasMap). An ELEMENT, not a component: it is only ever passed as
+// `<Suspense fallback={MAP_FALLBACK}>`, and it holds no state or props.
+// Shared because it was drifting between App.jsx and EuropeDesk.jsx.
+export const MAP_FALLBACK = (
+  <div className="border border-border bg-surface rounded px-4 py-8 text-center font-mono text-xs text-neutral-500">
+    Loading map…
+  </div>
+)

--- a/frontend/src/components/PowerOverviewMatrix.jsx
+++ b/frontend/src/components/PowerOverviewMatrix.jsx
@@ -6,8 +6,9 @@ import { POLL_FAST_MS } from '../utils/poll'
 // Single-glance overview — read all bidding zones at once, colour-first, like
 // Electricity Maps. Colour encodes how far each metric sits from its
 // own trailing norm (the window is whatever /overview reports as baseline_days), so the
-// European power picture reads in one second. Click a zone
-// to drill into its detail; click a column header to sort. Descriptive, not a forecast.
+// European power picture reads in one second. Click a column header to sort;
+// what a ROW click does is the caller's (`onSelect`) — on the desk it focuses
+// the zone on the map beside it. Descriptive, not a forecast.
 const API = '/api'
 
 const STATE = {
@@ -20,12 +21,17 @@ const STATE_ORDER = { CALM: 0, ELEVATED: 1, STRESSED: 2 }
 const zColor = (z) =>
   z == null ? 'text-neutral-400' : Math.abs(z) >= 3 ? 'text-red-400' : Math.abs(z) >= 2 ? 'text-yellow-400' : 'text-neutral-300'
 
+// `compact` = the desk-split rail (~1/3 width, beside the big map): same table,
+// same sorting, less horizontal ink. The units move OUT of every cell and INTO
+// the header (74 under "€/MWh" instead of €74 under "Day-ahead"), which is both
+// shorter per row and where a unit belongs; the State word becomes its dot
+// alone (the word stays reachable as the cell's title=).
 const COLUMNS = [
   { key: 'zone', label: 'Zone', align: 'left', get: (z) => z.zone_label || z.zone },
-  { key: 'state', label: 'State', align: 'left', get: (z) => STATE_ORDER[z.state] ?? -1 },
-  { key: 'price', label: 'Day-ahead', align: 'right', get: (z) => z.price_close },
-  { key: 'residual', label: 'Residual', align: 'right', get: (z) => z.residual_gw },
-  { key: 'renewables', label: 'Renewables', align: 'right', get: (z) => (z.renewable_reliable === false ? null : z.renewable_share) },
+  { key: 'state', label: 'State', compactLabel: '', align: 'left', get: (z) => STATE_ORDER[z.state] ?? -1 },
+  { key: 'price', label: 'Day-ahead', compactLabel: '€/MWh', align: 'right', get: (z) => z.price_close },
+  { key: 'residual', label: 'Residual', compactLabel: 'GW', align: 'right', get: (z) => z.residual_gw },
+  { key: 'renewables', label: 'Renewables', compactLabel: 'RES', align: 'right', get: (z) => (z.renewable_reliable === false ? null : z.renewable_share) },
 ]
 
 // One legend for the whole table (per-column popovers would be clipped by the
@@ -39,7 +45,7 @@ const TABLE_INFO = (
   + 'Renewables: wind + solar as a share of load, left blank when the feed is too incomplete to trust the share.'
 )
 
-export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
+export default function PowerOverviewMatrix({ selectedZone, onSelect, compact = false }) {
   const { data, loading, error } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
   const [sort, setSort] = useState({ key: 'zone', dir: 'asc' })
 
@@ -84,15 +90,20 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
 
   const toggle = (key) => setSort((s) => ({ key, dir: s.key === key && s.dir === 'asc' ? 'desc' : 'asc' }))
   const arrow = (key) => (sort.key === key ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : '')
+  // One padding pair for the whole table: `edge` is the two outer columns.
+  const cellX = compact ? 'px-1.5' : 'px-2'
+  const edgeX = compact ? 'px-1.5' : 'px-3'
 
   return (
     <div className="border border-border bg-surface rounded overflow-hidden shadow-sm">
       <div className="px-4 py-2.5 border-b border-border/60 flex items-center gap-2">
         <span className="font-mono text-[12px] font-semibold text-neutral-300">European power · all zones</span>
         <InfoPopover text={TABLE_INFO} />
-        <span className="font-mono text-[9px] text-neutral-700 ml-auto">sort ↕ · click a zone for detail →</span>
+        <span className="font-mono text-[9px] text-neutral-700 ml-auto">
+          {compact ? 'sort ↕ · click a zone to focus it' : 'sort ↕ · click a zone for detail →'}
+        </span>
       </div>
-      <div className="overflow-x-auto max-h-[520px] overflow-y-auto">
+      <div className={`overflow-x-auto ${compact ? 'max-h-[42vh]' : 'max-h-[520px]'} overflow-y-auto`}>
         <table className="w-full font-mono text-[11px]">
           <thead className="sticky top-0 bg-surface">
             <tr className="text-[9px] text-neutral-500">
@@ -100,9 +111,10 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
                 <th
                   key={c.key}
                   onClick={() => toggle(c.key)}
-                  className={`${c.align === 'right' ? 'text-right' : 'text-left'} ${c.key === 'zone' || c.key === 'renewables' ? 'px-3' : 'px-2'} py-1 font-normal cursor-pointer hover:text-neutral-300 select-none`}
+                  title={compact ? c.label : undefined}
+                  className={`${c.align === 'right' ? 'text-right' : 'text-left'} ${c.key === 'zone' || c.key === 'renewables' ? edgeX : cellX} py-1 font-normal cursor-pointer hover:text-neutral-300 select-none`}
                 >
-                  {c.label}{arrow(c.key)}
+                  {compact && c.compactLabel != null ? c.compactLabel : c.label}{arrow(c.key)}
                 </th>
               ))}
             </tr>
@@ -115,26 +127,32 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect }) {
                 <tr
                   key={z.zone}
                   onClick={() => onSelect?.(z.zone)}
-                  className={`cursor-pointer border-t border-border/40 hover:bg-white/[0.03] ${sel ? 'bg-cyan-glow/5' : ''}`}
+                  // The selected row's left bar is what ties it to the outlined
+                  // zone on the map. Unselected rows carry the same 2 px as
+                  // transparent, so selecting never nudges the row sideways.
+                  className={`cursor-pointer border-t border-border/40 border-l-2 hover:bg-white/[0.03] ${sel ? 'bg-cyan-glow/5 border-l-cyan-glow' : 'border-l-transparent'}`}
                 >
-                  <td className="px-3 py-2 text-neutral-200 whitespace-nowrap">
+                  <td className={`${edgeX} py-2 text-neutral-200 whitespace-nowrap`}>
                     {z.zone_label}
                     {sel && <span className="text-cyan-glow"> ‹</span>}
                     {z.stale && <span className="text-orange-400/70 text-[8px]"> stale</span>}
                   </td>
-                  <td className="px-2 py-2">
+                  {/* Compact drops the word and keeps the dot — title= keeps it
+                      readable, and the row's colour is not the only carrier
+                      (the zone's own state column stays sortable). */}
+                  <td className={`${cellX} py-2`} title={z.state}>
                     <span className={`inline-flex items-center gap-1 font-bold ${st.t}`}>
-                      <span className={`w-1.5 h-1.5 rounded-sm ${st.d}`} />
-                      {z.state}
+                      <span className={`${compact ? 'w-2 h-2' : 'w-1.5 h-1.5'} rounded-sm ${st.d}`} />
+                      {!compact && z.state}
                     </span>
                   </td>
-                  <td className={`px-2 py-2 text-right num ${zColor(z.price_z)}`}>
-                    {z.price_close != null ? `€${z.price_close.toFixed(0)}` : '—'}
+                  <td className={`${cellX} py-2 text-right num ${zColor(z.price_z)}`}>
+                    {z.price_close != null ? `${compact ? '' : '€'}${z.price_close.toFixed(0)}` : '—'}
                   </td>
-                  <td className={`px-2 py-2 text-right num ${zColor(z.residual_z)}`}>
-                    {z.residual_gw != null ? `${z.residual_gw.toFixed(0)} GW` : '—'}
+                  <td className={`${cellX} py-2 text-right num ${zColor(z.residual_z)}`}>
+                    {z.residual_gw != null ? `${z.residual_gw.toFixed(0)}${compact ? '' : ' GW'}` : '—'}
                   </td>
-                  <td className="px-3 py-2 text-right num text-neutral-300 whitespace-nowrap">
+                  <td className={`${edgeX} py-2 text-right num text-neutral-300 whitespace-nowrap`}>
                     {z.renewable_reliable === false ? '—' : z.renewable_share != null ? `${Math.round(z.renewable_share * 100)}%` : '—'}
                     {z.dunkelflaute && <span className="text-yellow-400" title="Dunkelflaute"> ⚠</span>}
                   </td>

--- a/frontend/src/components/PowerOverviewMatrix.jsx
+++ b/frontend/src/components/PowerOverviewMatrix.jsx
@@ -11,10 +11,13 @@ import { POLL_FAST_MS } from '../utils/poll'
 // the zone on the map beside it. Descriptive, not a forecast.
 const API = '/api'
 
+// `c` is the compact rail's one-letter code. It is NOT decoration: compact has
+// no room for the word, and green/amber/red dots alone are the textbook
+// red-green CVD collision — the letter is the second, non-colour carrier.
 const STATE = {
-  CALM: { t: 'text-green-glow', d: 'bg-green-glow' },
-  ELEVATED: { t: 'text-yellow-400', d: 'bg-yellow-400' },
-  STRESSED: { t: 'text-red-400', d: 'bg-red-400' },
+  CALM: { t: 'text-green-glow', d: 'bg-green-glow', c: 'C' },
+  ELEVATED: { t: 'text-yellow-400', d: 'bg-yellow-400', c: 'E' },
+  STRESSED: { t: 'text-red-400', d: 'bg-red-400', c: 'S' },
 }
 const STATE_ORDER = { CALM: 0, ELEVATED: 1, STRESSED: 2 }
 
@@ -24,11 +27,13 @@ const zColor = (z) =>
 // `compact` = the desk-split rail (~1/3 width, beside the big map): same table,
 // same sorting, less horizontal ink. The units move OUT of every cell and INTO
 // the header (74 under "€/MWh" instead of €74 under "Day-ahead"), which is both
-// shorter per row and where a unit belongs; the State word becomes its dot
-// alone (the word stays reachable as the cell's title=).
+// shorter per row and where a unit belongs; the State word shrinks to a dot plus
+// its one-letter code (see STATE.c — the letter is what survives colour
+// blindness), with the full word kept for screen readers.
 const COLUMNS = [
   { key: 'zone', label: 'Zone', align: 'left', get: (z) => z.zone_label || z.zone },
-  { key: 'state', label: 'State', compactLabel: '', align: 'left', get: (z) => STATE_ORDER[z.state] ?? -1 },
+  // 'ST' rather than '': a sortable column needs a visible thing to click.
+  { key: 'state', label: 'State', compactLabel: 'ST', align: 'left', get: (z) => STATE_ORDER[z.state] ?? -1 },
   { key: 'price', label: 'Day-ahead', compactLabel: '€/MWh', align: 'right', get: (z) => z.price_close },
   { key: 'residual', label: 'Residual', compactLabel: 'GW', align: 'right', get: (z) => z.residual_gw },
   { key: 'renewables', label: 'Renewables', compactLabel: 'RES', align: 'right', get: (z) => (z.renewable_reliable === false ? null : z.renewable_share) },
@@ -95,15 +100,24 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect, compact = 
   const edgeX = compact ? 'px-1.5' : 'px-3'
 
   return (
-    <div className="border border-border bg-surface rounded overflow-hidden shadow-sm">
-      <div className="px-4 py-2.5 border-b border-border/60 flex items-center gap-2">
+    // Compact fills the desk rail's column instead of capping itself: the rail
+    // is a flex column of a known height, so the card takes what is left
+    // (lg:flex-1) and hands it to the scroller below. No max-h — the old
+    // `42vh` was a number from nowhere that inner-scrolled at 14 of 37 zones
+    // while 400 px of rail sat empty. Only at lg: on a phone the rail has no
+    // forced height and the table simply renders, rather than trapping a scroll
+    // inside a page scroll.
+    <div className={`border border-border bg-surface rounded overflow-hidden shadow-sm ${
+      compact ? 'lg:flex-1 lg:min-h-0 lg:flex lg:flex-col' : ''
+    }`}>
+      <div className="shrink-0 px-4 py-2.5 border-b border-border/60 flex items-center gap-2">
         <span className="font-mono text-[12px] font-semibold text-neutral-300">European power · all zones</span>
         <InfoPopover text={TABLE_INFO} />
         <span className="font-mono text-[9px] text-neutral-700 ml-auto">
           {compact ? 'sort ↕ · click a zone to focus it' : 'sort ↕ · click a zone for detail →'}
         </span>
       </div>
-      <div className={`overflow-x-auto ${compact ? 'max-h-[42vh]' : 'max-h-[520px]'} overflow-y-auto`}>
+      <div className={`overflow-x-auto overflow-y-auto ${compact ? 'lg:flex-1 lg:min-h-0' : 'max-h-[520px]'}`}>
         <table className="w-full font-mono text-[11px]">
           <thead className="sticky top-0 bg-surface">
             <tr className="text-[9px] text-neutral-500">
@@ -137,13 +151,15 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect, compact = 
                     {sel && <span className="text-cyan-glow"> ‹</span>}
                     {z.stale && <span className="text-orange-400/70 text-[8px]"> stale</span>}
                   </td>
-                  {/* Compact drops the word and keeps the dot — title= keeps it
-                      readable, and the row's colour is not the only carrier
-                      (the zone's own state column stays sortable). */}
-                  <td className={`${cellX} py-2`} title={z.state}>
+                  {/* Compact swaps the word for the dot + its letter. The letter
+                      is the accessibility carrier (colour alone fails red-green
+                      CVD); the sr-only word is what assistive tech reads, since
+                      a title= on a <td> reaches neither it nor the keyboard. */}
+                  <td className={`${cellX} py-2`}>
                     <span className={`inline-flex items-center gap-1 font-bold ${st.t}`}>
                       <span className={`${compact ? 'w-2 h-2' : 'w-1.5 h-1.5'} rounded-sm ${st.d}`} />
-                      {!compact && z.state}
+                      {compact ? <span aria-hidden="true">{st.c}</span> : z.state}
+                      {compact && <span className="sr-only">{z.state}</span>}
                     </span>
                   </td>
                   <td className={`${cellX} py-2 text-right num ${zColor(z.price_z)}`}>
@@ -162,7 +178,7 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect, compact = 
           </tbody>
         </table>
       </div>
-      <div className="px-3 py-1 border-t border-border/40 font-mono text-[8px] text-neutral-700 leading-snug">
+      <div className="shrink-0 px-3 py-1 border-t border-border/40 font-mono text-[8px] text-neutral-700 leading-snug">
         Colour = how far each metric sits from its own {data.baseline_days ? `${data.baseline_days}-day` : 'trailing'} norm (grey normal · amber elevated · red extreme). Descriptive, not a forecast.
       </div>
     </div>

--- a/frontend/src/components/powermap/MapHeader.jsx
+++ b/frontend/src/components/powermap/MapHeader.jsx
@@ -22,42 +22,65 @@ function ToggleButton({ active, onClick, title, children }) {
   )
 }
 
+// ── The overlay registry ──────────────────────────────────────────────────────
+// ONE list, two consumers: it renders the toggle buttons AND supplies the ⓘ
+// entries below. It used to be an object read positionally (.flows / .outages),
+// which quietly reintroduced the very "central string someone must remember to
+// edit" that reading `info` off FILLS had just removed — a third overlay would
+// have shipped a button with no explanation. Same shape as a FILLS entry
+// (key/label/info) so both lists render through the same code.
+const OVERLAYS = [
+  {
+    key: 'flows',
+    label: 'FLOWS',
+    title: 'Cross-border flow arcs (latest hour)',
+    info: (
+      'Arcs = the latest cross-border flow per border: the faint end exports, the solid end '
+      + 'imports; width ∝ GW, colour = how loaded the border is vs its offered day-ahead capacity '
+      + '(grey = no NTC published or no reading — drawn thin and faint as context). They always '
+      + 'show the latest hour and hide while you scrub the past — click one for the border detail '
+      + 'below.'
+    ),
+  },
+  {
+    key: 'outages',
+    label: 'LINE OUTAGES',
+    title: 'Transmission lines out or de-rated now, or starting within 30 days (ENTSO-E A78)',
+    info: (
+      'A dashed chord on every border with a transmission asset out or de-rated now (tight dash) '
+      + 'or starting within 30 days (sparse dash); colour = forced/unplanned vs planned '
+      + 'maintenance. The chords stay put while you scrub — an outage is a window, not an hour '
+      + '(glossary in HOW TO READ).'
+    ),
+  },
+]
+
 // ── The ⓘ copy ────────────────────────────────────────────────────────────────
-// COMPOSED, not hand-written as one blob: what the map is, then ONE sentence
-// per fill (read straight off the FILLS registry, so a new fill ships its own
-// sentence with its colours instead of someone remembering to edit a string
-// here), then one per overlay, then the credits. Kept out of the JSX so the
-// header row stays readable.
+// STRUCTURED, per the PR #138 rule: a term list, not a wall of prose. It is
+// composed, never hand-written — one entry per fill and per overlay, read off
+// the two registries, so a new fill or overlay ships its own explanation beside
+// its colours instead of growing a central string. (It was briefly a ~1,900-char
+// single paragraph, which is exactly what that rule exists to prevent.)
 const INTRO = (
   'Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by whichever fill is '
-  + 'active — the day-ahead price, the grid state, or the technology setting the price. '
-  + 'Flat unlabelled shapes = neighbouring countries, no data by design.'
+  + 'active. Flat unlabelled shapes = neighbouring countries, no data by design.'
 )
-// Overlays are owned by this header's toggles (not by the FILLS registry), so
-// their sentences live here, one per toggle.
-const OVERLAY_INFO = {
-  flows: (
-    'FLOWS arcs = the latest cross-border flow per border: the faint end exports, the solid end '
-    + 'imports; width ∝ GW, colour = how loaded the border is vs its offered day-ahead capacity '
-    + '(grey = no NTC published or no reading — drawn thin and faint as context); they always show '
-    + 'the latest hour and hide while you scrub the past — click one for the border detail below.'
-  ),
-  outages: (
-    'LINE OUTAGES draws a dashed chord on every border with a transmission asset out or de-rated '
-    + 'now (tight dash) or starting within 30 days (sparse dash); colour = forced/unplanned vs '
-    + 'planned maintenance, and the chords stay put while you scrub — an outage is a window, not an '
-    + 'hour (glossary in HOW TO READ).'
-  ),
-}
 const CREDITS = 'Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast.'
 
-const MAP_INFO = [
-  INTRO,
-  ...FILLS.map((f) => f.info).filter(Boolean),
-  OVERLAY_INFO.flows,
-  OVERLAY_INFO.outages,
-  CREDITS,
-].join(' ')
+const MAP_INFO = (
+  <div className="space-y-2">
+    <p className="text-neutral-400 leading-snug">{INTRO}</p>
+    <dl className="space-y-1.5">
+      {[...FILLS, ...OVERLAYS].map(({ key, label, info }) => (
+        <div key={key}>
+          <dt className="text-cyan-glow/90">{label}</dt>
+          <dd className="text-neutral-400 leading-snug">{info}</dd>
+        </div>
+      ))}
+    </dl>
+    <div className="pt-1 border-t border-border/40 text-neutral-500">{CREDITS}</div>
+  </div>
+)
 
 export default function MapHeader({ view, setView, fill, setFill, fillDef, overlays, setOverlays }) {
   const toggleOverlay = (key) => setOverlays((o) => ({ ...o, [key]: !o[key] }))
@@ -78,20 +101,16 @@ export default function MapHeader({ view, setView, fill, setFill, fillDef, overl
             <ToggleButton key={m.key} active={fill === m.key} onClick={() => setFill(m.key)}>{m.label}</ToggleButton>
           ))}
         </div>
-        <ToggleButton
-          active={overlays.flows}
-          onClick={() => toggleOverlay('flows')}
-          title="Cross-border flow arcs (latest hour)"
-        >
-          FLOWS
-        </ToggleButton>
-        <ToggleButton
-          active={overlays.outages}
-          onClick={() => toggleOverlay('outages')}
-          title="Transmission lines out or de-rated now, or starting within 30 days (ENTSO-E A78)"
-        >
-          LINE OUTAGES
-        </ToggleButton>
+        {OVERLAYS.map((o) => (
+          <ToggleButton
+            key={o.key}
+            active={overlays[o.key]}
+            onClick={() => toggleOverlay(o.key)}
+            title={o.title}
+          >
+            {o.label}
+          </ToggleButton>
+        ))}
         {view === 'zones' && fillDef.labelText && (
           <ToggleButton
             active={overlays.labels}

--- a/frontend/src/components/powermap/MapHeader.jsx
+++ b/frontend/src/components/powermap/MapHeader.jsx
@@ -53,6 +53,22 @@ const OVERLAYS = [
       + '(glossary in HOW TO READ).'
     ),
   },
+  {
+    key: 'labels',
+    label: 'LABELS',
+    title: 'Per-zone labels (overlapping labels hide — zoom in to reveal)',
+    // Only offered where a label can exist: the TextLayer is a zones-view layer,
+    // and a fill without `labelText` has nothing to write. `when` keeps that
+    // condition here rather than as a separate branch in the button row, so the
+    // registry stays the ONE list — the point of it is that no toggle can ship
+    // without its ⓘ entry, which is exactly what a hand-rolled branch allowed.
+    when: ({ view, fillDef }) => view === 'zones' && Boolean(fillDef.labelText),
+    info: (
+      'Names each zone with its value ("DE-LU 74"; the grid-state fill writes the zone code '
+      + 'alone). Labels that would collide hide, keeping the extreme prices — zoom in to reveal '
+      + 'the rest.'
+    ),
+  },
 ]
 
 // ── The ⓘ copy ────────────────────────────────────────────────────────────────
@@ -101,7 +117,7 @@ export default function MapHeader({ view, setView, fill, setFill, fillDef, overl
             <ToggleButton key={m.key} active={fill === m.key} onClick={() => setFill(m.key)}>{m.label}</ToggleButton>
           ))}
         </div>
-        {OVERLAYS.map((o) => (
+        {OVERLAYS.filter((o) => !o.when || o.when({ view, fillDef })).map((o) => (
           <ToggleButton
             key={o.key}
             active={overlays[o.key]}
@@ -111,15 +127,6 @@ export default function MapHeader({ view, setView, fill, setFill, fillDef, overl
             {o.label}
           </ToggleButton>
         ))}
-        {view === 'zones' && fillDef.labelText && (
-          <ToggleButton
-            active={overlays.labels}
-            onClick={() => toggleOverlay('labels')}
-            title="Per-zone labels (overlapping labels hide — zoom in to reveal)"
-          >
-            LABELS
-          </ToggleButton>
-        )}
       </div>
     </div>
   )

--- a/frontend/src/components/powermap/MapHeader.jsx
+++ b/frontend/src/components/powermap/MapHeader.jsx
@@ -1,0 +1,107 @@
+import { InfoPopover } from '../Panel'
+import { FILLS } from './fills'
+
+// The map's chrome row: title + ⓘ + every toggle (view, fill, overlays).
+// Split out of index.jsx, which had grown to hold the container logic AND a
+// ~1800-character single-line ⓘ string that gained a sentence per fill and per
+// overlay. Nothing here holds state — the container still owns it.
+
+// Header toggle chip — the ONE source for the active/idle button styling
+// (ZONES/POINTS, the fill buttons, FLOWS, LINE OUTAGES, LABELS).
+function ToggleButton({ active, onClick, title, children }) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      className={`font-mono text-[9px] px-2 py-0.5 rounded border ${
+        active ? 'text-cyan-glow border-cyan-glow/40 bg-cyan-glow/10' : 'text-neutral-500 border-border hover:text-neutral-300'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+// ── The ⓘ copy ────────────────────────────────────────────────────────────────
+// COMPOSED, not hand-written as one blob: what the map is, then ONE sentence
+// per fill (read straight off the FILLS registry, so a new fill ships its own
+// sentence with its colours instead of someone remembering to edit a string
+// here), then one per overlay, then the credits. Kept out of the JSX so the
+// header row stays readable.
+const INTRO = (
+  'Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by whichever fill is '
+  + 'active — the day-ahead price, the grid state, or the technology setting the price. '
+  + 'Flat unlabelled shapes = neighbouring countries, no data by design.'
+)
+// Overlays are owned by this header's toggles (not by the FILLS registry), so
+// their sentences live here, one per toggle.
+const OVERLAY_INFO = {
+  flows: (
+    'FLOWS arcs = the latest cross-border flow per border: the faint end exports, the solid end '
+    + 'imports; width ∝ GW, colour = how loaded the border is vs its offered day-ahead capacity '
+    + '(grey = no NTC published or no reading — drawn thin and faint as context); they always show '
+    + 'the latest hour and hide while you scrub the past — click one for the border detail below.'
+  ),
+  outages: (
+    'LINE OUTAGES draws a dashed chord on every border with a transmission asset out or de-rated '
+    + 'now (tight dash) or starting within 30 days (sparse dash); colour = forced/unplanned vs '
+    + 'planned maintenance, and the chords stay put while you scrub — an outage is a window, not an '
+    + 'hour (glossary in HOW TO READ).'
+  ),
+}
+const CREDITS = 'Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast.'
+
+const MAP_INFO = [
+  INTRO,
+  ...FILLS.map((f) => f.info).filter(Boolean),
+  OVERLAY_INFO.flows,
+  OVERLAY_INFO.outages,
+  CREDITS,
+].join(' ')
+
+export default function MapHeader({ view, setView, fill, setFill, fillDef, overlays, setOverlays }) {
+  const toggleOverlay = (key) => setOverlays((o) => ({ ...o, [key]: !o[key] }))
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-2.5 border-b border-border">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="font-mono text-[12px] font-semibold text-neutral-300">Europe · power map</span>
+        <InfoPopover text={MAP_INFO} wide />
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-1">
+          {[['zones', 'ZONES'], ['points', 'POINTS']].map(([v, l]) => (
+            <ToggleButton key={v} active={view === v} onClick={() => setView(v)}>{l}</ToggleButton>
+          ))}
+        </div>
+        <div className="flex items-center gap-1">
+          {FILLS.map((m) => (
+            <ToggleButton key={m.key} active={fill === m.key} onClick={() => setFill(m.key)}>{m.label}</ToggleButton>
+          ))}
+        </div>
+        <ToggleButton
+          active={overlays.flows}
+          onClick={() => toggleOverlay('flows')}
+          title="Cross-border flow arcs (latest hour)"
+        >
+          FLOWS
+        </ToggleButton>
+        <ToggleButton
+          active={overlays.outages}
+          onClick={() => toggleOverlay('outages')}
+          title="Transmission lines out or de-rated now, or starting within 30 days (ENTSO-E A78)"
+        >
+          LINE OUTAGES
+        </ToggleButton>
+        {view === 'zones' && fillDef.labelText && (
+          <ToggleButton
+            active={overlays.labels}
+            onClick={() => toggleOverlay('labels')}
+            title="Per-zone labels (overlapping labels hide — zoom in to reveal)"
+          >
+            LABELS
+          </ToggleButton>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/powermap/constants.js
+++ b/frontend/src/components/powermap/constants.js
@@ -63,6 +63,19 @@ export const OUTAGE_CASING_PX = 2
 export const SELECTION_WIDTH_PX = 3
 export const SELECTION_CASING_PX = 3
 
+// The desk split's shared column height (EuropeDesk's rail AND the map card),
+// named once so the two can never drift apart — equal heights are what let both
+// columns hand their leftover space to a `flex-1 min-h-0` child instead of each
+// guessing a vh. One viewport, minus the grid's 12 px of top offset and 12 px of
+// air. The floor is NOT decorative: in-card chrome reaches ~333 px (1024 wide,
+// with the outage legend showing), so a 560 px floor would have left a 227 px
+// canvas — SHORTER than the 460 px the map had before this layout existed. 760
+// keeps ≥425 px of canvas at every width the `lg:` breakpoint can present.
+// Below the floor the column simply exceeds the viewport and the page scrolls;
+// one scroll is the right price for a map you can actually read.
+// A Tailwind literal on purpose — the scanner reads this file.
+export const DESK_COLUMN_H = 'lg:h-[max(760px,calc(100vh-1.5rem))]'
+
 export function fmtTs(iso) {
   if (!iso) return ''
   return new Date(iso).toLocaleString('en-US', {

--- a/frontend/src/components/powermap/constants.js
+++ b/frontend/src/components/powermap/constants.js
@@ -52,6 +52,17 @@ export const OUTAGE_WIDTH = { forced: 3, planned: 1.5 }
 // casing (the cartographic road-casing trick), not from picking a lucky hue.
 export const OUTAGE_CASING_PX = 2
 
+// The selected zone's contour, and the SAME casing trick for the same reason.
+// The accent alone used to be pal.posPole, which is also the price ramp's
+// expensive END — so selecting an expensive zone drew a teal rim on a teal fill
+// at ΔE 0.0 (measured, both themes: the outline was invisible on exactly the
+// zones you most want to inspect). Two tones fix it: whatever the fill, one of
+// them separates from it. Worst per-fill best-tone ΔE (dataviz validate_palette,
+// raw, vs price poles / mid / no-data slate / context) = 50.2 dark, 46.3 light;
+// accent↔casing 74.9 / 53.9.
+export const SELECTION_WIDTH_PX = 3
+export const SELECTION_CASING_PX = 3
+
 export function fmtTs(iso) {
   if (!iso) return ''
   return new Date(iso).toLocaleString('en-US', {

--- a/frontend/src/components/powermap/fills.js
+++ b/frontend/src/components/powermap/fills.js
@@ -6,9 +6,11 @@ import { techIndex, techRgb } from './tech'
 // per-fill contract so a new fill lands purely additively here;
 // index.jsx never branches on a fill key:
 //   key/label      — header toggle button
-//   info           — ONE sentence (or two) for the map's ⓘ popover, describing
-//                    what THIS fill encodes. MapHeader composes the popover
-//                    from these in registry order, so a new fill ships its own
+//   info           — REQUIRED. One or two sentences for the map's ⓘ popover,
+//                    describing what THIS fill encodes. MapHeader renders it as
+//                    the <dd> of a <dl> whose <dt> is `label`, so do NOT open by
+//                    repeating the fill's own name — start with the explanation.
+//                    Composed in registry order, so a new fill ships its
 //                    explanation next to its colours — there is no central
 //                    string to remember to edit.
 //   scrub          — whether the time scrubber applies (grid state is always live)
@@ -39,12 +41,12 @@ export const FILLS = [
     key: 'price',
     label: 'DAY-AHEAD €/MWh',
     info: (
-      'DAY-AHEAD shades each zone by its cleared auction price. IMPORTANT: ONE HOUR at a time (the '
-      + 'hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the '
-      + 'all-zones table shows a positive daily mean; drag the slider to move through the hours. '
-      + 'Fixed equal-frequency colour scale across the shown week: colours spread by rank among the '
-      + "week's all-zone hours, not by € distance (tooltips carry exact €) — violet = negative prices "
-      + '(a distinct state, not just cheap), brighter cyan = more expensive.'
+      'Each zone by its cleared auction price. IMPORTANT: ONE HOUR at a time (the hour on the '
+      + 'slider below), not the whole day — so a zone can read €0 here at 08:00 while the all-zones '
+      + 'table shows a positive daily mean; drag the slider to move through the hours. Fixed '
+      + 'equal-frequency colour scale across the shown week: colours spread by rank among the '
+      + "week's all-zone hours, not by € distance (tooltips carry exact €) — violet = negative "
+      + 'prices (a distinct state, not just cheap), brighter cyan = more expensive.'
     ),
     scrub: true,
     labelText: (p) => (p.price == null ? null : `${p.label} ${Math.round(p.price)}`),
@@ -68,9 +70,9 @@ export const FILLS = [
     key: 'state',
     label: 'GRID STATE',
     info: (
-      'GRID STATE shades each zone by how far it sits from its own 30-day norm — CALM / ELEVATED / '
-      + 'STRESSED. A deviation vs history, not a forecast, and always the latest reading (no slider: '
-      + 'the state is only ever "now").'
+      'Each zone by how far it sits from its own 30-day norm — CALM / ELEVATED / STRESSED. A '
+      + 'deviation vs history, not a forecast, and always the latest reading (no slider: the state '
+      + 'is only ever "now").'
     ),
     scrub: false,
     // State is already the color — the label only answers "which zone is that",
@@ -91,10 +93,9 @@ export const FILLS = [
     key: 'tech',
     label: 'PRICE-SETTING TECH',
     info: (
-      'PRICE-SETTING TECH shades each zone by the technology estimated to have set its latest price '
-      + '— a fixed-merit-order attribution in the generation-mix fuel colours, not a cost model (a '
-      + 'slate zone is in scope but has no value, and each zone carries its own hour — hover it; '
-      + 'glossary in HOW TO READ).'
+      'Each zone by the technology estimated to have set its latest price — a fixed-merit-order '
+      + 'attribution in the generation-mix fuel colours, not a cost model (a slate zone is in scope '
+      + 'but has no value, and each zone carries its own hour — hover it; glossary in HOW TO READ).'
     ),
     // No scrubber: the estimate is computed on read for the LATEST hour only —
     // there is no per-hour matrix to scrub, and back-dating one colour across

--- a/frontend/src/components/powermap/fills.js
+++ b/frontend/src/components/powermap/fills.js
@@ -6,6 +6,11 @@ import { techIndex, techRgb } from './tech'
 // per-fill contract so a new fill lands purely additively here;
 // index.jsx never branches on a fill key:
 //   key/label      — header toggle button
+//   info           — ONE sentence (or two) for the map's ⓘ popover, describing
+//                    what THIS fill encodes. MapHeader composes the popover
+//                    from these in registry order, so a new fill ships its own
+//                    explanation next to its colours — there is no central
+//                    string to remember to edit.
 //   scrub          — whether the time scrubber applies (grid state is always live)
 //   labelText(pt, ctx) — OPTIONAL label string for one point row, ctx as in
 //                    getColor; null = no label for this point (price fill skips
@@ -33,6 +38,14 @@ export const FILLS = [
   {
     key: 'price',
     label: 'DAY-AHEAD €/MWh',
+    info: (
+      'DAY-AHEAD shades each zone by its cleared auction price. IMPORTANT: ONE HOUR at a time (the '
+      + 'hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the '
+      + 'all-zones table shows a positive daily mean; drag the slider to move through the hours. '
+      + 'Fixed equal-frequency colour scale across the shown week: colours spread by rank among the '
+      + "week's all-zone hours, not by € distance (tooltips carry exact €) — violet = negative prices "
+      + '(a distinct state, not just cheap), brighter cyan = more expensive.'
+    ),
     scrub: true,
     labelText: (p) => (p.price == null ? null : `${p.label} ${Math.round(p.price)}`),
     // |price| so the EXTREME zones survive the collision cull — a €300 spike or
@@ -54,6 +67,11 @@ export const FILLS = [
   {
     key: 'state',
     label: 'GRID STATE',
+    info: (
+      'GRID STATE shades each zone by how far it sits from its own 30-day norm — CALM / ELEVATED / '
+      + 'STRESSED. A deviation vs history, not a forecast, and always the latest reading (no slider: '
+      + 'the state is only ever "now").'
+    ),
     scrub: false,
     // State is already the color — the label only answers "which zone is that",
     // so it's the bare zone code. Cull priority = severity: a STRESSED zone's
@@ -72,6 +90,12 @@ export const FILLS = [
   {
     key: 'tech',
     label: 'PRICE-SETTING TECH',
+    info: (
+      'PRICE-SETTING TECH shades each zone by the technology estimated to have set its latest price '
+      + '— a fixed-merit-order attribution in the generation-mix fuel colours, not a cost model (a '
+      + 'slate zone is in scope but has no value, and each zone carries its own hour — hover it; '
+      + 'glossary in HOW TO READ).'
+    ),
     // No scrubber: the estimate is computed on read for the LATEST hour only —
     // there is no per-hour matrix to scrub, and back-dating one colour across
     // the week would be a lie. Flow arcs stay on (latest-on-latest is honest).

--- a/frontend/src/components/powermap/index.jsx
+++ b/frontend/src/components/powermap/index.jsx
@@ -167,8 +167,11 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
   // polygons for 37 zones — IT_CALABRIA has no shape) would otherwise outline
   // NOTHING and look like a broken click. Since the rail's row click is now the
   // primary way to select, say so where the shape should have appeared.
+  // Zones-view only: POINTS draws from ZONE_COORDS, which DOES carry the zone,
+  // so its dot is there and the message would be wrong.
   const selectionHasNoShape = Boolean(
-    selectedZone && geo && !geo.features.some((f) => f.properties.zone === selectedZone)
+    view === 'zones' && selectedZone && geo
+    && !geo.features.some((f) => f.properties.zone === selectedZone)
   )
 
   return (
@@ -224,7 +227,7 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
         {selectionHasNoShape && (
           <div className="absolute bottom-2 left-2 right-2 pointer-events-none">
             <span className="inline-block border border-border bg-surface/90 rounded px-2 py-1 font-mono text-[9px] text-neutral-400">
-              {byZone.get(selectedZone)?.zone_label || selectedZone} has no map geometry — its row is selected, but no shape can be outlined.
+              {byZone.get(selectedZone)?.zone_label || selectedZone} has no zone shape in the map geometry — its row is selected, but there is nothing to outline. Switch to POINTS to see it.
             </span>
           </div>
         )}

--- a/frontend/src/components/powermap/index.jsx
+++ b/frontend/src/components/powermap/index.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import DeckGL from '@deck.gl/react'
 import { useTheme } from '../../context/ThemeContext'
 import { PALETTES } from './palettes'
-import { ZONE_COORDS, INITIAL_VIEW } from './constants'
+import { ZONE_COORDS, INITIAL_VIEW, DESK_COLUMN_H } from './constants'
 import { collectWeekValues, makeQuantileScale } from './scales'
 import { FILLS } from './fills'
 import useMapData from './useMapData'
@@ -163,22 +163,28 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
 
   const zoneCount = byZone.size
 
+  // A selected zone the geometry does not contain (the bundle carries 36
+  // polygons for 37 zones — IT_CALABRIA has no shape) would otherwise outline
+  // NOTHING and look like a broken click. Since the rail's row click is now the
+  // primary way to select, say so where the shape should have appeared.
+  const selectionHasNoShape = Boolean(
+    selectedZone && geo && !geo.features.some((f) => f.properties.zone === selectedZone)
+  )
+
   return (
-    // `tall` on lg: the CARD is exactly one viewport minus the desk's 12 px top
-    // offset and 12 px of air, and the canvas takes whatever the chrome leaves
-    // — a flex column, not a magic constant. The chrome is NOT a fixed height:
-    // the header and the legends flex-wrap, so it measures 142 px at 1920 wide
-    // and 298 px at 1024, and grows again when LINE OUTAGES adds its legend.
-    // Any `calc(100vh - <constant>)` for the CANVAS is therefore wrong at most
-    // widths — it overflowed the viewport by 15 px at 1280×800.
-    // The height must be DEFINITE (h-, not max-h-): `flex-1` distributes free
-    // space, and a max-height leaves none to distribute — under max-h the canvas
-    // collapsed onto its own floor (360 px) at every desktop width, i.e. the
+    // `tall` on lg: the card takes the desk's shared column height
+    // (DESK_COLUMN_H — the rail wears the identical class) and the canvas takes
+    // whatever the chrome leaves, as a flex column rather than a magic constant.
+    // The chrome is NOT a fixed height: the header and the legends flex-wrap, so
+    // it measures 142 px at 1920 wide and ~300 px at 1024, and grows again when
+    // LINE OUTAGES adds its legend. Any `calc(100vh - <constant>)` for the
+    // CANVAS is therefore wrong at most widths — it overflowed by 15 px at
+    // 1280×800. The height must also be DEFINITE (h-, not max-h-): `flex-1`
+    // distributes free space and a max-height leaves none to distribute — under
+    // max-h the canvas collapsed onto its own floor at every desktop width, the
     // exact "map is too small" this layout exists to fix.
-    // The max() floor is for short-but-wide viewports: below it the card simply
-    // exceeds the viewport (and scrolls) instead of squeezing the map flat.
     <div className={`border border-border bg-surface rounded overflow-hidden shadow-sm ${
-      tall ? 'lg:flex lg:flex-col lg:h-[max(560px,calc(100vh-1.5rem))]' : ''
+      tall ? `lg:flex lg:flex-col ${DESK_COLUMN_H}` : ''
     }`}>
       <MapHeader
         view={view} setView={setView}
@@ -193,8 +199,35 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
         style={tall ? { background: pal.surface } : { height: 460, background: pal.surface }}
       >
         {/* pickingRadius: the demoted 2 px context arcs stay clickable without
-            pixel-hunting — widens hit-testing only, no visual change. */}
-        <DeckGL initialViewState={INITIAL_VIEW} controller={true} layers={layers} getTooltip={getTooltip} pickingRadius={4} />
+            pixel-hunting — widens hit-testing only, no visual change.
+            touchAction 'pan-y' — a TOP-LEVEL Deck prop, NOT a controller option
+            (deck.gl passes props.touchAction straight to its EventManager;
+            inside `controller` it is silently ignored, which measures as
+            touch-action:none and no page scroll). deck.gl otherwise computes
+            `touch-action: none` on its container and swallows every touch, so on
+            a phone — where this card is TALLER than the viewport, leaving no
+            page margin to grab — a vertical swipe panned the map and the page
+            could not be scrolled past it at all. 'pan-y' hands vertical swipes
+            back to the browser; per the touch-action spec only vertical panning
+            goes to the browser, so the map keeps pinch-zoom, double-tap and
+            horizontal drag, and a mouse is unaffected. The trade is
+            single-finger VERTICAL panning of the map on touch: pinch to zoom and
+            drag sideways instead. Scrolling past the map beats panning in it. */}
+        <DeckGL
+          initialViewState={INITIAL_VIEW}
+          controller={true}
+          touchAction="pan-y"
+          layers={layers}
+          getTooltip={getTooltip}
+          pickingRadius={4}
+        />
+        {selectionHasNoShape && (
+          <div className="absolute bottom-2 left-2 right-2 pointer-events-none">
+            <span className="inline-block border border-border bg-surface/90 rounded px-2 py-1 font-mono text-[9px] text-neutral-400">
+              {byZone.get(selectedZone)?.zone_label || selectedZone} has no map geometry — its row is selected, but no shape can be outlined.
+            </span>
+          </div>
+        )}
       </div>
 
       {fillDef.scrub && ts.length > 1 && <Scrubber ts={ts} effIdx={effIdx} setIdx={setIdx} />}

--- a/frontend/src/components/powermap/index.jsx
+++ b/frontend/src/components/powermap/index.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
 import DeckGL from '@deck.gl/react'
-import { InfoPopover } from '../Panel'
 import { useTheme } from '../../context/ThemeContext'
 import { PALETTES } from './palettes'
 import { ZONE_COORDS, INITIAL_VIEW } from './constants'
@@ -9,6 +8,7 @@ import { FILLS } from './fills'
 import useMapData from './useMapData'
 import { makeTooltip } from './tooltip'
 import { makeZonesLayer, makeContextZonesLayer } from './layers/zonesLayer'
+import { makeSelectionLayers } from './layers/selectionLayer'
 import { makeLabelsLayer } from './layers/labelsLayer'
 import { buildArcs, makeFlowArcsLayer } from './layers/flowArcsLayer'
 import { makePointsLayer } from './layers/pointsLayer'
@@ -16,6 +16,7 @@ import { buildOutagePaths, makeOutageLayers, outageTooltip } from './layers/outa
 import { FlowArcLegend, OutageLegend } from './legends'
 import useFetchWithError from '../../hooks/useFetchWithError'
 import Scrubber from './Scrubber'
+import MapHeader from './MapHeader'
 
 // The A78 overlay's own feed. NOT in useMapData's EXTRA_BY_FILL: that seam is
 // keyed by the active FILL, and this is an overlay — it is owned by the
@@ -28,27 +29,15 @@ const OUTAGES_URL = '/api/power/outages/transmission'
 // so the memo below is not invalidated on every render.
 const OVERLAY_TIPS = [outageTooltip]
 
-// Header toggle chip — the ONE source for the active/idle button styling
-// (ZONES/POINTS, the fill buttons, FLOWS; later PRs add more).
-function ToggleButton({ active, onClick, title, children }) {
-  return (
-    <button
-      onClick={onClick}
-      title={title}
-      className={`font-mono text-[9px] px-2 py-0.5 rounded border ${
-        active ? 'text-cyan-glow border-cyan-glow/40 bg-cyan-glow/10' : 'text-neutral-500 border-border hover:text-neutral-300'
-      }`}
-    >
-      {children}
-    </button>
-  )
-}
-
 // Container: owns the map state (fill, view, overlays, scrub index), composes
-// the data hook + layer factories + chrome. Everything fill-specific (color,
-// alpha, legend, labels, scrub, triggers) is dispatched through the FILLS
-// registry — no fill-key branches live here. `onZoneSelect`/`selectedZone`/
-// `tall` are optional and no-ops until the desk threads them (PR 8).
+// the data hook + layer factories + chrome (MapHeader). Everything fill-specific
+// (color, alpha, legend, labels, scrub, triggers, ⓘ copy) is dispatched through
+// the FILLS registry — no fill-key branches live here.
+//   selectedZone / onZoneSelect — the desk's zone selection, two-way: the rail's
+//     table highlights the outlined zone and a click on the map selects the row
+//     (EuropeDesk owns the state). Both optional; the map is standalone without.
+//   tall — the desk-split layout's map column, where the map is the page's
+//     subject and gets the viewport height it deserves.
 export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, tall = false }) {
   const { theme } = useTheme()
   const pal = PALETTES[theme] || PALETTES.dark
@@ -140,14 +129,19 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
       ? makeOutageLayers({ paths: outagePaths, pal, onBorderSelect })
       : []
     const zonesLayer = makeZonesLayer({
-      geo, zoneFill, pal, theme, fillColorTriggers, selectedZone, onZoneClick: onZoneSelect,
+      geo, zoneFill, pal, theme, fillColorTriggers, onZoneClick: onZoneSelect,
     })
+    // Straight above the choropleth, below every overlay: the contour marks
+    // which zone the rail is looking at, but the arcs/chords/labels are the
+    // information ON the map and keep the top of the stack.
+    const selectionLayers = makeSelectionLayers({ geo, selectedZone, pal })
     if (view === 'points') {
       // Every point's zone is in byZone by construction (both derive from
       // effRows), so the pal.mid fallback is only defensive.
       const pointFill = (p) => [...(fillDef.getColor(p.zone, fillCtx) || pal.mid), fillDef.alpha.point]
       return [
-        makeContextZonesLayer(zonesLayer, { pal, theme, selectedZone }),
+        makeContextZonesLayer(zonesLayer, { pal, theme }),
+        ...selectionLayers,
         ...outageLayers,
         ...(arcLayer ? [arcLayer] : []),
         makePointsLayer({ points, pointFill, pal, theme, fillColorTriggers, onZoneClick: onZoneSelect }),
@@ -158,7 +152,7 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
       : null
     // Labels ride ABOVE the outage chords (they carry an outline halo and are
     // not pickable, so they stay readable without stealing a hover).
-    const base = [zonesLayer, ...outageLayers, ...(labels ? [labels] : [])]
+    const base = [zonesLayer, ...selectionLayers, ...outageLayers, ...(labels ? [labels] : [])]
     return arcLayer ? [...base, arcLayer] : base
   }, [geo, view, fill, fillDef, fillCtx, effRows, points, theme, arcs, outagePaths, overlays, atLatest, onBorderSelect, onZoneSelect, selectedZone, pal])
 
@@ -170,51 +164,32 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
   const zoneCount = byZone.size
 
   return (
-    <div className="border border-border bg-surface rounded overflow-hidden shadow-sm">
-      <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-2.5 border-b border-border">
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="font-mono text-[12px] font-semibold text-neutral-300">Europe · power map</span>
-          <InfoPopover text="Real bidding-zone geometry (SE1–SE4, NO1–NO5, Italian sub-zones), shaded by the day-ahead price — or by grid state, or by the technology setting the price. IMPORTANT: it shades ONE HOUR at a time (the hour on the slider below), not the whole day — so a zone can read €0 here at 08:00 while the all-zones table shows a positive daily mean. Drag the slider to move through the hours. Fixed equal-frequency colour scale across the shown week: colours spread by rank among the week's all-zone hours, not by € distance (tooltips carry exact €) — violet = negative prices (a distinct state, not just cheap), brighter cyan = more expensive. Flat unlabelled shapes = neighbouring countries, no data by design. PRICE-SETTING TECH shades each zone by the technology estimated to have set its latest price — a fixed-merit-order attribution in the generation-mix fuel colours, not a cost model (a slate zone is in scope but has no value, and each zone carries its own hour — hover it; glossary in HOW TO READ). FLOWS arcs = the latest cross-border flow per border: the faint end exports, the solid end imports; width ∝ GW, colour = how loaded the border is vs its offered day-ahead capacity (grey = no NTC published or no reading — drawn thin and faint as context); they always show the latest hour and hide while you scrub the past — click one for the border detail below. LINE OUTAGES draws a dashed chord on every border with a transmission asset out or de-rated now (tight dash) or starting within 30 days (sparse dash); colour = forced/unplanned vs planned maintenance, and the chords stay put while you scrub — an outage is a window, not an hour (glossary in HOW TO READ). Zone geometry © Electricity Maps contributors (AGPL). Data: ENTSO-E. Descriptive, not a forecast." />
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="flex items-center gap-1">
-            {[['zones', 'ZONES'], ['points', 'POINTS']].map(([v, l]) => (
-              <ToggleButton key={v} active={view === v} onClick={() => setView(v)}>{l}</ToggleButton>
-            ))}
-          </div>
-          <div className="flex items-center gap-1">
-            {FILLS.map((m) => (
-              <ToggleButton key={m.key} active={fill === m.key} onClick={() => setFill(m.key)}>{m.label}</ToggleButton>
-            ))}
-          </div>
-          <ToggleButton
-            active={overlays.flows}
-            onClick={() => setOverlays((o) => ({ ...o, flows: !o.flows }))}
-            title="Cross-border flow arcs (latest hour)"
-          >
-            FLOWS
-          </ToggleButton>
-          <ToggleButton
-            active={overlays.outages}
-            onClick={() => setOverlays((o) => ({ ...o, outages: !o.outages }))}
-            title="Transmission lines out or de-rated now, or starting within 30 days (ENTSO-E A78)"
-          >
-            LINE OUTAGES
-          </ToggleButton>
-          {view === 'zones' && fillDef.labelText && (
-            <ToggleButton
-              active={overlays.labels}
-              onClick={() => setOverlays((o) => ({ ...o, labels: !o.labels }))}
-              title="Per-zone labels (overlapping labels hide — zoom in to reveal)"
-            >
-              LABELS
-            </ToggleButton>
-          )}
-        </div>
-      </div>
+    // `tall` on lg: the CARD is exactly one viewport minus the desk's 12 px top
+    // offset and 12 px of air, and the canvas takes whatever the chrome leaves
+    // — a flex column, not a magic constant. The chrome is NOT a fixed height:
+    // the header and the legends flex-wrap, so it measures 142 px at 1920 wide
+    // and 298 px at 1024, and grows again when LINE OUTAGES adds its legend.
+    // Any `calc(100vh - <constant>)` for the CANVAS is therefore wrong at most
+    // widths — it overflowed the viewport by 15 px at 1280×800.
+    // The height must be DEFINITE (h-, not max-h-): `flex-1` distributes free
+    // space, and a max-height leaves none to distribute — under max-h the canvas
+    // collapsed onto its own floor (360 px) at every desktop width, i.e. the
+    // exact "map is too small" this layout exists to fix.
+    // The max() floor is for short-but-wide viewports: below it the card simply
+    // exceeds the viewport (and scrolls) instead of squeezing the map flat.
+    <div className={`border border-border bg-surface rounded overflow-hidden shadow-sm ${
+      tall ? 'lg:flex lg:flex-col lg:h-[max(560px,calc(100vh-1.5rem))]' : ''
+    }`}>
+      <MapHeader
+        view={view} setView={setView}
+        fill={fill} setFill={setFill} fillDef={fillDef}
+        overlays={overlays} setOverlays={setOverlays}
+      />
 
+      {/* min-h-0 lets the canvas yield to the chrome rather than push the
+          scrubber/legends out of the clipped card. */}
       <div
-        className={`relative ${tall ? 'h-[60vh] lg:h-[min(75vh,calc(100vh-230px))]' : ''}`}
+        className={`relative ${tall ? 'h-[60vh] lg:h-auto lg:flex-1 lg:min-h-0' : ''}`}
         style={tall ? { background: pal.surface } : { height: 460, background: pal.surface }}
       >
         {/* pickingRadius: the demoted 2 px context arcs stay clickable without

--- a/frontend/src/components/powermap/layers/selectionLayer.js
+++ b/frontend/src/components/powermap/layers/selectionLayer.js
@@ -1,0 +1,51 @@
+import { GeoJsonLayer } from '@deck.gl/layers'
+import { SELECTION_WIDTH_PX, SELECTION_CASING_PX } from '../constants'
+
+// The selected zone's contour, drawn as its OWN pair of layers rather than as a
+// branch inside the choropleth's stroke accessors. Two reasons:
+//   1. Legibility. A single accent cannot work: pal.posPole IS the price ramp's
+//      expensive end, so the old accent-only outline sat at ΔE 0.0 on exactly
+//      the zones worth inspecting. A casing under the accent makes the contour
+//      two-toned, so one tone always separates from the fill (see constants).
+//   2. Stacking. Inside the choropleth every polygon is one layer, so a
+//      neighbour's fill can paint over the selected zone's stroke. On top, the
+//      contour is never half-covered.
+// NOT pickable: the choropleth underneath owns hover + click, and a transparent
+// contour layer on top would swallow both.
+// NOTE: the geojson `zone` property is NOT unique (DE_LU spans DE + LU, FR spans
+// FR + FR-COR), so this filters — every feature of the zone gets the contour.
+export function makeSelectionLayers({ geo, selectedZone, pal }) {
+  if (!geo || !selectedZone) return []
+  const features = geo.features.filter((f) => f.properties.zone === selectedZone)
+  if (features.length === 0) return []
+  const data = { type: 'FeatureCollection', features }
+
+  const base = {
+    data,
+    pickable: false,
+    stroked: true,
+    filled: false,
+    lineWidthUnits: 'pixels',
+    lineJointRounded: true,
+    lineCapRounded: true,
+    // The contour is a pure function of (zone, theme) — deck.gl caches the
+    // stroke accessors, so both must repaint when either changes.
+    updateTriggers: { getLineColor: [selectedZone], getLineWidth: [selectedZone] },
+  }
+
+  return [
+    new GeoJsonLayer({
+      ...base,
+      id: 'eu-zone-selected-casing',
+      getLineColor: pal.labelOutline,
+      // Centred strokes: the casing shows SELECTION_CASING_PX/2 on each side.
+      getLineWidth: SELECTION_WIDTH_PX + SELECTION_CASING_PX,
+    }),
+    new GeoJsonLayer({
+      ...base,
+      id: 'eu-zone-selected',
+      getLineColor: [...pal.posPole, 255],
+      getLineWidth: SELECTION_WIDTH_PX,
+    }),
+  ]
+}

--- a/frontend/src/components/powermap/layers/selectionLayer.js
+++ b/frontend/src/components/powermap/layers/selectionLayer.js
@@ -20,6 +20,12 @@ export function makeSelectionLayers({ geo, selectedZone, pal }) {
   if (features.length === 0) return []
   const data = { type: 'FeatureCollection', features }
 
+  // No updateTriggers: both stroke accessors below are CONSTANTS, not per-feature
+  // functions, so there is nothing for deck.gl to cache and re-evaluate — a
+  // constant accessor is re-read whenever the prop itself changes. What actually
+  // varies here is `data` (a new selection is a new filtered FeatureCollection,
+  // and these layers are not created at all when nothing is selected) and the
+  // palette (a theme flip changes pal, hence the constants themselves).
   const base = {
     data,
     pickable: false,
@@ -28,9 +34,6 @@ export function makeSelectionLayers({ geo, selectedZone, pal }) {
     lineWidthUnits: 'pixels',
     lineJointRounded: true,
     lineCapRounded: true,
-    // The contour is a pure function of (zone, theme) — deck.gl caches the
-    // stroke accessors, so both must repaint when either changes.
-    updateTriggers: { getLineColor: [selectedZone], getLineWidth: [selectedZone] },
   }
 
   return [

--- a/frontend/src/components/powermap/layers/zonesLayer.js
+++ b/frontend/src/components/powermap/layers/zonesLayer.js
@@ -2,14 +2,15 @@ import { GeoJsonLayer } from '@deck.gl/layers'
 
 // Choropleth over the real bidding-zone geometry. Features without a `zone`
 // property are neighbouring countries — context only: muted fill, no tooltip,
-// and they never fire onZoneClick. NOTE: the geojson `zone` property is NOT
-// unique — DE_LU spans two features (DE + LU), FR two (FR + FR-COR) — so the
-// selectedZone outline matches by property value and lights up ALL of a
-// zone's features.
+// and they never fire onZoneClick.
+//
+// The SELECTED zone's outline is deliberately not here: it is its own casing +
+// accent pair drawn on top (see selectionLayer). Inside this layer it could only
+// ever be one flat colour, and a neighbour's fill could paint over it.
 //
 // `fillColorTriggers` is the fully assembled getFillColor updateTriggers array
 // (index.jsx builds it as [fill, effRows, ...(fillDef.triggers?.(ctx) ?? []), theme]).
-export function makeZonesLayer({ geo, zoneFill, pal, theme, fillColorTriggers, selectedZone, onZoneClick }) {
+export function makeZonesLayer({ geo, zoneFill, pal, theme, fillColorTriggers, onZoneClick }) {
   return new GeoJsonLayer({
     id: 'eu-zones',
     data: geo,
@@ -17,15 +18,8 @@ export function makeZonesLayer({ geo, zoneFill, pal, theme, fillColorTriggers, s
     stroked: true,
     filled: true,
     getFillColor: (f) => (f.properties.zone ? zoneFill(f.properties.zone) : pal.contextFill),
-    getLineColor: (f) => {
-      if (!f.properties.zone) return pal.contextLine
-      if (selectedZone && f.properties.zone === selectedZone) return [...pal.posPole, 255]
-      return pal.zoneLine
-    },
-    // Selected-zone accent outline: thicker stroke on the matching feature(s).
-    // A strict no-op while selectedZone is null/undefined — 2.5 px only when
-    // selected, otherwise 1 px (== the lineWidthMinPixels floor as before).
-    getLineWidth: (f) => (selectedZone && f.properties.zone === selectedZone ? 2.5 : 1),
+    getLineColor: (f) => (f.properties.zone ? pal.zoneLine : pal.contextLine),
+    getLineWidth: 1,
     lineWidthUnits: 'pixels',
     lineWidthMinPixels: 1,
     autoHighlight: true,
@@ -36,8 +30,7 @@ export function makeZonesLayer({ geo, zoneFill, pal, theme, fillColorTriggers, s
     },
     updateTriggers: {
       getFillColor: fillColorTriggers,
-      getLineColor: [theme, selectedZone],
-      getLineWidth: [selectedZone],
+      getLineColor: [theme],
     },
   })
 }
@@ -47,15 +40,14 @@ export function makeZonesLayer({ geo, zoneFill, pal, theme, fillColorTriggers, s
 // in lock-step with the main variant by construction. theme stays in the line
 // triggers: a theme flip while in POINTS view must repaint the (inherited)
 // stroke accessors, not leave stale outlines.
-export function makeContextZonesLayer(zonesLayer, { pal, theme, selectedZone }) {
+export function makeContextZonesLayer(zonesLayer, { pal, theme }) {
   return zonesLayer.clone({
     pickable: false,
     autoHighlight: false,
     getFillColor: pal.contextFill,
     updateTriggers: {
       getFillColor: [theme],
-      getLineColor: [theme, selectedZone],
-      getLineWidth: [theme, selectedZone],
+      getLineColor: [theme],
     },
   })
 }


### PR DESCRIPTION
## Was
PR 8/9 des Map-Redesign-Plans — die Layout-Änderung, um die es dem Owner ging („Karte zu klein", „nichts ist optisch klar zu sehen"). Der EUROPE-Tab wird ein **Desk-Split**: große Karte rechts, schmales Rail mit der Zonen-Tabelle links.

**Karte: 819×772 statt 614×460 px** — mehr als doppelte Fläche.

## Wie
- Neuer `EuropeDesk.jsx` trägt den ganzen Tab; `App.jsx` behält drei Zeilen. Grid `lg:grid-cols-[minmax(340px,1fr)_2fr]`, mobil einspaltig mit Karte zuerst.
- **Beide Spalten teilen eine Höhe** (`DESK_COLUMN_H`) und sind Flex-Spalten: Karten-Canvas und Tabelle nehmen jeweils, was ihre eigene Chrome übriglässt. Damit ist der Totraum weg (vorher 427 px leere Spalte neben einer Tabelle, die bei 14 von 37 Zonen scrollte — jetzt 23 sichtbar) und PR 9s Detailkarte bekommt ein Höhenbudget statt einer weiteren `vh`-Zahl. Gleiche Spaltenhöhen heißt auch: ein Sticky könnte nie wandern — die Deklaration ist deshalb raus statt vertagt.
- `PowerOverviewMatrix` bekommt ein `compact`-Prop (kein Fork): Einheiten in die Kopfzeile, State als Punkt **plus Buchstabe plus sr-only-Wort** (rot/grün allein ist die klassische CVD-Kollision), Zeilenklick wählt nur noch die Zone statt in den Tab zu springen.
- Karte ↔ Rail sind beidseitig verdrahtet: Zonenklick markiert die Zeile, Zeilenklick umrandet die Zone. Die Auswahlkontur bekam dabei einen eigenen Layer — die alte Umrandung war `posPole`, also **exakt die Farbe des teuren Preis-Endes** (ΔE 0,0 in beiden Themes): auf teuren Zonen unsichtbar, genau dort, wo man hinschaut.

## Zwei Bugs, die beim Bauen auffielen
- **Die Karte kollabierte auf 360 px** an jeder Desktop-Breite: `max-h` lässt `flex-1` keinen Freiraum zu verteilen, der Canvas fiel auf seinen eigenen Floor — genau das „zu klein", das dieser PR beheben soll. Jetzt definite Höhe + Flex-Spalte.
- **Mobil war die Karte eine Wischfalle:** deck.gl setzt `touch-action: none`, die Karte ist höher als der Viewport, es blieb kein Seitenrand zum Greifen — vertikales Wischen schwenkte die Karte, statt zu scrollen. `touchAction="pan-y"` (Top-Level-Deck-Prop; im `controller` wird es still ignoriert) gibt vertikales Wischen an den Browser zurück, Pinch-Zoom und horizontales Ziehen bleiben.

## Außerdem
`MapHeader.jsx` ausgelagert; die ⓘ ist eine Term-Liste, komponiert aus den Fill- und Overlay-Registern statt einer 1,9k-Zeichen-Prosa — ein neuer Fill/Overlay bringt seine Erklärung mit, statt einen zentralen String wachsen zu lassen (LABELS gehört jetzt per `when`-Prädikat dazu). Doppelte Überschrift raus, `MapFallback` entdoppelt, und eine gewählte Zone ohne Geometrie (IT-Calabria — 36 Polygone für 37 Zonen) sagt das, statt nichts zu umranden.

## Verifikation
Build + Lint grün; Messungen bei 1500×1000 / 1280×800 / 390×844 in beiden Themes (Rail-Höhe = Kartenhöhe, kein horizontaler Overflow, `touch-action: pan-y` überall); Zone-Coherence-Guard bestanden; ⓘ-`dl`, IT-Calabria-Pfad und beidseitige Auswahl live im Browser geprüft; zwei-stufiges Review bestanden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)