### PR TITLE
Tell desk visitors the truth when the API is down

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -357,8 +357,16 @@ function Dashboard() {
           <div className="text-red-400 font-mono text-xs mb-2">// CONNECTION ERROR</div>
           <div className="text-red-300 font-mono text-sm">{error}</div>
           <div className="text-neutral-500 font-mono text-xs mt-3">
-            Ensure backend is running at localhost:8000
+            The data API is not responding — usually temporary. Self-hosting? Check that the
+            backend is running (default localhost:8000).
           </div>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="mt-4 px-4 py-2 text-[11px] tracking-wider font-mono border border-red-500/40 text-red-300 hover:bg-red-500/10 transition-colors"
+          >
+            RELOAD
+          </button>
         </div>
       </div>
     )


### PR DESCRIPTION
Finding from the frontend rendering check (continuation of the readiness audit, D2 family): with every `/api/*` request failing, `/app` collapses to a single card saying "Ensure backend is running at localhost:8000" — a dev leftover that is wrong and confusing for cloud visitors on obsyd.dev.

The card now states what it knows (data API not responding, usually temporary), keeps the localhost hint explicitly addressed to self-hosters, and adds a RELOAD button so the dead end has an exit.

Verified: `npm run build` green; behavior exercised via Playwright with `/api/*` routes aborted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)