### PR TITLE
Zone detail card in the desk rail

### DIFF
--- a/frontend/src/components/BordersPanel.jsx
+++ b/frontend/src/components/BordersPanel.jsx
@@ -141,20 +141,29 @@ export default function BordersPanel({ focus }) {
   }
   const mountFocus = useRef(focus)
   useEffect(() => {
-    if (!focus?.a || !focus?.b || focus === mountFocus.current) return
+    // `scroll: false` = prepare the row but STAY PUT. The EUROPE tab sends it
+    // for map clicks: the panel is two screens below the map, so scrolling here
+    // dragged the page off the thing the user had just clicked. Opening +
+    // expanding is unchanged, so the row is ready whenever they come down —
+    // by their own scroll, or via the chip the map offers. Any caller that
+    // omits the field keeps the original scroll-into-view behaviour.
+    if (!focus?.a || !focus?.b || focus === mountFocus.current || focus.scroll === false) return
     document.getElementById('panel-power-borders')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }, [focus])
 
+  // The degraded states keep the panel's ANCHOR id: something on the map always
+  // offers to scroll here (the EUROPE tab's border chip), and a link that
+  // silently goes nowhere is worse than one that lands on "fetch error".
   if (error) {
     return (
-      <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
+      <div id="panel-power-borders" className="border border-red-500/20 bg-surface rounded px-4 py-3">
         <div className="font-mono text-[10px] text-red-400">BORDERS // FETCH ERROR</div>
       </div>
     )
   }
   if (!data?.available && !loading) {
     return (
-      <div className="border border-border bg-surface rounded px-4 py-3">
+      <div id="panel-power-borders" className="border border-border bg-surface rounded px-4 py-3">
         <div className="font-mono text-[10px] text-neutral-500">
           BORDERS — {data?.reason || 'no border data yet.'}
         </div>

--- a/frontend/src/components/EuropeDesk.jsx
+++ b/frontend/src/components/EuropeDesk.jsx
@@ -11,6 +11,10 @@ import LiveCharts from './LiveCharts'
 import HowToRead from './HowToRead'
 import { MAP_FALLBACK } from './MapFallback'
 import { DESK_COLUMN_H } from './powermap/constants'
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_SLOW_MS } from '../utils/poll'
+
+const API = '/api'
 
 // The EUROPE tab — the desk's front door, lifted out of App.jsx so the layout
 // that makes it a *map-first desk* lives in one file instead of inline in the
@@ -26,14 +30,12 @@ import { DESK_COLUMN_H } from './powermap/constants'
 // takes what is left rather than picking a vh of its own. Under it the rail now
 // answers the click it collects: the border chip's reserved slot (28 px, fixed
 // — the chip appearing must never cost the table a row), then the zone detail
-// card (342 px) — both `shrink-0`, so they come out of the SAME budget and the
-// table simply yields the rows they cost. Measured across all 37 zones ×
-// {1500×1000, 1280×800, 1024×768}: card 342 px for every zone, column overflow
-// 0 px everywhere, 13 rows fully visible at 1500×1000 and 6 at both smaller
-// sizes. The one thing that moves it is the flag row: the synthetic worst case
-// (3 flags + a 2-line headline, more than any zone carries today) grows the
-// card to 363/385 px and costs the table ONE row — still no overflow, because
-// the table is the flex child that yields. Nothing else about a zone may.
+// card (160 px) — both `shrink-0`, so they come out of the SAME budget and the
+// table simply yields the rows they cost. Both are kept CHEAP on purpose: this
+// rail is the map's index, and PR 8 split the desk precisely because a table
+// that shows 14 of 37 zones is not one. An earlier draft of the card carried a
+// generation-mix chart and landed the table at 6 of 37 — the same defect, worse;
+// see ZoneDetailCard's docblock for what came out and why.
 // Below lg the split collapses, NOTHING is force-fitted to the viewport, and the
 // MAP COMES FIRST (order-1) — on a phone it is still the thing you came for.
 // Everything below the grid (radar, borders, hydro, charts, orientation) stays
@@ -57,6 +59,20 @@ export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
   // Which focus the user has already dealt with (clicked through or dismissed).
   const [chipDoneTs, setChipDoneTs] = useState(null)
   const showChip = Boolean(borderFocus && borderFocus.ts !== chipDoneTs)
+
+  // The chip says a row "opened in Borders", so it has to KNOW one did. Flow
+  // arcs are built from this very payload and always have a row; A78 outage
+  // chords are not — outageLayer notes a chord can name a pair the borders table
+  // does not carry, and then nothing opens and the chip would be lying. Same url
+  // and cadence as BordersPanel, so useFetchWithError's dedupe + SWR cache serve
+  // it from that panel's request: no second GET for the claim.
+  const { data: bordersData } = useFetchWithError(`${API}/power/borders?days=30`, {
+    pollMs: POLL_SLOW_MS,
+  })
+  // null = not answered yet (say nothing either way); true/false = verified.
+  const focusHasRow = !borderFocus || !bordersData?.borders
+    ? null
+    : bordersData.borders.some((b) => b.zone_a === borderFocus.a && b.zone_b === borderFocus.b)
 
   // The zone the SPLIT is looking at — table row ⇄ map outline, both ways.
   // Deliberately NOT the global `energyZone`: selecting here is "show me this
@@ -100,15 +116,32 @@ export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
               the one thing a click MUST produce is feedback you can see. */}
           <div className="shrink-0 h-7 flex items-center">
             {showChip ? (
-              <div className="inline-flex items-center gap-1 max-w-full border border-cyan-glow/40 bg-surface rounded pl-2 pr-1 py-1">
+              <div className={`inline-flex items-center gap-1 max-w-full border bg-surface rounded pl-2 pr-1 py-1 ${
+                focusHasRow === false ? 'border-border' : 'border-cyan-glow/40'
+              }`}>
+                {/* Truncation is the normal case, not the exception: the longest
+                    pair (IT-Centro-Nord↔IT-Centro-Sud) needs 312 px into 306 px,
+                    and what falls off the end is the AFFORDANCE. The title=
+                    carries the whole sentence — the repo's "short at the element"
+                    rule — so a clipped chip is still readable on hover. */}
                 <button
                   onClick={() => {
                     document.getElementById('panel-power-borders')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
                     setChipDoneTs(borderFocus.ts)
                   }}
+                  title={focusHasRow === false
+                    ? `${zoneLabel(borderFocus.a)}↔${zoneLabel(borderFocus.b)} has no row in the Borders table — the outage feed names pairs the border stats do not cover. Click to go to Borders anyway.`
+                    : `${zoneLabel(borderFocus.a)}↔${zoneLabel(borderFocus.b)} is open in the Borders panel below — click to scroll to it.`}
                   className="font-mono text-[9px] text-neutral-300 hover:text-cyan-glow transition-colors truncate"
                 >
-                  {zoneLabel(borderFocus.a)}↔{zoneLabel(borderFocus.b)} opened in Borders <span className="text-cyan-glow">· view ↓</span>
+                  {zoneLabel(borderFocus.a)}↔{zoneLabel(borderFocus.b)}
+                  {/* Only claim the row opened once the borders payload says it
+                      exists. An A78 chord can name a pair the table does not
+                      carry; then nothing opened and saying so beats sending the
+                      user down two screens to find out. */}
+                  {focusHasRow === false
+                    ? <span className="text-neutral-500"> · not in Borders</span>
+                    : <>{focusHasRow ? ' opened in Borders' : ' → Borders'} <span className="text-cyan-glow">· view ↓</span></>}
                 </button>
                 <button
                   onClick={() => setChipDoneTs(borderFocus.ts)}

--- a/frontend/src/components/EuropeDesk.jsx
+++ b/frontend/src/components/EuropeDesk.jsx
@@ -3,6 +3,7 @@ import useZones from '../hooks/useZones'
 import ErrorBoundary from './ErrorBoundary'
 import NarrativeHero from './NarrativeHero'
 import PowerOverviewMatrix from './PowerOverviewMatrix'
+import ZoneDetailCard from './ZoneDetailCard'
 import InsightsStrip from './InsightsStrip'
 import BordersPanel from './BordersPanel'
 import HydroReservoirPanel from './HydroReservoirPanel'
@@ -21,9 +22,18 @@ import { DESK_COLUMN_H } from './powermap/constants'
 // columns, so the row has ONE height and neither column invents its own: the
 // map's canvas and the rail's table are both `flex-1 min-h-0` and simply take
 // what is left after their own chrome. That is why there is no sticky here —
-// equal columns mean a sticky one could never travel — and why the rail shows
-// ~30 of 37 zones instead of inner-scrolling at 14 beside 400 px of dead space.
-// PR 9's detail card inherits the same budget instead of picking another vh.
+// equal columns mean a sticky one could never travel — and why the rail's table
+// takes what is left rather than picking a vh of its own. Under it the rail now
+// answers the click it collects: the border chip's reserved slot (28 px, fixed
+// — the chip appearing must never cost the table a row), then the zone detail
+// card (342 px) — both `shrink-0`, so they come out of the SAME budget and the
+// table simply yields the rows they cost. Measured across all 37 zones ×
+// {1500×1000, 1280×800, 1024×768}: card 342 px for every zone, column overflow
+// 0 px everywhere, 13 rows fully visible at 1500×1000 and 6 at both smaller
+// sizes. The one thing that moves it is the flag row: the synthetic worst case
+// (3 flags + a 2-line headline, more than any zone carries today) grows the
+// card to 363/385 px and costs the table ONE row — still no overflow, because
+// the table is the flex child that yields. Nothing else about a zone may.
 // Below lg the split collapses, NOTHING is force-fitted to the viewport, and the
 // MAP COMES FIRST (order-1) — on a phone it is still the thing you came for.
 // Everything below the grid (radar, borders, hydro, charts, orientation) stays
@@ -32,19 +42,28 @@ const PowerMap = lazy(() => import('./powermap'))
 
 export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
   // Map arc / outage chord click → border detail: the focus travels as a prop to
-  // BordersPanel (opens the row, expands + scrolls the panel). `ts` makes every
-  // click a NEW signal, so re-clicking the same border still scrolls/expands.
+  // BordersPanel, which opens the row and un-collapses the panel. `ts` makes
+  // every click a NEW signal, so re-clicking the same border still expands.
   // Stable callback — PowerMap's layers memo depends on it. Lives here, not in
   // App: the EUROPE tab is the only place a border can be clicked.
+  //
+  // `scroll: false` is the whole point: the panel is two screens down, so
+  // auto-scrolling there yanked the MAP out from under the hand that clicked
+  // the arc — a click on the subject of the page should not navigate away from
+  // it. The row is prepared anyway; the chip below offers the trip.
   const [borderFocus, setBorderFocus] = useState(null)
-  const onBorderSelect = useCallback((a, b) => setBorderFocus({ a, b, ts: Date.now() }), [])
+  const onBorderSelect = useCallback(
+    (a, b) => setBorderFocus({ a, b, ts: Date.now(), scroll: false }), [])
+  // Which focus the user has already dealt with (clicked through or dismissed).
+  const [chipDoneTs, setChipDoneTs] = useState(null)
+  const showChip = Boolean(borderFocus && borderFocus.ts !== chipDoneTs)
 
   // The zone the SPLIT is looking at — table row ⇄ map outline, both ways.
   // Deliberately NOT the global `energyZone`: selecting here is "show me this
   // zone on the map", a look, not a navigation. It FOLLOWS the global zone
   // (so it is never empty on arrival, and picks up the async server default),
   // but a look here never writes back. Jumping the whole desk is the explicit
-  // "Open zone →" button below (PR 9 grows it into a detail card).
+  // "Open zone →" button in the detail card's header, and nothing else.
   // Render-phase sync, the repo's derive-from-props pattern (cf. Panel's
   // expandSignal) — no effect, so the rail never paints the wrong zone first.
   const [focusZone, setFocusZone] = useState(energyZone)
@@ -55,7 +74,7 @@ export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
   }
 
   const { zones } = useZones()
-  const focusLabel = zones.find((z) => z.key === focusZone)?.label || focusZone
+  const zoneLabel = (key) => zones.find((z) => z.key === key)?.label || key
 
   return (
     <div className="space-y-3">
@@ -65,22 +84,54 @@ export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
       <div className="grid grid-cols-1 lg:grid-cols-[minmax(340px,1fr)_2fr] gap-3 items-start">
         {/* The rail is a flex COLUMN of the same height as the map card: the
             table takes the space (flex-1 min-h-0 — see PowerOverviewMatrix's
-            `compact`), the button stays parked at the bottom. `gap-3` rather
-            than space-y so the button keeps its spacing as a flex item. */}
+            `compact`), the detail card is parked at the bottom on a bounded,
+            `shrink-0` budget of its own. `gap-3` rather than space-y so the
+            card keeps its spacing as a flex item. */}
         <div className={`order-2 lg:order-1 min-w-0 flex flex-col gap-3 ${DESK_COLUMN_H}`}>
           <ErrorBoundary name="power-overview">
             <PowerOverviewMatrix compact selectedZone={focusZone} onSelect={setFocusZone} />
           </ErrorBoundary>
