### PR TITLE
Give the page a first sentence that doesn't need JavaScript

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -60,7 +60,43 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!--
+        Static shell: the one part of the page that exists without JavaScript.
+        Crawlers, link-preview bots and no-JS readers see this; React replaces it
+        on mount (createRoot().render() clears #root). Keep its claims in sync
+        with the meta description above — same audit-fast wording, one story.
+      -->
+      <div id="static-shell" style="min-height:100vh;background:#06060a;color:#d4d4d8;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;padding:48px 24px;box-sizing:border-box">
+        <div style="max-width:64rem;margin:0 auto">
+          <p style="color:#5bbfb5;letter-spacing:4px;font-size:11px;font-weight:700">OBSYD</p>
+          <h1 style="color:#f4f4f5;font-size:28px;line-height:1.3;margin:16px 0">The European power grid — every zone, one desk, free.</h1>
+          <p style="max-width:42rem;line-height:1.6;font-size:14px;color:#a1a1aa">
+            The European electricity desk: day-ahead prices, load &amp; residual load and generation mix
+            for 37 European bidding zones — hourly everywhere, 15-minute where SDAC trades it — plus
+            generation outages, cross-border flows, reservoir levels, forecasts and the gas that fuels
+            the marginal price, with a live anomaly radar. From the official record (ENTSO-E, GIE) and
+            Fraunhofer Energy-Charts. Descriptive, auditable, free &amp; open source (AGPL-3.0).
+          </p>
+          <ul style="list-style:none;padding:0;line-height:2;font-size:13px">
+            <li><a href="/app" style="color:#5bbfb5">Open the live desk</a></li>
+            <li><a href="https://github.com/jo20ow/Obsyd" style="color:#5bbfb5">Source on GitHub (AGPL-3.0)</a></li>
+            <li><a href="https://github.com/jo20ow/Obsyd/blob/main/docs/API.md" style="color:#5bbfb5">Public data API — JSON, CSV, Parquet</a></li>
+            <li><a href="https://pypi.org/project/obsyd/" style="color:#5bbfb5">Python client — pip install obsyd</a></li>
+            <li><a href="/api/alerts/rss" style="color:#5bbfb5">Anomaly radar as RSS</a></li>
+          </ul>
+          <p style="font-size:12px;color:#71717a">This site is an interactive dashboard and needs JavaScript — the links above work without it.</p>
+        </div>
+      </div>
+    </div>
+    <script>
+      // The shell mirrors the landing ("/"); on deep links (/app, /builder, …)
+      // drop it before paint so slow connections don't flash landing copy.
+      if (location.pathname !== '/') {
+        var shell = document.getElementById('static-shell')
+        if (shell) shell.remove()
+      }
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/frontend/src/components/Landing.jsx
+++ b/frontend/src/components/Landing.jsx
@@ -25,7 +25,7 @@ const PILLARS = [
 const STATS = [
   { label: 'European bidding zones', value: '37' },
   { label: 'day-ahead resolution (as traded)', value: '15 min' },
-  { label: 'official public-domain data', value: '100%' },
+  { label: 'open, redistributable sources', value: '100%' },
   { label: 'license', value: 'AGPL-3.0' },
 ]
 


### PR DESCRIPTION
## What

Befund 3 from the external site review: without JavaScript, obsyd.dev served an empty `<div id="root">` — non-Google crawlers, academic aggregators and any link-checking tool saw a blank page.

- `#root` now contains a **static shell**: the same audit-fast description as the meta tags (one story everywhere, per #154) plus the five links that matter — live desk, GitHub, API docs, PyPI client, radar RSS. React's `createRoot().render()` replaces it on mount, so the app is unchanged.
- On slow connections the shell doubles as a meaningful first paint instead of a white page. On deep links (`/app`, `/builder`, …) an inline script removes it before paint so desk users never see landing copy flash.
- Stat-tile claim fix: "official public-domain data 100%" → "open, redistributable sources" (Energy-Charts is CC BY 4.0; ENTSO-E is free-to-reuse — neither is public domain).

## Verification

- `npm run build` green; `static-shell` present in `dist/index.html`
- Claims identical to the #154 canonical wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)