### PR TITLE
Let Google verify who owns the shopfront

### DIFF
--- a/frontend/public/google6c2e5df68c892917.html
+++ b/frontend/public/google6c2e5df68c892917.html
@@ -1,0 +1,1 @@
+google-site-verification: google6c2e5df68c892917.html


### PR DESCRIPTION
Search Console site-verification file for the https://obsyd.dev/ URL-prefix property — prerequisite for requesting the reindex that replaces the stale pre-pivot Google snippet ("OBSYD — Energy Market Intelligence"). Served from `frontend/public/`, so it lands in `dist/` on build. Must stay in place after verification passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)