-          {/* Temporary until PR 9's zone detail card: a row click no longer
-              jumps tabs, so the jump needs a door of its own — otherwise the
-              only way from "that zone looks odd" to its desk is the pills.
-              shrink-0: the button is chrome, the table is what yields. */}
-          <button
-            onClick={() => { setEnergyZone(focusZone); goToTab('energy') }}
-            className="shrink-0 w-full border border-border bg-surface rounded px-3 py-2 font-mono text-[11px] text-neutral-400 hover:text-cyan-glow hover:border-cyan-glow/40 text-left"
-          >
-            Open zone <span className="text-neutral-200">{focusLabel}</span> <span className="text-cyan-glow">→</span>
-          </button>
+          {/* Border-click feedback, on a slot that is ALWAYS this tall: the chip
+              appearing must not cost the table a row, and the empty state is
+              not dead space — it is where the flow arcs say they are clickable.
+              In the RAIL, not under the map: the desk column runs past the fold
+              by design (see DESK_COLUMN_H), so anything anchored to the map's
+              bottom edge would land ~250 px below the viewport — measured — and
+              the one thing a click MUST produce is feedback you can see. */}
+          <div className="shrink-0 h-7 flex items-center">
+            {showChip ? (
+              <div className="inline-flex items-center gap-1 max-w-full border border-cyan-glow/40 bg-surface rounded pl-2 pr-1 py-1">
+                <button
+                  onClick={() => {
+                    document.getElementById('panel-power-borders')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                    setChipDoneTs(borderFocus.ts)
+                  }}
+                  className="font-mono text-[9px] text-neutral-300 hover:text-cyan-glow transition-colors truncate"
+                >
+                  {zoneLabel(borderFocus.a)}↔{zoneLabel(borderFocus.b)} opened in Borders <span className="text-cyan-glow">· view ↓</span>
+                </button>
+                <button
+                  onClick={() => setChipDoneTs(borderFocus.ts)}
+                  title="Dismiss" aria-label="Dismiss"
+                  className="shrink-0 px-1 font-mono text-[10px] text-neutral-600 hover:text-neutral-300"
+                >
+                  ×
+                </button>
+              </div>
+            ) : (
+              <span className="font-mono text-[9px] text-neutral-700 truncate">
+                Click a flow arc or outage line on the map to open its border.
+              </span>
+            )}
+          </div>
+          {/* The answer to a row/map click — and the only door out of the tab
+              ("Open zone →"), since a click here is a look, not a navigation. */}
+          <ErrorBoundary name="zone-detail">
+            <ZoneDetailCard
+              zone={focusZone}
+              onOpenZone={() => { setEnergyZone(focusZone); goToTab('energy') }}
+            />
+          </ErrorBoundary>
         </div>
         <div className="order-1 lg:order-2 min-w-0">
           <ErrorBoundary name="power-map">

--- a/frontend/src/components/EuropeDesk.jsx
+++ b/frontend/src/components/EuropeDesk.jsx
@@ -92,6 +92,47 @@ export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
   const { zones } = useZones()
   const zoneLabel = (key) => zones.find((z) => z.key === key)?.label || key
 
+  // Border-click feedback, pinned to the top of the CANVAS — the surface the
+  // click was made on, and the one part of the desk column that is on screen
+  // whenever the map is being looked at.
+  const borderChip = borderFocus && (
+    <div className={`inline-flex items-center gap-1 max-w-full border bg-surface/95 rounded pl-2 pr-1 py-1 shadow-sm ${
+      focusHasRow === false ? 'border-border' : 'border-cyan-glow/40'
+    }`}>
+      {/* Truncation is the normal case, not the exception: the longest pair
+          (IT-Centro-Nord↔IT-Centro-Sud) needs 312 px into 306 px, and what falls
+          off the end is the AFFORDANCE. The title= carries the whole sentence —
+          the repo's "short at the element" rule — so a clipped chip still reads
+          on hover. */}
+      <button
+        onClick={() => {
+          document.getElementById('panel-power-borders')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          setChipDoneTs(borderFocus.ts)
+        }}
+        title={focusHasRow === false
+          ? `${zoneLabel(borderFocus.a)}↔${zoneLabel(borderFocus.b)} has no row in the Borders table — the outage feed names pairs the border stats do not cover. Click to go to Borders anyway.`
+          : `${zoneLabel(borderFocus.a)}↔${zoneLabel(borderFocus.b)} is open in the Borders panel below — click to scroll to it.`}
+        className="font-mono text-[9px] text-neutral-300 hover:text-cyan-glow transition-colors truncate"
+      >
+        {zoneLabel(borderFocus.a)}↔{zoneLabel(borderFocus.b)}
+        {/* Only claim the row opened once the borders payload says it exists. An
+            A78 chord can name a pair the table does not carry; then nothing
+            opened, and saying so beats sending the user down two screens to
+            find out. */}
+        {focusHasRow === false
+          ? <span className="text-neutral-500"> · not in Borders</span>
+          : <>{focusHasRow ? ' opened in Borders' : ' → Borders'} <span className="text-cyan-glow">· view ↓</span></>}
+      </button>
+      <button
+        onClick={() => setChipDoneTs(borderFocus.ts)}
+        title="Dismiss" aria-label="Dismiss"
+        className="shrink-0 px-1 font-mono text-[10px] text-neutral-600 hover:text-neutral-300"
+      >
+        ×
+      </button>
+    </div>
+  )
+
   return (
     <div className="space-y-3">
       <ErrorBoundary name="narrative">
@@ -107,55 +148,14 @@ export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
           <ErrorBoundary name="power-overview">
             <PowerOverviewMatrix compact selectedZone={focusZone} onSelect={setFocusZone} />
           </ErrorBoundary>
-          {/* Border-click feedback, on a slot that is ALWAYS this tall: the chip
-              appearing must not cost the table a row, and the empty state is
-              not dead space — it is where the flow arcs say they are clickable.
-              In the RAIL, not under the map: the desk column runs past the fold
-              by design (see DESK_COLUMN_H), so anything anchored to the map's
-              bottom edge would land ~250 px below the viewport — measured — and
-              the one thing a click MUST produce is feedback you can see. */}
+          {/* The standing hint that the arcs are clickable. It never changes, so
+              it costs the table one fixed line and never a reflow — the chip it
+              used to share this slot with now answers on the map itself, where
+              the click was made (see `canvasOverlay`). */}
           <div className="shrink-0 h-7 flex items-center">
-            {showChip ? (
-              <div className={`inline-flex items-center gap-1 max-w-full border bg-surface rounded pl-2 pr-1 py-1 ${
-                focusHasRow === false ? 'border-border' : 'border-cyan-glow/40'
-              }`}>
-                {/* Truncation is the normal case, not the exception: the longest
-                    pair (IT-Centro-Nord↔IT-Centro-Sud) needs 312 px into 306 px,
-                    and what falls off the end is the AFFORDANCE. The title=
-                    carries the whole sentence — the repo's "short at the element"
-                    rule — so a clipped chip is still readable on hover. */}
-                <button
-                  onClick={() => {
-                    document.getElementById('panel-power-borders')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-                    setChipDoneTs(borderFocus.ts)
-                  }}
-                  title={focusHasRow === false
-                    ? `${zoneLabel(borderFocus.a)}↔${zoneLabel(borderFocus.b)} has no row in the Borders table — the outage feed names pairs the border stats do not cover. Click to go to Borders anyway.`
-                    : `${zoneLabel(borderFocus.a)}↔${zoneLabel(borderFocus.b)} is open in the Borders panel below — click to scroll to it.`}
-                  className="font-mono text-[9px] text-neutral-300 hover:text-cyan-glow transition-colors truncate"
-                >
-                  {zoneLabel(borderFocus.a)}↔{zoneLabel(borderFocus.b)}
-                  {/* Only claim the row opened once the borders payload says it
-                      exists. An A78 chord can name a pair the table does not
-                      carry; then nothing opened and saying so beats sending the
-                      user down two screens to find out. */}
-                  {focusHasRow === false
-                    ? <span className="text-neutral-500"> · not in Borders</span>
-                    : <>{focusHasRow ? ' opened in Borders' : ' → Borders'} <span className="text-cyan-glow">· view ↓</span></>}
-                </button>
-                <button
-                  onClick={() => setChipDoneTs(borderFocus.ts)}
-                  title="Dismiss" aria-label="Dismiss"
-                  className="shrink-0 px-1 font-mono text-[10px] text-neutral-600 hover:text-neutral-300"
-                >
-                  ×
-                </button>
-              </div>
-            ) : (
-              <span className="font-mono text-[9px] text-neutral-700 truncate">
-                Click a flow arc or outage line on the map to open its border.
-              </span>
-            )}
+            <span className="font-mono text-[9px] text-neutral-700 truncate">
+              Click a flow arc or outage line on the map to open its border.
+            </span>
           </div>
           {/* The answer to a row/map click — and the only door out of the tab
               ("Open zone →"), since a click here is a look, not a navigation. */}
@@ -174,6 +174,7 @@ export default function EuropeDesk({ energyZone, setEnergyZone, goToTab }) {
                 onBorderSelect={onBorderSelect}
                 selectedZone={focusZone}
                 onZoneSelect={setFocusZone}
+                canvasOverlay={showChip ? borderChip : null}
               />
             </Suspense>
           </ErrorBoundary>

--- a/frontend/src/components/FreshnessCaption.jsx
+++ b/frontend/src/components/FreshnessCaption.jsx
@@ -6,24 +6,38 @@
  * A hung feed used to look identical to a healthy one — the panels only said
  * "latest {date}". Fresh data renders as a quiet date stamp; a lagging series
  * gets an amber STALE tag with its age. Dates are delivery dates in UTC.
+ *
+ * `dense` is the desk rail's variant: the same two states one type-step down,
+ * and the date stays visible instead of hiding below sm — the rail is narrow at
+ * EVERY width, so `hidden sm:inline` would drop the stamp on the exact layout
+ * that needs it most. It exists so the rail does not grow a third private copy
+ * of this chip: ZoneDetailCard shows the as_of triple twice (the overview row's
+ * in its header, the situation feed's beside the headline it belongs to), and
+ * two feeds that can disagree about freshness must not disagree about how
+ * freshness LOOKS.
+ *
+ * `age_days` is optional throughout: /power/overview rows carry `stale` and
+ * `as_of` but no age, and "STALE · nulld" is worse than an unqualified STALE.
  */
-export default function FreshnessCaption({ meta }) {
+export default function FreshnessCaption({ meta, dense = false }) {
   if (!meta?.as_of) return null
 
   if (meta.stale) {
     return (
       <span
-        className="font-mono text-[9px] tracking-wide text-orange-400 border border-orange-500/30 rounded px-1.5 py-0.5"
-        title={`Latest data ${meta.as_of} (UTC) — ${meta.age_days}d old, this feed may be stalled`}
+        className={`shrink-0 font-mono tracking-wide text-orange-400 border border-orange-500/30 rounded ${
+          dense ? 'text-[8px] px-1 py-px' : 'text-[9px] px-1.5 py-0.5'
+        }`}
+        title={`Latest data ${meta.as_of} (UTC)${meta.age_days != null ? ` — ${meta.age_days}d old` : ''}, this feed may be stalled`}
       >
-        STALE · {meta.age_days}d
+        STALE{meta.age_days != null ? ` · ${meta.age_days}d` : ''}
       </span>
     )
   }
 
   return (
     <span
-      className="font-mono text-[9px] text-neutral-600 hidden sm:inline"
+      className={`shrink-0 font-mono ${dense ? 'num text-[8px] text-neutral-700' : 'text-[9px] text-neutral-600 hidden sm:inline'}`}
       title="Delivery date of the newest data point (UTC)"
     >
       {meta.as_of}

--- a/frontend/src/components/PowerOverviewMatrix.jsx
+++ b/frontend/src/components/PowerOverviewMatrix.jsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { InfoPopover } from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { POLL_FAST_MS } from '../utils/poll'
-import { ZONE_STATE, STATE_ORDER, zColor } from '../utils/zoneState'
+import { ZONE_STATE, STATE_ORDER, zColor, metricGlossary } from '../utils/zoneState'
 
 // Single-glance overview — read all bidding zones at once, colour-first, like
 // Electricity Maps. Colour encodes how far each metric sits from its
@@ -31,15 +31,20 @@ const COLUMNS = [
 ]
 
 // One legend for the whole table (per-column popovers would be clipped by the
-// scroll container). Spells out what each column is — and, crucially, that
-// Day-ahead here is the DAILY MEAN, while the map shades a single hour.
-const TABLE_INFO = (
-  'What each column means. '
-  + 'State: how far this zone sits from its own 30-day norm — CALM / ELEVATED (amber) / STRESSED (red); a deviation vs history, not a forecast. '
-  + 'Day-ahead: the auction price (€/MWh), cleared the day before for this delivery day — a settled market price, NOT a forecast. It is the DAILY MEAN across the day’s hours; the map shades one hour at a time (its slider), so the map’s number differs from this average. '
-  + 'Residual: demand − wind − solar (GW), the gap conventional plants must fill — what actually sets the price. '
-  + 'Renewables: wind + solar as a share of load, left blank when the feed is too incomplete to trust the share.'
-)
+// scroll container). The four definitions are SHARED with ZoneDetailCard's ⓘ
+// ~200 px below in the same rail (utils/zoneState.js) — they must not be
+// rewritten here; this copy hardcoded "30-day" and could contradict the footer
+// two lines down, which reads the live baseline_days. Only the map caveat is
+// this table's own: Day-ahead here is the DAILY MEAN, the map shades one hour.
+const TABLE_INFO = (baselineDays) => {
+  const g = metricGlossary(baselineDays)
+  return [
+    'What each column means.',
+    g.state, g.dayAhead,
+    'The map shades one hour at a time (its slider), so the map’s number differs from this average.',
+    g.residual, g.renewables,
+  ].join(' ')
+}
 
 export default function PowerOverviewMatrix({ selectedZone, onSelect, compact = false }) {
   const { data, loading, error } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
@@ -103,7 +108,7 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect, compact = 
     }`}>
       <div className="shrink-0 px-4 py-2.5 border-b border-border/60 flex items-center gap-2">
         <span className="font-mono text-[12px] font-semibold text-neutral-300">European power · all zones</span>
-        <InfoPopover text={TABLE_INFO} />
+        <InfoPopover text={TABLE_INFO(data.baseline_days)} />
         <span className="font-mono text-[9px] text-neutral-700 ml-auto">
           {compact ? 'sort ↕ · click a zone to focus it' : 'sort ↕ · click a zone for detail →'}
         </span>

--- a/frontend/src/components/PowerOverviewMatrix.jsx
+++ b/frontend/src/components/PowerOverviewMatrix.jsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { InfoPopover } from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { POLL_FAST_MS } from '../utils/poll'
+import { ZONE_STATE, STATE_ORDER, zColor } from '../utils/zoneState'
 
 // Single-glance overview — read all bidding zones at once, colour-first, like
 // Electricity Maps. Colour encodes how far each metric sits from its
@@ -11,24 +12,14 @@ import { POLL_FAST_MS } from '../utils/poll'
 // the zone on the map beside it. Descriptive, not a forecast.
 const API = '/api'
 
-// `c` is the compact rail's one-letter code. It is NOT decoration: compact has
-// no room for the word, and green/amber/red dots alone are the textbook
-// red-green CVD collision — the letter is the second, non-colour carrier.
-const STATE = {
-  CALM: { t: 'text-green-glow', d: 'bg-green-glow', c: 'C' },
-  ELEVATED: { t: 'text-yellow-400', d: 'bg-yellow-400', c: 'E' },
-  STRESSED: { t: 'text-red-400', d: 'bg-red-400', c: 'S' },
-}
-const STATE_ORDER = { CALM: 0, ELEVATED: 1, STRESSED: 2 }
-
-const zColor = (z) =>
-  z == null ? 'text-neutral-400' : Math.abs(z) >= 3 ? 'text-red-400' : Math.abs(z) >= 2 ? 'text-yellow-400' : 'text-neutral-300'
-
+// State colours + the compact rail's one-letter code now live in
+// utils/zoneState.js: the desk rail renders this table and ZoneDetailCard for
+// the SAME zone at the same time, so the two must read from one map.
 // `compact` = the desk-split rail (~1/3 width, beside the big map): same table,
 // same sorting, less horizontal ink. The units move OUT of every cell and INTO
 // the header (74 under "€/MWh" instead of €74 under "Day-ahead"), which is both
 // shorter per row and where a unit belongs; the State word shrinks to a dot plus
-// its one-letter code (see STATE.c — the letter is what survives colour
+// its one-letter code (see ZONE_STATE.code — the letter is what survives colour
 // blindness), with the full word kept for screen readers.
 const COLUMNS = [
   { key: 'zone', label: 'Zone', align: 'left', get: (z) => z.zone_label || z.zone },
@@ -135,7 +126,7 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect, compact = 
           </thead>
           <tbody>
             {sorted.map((z) => {
-              const st = STATE[z.state] || STATE.CALM
+              const st = ZONE_STATE[z.state] || ZONE_STATE.CALM
               const sel = z.zone === selectedZone
               return (
                 <tr
@@ -156,9 +147,9 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect, compact = 
                       CVD); the sr-only word is what assistive tech reads, since
                       a title= on a <td> reaches neither it nor the keyboard. */}
                   <td className={`${cellX} py-2`}>
-                    <span className={`inline-flex items-center gap-1 font-bold ${st.t}`}>
-                      <span className={`${compact ? 'w-2 h-2' : 'w-1.5 h-1.5'} rounded-sm ${st.d}`} />
-                      {compact ? <span aria-hidden="true">{st.c}</span> : z.state}
+                    <span className={`inline-flex items-center gap-1 font-bold ${st.text}`}>
+                      <span className={`${compact ? 'w-2 h-2' : 'w-1.5 h-1.5'} rounded-sm ${st.dot}`} />
+                      {compact ? <span aria-hidden="true">{st.code}</span> : z.state}
                       {compact && <span className="sr-only">{z.state}</span>}
                     </span>
                   </td>

--- a/frontend/src/components/ZoneDetailCard.jsx
+++ b/frontend/src/components/ZoneDetailCard.jsx
@@ -1,0 +1,233 @@
+import useFetchWithError from '../hooks/useFetchWithError'
+import { POLL_FAST_MS } from '../utils/poll'
+import { ZONE_STATE, zColor } from '../utils/zoneState'
+import { InfoPopover } from './Panel'
+import MiniMixCard from './MiniMixCard'
+
+const API = '/api'
+
+// The desk rail's bottom half: the one zone the split is looking at, in the
+// same narrow column as the table that selects it. It is the ANSWER to a row or
+// map click — the click stays a LOOK (nothing navigates), and the only door out
+// of the tab is the explicit "Open zone →" button in this card's header.
+//
+// TWO feeds, deliberately:
+//   /power/overview  — the headline numbers. The SAME url the matrix above
+//     already polls, so useFetchWithError's url-keyed dedupe + SWR cache serve
+//     this from the matrix's request: no second GET, and the card can never
+//     show a different price than the row it sits under.
+//   /power/situation?zone= — the flags and the one-line read. One request per
+//     SELECTED zone (not per zone in the table), cached per url on the way back.
+// Each feed carries its own freshness, so neither can make the other look
+// current: the header stamps the overview row's as_of, the situation block
+// stamps its own age when it lags.
+
+// Per-zone flags from /situation, in the backend's own severity. Reported, not
+// restyled: warning is amber and critical is red because that is what the
+// backend said, and the label travels verbatim from the API.
+const FLAG_STYLE = {
+  critical: 'border-red-500/40 text-red-400',
+  warning: 'border-yellow-500/40 text-yellow-400',
+}
+
+// The prose that would otherwise eat three lines of a rail this narrow. Lives
+// in the header's ⓘ, the repo's convention for "structured, not a raw note".
+const CARD_INFO = (baselineDays) => (
+  'This zone, as the desk reads it right now. '
+  + 'Day-ahead: the auction price cleared the day before for this delivery day — the DAILY MEAN across its hours, a settled market price, not a forecast. '
+  + 'Residual: load − wind − solar, the gap conventional plants must fill. '
+  + 'Renewables: wind + solar as a share of load, blank when the feed is too incomplete to divide by. '
+  + `σ: distance from this zone's own ${baselineDays ? `${baselineDays}-day` : 'trailing'} norm — amber past 2σ, red past 3σ. Descriptive, never a forecast. `
+  + 'Flags and the one-line read come from the zone situation feed and carry their own timestamp.'
+)
+
+function StaleChip({ asOf, ageDays }) {
+  return (
+    <span
+      className="shrink-0 font-mono text-[8px] tracking-wide text-orange-400 border border-orange-500/30 rounded px-1 py-px"
+      title={`Latest data ${asOf} — this zone's feed may be stalled`}
+    >
+      STALE{ageDays != null ? ` · ${ageDays}d` : ''}
+    </span>
+  )
+}
+
+// One headline number + what it is measured against. `sub` is never decoration:
+// it carries the σ, i.e. the only thing that makes the number mean "unusual".
+function Stat({ label, value, sub, color = 'text-neutral-200' }) {
+  return (
+    <div className="min-w-0">
+      <div className="font-mono text-[8px] text-neutral-600 uppercase tracking-wider truncate">{label}</div>
+      <div className={`num text-[13px] font-bold leading-tight truncate ${color}`}>{value}</div>
+      <div className="font-mono text-[8px] text-neutral-600 truncate">{sub}</div>
+    </div>
+  )
+}
+
+// The σ line under a stat. Two different silences, told apart: no VALUE means
+// the zone does not publish this series (IE-SEM has no load), no Z means the
+// value is there but its baseline is not built yet.
+const sigma = (value, z) => (
+  value == null ? 'not published here' : z == null ? 'no baseline yet' : `${z >= 0 ? '+' : ''}${z.toFixed(1)}σ vs norm`
+)
+
+// One height for every state of the situation block, so switching zones does
+// not make the table above gain a row while /situation is in flight.
+const SITUATION_BOX = 'min-h-[55px] space-y-1.5'
+
+// Flags + the one-line read for the selected zone. Owns its own fetch so the
+// card above stays on the shared /overview payload — and so a dead /situation
+// degrades to a line of text inside the card instead of blanking the numbers.
+function ZoneSituation({ zone }) {
+  const { data, loading, error } = useFetchWithError(`${API}/power/situation?zone=${zone}`, {
+    deps: [zone], pollMs: POLL_FAST_MS,
+  })
+
+  if (error && !data)
+    return <div className={`${SITUATION_BOX} font-mono text-[9px] text-red-400`}>Flags &amp; read // fetch error — retrying on next refresh.</div>
+  if (loading && !data)
+    return <div className={`${SITUATION_BOX} font-mono text-[9px] text-neutral-600 animate-pulse`}>Loading zone situation…</div>
+  if (!data?.available)
+    return <div className={`${SITUATION_BOX} font-mono text-[9px] text-neutral-500`}>No situation read for this zone yet.</div>
+
+  const flags = data.flags ?? []
+  return (
+    <div className={SITUATION_BOX}>
+      {/* The flag row is ALWAYS rendered, even empty: "nothing flagged" is a
+          real reading, and a row that appears and disappears would make the
+          table above it gain and lose a row on every zone click. */}
+      <div className="flex flex-wrap gap-1">
+        {flags.length === 0 ? (
+          <span className="font-mono text-[8px] text-neutral-700">No flags — nothing unusual enough to name.</span>
+        ) : flags.map((f) => (
+          <span
+            key={f.key}
+            className={`font-mono text-[8px] px-1.5 py-px rounded border leading-snug ${FLAG_STYLE[f.severity] || FLAG_STYLE.warning}`}
+          >
+            {f.label}
+          </span>
+        ))}
+      </div>
+      <div className="flex items-start gap-1.5">
+        {/* The desk's one-line read of this zone. Clamped, not truncated: the
+            tail (dirty spark) is the part the three numbers above do not carry,
+            so it stays reachable on hover instead of being cut for good. */}
+        <div className="font-mono text-[9px] text-neutral-500 leading-snug line-clamp-2" title={data.headline}>
+          {data.headline}
+        </div>
+        {/* This feed's OWN age — it can lag the overview row the numbers come
+            from, and then it must say so next to its own sentence. */}
+        {data.stale && <StaleChip asOf={data.as_of} ageDays={data.age_days} />}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The selected zone, read in the rail. Never a silent hole: a fetch error, a
+ * still-loading feed and a zone the overview does not carry each say so in the
+ * card's own frame rather than rendering nothing.
+ *
+ * Height budget: the rail is a flex column of ONE shared height (DESK_COLUMN_H)
+ * and the TABLE is its `flex-1 min-h-0` child, so every pixel this card takes is
+ * a row the table loses. Everything here is therefore `shrink-0` and bounded —
+ * a fixed 3-stat grid, a 2-line clamp on the read, a min-height on the situation
+ * box, a flag row that renders even when empty — so the card measures 342 px for
+ * every one of the 37 zones and switching zones does not re-flow the table.
+ * The single moving part is how many flags the backend raises: the synthetic
+ * worst case (3 flags wrapping to 3 lines + a 2-line headline) reaches 385 px at
+ * 1280 wide and costs the table one row. That is the right thing to spend a row
+ * on, and it cannot overflow the column — the table yields, this card does not.
+ *
+ * That constant is also why RecordChip is NOT here, though it is narrow enough
+ * and stays silent without a fresh record. Measured: it costs 47–106 px when it
+ * does fire, which took the table from 6 visible rows to 3 at 1280×800 (2 at
+ * 1024×768) — and it fires for whichever zones happen to hold a 7-day record
+ * (10 of 37 the day this was measured), so the table would gain and lose half
+ * its rows as the user clicks around. A conditional element is affordable in a
+ * full-width panel and not in a rail on a fixed budget. Fresh records stay one
+ * click away behind "Open zone →", where RecordsPanel already carries them.
+ */
+export default function ZoneDetailCard({ zone, onOpenZone }) {
+  const { data, loading, error } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
+  const row = data?.zones?.find((z) => z.zone === zone)
+
+  if (error && !row)
+    return (
+      <div className="shrink-0 border border-red-500/20 bg-surface rounded px-3 py-2">
+        <div className="font-mono text-[10px] text-red-400">ZONE DETAIL // FETCH ERROR</div>
+      </div>
+    )
+  if (!row)
+    return (
+      <div className="shrink-0 border border-border bg-surface rounded px-3 py-2">
+        <div className={`font-mono text-[10px] ${loading ? 'text-neutral-600 animate-pulse' : 'text-neutral-500'}`}>
+          {loading ? 'Loading zone detail…' : `No overview row for ${zone} — nothing to detail.`}
+        </div>
+      </div>
+    )
+
+  const st = ZONE_STATE[row.state] || ZONE_STATE.CALM
+  return (
+    // gap-3 matches the rail's own gap, so the three boxes read as one stack.
+    <div className="shrink-0 flex flex-col gap-3">
+      <div className={`border ${st.border} bg-surface rounded overflow-hidden shadow-sm`}>
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border/60">
+          <span
+            className={`inline-flex items-center gap-1 shrink-0 font-mono text-[11px] font-bold ${st.text}`}
+            title={`${row.state} — how far this zone sits from its own norm`}
+          >
+            <span className={`w-2 h-2 rounded-sm ${st.dot}`} />
+            <span aria-hidden="true">{st.code}</span>
+            <span className="sr-only">{row.state}</span>
+          </span>
+          <span className="font-mono text-[12px] font-semibold text-neutral-200 truncate" title={row.zone_label || zone}>
+            {row.zone_label || zone}
+          </span>
+          <InfoPopover text={CARD_INFO(data.baseline_days)} />
+          {/* The date the NUMBERS below are for — always on screen, replaced by
+              the louder chip when the row is stale. */}
+          {row.stale
+            ? <StaleChip asOf={row.as_of} />
+            : <span className="shrink-0 num text-[8px] text-neutral-700">{row.as_of}</span>}
+          {/* The deliberate door: a row click is a look, THIS navigates. */}
+          <button
+            onClick={onOpenZone}
+            title={`Open the full power desk for ${row.zone_label || zone}`}
+            className="ml-auto shrink-0 border border-border rounded px-2 py-0.5 font-mono text-[9px] text-neutral-400 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+          >
+            Open zone <span className="text-cyan-glow">→</span>
+          </button>
+        </div>
+
+        <div className="px-3 py-2 space-y-1.5">
+          <ZoneSituation zone={zone} />
+          <div className="grid grid-cols-3 gap-2">
+            <Stat
+              label="Day-ahead"
+              value={row.price_close != null ? `€${row.price_close.toFixed(0)}` : '—'}
+              sub={sigma(row.price_close, row.price_z)}
+              color={zColor(row.price_z)}
+            />
+            <Stat
+              label="Residual"
+              value={row.residual_gw != null ? `${row.residual_gw.toFixed(1)} GW` : '—'}
+              sub={sigma(row.residual_gw, row.residual_z)}
+              color={zColor(row.residual_z)}
+            />
+            {/* An unreliable share is blank WITH a reason — the feed is too
+                incomplete to divide by, which is coverage, not a zero. */}
+            <Stat
+              label="Renewables"
+              value={row.renewable_reliable === false || row.renewable_share == null
+                ? '—' : `${Math.round(row.renewable_share * 100)}%`}
+              sub={row.renewable_reliable === false ? 'feed incomplete' : 'wind + solar of load'}
+            />
+          </div>
+        </div>
+      </div>
+
+      <MiniMixCard title="Generation mix" zone={zone} height={110} />
+    </div>
+  )
+}

--- a/frontend/src/components/ZoneDetailCard.jsx
+++ b/frontend/src/components/ZoneDetailCard.jsx
@@ -47,8 +47,11 @@ const CARD_INFO = (baselineDays) => {
 // One headline number + what it is measured against. `sub` is never decoration:
 // it carries the σ, i.e. the only thing that makes the number mean "unusual".
 function Stat({ label, value, sub, color = 'text-neutral-200' }) {
+  // Three columns share a ~340 px rail, so ~100 px each: the σ strings fit but
+  // the longer captions ("wind + solar of load") clip. `title` on the whole
+  // tile is the recovery — the repo's "short at the element" rule.
   return (
-    <div className="min-w-0">
+    <div className="min-w-0" title={`${label} — ${value} (${sub})`}>
       <div className="font-mono text-[8px] text-neutral-600 uppercase tracking-wider truncate">{label}</div>
       <div className={`num text-[13px] font-bold leading-tight truncate ${color}`}>{value}</div>
       <div className="font-mono text-[8px] text-neutral-600 truncate">{sub}</div>

--- a/frontend/src/components/ZoneDetailCard.jsx
+++ b/frontend/src/components/ZoneDetailCard.jsx
@@ -1,8 +1,8 @@
 import useFetchWithError from '../hooks/useFetchWithError'
 import { POLL_FAST_MS } from '../utils/poll'
-import { ZONE_STATE, zColor } from '../utils/zoneState'
+import { ZONE_STATE, zColor, metricGlossary } from '../utils/zoneState'
 import { InfoPopover } from './Panel'
-import MiniMixCard from './MiniMixCard'
+import FreshnessCaption from './FreshnessCaption'
 
 const API = '/api'
 
@@ -32,24 +32,16 @@ const FLAG_STYLE = {
 
 // The prose that would otherwise eat three lines of a rail this narrow. Lives
 // in the header's ⓘ, the repo's convention for "structured, not a raw note".
-const CARD_INFO = (baselineDays) => (
-  'This zone, as the desk reads it right now. '
-  + 'Day-ahead: the auction price cleared the day before for this delivery day — the DAILY MEAN across its hours, a settled market price, not a forecast. '
-  + 'Residual: load − wind − solar, the gap conventional plants must fill. '
-  + 'Renewables: wind + solar as a share of load, blank when the feed is too incomplete to divide by. '
-  + `σ: distance from this zone's own ${baselineDays ? `${baselineDays}-day` : 'trailing'} norm — amber past 2σ, red past 3σ. Descriptive, never a forecast. `
-  + 'Flags and the one-line read come from the zone situation feed and carry their own timestamp.'
-)
-
-function StaleChip({ asOf, ageDays }) {
-  return (
-    <span
-      className="shrink-0 font-mono text-[8px] tracking-wide text-orange-400 border border-orange-500/30 rounded px-1 py-px"
-      title={`Latest data ${asOf} — this zone's feed may be stalled`}
-    >
-      STALE{ageDays != null ? ` · ${ageDays}d` : ''}
-    </span>
-  )
+// The four definitions are SHARED with the matrix's column legend directly above
+// (utils/zoneState.js) — see the note there for why they may not be rewritten
+// here. Only the first and last sentences are this card's own.
+const CARD_INFO = (baselineDays) => {
+  const g = metricGlossary(baselineDays)
+  return [
+    'This zone, as the desk reads it right now.',
+    g.state, g.dayAhead, g.residual, g.renewables, g.sigma,
+    'Flags and the one-line read come from the zone situation feed and carry their own timestamp, which can lag the numbers above.',
+  ].join(' ')
 }
 
 // One headline number + what it is measured against. `sub` is never decoration:
@@ -117,7 +109,7 @@ function ZoneSituation({ zone }) {
         </div>
         {/* This feed's OWN age — it can lag the overview row the numbers come
             from, and then it must say so next to its own sentence. */}
-        {data.stale && <StaleChip asOf={data.as_of} ageDays={data.age_days} />}
+        {data.stale && <FreshnessCaption meta={data} dense />}
       </div>
     </div>
   )
@@ -132,21 +124,37 @@ function ZoneSituation({ zone }) {
  * and the TABLE is its `flex-1 min-h-0` child, so every pixel this card takes is
  * a row the table loses. Everything here is therefore `shrink-0` and bounded —
  * a fixed 3-stat grid, a 2-line clamp on the read, a min-height on the situation
- * box, a flag row that renders even when empty — so the card measures 342 px for
- * every one of the 37 zones and switching zones does not re-flow the table.
- * The single moving part is how many flags the backend raises: the synthetic
- * worst case (3 flags wrapping to 3 lines + a 2-line headline) reaches 385 px at
- * 1280 wide and costs the table one row. That is the right thing to spend a row
- * on, and it cannot overflow the column — the table yields, this card does not.
+ * box, a flag row that renders even when empty — so the card measures 160 px for
+ * every one of the 37 zones AND through every loading state, and clicking from
+ * zone to zone never re-flows the table. The only moving part is how many flags
+ * the backend raises: the synthetic worst case (3 flags wrapping to 3 lines +
+ * a 2-line headline) reaches 203 px and costs the table one row. That is the
+ * right thing to spend a row on, and it cannot overflow the column — the table
+ * yields, this card does not.
  *
- * That constant is also why RecordChip is NOT here, though it is narrow enough
- * and stays silent without a fresh record. Measured: it costs 47–106 px when it
- * does fire, which took the table from 6 visible rows to 3 at 1280×800 (2 at
- * 1024×768) — and it fires for whichever zones happen to hold a 7-day record
- * (10 of 37 the day this was measured), so the table would gain and lose half
- * its rows as the user clicks around. A conditional element is affordable in a
- * full-width panel and not in a rail on a fixed budget. Fresh records stay one
- * click away behind "Open zone →", where RecordsPanel already carries them.
+ * That budget is why two things the plan offered are NOT here.
+ *
+ * MiniMixCard was, and cost 182 px — 53 % of the card — to stack 15 unlabelled
+ * series in a 330 px-wide rail. Removing it took the table from 6 visible zones
+ * to 11 at 1280×800 and 13 to 18 at 1500×1000. PowerOverviewMatrix's own comment
+ * records that the desk split exists because the old `42vh` table "inner-scrolled
+ * at 14 of 37 zones"; a rail showing 6 of 37 is that same defect, worse. The
+ * chart is also the one element here that is LESS useful than where it already
+ * lives — LiveCharts renders this exact component at full width, one click away
+ * behind "Open zone →".
+ *
+ * RecordChip, for the same budget and a second reason: measured at 47–106 px,
+ * and it fires only for whichever zones hold a 7-day record (10 of 37 the day
+ * this was measured), so the table would gain and lose rows as the user clicks
+ * around. A conditional element is affordable in a full-width panel and not in a
+ * rail on a fixed budget. Records too are behind "Open zone →" (RecordsPanel).
+ *
+ * The general rule both cases teach: in this card, height must not depend on
+ * WHICH zone is selected or on whether a feed has answered yet. A child whose
+ * loading state is a different height than its loaded state (MiniMixCard's was:
+ * `px-3 py-8` placeholder vs `px-1 py-2` + 110 px chart, a 45 px delta, and
+ * useFetchWithError clears `data` on every url change) makes the table twitch on
+ * EVERY click, which is the same defect as RecordChip at 100 % of clicks.
  */
 export default function ZoneDetailCard({ zone, onOpenZone }) {
   const { data, loading, error } = useFetchWithError(`${API}/power/overview`, { pollMs: POLL_FAST_MS })
@@ -169,9 +177,16 @@ export default function ZoneDetailCard({ zone, onOpenZone }) {
 
   const st = ZONE_STATE[row.state] || ZONE_STATE.CALM
   return (
-    // gap-3 matches the rail's own gap, so the three boxes read as one stack.
-    <div className="shrink-0 flex flex-col gap-3">
-      <div className={`border ${st.border} bg-surface rounded overflow-hidden shadow-sm`}>
+    // NO `overflow-hidden` on this frame, unlike the panels it sits under. Those
+    // are 380–580 px tall and clip nothing that matters; this card is ~160 px, so
+    // the clip landed inside its own ⓘ — 154 of the popover's 283 px cut off mid
+    // sentence, right after "Residual: load − wind − solar…", taking the σ
+    // paragraph that explains the "+0.7σ vs norm" printed on every tile. The
+    // ancestor is hidden, not scrollable, so the text was unreachable, not just
+    // out of view. All the class bought was clipping a header border against a
+    // 4 px radius. A popover on a short card outranks a rounded corner.
+    <div className="shrink-0">
+      <div className={`border ${st.border} bg-surface rounded shadow-sm`}>
         <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border/60">
           <span
             className={`inline-flex items-center gap-1 shrink-0 font-mono text-[11px] font-bold ${st.text}`}
@@ -186,10 +201,10 @@ export default function ZoneDetailCard({ zone, onOpenZone }) {
           </span>
           <InfoPopover text={CARD_INFO(data.baseline_days)} />
           {/* The date the NUMBERS below are for — always on screen, replaced by
-              the louder chip when the row is stale. */}
-          {row.stale
-            ? <StaleChip asOf={row.as_of} />
-            : <span className="shrink-0 num text-[8px] text-neutral-700">{row.as_of}</span>}
+              the louder chip when the row is stale. Overview rows carry no
+              `age_days`, so this renders a bare STALE; the situation block below
+              has the age and prints it. */}
+          <FreshnessCaption meta={row} dense />
           {/* The deliberate door: a row click is a look, THIS navigates. */}
           <button
             onClick={onOpenZone}
@@ -226,8 +241,6 @@ export default function ZoneDetailCard({ zone, onOpenZone }) {
           </div>
         </div>
       </div>
-
-      <MiniMixCard title="Generation mix" zone={zone} height={110} />
     </div>
   )
 }

--- a/frontend/src/components/powermap/index.jsx
+++ b/frontend/src/components/powermap/index.jsx
@@ -47,7 +47,13 @@ const OVERLAY_TIPS = [outageTooltip]
 // rail's ZoneDetailCard either way. The fix, when wanted, is an OFFERED recenter
 // shown only while the selection is off-screen — that needs a controlled
 // `viewState` + `onViewStateChange`, i.e. a change in who owns the camera.
-export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, tall = false }) {
+// `canvasOverlay` is a slot pinned to the TOP of the canvas, for feedback that
+// answers a click ON the map. Top, not bottom: the desk column runs past the
+// fold by design (DESK_COLUMN_H), so the card's lower edge — and anything
+// anchored to it — can sit below the viewport at the very moment the user is
+// looking at the map's upper half and clicking the Nordic arcs. The top edge of
+// the canvas is visible whenever any of the map is.
+export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, tall = false, canvasOverlay }) {
   const { theme } = useTheme()
   const pal = PALETTES[theme] || PALETTES.dark
   const [fill, setFill] = useState('price')
@@ -236,6 +242,9 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
           getTooltip={getTooltip}
           pickingRadius={4}
         />
+        {canvasOverlay && (
+          <div className="absolute top-2 left-2 right-2 flex justify-start">{canvasOverlay}</div>
+        )}
         {selectionHasNoShape && (
           <div className="absolute bottom-2 left-2 right-2 pointer-events-none">
             <span className="inline-block border border-border bg-surface/90 rounded px-2 py-1 font-mono text-[9px] text-neutral-400">

--- a/frontend/src/components/powermap/index.jsx
+++ b/frontend/src/components/powermap/index.jsx
@@ -216,6 +216,22 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
             horizontal drag, and a mouse is unaffected. The trade is
             single-finger VERTICAL panning of the map on touch: pinch to zoom and
             drag sideways instead. Scrolling past the map beats panning in it. */}
+        {/* UNCONTROLLED view state, deliberately — deck.gl owns the camera and
+            nothing in the app moves it. Known limit, measured: zoom into
+            Denmark, click IT-Sicilia in the rail's table, and the map shows no
+            change at all (the zone is off-screen and its outline is drawn where
+            nobody can see it). Selecting a zone does NOT fly the camera there,
+            for the same reason a border click no longer scrolls the page (see
+            EuropeDesk): a click is a look, and moving the viewport the user
+            arranged is a move they did not ask for. Auto-flying would fire on
+            the COMMON case — default zoom, whole continent visible, clicking
+            rows to compare — where the camera move is pure noise. The click is
+            answered either way: ZoneDetailCard under the table updates.
+            The right fix is an OFFERED recenter (a chip, like the border one)
+            shown only while the selection is actually outside the viewport.
+            That needs a CONTROLLED `viewState` + `onViewStateChange`, i.e. a
+            real change in who owns the camera, with pan/zoom/scrub/picking to
+            re-verify — its own PR, not a rider on this one. */}
         <DeckGL
           initialViewState={INITIAL_VIEW}
           controller={true}

--- a/frontend/src/components/powermap/index.jsx
+++ b/frontend/src/components/powermap/index.jsx
@@ -38,6 +38,15 @@ const OVERLAY_TIPS = [outageTooltip]
 //     (EuropeDesk owns the state). Both optional; the map is standalone without.
 //   tall — the desk-split layout's map column, where the map is the page's
 //     subject and gets the viewport height it deserves.
+//
+// Selecting a zone does NOT move the camera, and the view state is uncontrolled.
+// The limit, measured: zoom into Denmark, click IT-Sicilia in the rail, and the
+// map shows nothing — the outline is drawn off-screen. Left as is on purpose: a
+// click is a look, and auto-flying would fire on the common case (default zoom,
+// whole continent visible) where the move is noise; the click is answered by the
+// rail's ZoneDetailCard either way. The fix, when wanted, is an OFFERED recenter
+// shown only while the selection is off-screen — that needs a controlled
+// `viewState` + `onViewStateChange`, i.e. a change in who owns the camera.
 export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, tall = false }) {
   const { theme } = useTheme()
   const pal = PALETTES[theme] || PALETTES.dark
@@ -216,22 +225,9 @@ export default function PowerMap({ onBorderSelect, onZoneSelect, selectedZone, t
             horizontal drag, and a mouse is unaffected. The trade is
             single-finger VERTICAL panning of the map on touch: pinch to zoom and
             drag sideways instead. Scrolling past the map beats panning in it. */}
-        {/* UNCONTROLLED view state, deliberately — deck.gl owns the camera and
-            nothing in the app moves it. Known limit, measured: zoom into
-            Denmark, click IT-Sicilia in the rail's table, and the map shows no
-            change at all (the zone is off-screen and its outline is drawn where
-            nobody can see it). Selecting a zone does NOT fly the camera there,
-            for the same reason a border click no longer scrolls the page (see
-            EuropeDesk): a click is a look, and moving the viewport the user
-            arranged is a move they did not ask for. Auto-flying would fire on
-            the COMMON case — default zoom, whole continent visible, clicking
-            rows to compare — where the camera move is pure noise. The click is
-            answered either way: ZoneDetailCard under the table updates.
-            The right fix is an OFFERED recenter (a chip, like the border one)
-            shown only while the selection is actually outside the viewport.
-            That needs a CONTROLLED `viewState` + `onViewStateChange`, i.e. a
-            real change in who owns the camera, with pan/zoom/scrub/picking to
-            re-verify — its own PR, not a rider on this one. */}
+        {/* initialViewState = deck.gl owns the camera; nothing in the app moves
+            it. See "Selecting a zone" in the module docblock for the limit this
+            leaves and why it was left. */}
         <DeckGL
           initialViewState={INITIAL_VIEW}
           controller={true}

--- a/frontend/src/components/powermap/layers/outageLayer.js
+++ b/frontend/src/components/powermap/layers/outageLayer.js
@@ -228,8 +228,10 @@ export function makeOutageLayers({ paths, pal, onBorderSelect }) {
       // The pair is the /borders canonical sorted pair (same convention as the
       // arcs), so BordersPanel opens the matching row. If a pair has no row
       // (none of today's 37 do, but A78 names the counterparty, not the border)
-      // the panel still expands and scrolls into view with nothing pre-opened —
-      // degraded, never dead, and never throwing.
+      // the panel un-collapses with nothing pre-opened, and the chip on the
+      // canvas says "not in Borders" rather than claiming a row — degraded,
+      // never dead, and never throwing. The click no longer scrolls the page;
+      // the chip offers that trip (EuropeDesk).
       onClick: ({ object }) => { if (object) onBorderSelect?.(object.zone_a, object.zone_b) },
     }),
   ]

--- a/frontend/src/utils/zoneState.js
+++ b/frontend/src/utils/zoneState.js
@@ -24,3 +24,27 @@ export const STATE_ORDER = { CALM: 0, ELEVATED: 1, STRESSED: 2 }
 // and a red number in the row always mean the identical thing.
 export const zColor = (z) =>
   z == null ? 'text-neutral-400' : Math.abs(z) >= 3 ? 'text-red-400' : Math.abs(z) >= 2 ? 'text-yellow-400' : 'text-neutral-300'
+
+// ── What the four numbers MEAN ────────────────────────────────────────────────
+// The desk rail puts two ⓘ popovers ~200 px apart — the matrix's column legend
+// and the detail card's — and they define the same four things. Written twice
+// they drift, and they had: the table's copy hardcoded "its own 30-day norm"
+// while the card's read the live `baseline_days`, so the table's popover could
+// contradict the table's OWN footer two lines below it. Same lesson as the price
+// strings that lived in three files (CLAUDE.md, "Preis-Strings leben verstreut")
+// and the state colours above. Definitions live here; each popover adds only the
+// sentence that is true of ITS surface.
+//
+// `baselineDays` comes from /power/overview's own `baseline_days` — never a
+// literal, so the prose cannot outlive a backend change to the window.
+export const metricGlossary = (baselineDays) => {
+  const norm = baselineDays ? `${baselineDays}-day` : 'trailing'
+  return {
+    norm,
+    state: `State: how far this zone sits from its own ${norm} norm — CALM / ELEVATED (amber) / STRESSED (red); a deviation vs history, not a forecast.`,
+    dayAhead: 'Day-ahead: the auction price (€/MWh), cleared the day before for this delivery day — a settled market price, NOT a forecast. It is the DAILY MEAN across the day’s hours.',
+    residual: 'Residual: demand − wind − solar (GW), the gap conventional plants must fill — what actually sets the price.',
+    renewables: 'Renewables: wind + solar as a share of load, left blank when the feed is too incomplete to trust the share.',
+    sigma: `σ: distance from this zone’s own ${norm} norm — amber past 2σ, red past 3σ. Descriptive, never a forecast.`,
+  }
+}

--- a/frontend/src/utils/zoneState.js
+++ b/frontend/src/utils/zoneState.js
@@ -1,0 +1,26 @@
+// The descriptive desk state (CALM / ELEVATED / STRESSED) as the backend
+// derives it — how far a zone sits from its OWN trailing norm, never a forecast.
+//
+// Named once because the desk rail now shows the same zone's state TWICE at the
+// same time: the matrix row and the detail card directly under it. Two private
+// copies of "amber means ELEVATED" is exactly how a row and its own card end up
+// disagreeing about the zone the user just clicked.
+//
+// `code` is the one-letter carrier for the compact rail: green/amber/red dots
+// alone are the textbook red-green CVD collision, and the compact table has no
+// room for the word.
+export const ZONE_STATE = {
+  CALM: { text: 'text-green-glow', dot: 'bg-green-glow', border: 'border-green-500/30', code: 'C' },
+  ELEVATED: { text: 'text-yellow-400', dot: 'bg-yellow-400', border: 'border-yellow-500/30', code: 'E' },
+  STRESSED: { text: 'text-red-400', dot: 'bg-red-400', border: 'border-red-500/30', code: 'S' },
+}
+
+// Sort rank for the matrix's State column — calm first, worst last.
+export const STATE_ORDER = { CALM: 0, ELEVATED: 1, STRESSED: 2 }
+
+// The same language one level down: how far a single METRIC sits from its own
+// trailing norm. Grey normal · amber elevated · red extreme, at the 2σ/3σ cuts
+// the backend uses to derive the zone state above — so a red number in the card
+// and a red number in the row always mean the identical thing.
+export const zColor = (z) =>
+  z == null ? 'text-neutral-400' : Math.abs(z) >= 3 ? 'text-red-400' : Math.abs(z) >= 2 ? 'text-yellow-400' : 'text-neutral-300'


### PR DESCRIPTION
## Was
PR 9/9 des Map-Redesign-Plans — der letzte. Das linke Rail bekommt eine **Zonen-Detailkarte**: Klick auf eine Tabellenzeile oder eine Zone auf der Karte beantwortet sich sofort daneben, statt in einen anderen Tab zu springen.

## Wie
- **`ZoneDetailCard`**: Zustands-Pill, Flags mit Severity (Dunkelflaute / Negativpreise / erzwungene Ausfälle), der Ein-Satz-Befund aus dem Situation-Feed, drei Kennzahlen mit σ-Kontext, Frische-Stempel — und „Open zone →" als bewusste Tür in den POWER-Tab (der Zeilenklick ist jetzt ein Blick, keine Navigation).
- **Ein Request, nicht zwei:** Die Karte liest dieselbe `/power/overview`-URL wie die Tabelle darüber; `useFetchWithError` dedupliziert nach URL, also kann die Karte strukturell keinen anderen Preis zeigen als die Zeile über ihr.
- **Klick-Semantik:** Ein Klick auf einen Grenz-Arc scrollt die Seite nicht mehr zwei Bildschirme nach unten — er zog die Karte unter der Hand weg, die gerade auf sie geklickt hatte. Die Zeile im Borders-Panel wird trotzdem geöffnet; ein Chip **oben auf der Karte** meldet das und bietet den Sprung an. Er behauptet nur „opened in Borders", wenn die Zeile wirklich existiert (ein A78-Akkord kann ein Paar nennen, das die Border-Tabelle nicht führt).

## Zwei Messungen, die den Zuschnitt bestimmt haben
- **Das Mix-Chart flog wieder raus.** Mit ihm stand die Tabelle bei 6 von 37 Zonen auf einem Laptop — eine schlechtere Version genau des Fehlers, den PR 8 beseitigt hat. Es war 53 % der Kartenhöhe, stapelte 15 unbeschriftete Serien in 330 px, und `LiveCharts` zeigt dieselbe Komponente in voller Breite hinter „Open zone →". Ohne es: **6 → 11 Zonen** (1280×800), **13 → 18** (1500×1000), Karte 342 → 160 px. Es beseitigt zugleich einen Reflow bei *jedem* Zonenklick (der Ladezustand des Charts ist 45 px höher als der geladene).
- **Der Chip lag selbst unter der Falz.** Im Rail, ~576 px in eine Spalte, die absichtlich über den Viewport hinausläuft. Jetzt auf der Karte: Klick auf einen Nordic-Arc bei scrollY 0 → Chip bei y=381 im Bild statt bei ~877.

## Bewusst nicht gebaut
Ein automatisches Heranfliegen an die gewählte Zone. Eine ungefragte Kamerabewegung ist derselbe Fehler wie das ungefragte Scrollen, das dieser PR behebt; der richtige Weg wäre ein *angebotener* Recenter-Chip, der nur erscheint, wenn die Auswahl außerhalb des Bildes liegt — das braucht kontrollierten `viewState` und ist ein eigener PR. Begründung steht im Code.

## Verifikation
Build + Lint grün; Rail-Messungen bei 1280×800 und 1500×1000 in beiden Themes (kein Overflow, Kartenhöhe konstant 160 px über FR→FI→ES-Klicks); Arc-Klick per Playwright mit echtem Treffer verifiziert (kein Seiten-Scroll, Chip im Bild, Zeile offen); zwei-stufiges Review bestanden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)