### PR TITLE
The Honest Record: provenance layer + forecast scoreboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ Notable changes to OBSYD. Versions correspond to GitHub releases (and, from 1.0.
 on, to the Zenodo-archived releases referenced in [CITATION.cff](CITATION.cff)).
 The Python client is versioned separately (`clients/python`, tags `client-vX.Y.Z`).
 
+## 1.1.0 — 2026-08-05
+
+The Honest Record: OBSYD now documents the official record's own behavior — and
+publicly grades the official forecasts. Everything remains descriptive; the
+scoreboard grades ENTSO-E's published D-1 forecasts and OBSYD makes none.
+
+- **Revision ledger** — every write to the canonical hourly store now records
+  restatements (old value → new value, when observed) and arrivals. Forward-only
+  from this release; the source's provisional fill-ins are separated from mature
+  restatements (observed >48 h after the hour) at read time.
+- **Data-quality aggregates** — nightly per zone × series × UTC day: completeness
+  vs expected intervals plus rule-based flags (solar at night, load flatlining at
+  zero, outsized hourly steps, generation below load + exports where coverage
+  allows the comparison). Each flag describes the feed, never the market.
+- **Public quality API** — `GET /api/v1/quality/{summary,series,revisions}`:
+  completeness matrix, per-day history with arrival-lag stats, and the revision
+  ledger with a restated-hours roll-up.
+- **Forecast scoreboard** — nightly MAE/RMSE/bias (MAPE for load) for ENTSO-E's
+  published day-ahead load/residual/wind/solar forecasts vs its published
+  actuals, with skill vs two naive yardsticks built from actuals alone
+  (persistence, seasonal). `GET /api/v1/scoreboard/{summary,ranking,monthly,profile}`;
+  wind/solar rank capacity-normalized (A68), zones a normalization cannot cover
+  are listed signposted, never hidden.
+- **Radar integration** — completeness drops vs a zone's own 30-day norm and
+  major mature restatements surface in the anomaly radar and RSS.
+- **Desk surfaces** — DATA QUALITY + REVISIONS LEDGER panels on EXPLORE,
+  FORECAST SCOREBOARD on ANALYTICS, with methodology in HOW TO READ.
+
 ## 1.0.0 — 2026-07-29
 
 First archived release. OBSYD is a free, open-source European power desk built on

--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -27,6 +27,7 @@ from backend.models.energy import (
     PowerHourly,
     PowerOutage,
     PowerPriceDaily,
+    QualityDaily,
     SeriesDim,
     UnitGeneration,
 )
@@ -138,6 +139,9 @@ SPECS += [
     # The forecast scoreboard is derived the same way (nightly re-score of ENTSO-E's published
     # forecasts) — a silent scoring engine looks exactly like a scoreboard with nothing to say.
     FreshnessSpec("forecast_scoreboard", ForecastScoreDaily, "updated_at", timedelta(days=2)),
+    # Data-quality aggregates are derived the same way (nightly completeness + rule flags,
+    # backend/power/quality.py) — a silent quality engine looks exactly like clean data.
+    FreshnessSpec("quality_daily", QualityDaily, "updated_at", timedelta(days=2)),
     # /api/power/live (near-real-time TODAY). The intraday scheduler writes
     # load.actual every ~30 min and ENTSO-E's own publication lag is ~1-2h, so 6h
     # would be the honest window for THIS probe alone — but test_outage_history.py

--- a/backend/collectors/freshness.py
+++ b/backend/collectors/freshness.py
@@ -20,6 +20,7 @@ from sqlalchemy import func
 
 from backend.models.energy import (
     EnergyPrice,
+    ForecastScoreDaily,
     PowerEpisode,
     PowerFlow,
     PowerGrid,
@@ -134,6 +135,9 @@ SPECS += [
     # Episodes are DERIVED, not ingested — so the probe asks whether the nightly recompute ran,
     # not whether a feed arrived. A silent episode engine looks exactly like a quiet Europe.
     FreshnessSpec("episodes", PowerEpisode, "updated_at", timedelta(days=2)),
+    # The forecast scoreboard is derived the same way (nightly re-score of ENTSO-E's published
+    # forecasts) — a silent scoring engine looks exactly like a scoreboard with nothing to say.
+    FreshnessSpec("forecast_scoreboard", ForecastScoreDaily, "updated_at", timedelta(days=2)),
     # /api/power/live (near-real-time TODAY). The intraday scheduler writes
     # load.actual every ~30 min and ENTSO-E's own publication lag is ~1-2h, so 6h
     # would be the honest window for THIS probe alone — but test_outage_history.py

--- a/backend/collectors/retention.py
+++ b/backend/collectors/retention.py
@@ -1,20 +1,30 @@
 """
-Smart Retention — tiered cleanup for vessel_positions.
+Smart Retention — tiered cleanup for vessel_positions (+ housekeeping deletes).
 
 - 0–7 days: keep all raw data
 - 7–30 days: thin to one position per MMSI per hour
 - >30 days: delete (geofence_events has daily aggregates)
 
+Also prunes anomaly alerts (>45 days) and the Honest-Record arrival log
+(ingest_arrival, >INGEST_ARRIVAL_RETENTION_DAYS). The REVISION ledger
+(power_revision) is deliberately never pruned: the ledger is the product.
+
 Runs daily at 04:00 UTC via scheduler.
 """
 
 import logging
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import text
 
 from backend.database import SessionLocal
 
 logger = logging.getLogger(__name__)
+
+# ingest_arrival is fetch-cadence EVIDENCE (one row per collector batch,
+# ~10^4 rows/day across 37 zones), not history — 90 days is three times the
+# widest freshness window on the desk, plenty for any cadence question.
+INGEST_ARRIVAL_RETENTION_DAYS = 90
 
 
 async def run_retention():
@@ -53,10 +63,22 @@ async def run_retention():
         r3 = db.execute(text("DELETE FROM alerts WHERE created_at < datetime('now', '-45 days')"))
         pruned_alerts = r3.rowcount
 
+        # Phase 4: Honest-Record arrival log. observed_at is epoch seconds UTC
+        # (not a datetime string), so the cutoff is computed here, not in SQL.
+        # power_revision is NOT touched — see the module docstring.
+        cutoff = int(
+            (datetime.now(timezone.utc) - timedelta(days=INGEST_ARRIVAL_RETENTION_DAYS)).timestamp()
+        )
+        r4 = db.execute(
+            text("DELETE FROM ingest_arrival WHERE observed_at < :cutoff"), {"cutoff": cutoff}
+        )
+        pruned_arrivals = r4.rowcount
+
         db.commit()
         logger.info(
             f"Retention: thinned {thinned} rows (7-30d), deleted {deleted} positions (>30d), "
-            f"pruned {pruned_alerts} alerts (>45d)"
+            f"pruned {pruned_alerts} alerts (>45d), "
+            f"pruned {pruned_arrivals} ingest arrivals (>{INGEST_ARRIVAL_RETENTION_DAYS}d)"
         )
 
     except Exception as e:

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -474,6 +474,44 @@ async def _run_forecast_scoreboard_nightly():
         db.close()
 
 
+async def _run_quality_nightly():
+    """Write down what the published data looked like: completeness + rule-based
+    anomaly flags per (zone, series, UTC day) — the Honest-Record quality
+    aggregate (backend/power/quality.py).
+
+    Recomputes the trailing 10 FINISHED days for every enabled zone: late data
+    keeps arriving for days, and a full-window recompute is records.py's
+    doctrine (no incremental state to corrupt, retraction included). Today is
+    excluded — a day still filling in would flag its own incompleteness.
+    Descriptive: every flag states a fact about the source's output.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from backend.power.quality import compute_and_store_range
+    from backend.power.zones import POWER_ZONES
+
+    db = SessionLocal()
+    try:
+        today = datetime.now(timezone.utc).date()
+        start = (today - timedelta(days=10)).isoformat()
+        end = (today - timedelta(days=1)).isoformat()
+        written = removed = 0
+        for zone_key in POWER_ZONES:
+            try:
+                result = compute_and_store_range(db, zone_key, start, end)
+                written += result["written"]
+                removed += result["removed"]
+            except Exception as exc:
+                db.rollback()
+                logger.error("quality nightly [%s] failed: %s", zone_key, exc)
+        logger.info("quality nightly: %d rows written, %d retracted (%s..%s)",
+                    written, removed, start, end)
+    except Exception as exc:
+        logger.error("_run_quality_nightly failed: %s", exc)
+    finally:
+        db.close()
+
+
 async def _run_outage_snapshot():
     """Write down how much capacity is offline RIGHT NOW, every hour.
 
@@ -650,6 +688,9 @@ def start_scheduler():
     # Episodes: 23:50, right after the records — same doctrine (full recompute from the canonical
     # store, no incremental state), and it wants the same freshly-ingested day underneath it.
     scheduler.add_job(_run_episodes_nightly, CronTrigger(hour=23, minute=50), id="episodes_nightly", **JOB_DEFAULTS)
+    # Quality aggregates: 23:55, after records + episodes — same derived-table doctrine
+    # (trailing-window recompute + retraction), and it grades the same fresh day.
+    scheduler.add_job(_run_quality_nightly, CronTrigger(hour=23, minute=55), id="quality_nightly", **JOB_DEFAULTS)
     # Forecast scoreboard: 23:58, after records + episodes — same derived-table doctrine
     # (trailing-window recompute from the canonical store), wants the same fresh day.
     scheduler.add_job(_run_forecast_scoreboard_nightly, CronTrigger(hour=23, minute=58), id="forecast_scoreboard_nightly", **JOB_DEFAULTS)

--- a/backend/collectors/scheduler.py
+++ b/backend/collectors/scheduler.py
@@ -437,6 +437,43 @@ async def _run_episodes_nightly():
         db.close()
 
 
+async def _run_forecast_scoreboard_nightly():
+    """Grade ENTSO-E's published day-ahead forecasts against the published
+    actuals, per (zone, series, day) — the Honest-Record scoreboard aggregate.
+
+    Recomputes the trailing 10 FINISHED days for every enabled zone: forecast
+    and actual revisions drift for days after first publication, and a full
+    re-score is records.py's doctrine (no incremental state to corrupt). Today
+    is not scored — a partial day's error would describe our polling, not the
+    forecast. Descriptive: OBSYD grades the TSOs' forecasts, it makes none.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from backend.power.forecast_score import compute_and_store_range
+    from backend.power.zones import POWER_ZONES
+
+    db = SessionLocal()
+    try:
+        today = datetime.now(timezone.utc).date()
+        start = (today - timedelta(days=10)).isoformat()
+        end = (today - timedelta(days=1)).isoformat()
+        written = removed = 0
+        for zone_key in POWER_ZONES:
+            try:
+                result = compute_and_store_range(db, zone_key, start, end)
+                written += result["written"]
+                removed += result["removed"]
+            except Exception as exc:
+                db.rollback()
+                logger.error("forecast scoreboard [%s] failed: %s", zone_key, exc)
+        logger.info("forecast scoreboard nightly: %d rows written, %d retracted (%s..%s)",
+                    written, removed, start, end)
+    except Exception as exc:
+        logger.error("_run_forecast_scoreboard_nightly failed: %s", exc)
+    finally:
+        db.close()
+
+
 async def _run_outage_snapshot():
     """Write down how much capacity is offline RIGHT NOW, every hour.
 
@@ -613,6 +650,9 @@ def start_scheduler():
     # Episodes: 23:50, right after the records — same doctrine (full recompute from the canonical
     # store, no incremental state), and it wants the same freshly-ingested day underneath it.
     scheduler.add_job(_run_episodes_nightly, CronTrigger(hour=23, minute=50), id="episodes_nightly", **JOB_DEFAULTS)
+    # Forecast scoreboard: 23:58, after records + episodes — same derived-table doctrine
+    # (trailing-window recompute from the canonical store), wants the same fresh day.
+    scheduler.add_job(_run_forecast_scoreboard_nightly, CronTrigger(hour=23, minute=58), id="forecast_scoreboard_nightly", **JOB_DEFAULTS)
 
     # Energy prices (TTF for the spark spread, + power ticker): daily 22:15 UTC.
     scheduler.add_job(collect_energy_prices, CronTrigger(hour=22, minute=15), id="energy_prices_daily", **JOB_DEFAULTS)

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,7 @@ from backend.routes import portwatch as portwatch_routes
 from backend.routes import power as power_routes
 from backend.routes import quality as quality_routes
 from backend.routes import rates as rates_routes
+from backend.routes import scoreboard as scoreboard_routes
 from backend.routes import settings as settings_routes
 from backend.routes import signals as signals_routes
 from backend.routes import situation as situation_routes
@@ -194,6 +195,7 @@ app.include_router(atlas_routes.router)
 app.include_router(power_routes.router)
 app.include_router(api_v1.router)  # public data API v1 (/api/v1/series, catalog, meta)
 app.include_router(quality_routes.router)  # /api/v1/quality/* — Honest-Record read API
+app.include_router(scoreboard_routes.router)  # /api/v1/scoreboard/* — forecast scoreboard read API
 app.include_router(embed_routes.router)  # /api/v1/badge/*.svg — embeddable status badges
 app.include_router(situation_routes.router)
 app.include_router(watchlist_routes.router)

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,6 +31,7 @@ from backend.routes import metals as metals_routes
 from backend.routes import news as news_routes
 from backend.routes import portwatch as portwatch_routes
 from backend.routes import power as power_routes
+from backend.routes import quality as quality_routes
 from backend.routes import rates as rates_routes
 from backend.routes import settings as settings_routes
 from backend.routes import signals as signals_routes
@@ -192,6 +193,7 @@ app.include_router(metals_routes.router)
 app.include_router(atlas_routes.router)
 app.include_router(power_routes.router)
 app.include_router(api_v1.router)  # public data API v1 (/api/v1/series, catalog, meta)
+app.include_router(quality_routes.router)  # /api/v1/quality/* — Honest-Record read API
 app.include_router(embed_routes.router)  # /api/v1/badge/*.svg — embeddable status badges
 app.include_router(situation_routes.router)
 app.include_router(watchlist_routes.router)

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -262,7 +262,9 @@ class PowerRevision(Base):
     Forward-only by design: upstream re-fetches overwrite caches, so history
     before deploy is unrecoverable — the ledger accrues from first write.
     "Maturity" (real restatement vs normal provisional fill-in) is a READ-time
-    concern for a later slice; everything beyond epsilon is stored.
+    concern for a later slice; everything beyond epsilon is stored. Epsilon
+    caveat: the diff is against the CURRENT stored value, so successive
+    sub-epsilon steps can accumulate real movement without ever ledgering.
 
     All timestamps follow power_hourly's convention: epoch seconds UTC.
     `observed_at` is the ingest wall clock, `ts_utc` the hour that changed."""
@@ -294,7 +296,11 @@ class IngestArrival(Base):
     fetch health ("no row" must mean "never polled", not "polled, unchanged").
     min/max_ts_new span only the batch's NEW hours (NULL when n_new == 0);
     frontier lag is derivable as observed_at − max_ts_new. Epoch seconds UTC
-    throughout, like power_hourly."""
+    throughout, like power_hourly.
+
+    TODO: retention/pruning is owned by a later slice (hook into
+    backend/collectors/retention.py) — the log grows by one row per scheduled
+    fetch, unbounded until then."""
 
     __tablename__ = "ingest_arrival"
 
@@ -306,6 +312,13 @@ class IngestArrival(Base):
     n_changed: Mapped[int] = mapped_column(Integer, nullable=False)
     min_ts_new: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     max_ts_new: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    # Arrival-cadence reads are "rows for one series+zone ordered by time" —
+    # without this they full-scan a table growing by ~10^4 rows/day. New table,
+    # so create_all creates it everywhere; no migrations.py retrofit needed.
+    __table_args__ = (
+        Index("ix_ingest_arrival_series_zone_observed", "series_id", "zone_id", "observed_at"),
+    )
 
 
 class InstalledCapacity(Base):

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -279,11 +279,18 @@ class PowerRevision(Base):
     new_value: Mapped[float] = mapped_column(Float, nullable=False)
     observed_at: Mapped[int] = mapped_column(Integer, nullable=False)  # epoch sec UTC
 
-    # The read pattern of the later quality slices is "revisions for one series+zone
-    # in a time window" — same shape as power_hourly's PK scan. New table, so
-    # create_all creates the index everywhere; no migrations.py retrofit needed.
+    # Every read (routes/quality.py) filters/aggregates on observed_at — the
+    # /revisions window rides it (and gets its ORDER BY observed_at free), and
+    # the summary's trailing-30d GROUP BY becomes a covering index scan instead
+    # of a full-table scan (measured ~924ms → 4-40ms at 2M rows). Nothing reads
+    # by ts_utc range, so observed_at is the third column — the exact shape
+    # ingest_arrival's index already has. New table: create_all creates this
+    # everywhere (the branch is undeployed, so prod gets it free). A LOCAL dev
+    # DB that already ran the earlier index needs a one-time
+    #   DROP INDEX ix_power_revision_series_zone_ts;
+    # (the stale index is harmless but dead weight — create_all never drops).
     __table_args__ = (
-        Index("ix_power_revision_series_zone_ts", "series_id", "zone_id", "ts_utc"),
+        Index("ix_power_revision_series_zone_observed", "series_id", "zone_id", "observed_at"),
     )
 
 

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -248,6 +248,66 @@ class PowerHourly(Base):
     __table_args__ = {"sqlite_with_rowid": False}
 
 
+class PowerRevision(Base):
+    """Revision ledger (Honest Record slice A1): one row per REAL value change
+    observed at the single hourly write path (backend/power/hourly_store.py).
+
+    "Real" = the (series, zone, hour) row already existed and the re-published
+    value moved beyond the float-noise epsilon (REVISION_FLOOR/REVISION_REL_TOL
+    in hourly_store). First-time arrivals are NOT revisions — they land in
+    ingest_arrival's n_new instead. Derived series (residual.*) are excluded at
+    write time: they restate whenever their inputs restate, so ledgering them
+    would double-count every upstream revision.
+
+    Forward-only by design: upstream re-fetches overwrite caches, so history
+    before deploy is unrecoverable — the ledger accrues from first write.
+    "Maturity" (real restatement vs normal provisional fill-in) is a READ-time
+    concern for a later slice; everything beyond epsilon is stored.
+
+    All timestamps follow power_hourly's convention: epoch seconds UTC.
+    `observed_at` is the ingest wall clock, `ts_utc` the hour that changed."""
+
+    __tablename__ = "power_revision"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    series_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    zone_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    ts_utc: Mapped[int] = mapped_column(Integer, nullable=False)  # epoch sec, top-of-hour UTC
+    old_value: Mapped[float] = mapped_column(Float, nullable=False)
+    new_value: Mapped[float] = mapped_column(Float, nullable=False)
+    observed_at: Mapped[int] = mapped_column(Integer, nullable=False)  # epoch sec UTC
+
+    # The read pattern of the later quality slices is "revisions for one series+zone
+    # in a time window" — same shape as power_hourly's PK scan. New table, so
+    # create_all creates the index everywhere; no migrations.py retrofit needed.
+    __table_args__ = (
+        Index("ix_power_revision_series_zone_ts", "series_id", "zone_id", "ts_utc"),
+    )
+
+
+class IngestArrival(Base):
+    """Arrival log (Honest Record slice A1): ONE row per non-empty upsert batch
+    (per series+zone call through hourly_store.upsert_hourly), not per point.
+
+    A batch with nothing new and nothing changed still logs a row — it is
+    evidence the source was fetched, and later slices read arrival cadence as
+    fetch health ("no row" must mean "never polled", not "polled, unchanged").
+    min/max_ts_new span only the batch's NEW hours (NULL when n_new == 0);
+    frontier lag is derivable as observed_at − max_ts_new. Epoch seconds UTC
+    throughout, like power_hourly."""
+
+    __tablename__ = "ingest_arrival"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    series_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    zone_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    observed_at: Mapped[int] = mapped_column(Integer, nullable=False)  # epoch sec UTC
+    n_new: Mapped[int] = mapped_column(Integer, nullable=False)
+    n_changed: Mapped[int] = mapped_column(Integer, nullable=False)
+    min_ts_new: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    max_ts_new: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+
 class InstalledCapacity(Base):
     """ENTSO-E installed generation capacity per production type (A68/A33) — annual, per
     zone. Reference/context data (how much wind/solar/gas/etc. a zone has), not a time

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -298,9 +298,11 @@ class IngestArrival(Base):
     frontier lag is derivable as observed_at − max_ts_new. Epoch seconds UTC
     throughout, like power_hourly.
 
-    TODO: retention/pruning is owned by a later slice (hook into
-    backend/collectors/retention.py) — the log grows by one row per scheduled
-    fetch, unbounded until then."""
+    Retention: pruned to the trailing 90 days by the daily retention job
+    (backend/collectors/retention.py, INGEST_ARRIVAL_RETENTION_DAYS) — the log
+    grows by one row per scheduled fetch and is cadence evidence, not history.
+    The revision ledger (power_revision) is deliberately NEVER pruned: the
+    ledger is the product."""
 
     __tablename__ = "ingest_arrival"
 
@@ -615,4 +617,47 @@ class ForecastScoreDaily(Base):
 
     __table_args__ = (
         UniqueConstraint("zone", "series", "date", name="uq_forecast_score_zone_series_date"),
+    )
+
+
+class QualityDaily(Base):
+    """Per-(zone, series, UTC-day) data-quality aggregate: completeness plus
+    rule-based anomaly flags — the Honest-Record statement of what the published
+    data looks like. Posture B: every row DESCRIBES the source's output (hours
+    missing, physically implausible values); nothing here judges the market.
+
+    `hours_present`/`hours_expected` count the series' native intervals: 24 for
+    hourly series, 96 for `.qh` quarter-hour series (the column name keeps the
+    dominant hourly reading; see backend/power/quality.py::hours_expected).
+
+    `flags` is a JSON-encoded list of flag dicts
+    (`{"rule", "hours": [epoch ts], "detail": {...}}`) — Text-JSON, the project
+    convention (no native JSON type; see PowerPriceDaily.hourly_prices).
+    Zone-level rules (currently gen_below_load_exports) live under the reserved
+    series_key `_zone`; those rows carry hours_present = hours_expected = 0 and
+    exist ONLY on flagged days.
+
+    A day with no points still gets a row (hours_present=0) only while the
+    series shows activity in the surrounding 30 days — otherwise the zone
+    simply doesn't carry that series and a row would be noise. Recomputed
+    nightly over the trailing window: recompute replaces the row in place
+    (idempotent), and a day the data no longer supports is deleted, not left
+    to rot (episodes doctrine). Auto-created by Base.metadata.create_all on
+    startup like every sibling table here.
+    """
+
+    __tablename__ = "quality_daily"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    zone: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    series_key: Mapped[str] = mapped_column(String, nullable=False)          # e.g. "load.actual", "_zone"
+    date: Mapped[str] = mapped_column(String, nullable=False, index=True)    # YYYY-MM-DD (UTC day)
+    hours_present: Mapped[int] = mapped_column(Integer, nullable=False)
+    hours_expected: Mapped[int] = mapped_column(Integer, nullable=False)
+    flags: Mapped[str] = mapped_column(Text, nullable=False, default="[]")   # JSON list of flag dicts
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow,
+                                                 onupdate=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("zone", "series_key", "date", name="uq_quality_daily_zone_series_date"),
     )

--- a/backend/models/energy.py
+++ b/backend/models/energy.py
@@ -564,3 +564,55 @@ class PowerEpisode(Base):
     __table_args__ = (
         UniqueConstraint("kind", "zone", "start_date", name="uq_power_episode_kind_zone_start"),
     )
+
+
+class ForecastScoreDaily(Base):
+    """Per-(zone, series, UTC-day) error metrics for ENTSO-E's published
+    day-ahead forecasts vs the published actuals — the persisted aggregate
+    behind the Honest-Record forecast scoreboard. Posture B: this GRADES the
+    TSOs' own forecasts; OBSYD forecasts nothing.
+
+    `series` is one of load | residual | wind | solar (the canonical pair table
+    in backend/power/forecast_score.py::FORECAST_PAIRS). `n_hours` counts hours
+    where both forecast and actual exist; the other metrics are means over that
+    set or a documented subset of it (see forecast_score.py).
+
+    Sign convention: `bias` = mean(forecast − actual) — positive means the
+    published forecast leaned HIGH. NOTE the /api/power/forecast-error endpoint
+    reports the OPPOSITE sign (mean(actual − forecast)), kept unchanged for its
+    existing readers.
+
+    `mape` is stored for the load pair only (percent; hours whose |actual| is
+    below the division floor are excluded) — NULL elsewhere. `mae_persistence`
+    / `mae_seasonal` are the MAEs of naive baselines built from actuals alone
+    (actual(t−24h) / actual(t−168h)), over the scored hours whose lagged actual
+    exists; NULL when none does. Skill (1 − mae/mae_baseline) is derived at
+    READ time — only the MAEs are stored, at full float precision, because
+    rounding here would compound into the read-time ratio.
+
+    Recomputed nightly over the trailing days (forecast/actual revisions
+    drift): recompute replaces the row in place (idempotent), and a day the
+    data no longer supports is deleted, not left to rot (episodes doctrine).
+    Auto-created by Base.metadata.create_all on startup like every sibling
+    table here.
+    """
+
+    __tablename__ = "forecast_score_daily"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    zone: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    series: Mapped[str] = mapped_column(String, nullable=False)             # load | residual | wind | solar
+    date: Mapped[str] = mapped_column(String, nullable=False, index=True)   # YYYY-MM-DD (UTC day)
+    n_hours: Mapped[int] = mapped_column(Integer, nullable=False)
+    mae: Mapped[Optional[float]] = mapped_column(Float, nullable=True)      # MW
+    rmse: Mapped[Optional[float]] = mapped_column(Float, nullable=True)     # MW
+    bias: Mapped[Optional[float]] = mapped_column(Float, nullable=True)     # MW, forecast − actual
+    mape: Mapped[Optional[float]] = mapped_column(Float, nullable=True)     # %, load only
+    mae_persistence: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # MW
+    mae_seasonal: Mapped[Optional[float]] = mapped_column(Float, nullable=True)     # MW
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow,
+                                                 onupdate=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("zone", "series", "date", name="uq_forecast_score_zone_series_date"),
+    )

--- a/backend/power/forecast_score.py
+++ b/backend/power/forecast_score.py
@@ -1,0 +1,185 @@
+"""Score ENTSO-E's published day-ahead forecasts against the published actuals.
+
+The desk's forecast-error endpoint answers "how wrong was the TSO forecast this
+week" on the fly; the scoreboard needs the same answer per (zone, series, day),
+kept, so a reader can see whether a forecast has been getting better or worse.
+This engine computes those daily aggregates from the canonical hourly store and
+persists them (`forecast_score_daily`) — records.py's doctrine: recomputation
+replaces the row, no incremental state to corrupt, and a day the data no longer
+supports is retracted rather than left to rot.
+
+Posture B, said plainly: every number here GRADES a forecast ENTSO-E published.
+OBSYD makes no forecast. The two naive baselines (persistence = actual(t−24h),
+seasonal = actual(t−168h)) are built from published actuals alone — they are the
+"no model at all" yardsticks a fair grade needs, not models of ours. Only their
+MAEs are stored; skill (1 − mae/mae_baseline) is derived at read time, so the
+stored floats stay unrounded (rounding here would compound into that ratio).
+
+n semantics: `n_hours` counts the hours where BOTH forecast and actual exist.
+MAPE and the baseline MAEs are means over their own (possibly smaller) subsets
+of those hours — MAPE drops hours whose |actual| is under the division floor,
+a baseline MAE drops hours whose lagged actual is missing — and each is NULL
+when its subset is empty. `n_hours` never shrinks for either.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+
+from sqlalchemy.orm import Session
+
+from backend.models.energy import ForecastScoreDaily
+from backend.power.hourly_store import day_hour_ts, read_hourly
+
+#: forecast series → the series whose SUM is the realised counterpart.
+#: There is no wind.actual/solar.actual — realised wind/solar live in the
+#: generation mix (B18+B19 / B16), same derivation the residual ingest uses.
+#: THE canonical pair table: the /api/power/forecast-error route imports it
+#: from here, so route and scoreboard can never grade different forecasts.
+FORECAST_PAIRS: dict[str, tuple[str, list[str]]] = {
+    "load": ("load.forecast", ["load.actual"]),
+    "residual": ("residual.forecast", ["residual.actual"]),
+    "wind": ("wind.forecast", ["gen.B18", "gen.B19"]),
+    "solar": ("solar.forecast", ["gen.B16"]),
+}
+
+#: Only load gets a MAPE. Wind/solar actuals hit honest zeros every calm night,
+#: and residual crosses zero by design — a percentage against those is noise.
+MAPE_SERIES = frozenset({"load"})
+
+#: MAPE division guard: hours whose |actual| reads below this are excluded from
+#: MAPE (they stay in MAE/RMSE/bias and n_hours). 100 MW is records.py's
+#: LOAD_MIN_PLAUSIBLE — no European zone's real load is that low, so such an
+#: hour is an ingest artifact, and a percentage against it would describe the
+#: glitch, not the forecast.
+MAPE_ACTUAL_FLOOR_MW = 100.0
+
+_DAY_S = 24 * 3600
+PERSISTENCE_LAG_S = 24 * 3600     # yesterday, same hour
+SEASONAL_LAG_S = 168 * 3600       # last week, same hour
+
+
+def score_hours(
+    forecast: dict[int, float],
+    actual: dict[int, float],
+    hours: list[int],
+    *,
+    with_mape: bool = False,
+) -> dict | None:
+    """Pure: error metrics over `hours` (each present in both dicts). None if empty.
+
+    bias = mean(forecast − actual): positive = the published forecast leaned
+    HIGH. (The forecast-error ROUTE reports the opposite sign; the model
+    docstring carries the warning.) `actual` may span more than `hours` — the
+    baselines reach back through it for the lagged values.
+    """
+    if not hours:
+        return None
+    errors = [forecast[t] - actual[t] for t in hours]
+    n = len(errors)
+    metrics = {
+        "n_hours": n,
+        "mae": sum(abs(e) for e in errors) / n,
+        "rmse": math.sqrt(sum(e * e for e in errors) / n),
+        "bias": sum(errors) / n,
+        "mape": None,
+        "mae_persistence": _baseline_mae(actual, hours, PERSISTENCE_LAG_S),
+        "mae_seasonal": _baseline_mae(actual, hours, SEASONAL_LAG_S),
+    }
+    if with_mape:
+        apes = [
+            abs(forecast[t] - actual[t]) / abs(actual[t])
+            for t in hours
+            if abs(actual[t]) >= MAPE_ACTUAL_FLOOR_MW
+        ]
+        if apes:
+            metrics["mape"] = 100.0 * sum(apes) / len(apes)
+    return metrics
+
+
+def _baseline_mae(actual: dict[int, float], hours: list[int], lag_s: int) -> float | None:
+    """MAE of the naive "actual, `lag_s` ago" baseline, over the scored hours
+    whose lagged actual exists. None when none does — a baseline scored on no
+    hours is not a small number, it is no number."""
+    diffs = [abs(actual[t] - actual[t - lag_s]) for t in hours if (t - lag_s) in actual]
+    return sum(diffs) / len(diffs) if diffs else None
+
+
+def compute_and_store_scores(db: Session, zone: str, day: str) -> dict:
+    """Recompute + upsert one zone's scores for one UTC day ("YYYY-MM-DD").
+    Idempotent; a zone/day with no overlapping data writes nothing (and retracts
+    a stale row if one exists). Returns {"written": n, "removed": m}."""
+    return compute_and_store_range(db, zone, day, day)
+
+
+def compute_and_store_range(db: Session, zone: str, start_day: str, end_day: str) -> dict:
+    """Recompute + upsert scores for `zone` over [start_day, end_day] inclusive.
+
+    The scheduler's trailing-window recompute and the one-time backfill both
+    land here, so they can never disagree. Each series is read ONCE over the
+    whole range (plus the seasonal lookback for actuals) and scored day by day
+    — a multi-year backfill is 9 indexed range scans per zone, not 9 per day.
+    Commits once at the end.
+    """
+    days = _day_list(start_day, end_day)
+    start_ts = day_hour_ts(start_day, 0)
+    end_ts = day_hour_ts(end_day, 0) + _DAY_S
+
+    written = removed = 0
+    for series, (fc_key, actual_keys) in FORECAST_PAIRS.items():
+        forecast = dict(read_hourly(db, fc_key, zone, start_ts, end_ts))
+        actual: dict[int, float] = {}
+        for key in actual_keys:
+            for t, v in read_hourly(db, key, zone, start_ts - SEASONAL_LAG_S, end_ts):
+                actual[t] = actual.get(t, 0.0) + v
+
+        # Bucket the common hours per day in ONE pass over the forecast points —
+        # a per-day scan of the whole range's dict would be O(days × points),
+        # which a multi-year backfill turns into minutes for no reason.
+        buckets: list[list[int]] = [[] for _ in days]
+        for t in forecast:
+            i = (t - start_ts) // _DAY_S
+            if 0 <= i < len(days) and t in actual:
+                buckets[i].append(t)
+
+        for day, hours in zip(days, buckets):
+            metrics = score_hours(forecast, actual, sorted(hours), with_mape=series in MAPE_SERIES)
+            w, r = _upsert(db, zone, series, day, metrics)
+            written += w
+            removed += r
+
+    db.commit()
+    return {"written": written, "removed": removed}
+
+
+def _upsert(db: Session, zone: str, series: str, day: str, metrics: dict | None) -> tuple[int, int]:
+    """One row per (zone, series, day), replaced in place. metrics=None RETRACTS:
+    a day a later revision of the data no longer supports disappears, rather
+    than sitting in the scoreboard forever (episodes doctrine)."""
+    row = (
+        db.query(ForecastScoreDaily)
+        .filter_by(zone=zone, series=series, date=day)
+        .one_or_none()
+    )
+    if metrics is None:
+        if row is not None:
+            db.delete(row)
+            return 0, 1
+        return 0, 0
+    if row is None:
+        row = ForecastScoreDaily(zone=zone, series=series, date=day)
+        db.add(row)
+    row.n_hours = metrics["n_hours"]
+    row.mae = metrics["mae"]
+    row.rmse = metrics["rmse"]
+    row.bias = metrics["bias"]
+    row.mape = metrics["mape"]
+    row.mae_persistence = metrics["mae_persistence"]
+    row.mae_seasonal = metrics["mae_seasonal"]
+    return 1, 0
+
+
+def _day_list(start_day: str, end_day: str) -> list[str]:
+    a, b = date.fromisoformat(start_day), date.fromisoformat(end_day)
+    return [(a + timedelta(days=i)).isoformat() for i in range((b - a).days + 1)]

--- a/backend/power/hourly_store.py
+++ b/backend/power/hourly_store.py
@@ -6,16 +6,22 @@ ingest process is the sole steady-state writer (roadmap Block 0/1). Dimension id
 (zone/series) are resolved get-or-create per call; the dims are tiny and indexed,
 so we deliberately avoid a module-level cache (it would leak ids across the
 per-test in-memory DBs and across a reconnect).
+
+Since Honest Record slice A1 every batch is also silently ledgered (see
+`_record_ledger`): real value changes → `power_revision`, one `ingest_arrival`
+row per non-empty batch. Transparent to all callers — same signature, same
+transaction, one extra indexed SELECT per batch.
 """
 from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime, timezone
 
+from sqlalchemy import insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
-from backend.models.energy import PowerHourly, SeriesDim, ZoneDim
+from backend.models.energy import IngestArrival, PowerHourly, PowerRevision, SeriesDim, ZoneDim
 
 
 def day_hour_ts(day: str, hour: int) -> int:
@@ -26,6 +32,19 @@ def day_hour_ts(day: str, hour: int) -> int:
 # Rows per multi-row INSERT. 4 cols × 2000 = 8000 bind params — well under SQLite's
 # default limit across versions; small enough to release the write lock frequently.
 _BATCH = 2000
+
+# --- Revision ledger (Honest Record slice A1) --------------------------------
+# An overwrite only counts as a revision when the re-published value moved by
+#   abs(new − old) > max(REVISION_FLOOR, REVISION_REL_TOL · abs(old))
+# — the absolute floor kills float noise on small magnitudes (prices near 0),
+# the relative term keeps the guard proportionate on MW-scale series.
+REVISION_FLOOR = 0.5
+REVISION_REL_TOL = 0.001
+
+# Derived series are not revision-ledgered: residual.* restates whenever its
+# inputs (load/wind/solar) restate, so ledgering it would double-count every
+# upstream revision. Their arrival rows are still written.
+REVISION_EXCLUDED_PREFIXES = ("residual.",)
 
 
 def _get_or_create_id(db: Session, model, key: str, **extra) -> int:
@@ -67,6 +86,7 @@ def upsert_hourly(
     ]
     if not rows:
         return 0
+    _record_ledger(db, series_key, series_id, zone_id, rows)
     written = 0
     for i in range(0, len(rows), _BATCH):
         chunk = rows[i : i + _BATCH]
@@ -79,6 +99,75 @@ def upsert_hourly(
         written += len(chunk)
     db.commit()
     return written
+
+
+def _record_ledger(db: Session, series_key: str, series_id: int, zone_id: int, rows: list[dict]) -> None:
+    """Diff the incoming batch against the stored values and write the Honest-
+    Record ledger: per-point PowerRevision rows for real changes plus ONE
+    IngestArrival row per (non-empty) batch. Must run BEFORE the upsert — it
+    reads the pre-overwrite values — and shares the caller's transaction (the
+    upsert's db.commit() lands data + ledger atomically).
+
+    ONE indexed SELECT over the batch's ts range (rides the power_hourly PK),
+    never per-row — backfill batches can be a whole month. A range read may
+    sweep in existing hours the batch doesn't touch; only batch keys are
+    diffed, so that is just a few spare rows in memory, not extra queries."""
+    observed_at = int(datetime.now(timezone.utc).timestamp())
+    # Last-wins dedupe mirrors what the ON CONFLICT upsert leaves behind should
+    # a batch carry the same hour twice.
+    incoming = {r["ts_utc"]: r["value"] for r in rows}
+    existing = dict(
+        db.query(PowerHourly.ts_utc, PowerHourly.value)
+        .filter(
+            PowerHourly.series_id == series_id,
+            PowerHourly.zone_id == zone_id,
+            PowerHourly.ts_utc >= min(incoming),
+            PowerHourly.ts_utc <= max(incoming),
+        )
+        .all()
+    )
+    new_ts = [ts for ts in incoming if ts not in existing]
+    ledgered = not series_key.startswith(REVISION_EXCLUDED_PREFIXES)
+    n_changed = 0
+    revision_rows: list[dict] = []
+    for ts, new_v in incoming.items():
+        old_v = existing.get(ts)
+        # power_hourly.value is NOT NULL, so None strictly means "no row yet" —
+        # a first arrival (counted in n_new above), never a revision.
+        if old_v is None:
+            continue
+        if abs(new_v - old_v) <= max(REVISION_FLOOR, REVISION_REL_TOL * abs(old_v)):
+            continue  # float noise / provisional jitter below epsilon
+        n_changed += 1
+        # Excluded (derived) series still COUNT their changes in the arrival row
+        # (a batch-level stat, no double-count risk) — they just get no
+        # per-point revision rows.
+        if ledgered:
+            revision_rows.append(
+                {
+                    "series_id": series_id,
+                    "zone_id": zone_id,
+                    "ts_utc": ts,
+                    "old_value": old_v,
+                    "new_value": new_v,
+                    "observed_at": observed_at,
+                }
+            )
+    if revision_rows:
+        db.execute(insert(PowerRevision), revision_rows)
+    # A no-change batch still logs its arrival: evidence of a fetch ("no row"
+    # must mean "never polled", not "polled, unchanged").
+    db.add(
+        IngestArrival(
+            series_id=series_id,
+            zone_id=zone_id,
+            observed_at=observed_at,
+            n_new=len(new_ts),
+            n_changed=n_changed,
+            min_ts_new=min(new_ts) if new_ts else None,
+            max_ts_new=max(new_ts) if new_ts else None,
+        )
+    )
 
 
 def upsert_day_hours(

--- a/backend/power/hourly_store.py
+++ b/backend/power/hourly_store.py
@@ -111,7 +111,10 @@ def _record_ledger(db: Session, series_key: str, series_id: int, zone_id: int, r
     ONE indexed SELECT over the batch's ts range (rides the power_hourly PK),
     never per-row — backfill batches can be a whole month. A range read may
     sweep in existing hours the batch doesn't touch; only batch keys are
-    diffed, so that is just a few spare rows in memory, not extra queries."""
+    diffed, so that is spare rows in memory, not extra queries. Worst case: a
+    sparse batch spanning a dense qh series materializes the whole span
+    (~35k rows per spanned year, transiently) — no current caller writes such
+    batches; if one ever appears, switch this read to an IN-list."""
     observed_at = int(datetime.now(timezone.utc).timestamp())
     # Last-wins dedupe mirrors what the ON CONFLICT upsert leaves behind should
     # a batch carry the same hour twice.

--- a/backend/power/quality.py
+++ b/backend/power/quality.py
@@ -1,0 +1,414 @@
+"""Nightly data-quality aggregates: completeness + rule-based anomaly flags.
+
+The desk republishes ENTSO-E's numbers; the Honest Record owes the reader a
+statement of what those numbers looked like — hours missing, solar generation
+at night, a load feed flatlining at zero. This engine computes that statement
+per (zone, series, UTC day) from the canonical hourly store and persists it
+(`quality_daily`) — records.py's doctrine: recomputation replaces the row, no
+incremental state to corrupt, and a day the data no longer supports is
+retracted rather than left to rot (forecast_score.py did the same).
+
+Posture B, said plainly: every flag DESCRIBES the published data. "Solar > 50 MW
+at 23:00 UTC" is a statement about the feed, not about the market, and none of
+it predicts anything.
+
+Completeness counts the series' native intervals: 24 for hourly series, 96 for
+`.qh` quarter-hour series (`hours_expected`). A day with zero points still gets
+a row (hours_present=0) ONLY while the series shows activity in the surrounding
+30 days — otherwise the zone simply doesn't carry that series, and a row would
+be noise, not information.
+
+Rules are small pure functions over the day's hour-points, wired per series by
+QUALITY_RULES. Conservatism is the design constraint throughout — a false
+positive here costs the product exactly the trust it exists to build:
+
+* pv_at_night (gen.B16): the night window is 22:00–01:00 UTC (NIGHT_HOURS_UTC).
+  Chosen from the map, not from taste: the latest sunset among enabled zones is
+  the west Irish coast at midsummer (~21:30 UTC), the earliest sunrise among
+  zones with a MATERIAL PV fleet is Finland at midsummer (~00:54 UTC), so the
+  window is dark wherever solar could plausibly move the number. Above the
+  Arctic Circle (SE1/SE2 midnight sun) no UTC window is dark year-round — those
+  fleets are at most tens of MW, which is what the MW floor is for.
+* zero_run (load.actual): six consecutive exact-0.0 hours. Zero LOAD is
+  physically implausible anywhere in Europe; zero or negative PRICES are real
+  market outcomes, so this rule must never be wired onto a price series.
+* step_jump (load.actual, price.dayahead): |Δ| beyond 8× the trailing-30-day
+  IQR of hourly deltas, with an absolute floor per series so a thin series
+  doesn't flag on its own noise. Real scarcity spikes clear neither bar the
+  way an ingest glitch does — and when they do, the flag still only SAYS "this
+  hour moved 8× more than this series' own month", which is true.
+* gen_below_load_exports (zone-level, series_key "_zone"): see the rule's
+  docstring — gated on the A75 coverage guard AND on flow data being present.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from bisect import bisect_left
+from collections import defaultdict
+from datetime import date, timedelta
+
+from sqlalchemy.orm import Session
+
+from backend.models.energy import QualityDaily, SeriesDim
+from backend.power.coverage import coverage_min_ratio
+from backend.power.hourly_store import day_hour_ts, iter_border_points, read_hourly
+
+_DAY_S = 24 * 3600
+_HOUR_S = 3600
+
+#: Series the completeness pass covers. Config-only: adding a series here gives
+#: it a daily hours_present/hours_expected row (and any rules wired below).
+QUALITY_SERIES: tuple[str, ...] = (
+    "load.actual",
+    "price.dayahead",
+    "price.dayahead.qh",
+    "gen.B16",
+    "gen.B18",
+    "gen.B19",
+)
+
+#: A day with no points only earns a row while the series has ANY point within
+#: this many days on either side — beyond that the zone doesn't carry the series.
+ACTIVITY_WINDOW_DAYS = 30
+
+# ── pv_at_night ───────────────────────────────────────────────────────────────
+#: 22:00–01:00 UTC — dark in every enabled zone whose PV fleet is material
+#: (rationale in the module docstring). Hour 0 is the day's pre-dawn end of the
+#: window, 22–23 its evening start; a per-day rule checks all three.
+NIGHT_HOURS_UTC = (0, 22, 23)
+PV_NIGHT_FLOOR_MW = 50.0
+PV_NIGHT_DAY_MAX_FRACTION = 0.01
+
+# ── zero_run ──────────────────────────────────────────────────────────────────
+ZERO_RUN_MIN_HOURS = 6
+
+# ── step_jump ─────────────────────────────────────────────────────────────────
+STEP_JUMP_IQR_MULT = 8.0
+STEP_LOOKBACK_DAYS = 30
+#: Absolute floors under the IQR threshold: 500 MW for load, 100 EUR for price.
+#: Presence here doubles as "this series gets the step_jump rule's delta pass".
+STEP_JUMP_FLOORS: dict[str, float] = {
+    "load.actual": 500.0,
+    "price.dayahead": 100.0,
+}
+
+# ── gen_below_load_exports ────────────────────────────────────────────────────
+#: The energy balance (generation = load + net exports) may be short by this
+#: fraction before it flags — provisional data and losses live inside it.
+GEN_DEFICIT_TOLERANCE = 0.10
+#: Reserved series_key for zone-level flags (no single series owns them).
+ZONE_SERIES_KEY = "_zone"
+
+
+# ── Rules: pure functions over one day's hour-points ─────────────────────────
+# Signature: rule(day_points, day_start, ctx) -> flag dict | None, where
+# day_points = {epoch_ts: value} for the day, day_start = epoch of 00:00 UTC,
+# ctx = the per-series context the engine precomputed for the whole range.
+
+
+def rule_pv_at_night(day_points: dict[int, float], day_start: int, ctx: dict) -> dict | None:
+    """Solar generation above max(50 MW, 1% of the day's own max) inside the
+    conservative night window — a timezone-shifted or garbage feed signature."""
+    if not day_points:
+        return None
+    threshold = max(PV_NIGHT_FLOOR_MW, PV_NIGHT_DAY_MAX_FRACTION * max(day_points.values()))
+    bad = []
+    for h in NIGHT_HOURS_UTC:
+        t = day_start + h * _HOUR_S
+        v = day_points.get(t)
+        if v is not None and v > threshold:
+            bad.append((t, v))
+    if not bad:
+        return None
+    return {
+        "rule": "pv_at_night",
+        "hours": sorted(t for t, _ in bad),
+        "detail": {"max_mw": round(max(v for _, v in bad), 1),
+                   "threshold_mw": round(threshold, 1)},
+    }
+
+
+def rule_zero_run(day_points: dict[int, float], day_start: int, ctx: dict) -> dict | None:
+    """≥6 consecutive exact-0.0 hours. Zero load is implausible; a MISSING hour
+    is a completeness fact, not a zero, so it breaks the run rather than joining
+    it. Never wire this onto prices — zero/negative prices are real."""
+    flagged: list[int] = []
+    longest = 0
+    run: list[int] = []
+    for h in range(24):
+        t = day_start + h * _HOUR_S
+        if day_points.get(t) == 0.0:
+            run.append(t)
+            continue
+        if len(run) >= ZERO_RUN_MIN_HOURS:
+            flagged.extend(run)
+            longest = max(longest, len(run))
+        run = []
+    if len(run) >= ZERO_RUN_MIN_HOURS:
+        flagged.extend(run)
+        longest = max(longest, len(run))
+    if not flagged:
+        return None
+    return {"rule": "zero_run", "hours": flagged, "detail": {"longest_run_hours": longest}}
+
+
+def rule_step_jump(day_points: dict[int, float], day_start: int, ctx: dict) -> dict | None:
+    """|Δ hour-to-hour| > max(8 × trailing-30-day IQR of this series' own hourly
+    deltas, an absolute floor). The IQR calibrates "8× more than this series'
+    normal month"; the floor keeps a flat series from flagging its own noise.
+    A delta belongs to the day containing its LATER hour (the midnight-crossing
+    pair counts toward the new day)."""
+    deltas: dict[int, float] = ctx["deltas"]
+    ts_sorted: list[int] = ctx["delta_ts"]
+    lo = bisect_left(ts_sorted, day_start - STEP_LOOKBACK_DAYS * _DAY_S)
+    mid = bisect_left(ts_sorted, day_start)
+    hi = bisect_left(ts_sorted, day_start + _DAY_S)
+    threshold = max(
+        STEP_JUMP_IQR_MULT * _iqr([deltas[t] for t in ts_sorted[lo:mid]]),
+        ctx["step_floor"],
+    )
+    jumps = [t for t in ts_sorted[mid:hi] if abs(deltas[t]) > threshold]
+    if not jumps:
+        return None
+    return {
+        "rule": "step_jump",
+        "hours": jumps,
+        "detail": {"max_abs_delta": round(max(abs(deltas[t]) for t in jumps), 1),
+                   "threshold": round(threshold, 1)},
+    }
+
+
+#: series_key → the rules that run on its day-points. Config-only wiring.
+QUALITY_RULES: dict[str, tuple] = {
+    "gen.B16": (rule_pv_at_night,),
+    "load.actual": (rule_zero_run, rule_step_jump),
+    "price.dayahead": (rule_step_jump,),
+}
+
+
+def rule_gen_below_load_exports(
+    zone: str,
+    gen_mwh: float | None,
+    load_mwh: float | None,
+    net_export_mwh: float,
+    has_flows: bool,
+) -> dict | None:
+    """Daily total generation short of load + net exports by more than 10%.
+
+    Energy bookkeeping: generation ≈ load + net exports. When the published
+    generation covers less than 90% of that, either the mix feed dropped fuels
+    for part of the day or something upstream is broken — worth a flag, but
+    ONLY where the comparison is honest, so two gates come first:
+
+    * A75 under-coverage exemption: coverage.py documents zones whose reported
+      generation is STRUCTURALLY a fraction of load (SE4 0.36, NO1 0.60,
+      IE_SEM 0.72 … measured 2026-07-13). This rule reuses that guard's exact
+      threshold (`coverage_min_ratio`, default 0.6 with per-zone overrides): a
+      day whose generation covers less than that fraction of load is exempt —
+      the shortfall is the known structural gap (or a genuine net importer,
+      which the guard admittedly cannot tell apart; same fail-safe false
+      negative coverage.py already accepts), not news.
+    * Flow-data gate: without the day's border flows an unmeasured IMPORT is
+      indistinguishable from a generation deficit — a healthy importer would
+      flag every day. No flow points, no flag.
+
+    `net_export_mwh` uses iter_border_points' sign (positive = `zone` exports),
+    summed over the day. Zone-level: recorded under series_key "_zone"."""
+    if load_mwh is None or load_mwh <= 0 or gen_mwh is None or not has_flows:
+        return None
+    if gen_mwh < coverage_min_ratio(zone) * load_mwh:
+        return None  # structurally under-covered (A75) — exempt, coverage.py doctrine
+    supplied = load_mwh + net_export_mwh
+    if supplied <= 0:
+        return None
+    if gen_mwh >= (1.0 - GEN_DEFICIT_TOLERANCE) * supplied:
+        return None
+    return {
+        "rule": "gen_below_load_exports",
+        "hours": [],
+        "detail": {
+            "gen_mwh": round(gen_mwh, 1),
+            "load_mwh": round(load_mwh, 1),
+            "net_export_mwh": round(net_export_mwh, 1),
+            "deficit_pct": round(100.0 * (1.0 - gen_mwh / supplied), 1),
+        },
+    }
+
+
+def hours_expected(series_key: str) -> int:
+    """Native intervals per UTC day: 96 for quarter-hour series, 24 otherwise."""
+    return 96 if series_key.endswith(".qh") else 24
+
+
+def compute_and_store_quality(db: Session, zone: str, day: str) -> dict:
+    """Recompute + upsert one zone's quality rows for one UTC day ("YYYY-MM-DD").
+    Idempotent; retracts rows the data no longer supports. Returns
+    {"written": n, "removed": m}."""
+    return compute_and_store_range(db, zone, day, day)
+
+
+def compute_and_store_range(db: Session, zone: str, start_day: str, end_day: str) -> dict:
+    """Recompute + upsert quality rows for `zone` over [start_day, end_day] incl.
+
+    The scheduler's trailing-window recompute and the one-time backfill both
+    land here, so they can never disagree. Each series is read ONCE over the
+    whole range plus the ±30-day activity/lookback margin and bucketed per day
+    in one pass — O(points), not O(days × points) (forecast_score.py's shape).
+    Commits once at the end.
+    """
+    days = _day_list(start_day, end_day)
+    start_ts = day_hour_ts(start_day, 0)
+    end_ts = day_hour_ts(end_day, 0) + _DAY_S
+    # One read per series covers both the activity check and the step-jump
+    # lookback — max() so retuning either constant can't silently starve the other.
+    margin = max(ACTIVITY_WINDOW_DAYS, STEP_LOOKBACK_DAYS) * _DAY_S
+    activity_margin = ACTIVITY_WINDOW_DAYS * _DAY_S
+
+    written = removed = 0
+    buckets_by_series: dict[str, dict[int, dict[int, float]]] = {}
+
+    for key in QUALITY_SERIES:
+        points = read_hourly(db, key, zone, start_ts - margin, end_ts + margin)
+        ts_all = [t for t, _ in points]  # read_hourly returns time-ordered rows
+        buckets: dict[int, dict[int, float]] = defaultdict(dict)
+        for t, v in points:
+            i = (t - start_ts) // _DAY_S
+            if 0 <= i < len(days):
+                buckets[i][t] = v
+        buckets_by_series[key] = buckets
+
+        ctx: dict = {}
+        if key in STEP_JUMP_FLOORS:
+            values = dict(points)
+            deltas = {t: v - values[t - _HOUR_S] for t, v in values.items() if (t - _HOUR_S) in values}
+            ctx = {"deltas": deltas, "delta_ts": sorted(deltas), "step_floor": STEP_JUMP_FLOORS[key]}
+
+        expected = hours_expected(key)
+        for i, day in enumerate(days):
+            day_start = start_ts + i * _DAY_S
+            day_points = buckets.get(i, {})
+            if not day_points and not _has_activity(
+                ts_all, day_start - activity_margin, day_start + _DAY_S + activity_margin
+            ):
+                metrics = None  # zone doesn't carry this series here — no row, no noise
+            else:
+                flags = [f for rule in QUALITY_RULES.get(key, ())
+                         if (f := rule(day_points, day_start, ctx)) is not None]
+                metrics = {"hours_present": len(day_points), "hours_expected": expected, "flags": flags}
+            w, r = _upsert(db, zone, key, day, metrics)
+            written += w
+            removed += r
+
+    w, r = _zone_level_pass(db, zone, days, start_ts, end_ts, buckets_by_series)
+    written += w
+    removed += r
+
+    db.commit()
+    return {"written": written, "removed": removed}
+
+
+def _zone_level_pass(
+    db: Session,
+    zone: str,
+    days: list[str],
+    start_ts: int,
+    end_ts: int,
+    buckets_by_series: dict[str, dict[int, dict[int, float]]],
+) -> tuple[int, int]:
+    """gen_below_load_exports per day, under series_key "_zone". Reuses the
+    load/gen buckets the completeness pass already read; only gen.* series
+    outside QUALITY_SERIES cost an extra indexed range scan each."""
+    gen_totals: dict[int, float] = defaultdict(float)
+    gen_seen: set[int] = set()
+    for (key,) in db.query(SeriesDim.key).filter(SeriesDim.key.like("gen.%")).all():
+        if key in buckets_by_series:
+            for i, day_points in buckets_by_series[key].items():
+                if day_points:
+                    gen_totals[i] += sum(day_points.values())
+                    gen_seen.add(i)
+        else:
+            for t, v in read_hourly(db, key, zone, start_ts, end_ts):
+                i = (t - start_ts) // _DAY_S
+                gen_totals[i] += v
+                gen_seen.add(i)
+
+    flow_totals: dict[int, float] = defaultdict(float)
+    flow_seen: set[int] = set()
+    for _neighbor, t, v in iter_border_points(db, zone, start_ts, end_ts):
+        i = (t - start_ts) // _DAY_S
+        flow_totals[i] += v  # positive = zone exports (iter_border_points' contract)
+        flow_seen.add(i)
+
+    load_buckets = buckets_by_series.get("load.actual", {})
+    written = removed = 0
+    for i, day in enumerate(days):
+        load_points = load_buckets.get(i, {})
+        flag = rule_gen_below_load_exports(
+            zone,
+            gen_totals[i] if i in gen_seen else None,
+            sum(load_points.values()) if load_points else None,
+            flow_totals.get(i, 0.0),
+            i in flow_seen,
+        )
+        metrics = (
+            {"hours_present": 0, "hours_expected": 0, "flags": [flag]}
+            if flag is not None
+            else None  # _zone rows exist only on flagged days; None also retracts
+        )
+        w, r = _upsert(db, zone, ZONE_SERIES_KEY, day, metrics)
+        written += w
+        removed += r
+    return written, removed
+
+
+def _upsert(db: Session, zone: str, series_key: str, day: str, metrics: dict | None) -> tuple[int, int]:
+    """One row per (zone, series_key, day), replaced in place. metrics=None
+    RETRACTS: a row a later revision of the data no longer supports disappears,
+    rather than sitting in the record forever (episodes doctrine)."""
+    row = (
+        db.query(QualityDaily)
+        .filter_by(zone=zone, series_key=series_key, date=day)
+        .one_or_none()
+    )
+    if metrics is None:
+        if row is not None:
+            db.delete(row)
+            return 0, 1
+        return 0, 0
+    if row is None:
+        row = QualityDaily(zone=zone, series_key=series_key, date=day)
+        db.add(row)
+    row.hours_present = metrics["hours_present"]
+    row.hours_expected = metrics["hours_expected"]
+    row.flags = json.dumps(metrics["flags"], separators=(",", ":"))
+    return 1, 0
+
+
+def _has_activity(ts_sorted: list[int], lo_ts: int, hi_ts: int) -> bool:
+    """Any point in [lo_ts, hi_ts)? `ts_sorted` is time-ordered."""
+    i = bisect_left(ts_sorted, lo_ts)
+    return i < len(ts_sorted) and ts_sorted[i] < hi_ts
+
+
+def _iqr(values: list[float]) -> float:
+    """Interquartile range (linear-interpolated quartiles). 0.0 under 4 values —
+    quartiles of a handful of deltas are noise, and the caller's absolute floor
+    governs then anyway."""
+    if len(values) < 4:
+        return 0.0
+    s = sorted(values)
+    return _quantile(s, 0.75) - _quantile(s, 0.25)
+
+
+def _quantile(sorted_values: list[float], q: float) -> float:
+    pos = (len(sorted_values) - 1) * q
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * (pos - lo)
+
+
+def _day_list(start_day: str, end_day: str) -> list[str]:
+    a, b = date.fromisoformat(start_day), date.fromisoformat(end_day)
+    return [(a + timedelta(days=i)).isoformat() for i in range((b - a).days + 1)]

--- a/backend/power/quality.py
+++ b/backend/power/quality.py
@@ -26,9 +26,10 @@ positive here costs the product exactly the trust it exists to build:
   Chosen from the map, not from taste: the latest sunset among enabled zones is
   the west Irish coast at midsummer (~21:30 UTC), the earliest sunrise among
   zones with a MATERIAL PV fleet is Finland at midsummer (~00:54 UTC), so the
-  window is dark wherever solar could plausibly move the number. Above the
-  Arctic Circle (SE1/SE2 midnight sun) no UTC window is dark year-round — those
-  fleets are at most tens of MW, which is what the MW floor is for.
+  window is dark wherever solar could plausibly move the number. At and above
+  the Arctic Circle (SE1/SE2, NO3/NO4, northern FI — midnight sun / no
+  astronomical night) no UTC window is dark year-round — those fleets are at
+  most tens of MW, which is what the MW floor is for.
 * zero_run (load.actual): six consecutive exact-0.0 hours. Zero LOAD is
   physically implausible anywhere in Europe; zero or negative PRICES are real
   market outcomes, so this rule must never be wired onto a price series.
@@ -89,6 +90,7 @@ STEP_JUMP_IQR_MULT = 8.0
 STEP_LOOKBACK_DAYS = 30
 #: Absolute floors under the IQR threshold: 500 MW for load, 100 EUR for price.
 #: Presence here doubles as "this series gets the step_jump rule's delta pass".
+#: Hourly series only — the delta pass assumes 3600 s spacing.
 STEP_JUMP_FLOORS: dict[str, float] = {
     "load.actual": 500.0,
     "price.dayahead": 100.0,
@@ -215,7 +217,11 @@ def rule_gen_below_load_exports(
       flag every day. No flow points, no flag.
 
     `net_export_mwh` uses iter_border_points' sign (positive = `zone` exports),
-    summed over the day. Zone-level: recorded under series_key "_zone"."""
+    summed over the day. Zone-level: recorded under series_key "_zone".
+
+    Known bias, stated: consumption.* series (pumped-storage absorption) are
+    ignored, which inflates generation relative to load + exports and therefore
+    only SUPPRESSES flags — errs in this module's chosen safe direction."""
     if load_mwh is None or load_mwh <= 0 or gen_mwh is None or not has_flows:
         return None
     if gen_mwh < coverage_min_ratio(zone) * load_mwh:
@@ -270,7 +276,11 @@ def compute_and_store_range(db: Session, zone: str, start_day: str, end_day: str
     buckets_by_series: dict[str, dict[int, dict[int, float]]] = {}
 
     for key in QUALITY_SERIES:
-        points = read_hourly(db, key, zone, start_ts - margin, end_ts + margin)
+        # One extra hour below the margin: the delta AT the lookback window's
+        # first hour needs its predecessor, or the first day of every run would
+        # see 719 trailing deltas where a later run sees 720 — and backfill and
+        # nightly must never disagree.
+        points = read_hourly(db, key, zone, start_ts - margin - _HOUR_S, end_ts + margin)
         ts_all = [t for t, _ in points]  # read_hourly returns time-ordered rows
         buckets: dict[int, dict[int, float]] = defaultdict(dict)
         for t, v in points:

--- a/backend/power/quality.py
+++ b/backend/power/quality.py
@@ -74,6 +74,20 @@ QUALITY_SERIES: tuple[str, ...] = (
 #: this many days on either side — beyond that the zone doesn't carry the series.
 ACTIVITY_WINDOW_DAYS = 30
 
+# ── revision maturity (read side of the A1 ledger) ────────────────────────────
+#: A restatement observed more than this long AFTER the hour it restates changed
+#: SETTLED data; anything earlier is the normal provisional fill-in window
+#: (ENTSO-E routinely re-publishes actuals for a day or two). The write path
+#: stores everything beyond epsilon (REVISION_FLOOR/REVISION_REL_TOL, next to it
+#: in backend/power/hourly_store.py); maturity is a READ-time judgement —
+#: PowerRevision's docstring defers it here. Shared by /api/v1/quality/revisions
+#: (routes/quality.py re-exports this name) and the radar's
+#: quality_major_restatement detector; the engine is its canonical home so
+#: neither reader has to import the other. 48 h is deliberately generous — a
+#: fill-in miscounted as a restatement would overstate the source's churn, and
+#: conservatism is this record's design constraint.
+REVISION_MATURITY_S = 48 * 3600
+
 # ── pv_at_night ───────────────────────────────────────────────────────────────
 #: 22:00–01:00 UTC — dark in every enabled zone whose PV fleet is material
 #: (rationale in the module docstring). Hour 0 is the day's pre-dawn end of the

--- a/backend/routes/power.py
+++ b/backend/routes/power.py
@@ -52,6 +52,7 @@ from backend.power.daily import share_is_claimable
 from backend.power.dunkelflaute import ABSOLUTE_THRESHOLD, TAIL_PERCENTILE
 from backend.power.energy_charts_flows import ATTRIBUTION
 from backend.power.entsoe_grid import PSR_LABELS
+from backend.power.forecast_score import FORECAST_PAIRS
 from backend.power.zones import DEFAULT_ZONE, POWER_ZONES
 from backend.signals.detectors.base import severity_from_zscore, trailing_zscore
 
@@ -1412,16 +1413,10 @@ def get_flows(
 
 
 # ─── Forecast error (free) ────────────────────────────────────────────────────
-
-#: forecast series → the series whose SUM is the realised counterpart.
-#: There is no wind.actual/solar.actual — realised wind/solar live in the
-#: generation mix (B18+B19 / B16), same derivation the residual ingest uses.
-_FORECAST_PAIRS: dict[str, tuple[str, list[str]]] = {
-    "load": ("load.forecast", ["load.actual"]),
-    "residual": ("residual.forecast", ["residual.actual"]),
-    "wind": ("wind.forecast", ["gen.B18", "gen.B19"]),
-    "solar": ("solar.forecast", ["gen.B16"]),
-}
+#
+# The canonical forecast→actual pair table is FORECAST_PAIRS in
+# backend/power/forecast_score.py (imported above) — shared with the nightly
+# forecast scoreboard so route and scoreboard can never grade different series.
 
 
 @router.get("/forecast-error")
@@ -1441,7 +1436,7 @@ def get_forecast_error(
     from backend.power.hourly_store import read_hourly
 
     resolved_zone = _resolve_zone(zone)
-    fc_key, actual_keys = _FORECAST_PAIRS[series]
+    fc_key, actual_keys = FORECAST_PAIRS[series]
     start_ts = int((datetime.utcnow() - timedelta(days=days)).timestamp())
 
     forecast = dict(read_hourly(db, fc_key, resolved_zone, start_ts))

--- a/backend/routes/quality.py
+++ b/backend/routes/quality.py
@@ -130,14 +130,23 @@ def _require_quality_series(series: str) -> None:
 
 def _decode_flags(raw: str | None) -> list[dict]:
     """quality_daily.flags (JSON text) → list of flag dicts with the stored
-    epoch `hours` converted to ISO strings, keeping one time format on the wire."""
-    flags = json.loads(raw) if raw else []
+    epoch `hours` converted to ISO strings, keeping one time format on the wire.
+
+    A row whose JSON won't parse yields a visible `_decode_error` flag instead
+    of 500ing the whole response — "panels never disappear silently" applies to
+    rows too, and one corrupt row must not hide the other 89 days."""
+    try:
+        flags = json.loads(raw) if raw else []
+    except json.JSONDecodeError:
+        return [{"rule": "_decode_error", "hours": [], "detail": {}}]
     return [{**f, "hours": [_iso(t) for t in f.get("hours", [])]} for f in flags]
 
 
 def _delta_pct(old: float, new: float) -> float | None:
     """Restatement size as % of the previously published value; None when the
-    old value was exactly 0 (no honest percentage exists)."""
+    old value was exactly 0 (no honest percentage exists). Divides by ABS(old),
+    so the sign always equals the direction of movement — a negative price
+    restated further down reads as a negative delta, never a sign flip."""
     if old == 0:
         return None
     return round(100.0 * (new - old) / abs(old), 2)
@@ -155,33 +164,56 @@ def _pctl(values: list[int], q: float) -> int | None:
     return int(round(s[lo] + (s[hi] - s[lo]) * (pos - lo)))
 
 
-def _latest_frontier_lag_s(db: Session, sid: int, zid: int) -> int | None:
-    """observed_at − max_ts_new of the NEWEST arrival row that brought new hours
-    (rows with n_new == 0 carry no frontier and are skipped). May be NEGATIVE:
-    day-ahead auctions publish hours that lie in the future, so their frontier
-    runs ahead of the wall clock — that is the honest number, not an error."""
-    row = (
-        db.query(IngestArrival.observed_at, IngestArrival.max_ts_new)
-        .filter(
-            IngestArrival.series_id == sid,
-            IngestArrival.zone_id == zid,
-            IngestArrival.max_ts_new.isnot(None),
+def _latest_frontier_lags(db: Session) -> dict[tuple[int, int], int]:
+    """(series_id, zone_id) → observed_at − max_ts_new of the NEWEST arrival row
+    that brought new hours (rows with n_new == 0 carry no frontier and are
+    skipped). ONE greatest-per-group join over ingest_arrival instead of a
+    point query per summary cell (O(cells) SELECTs at 37 zones × 6 series —
+    pinned by the SELECT-budget test). Lag may be NEGATIVE: day-ahead auctions
+    publish hours that lie in the future, so their frontier runs ahead of the
+    wall clock — that is the honest number, not an error. Should two frontier
+    batches for one pair share the same observed_at second, MIN(max_ts_new)
+    wins — the conservative (larger) lag."""
+    newest = (
+        db.query(
+            IngestArrival.series_id.label("sid"),
+            IngestArrival.zone_id.label("zid"),
+            func.max(IngestArrival.observed_at).label("obs"),
         )
-        .order_by(IngestArrival.observed_at.desc())
-        .first()
+        .filter(IngestArrival.max_ts_new.isnot(None))
+        .group_by(IngestArrival.series_id, IngestArrival.zone_id)
+        .subquery()
     )
-    return int(row[0] - row[1]) if row else None
+    rows = (
+        db.query(
+            IngestArrival.series_id,
+            IngestArrival.zone_id,
+            IngestArrival.observed_at,
+            func.min(IngestArrival.max_ts_new),
+        )
+        .join(
+            newest,
+            (IngestArrival.series_id == newest.c.sid)
+            & (IngestArrival.zone_id == newest.c.zid)
+            & (IngestArrival.observed_at == newest.c.obs),
+        )
+        .filter(IngestArrival.max_ts_new.isnot(None))
+        .group_by(IngestArrival.series_id, IngestArrival.zone_id, IngestArrival.observed_at)
+        .all()
+    )
+    return {(sid, zid): int(obs - mts) for sid, zid, obs, mts in rows}
 
 
 # ─── /summary ─────────────────────────────────────────────────────────────────
 
 
 def _summary_payload(db: Session) -> dict:
-    """The full enabled-zones × charter-series quality matrix. Expensive-ish
-    (one 90-day quality scan, one revision GROUP BY, one arrival point-lookup
-    per emitted cell) → computed at most once per SUMMARY_TTL_S via
-    cached_value; freshness stamps are added per REQUEST, outside the cache
-    (a warm cache must not freeze age_days — marginal/overview convention)."""
+    """The full enabled-zones × charter-series quality matrix. A fixed handful
+    of queries (one 90-day quality scan, one revision GROUP BY, one
+    greatest-per-group arrival join — never O(cells); the SELECT-budget test
+    pins it) → computed at most once per SUMMARY_TTL_S via cached_value;
+    freshness stamps are added per REQUEST, outside the cache (a warm cache
+    must not freeze age_days — marginal/overview convention)."""
     now = datetime.now(UTC)
     today = now.date()
     cut_long = (today - timedelta(days=SUMMARY_LONG_DAYS)).isoformat()
@@ -219,9 +251,10 @@ def _summary_payload(db: Session) -> dict:
             if flagged:
                 c["flagged30"] += 1
 
-    # Trailing-30d revision counts per (series, zone), one GROUP BY. observed_at
-    # is unindexed, but the ledger accrues from first deploy (A1) and this runs
-    # at most once per cache TTL behind the heavy guard.
+    # Trailing-30d revision counts per (series, zone), one GROUP BY — a covering
+    # scan of ix_power_revision_series_zone_observed (series, zone, observed_at):
+    # grouped by the index's own prefix, windowed on its third column, no table
+    # touch (measured ~924ms full-scan → 4-40ms covering at 2M rows).
     cut_epoch_30 = int(now.timestamp()) - SUMMARY_SHORT_DAYS * _DAY_S
     sid_key = dict(db.query(SeriesDim.id, SeriesDim.key).all())
     zid_key = dict(db.query(ZoneDim.id, ZoneDim.key).all())
@@ -238,6 +271,7 @@ def _summary_payload(db: Session) -> dict:
 
     key_sid = {v: k for k, v in sid_key.items()}
     key_zid = {v: k for k, v in zid_key.items()}
+    frontier = _latest_frontier_lags(db)
 
     zones_out = []
     for zone in POWER_ZONES:  # registry order — deterministic
@@ -252,12 +286,7 @@ def _summary_payload(db: Session) -> dict:
                 revisions, lag = None, None
             else:
                 revisions = rev30.get((zone, skey), 0)
-                sid, zid = key_sid.get(skey), key_zid.get(zone)
-                lag = (
-                    _latest_frontier_lag_s(db, sid, zid)
-                    if sid is not None and zid is not None
-                    else None
-                )
+                lag = frontier.get((key_sid.get(skey), key_zid.get(zone)))
             series_out.append(
                 {
                     "series_key": skey,

--- a/backend/routes/quality.py
+++ b/backend/routes/quality.py
@@ -50,22 +50,22 @@ from backend.collectors.freshness import SPECS, freshness_meta
 from backend.database import get_db
 from backend.models.energy import IngestArrival, PowerRevision, QualityDaily, SeriesDim, ZoneDim
 from backend.power.hourly_store import REVISION_EXCLUDED_PREFIXES
-from backend.power.quality import QUALITY_SERIES, ZONE_SERIES_KEY
+from backend.power.quality import (
+    QUALITY_SERIES,
+    REVISION_MATURITY_S,  # noqa: F401 — re-export; canonical home is the engine
+    ZONE_SERIES_KEY,
+)
 from backend.power.zones import POWER_ZONES
 from backend.routes.api_v1 import _rate_limit  # same v1 per-IP budget — quality IS v1 traffic
 
 router = APIRouter(prefix="/api/v1/quality", tags=["v1"])
 
-#: READ-time maturity threshold for /revisions (the write path stores everything
-#: beyond epsilon; PowerRevision's docstring defers maturity to read time — this
-#: is that read side; the write-time epsilons REVISION_FLOOR/REVISION_REL_TOL
-#: live next to the write path in backend/power/hourly_store.py). A restatement
-#: observed more than 48 h AFTER the hour it restates changed settled data;
-#: anything earlier is the normal provisional fill-in window (ENTSO-E routinely
-#: re-publishes actuals for a day or two). 48 h is deliberately generous — a
-#: fill-in miscounted as a restatement would overstate the source's churn, and
-#: conservatism is this record's design constraint.
-REVISION_MATURITY_S = 48 * 3600
+# READ-time maturity threshold for /revisions: canonically defined (and
+# documented) in backend/power/quality.py::REVISION_MATURITY_S — the radar's
+# quality_major_restatement detector reads the same number, and the engine is
+# the one home both can import without pulling in the router stack. Re-exported
+# above so this module's name (used by tests/docs and the response payload)
+# keeps working.
 
 #: /revisions per-request row cap (MAX_SCAN_ROWS pattern from routes/api_v1):
 #: fetch cap+1 and refuse with a reason rather than silently truncate — a

--- a/backend/routes/quality.py
+++ b/backend/routes/quality.py
@@ -1,0 +1,544 @@
+"""Honest-Record read API (/api/v1/quality/*) — slice A3.
+
+Public, versioned endpoints over the A1/A2 transparency tables:
+
+* `quality_daily` (backend/power/quality.py) — nightly completeness + rule
+  flags per (zone, series, UTC day),
+* `power_revision` — one row per REAL value restatement observed at the single
+  hourly write path (backend/power/hourly_store.py),
+* `ingest_arrival` — one row per fetch batch (arrival cadence + frontier lag).
+
+Posture B throughout: every field DESCRIBES what the SOURCE published, when it
+arrived, and how it was later restated. Nothing here says "wrong data" — a
+restatement is the source revising its own publication, a low completeness day
+is hours the source has not (yet) published.
+
+Conventions (matching the rest of /api/v1):
+* every handler is `def`, never `async def` — sync-DB routes must run in
+  Starlette's threadpool (repo rule, PR #116);
+* the shared v1 per-IP budget applies (`_rate_limit` from routes/api_v1);
+* timestamps in JSON are ISO 8601 UTC strings, like /api/v1/series'
+  `datetime_utc` — the store's epoch seconds are converted at the edge;
+* every response carries `as_of`/`age_days`/`stale` (freshness_meta);
+* a valid-but-empty combination is HTTP 200 with `available: false` + empty
+  lists, never a 404; unknown series/zone keys are HTTP 400 with a `detail`
+  that lists (or points at) the valid values.
+
+Freshness sources, decided + documented per endpoint:
+* quality endpoints (`/summary`, `/series`): `as_of` = the newest quality_daily
+  DATE in scope; the stale window is the `quality_daily` freshness spec's
+  (backend/collectors/freshness.py::SPECS), looked up by key so retuning the
+  spec retunes these endpoints.
+* `/revisions`: the ledger is forward-only and a quiet series is a FEATURE, so
+  pretending a per-spec window exists would be false precision. Its honest
+  freshness signal is the newest `ingest_arrival.observed_at` for the
+  series+zone — the last time the source was polled and could have restated
+  something — exposed as `as_of`, stale after ARRIVAL_STALE_DAYS.
+"""
+from __future__ import annotations
+
+import json
+import math
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from backend.api_guard import cached_value, heavy_query_guard
+from backend.collectors.freshness import SPECS, freshness_meta
+from backend.database import get_db
+from backend.models.energy import IngestArrival, PowerRevision, QualityDaily, SeriesDim, ZoneDim
+from backend.power.hourly_store import REVISION_EXCLUDED_PREFIXES
+from backend.power.quality import QUALITY_SERIES, ZONE_SERIES_KEY
+from backend.power.zones import POWER_ZONES
+from backend.routes.api_v1 import _rate_limit  # same v1 per-IP budget — quality IS v1 traffic
+
+router = APIRouter(prefix="/api/v1/quality", tags=["v1"])
+
+#: READ-time maturity threshold for /revisions (the write path stores everything
+#: beyond epsilon; PowerRevision's docstring defers maturity to read time — this
+#: is that read side; the write-time epsilons REVISION_FLOOR/REVISION_REL_TOL
+#: live next to the write path in backend/power/hourly_store.py). A restatement
+#: observed more than 48 h AFTER the hour it restates changed settled data;
+#: anything earlier is the normal provisional fill-in window (ENTSO-E routinely
+#: re-publishes actuals for a day or two). 48 h is deliberately generous — a
+#: fill-in miscounted as a restatement would overstate the source's churn, and
+#: conservatism is this record's design constraint.
+REVISION_MATURITY_S = 48 * 3600
+
+#: /revisions per-request row cap (MAX_SCAN_ROWS pattern from routes/api_v1):
+#: fetch cap+1 and refuse with a reason rather than silently truncate — a
+#: truncated ledger is a wrong ledger. 20k rows ≈ months of heavy restatement
+#: for one series+zone; a UI never needs more per pull.
+MAX_REVISION_ROWS = 20_000
+
+#: /summary windows (days): trailing short/long completeness horizons.
+SUMMARY_SHORT_DAYS = 30
+SUMMARY_LONG_DAYS = 90
+#: /summary is one all-zones × all-series matrix — computed once, served from
+#: the keyed TTL cache (api_guard.cached_value) for 15 min. The nightly quality
+#: job is the only writer, so even 15 min is generous.
+SUMMARY_TTL_S = 900.0
+
+#: /revisions staleness window (days) for the arrival-based `as_of` (module
+#: docstring): every live series is fetched at least daily, so two days of NO
+#: arrival rows means the fetch path is quiet — the same window the
+#: quality_daily spec uses for the nightly engine, kept as one number on
+#: purpose (both say "the honest-record machinery ran recently").
+ARRIVAL_STALE_DAYS = 2
+
+#: Stale window for the quality endpoints — the quality_daily freshness spec's
+#: own max age, looked up by key so spec and API can never drift.
+_QUALITY_MAX_AGE_DAYS = int(
+    next(s for s in SPECS if s.key == "quality_daily").max_age.total_seconds() // 86400
+)
+
+#: The charter matrix: the completeness series plus the reserved zone-level key.
+_VALID_QUALITY_SERIES: tuple[str, ...] = QUALITY_SERIES + (ZONE_SERIES_KEY,)
+
+_DAY_S = 86400
+
+
+# ─── shared helpers ───────────────────────────────────────────────────────────
+
+
+def _iso(ts: int | None) -> str | None:
+    """Epoch seconds UTC → ISO 8601 UTC string (the v1 wire format)."""
+    return datetime.fromtimestamp(ts, UTC).isoformat() if ts is not None else None
+
+
+def _require_zone(zone: str) -> None:
+    if zone not in POWER_ZONES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown zone {zone!r}. Valid zones: {', '.join(POWER_ZONES)}.",
+        )
+
+
+def _require_quality_series(series: str) -> None:
+    if series not in _VALID_QUALITY_SERIES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unknown quality series {series!r}. Valid: "
+                f"{', '.join(_VALID_QUALITY_SERIES)} "
+                f"({ZONE_SERIES_KEY!r} = zone-level flags such as gen_below_load_exports)."
+            ),
+        )
+
+
+def _decode_flags(raw: str | None) -> list[dict]:
+    """quality_daily.flags (JSON text) → list of flag dicts with the stored
+    epoch `hours` converted to ISO strings, keeping one time format on the wire."""
+    flags = json.loads(raw) if raw else []
+    return [{**f, "hours": [_iso(t) for t in f.get("hours", [])]} for f in flags]
+
+
+def _delta_pct(old: float, new: float) -> float | None:
+    """Restatement size as % of the previously published value; None when the
+    old value was exactly 0 (no honest percentage exists)."""
+    if old == 0:
+        return None
+    return round(100.0 * (new - old) / abs(old), 2)
+
+
+def _pctl(values: list[int], q: float) -> int | None:
+    """Linear-interpolated percentile of `values`, rounded to whole seconds.
+    None when empty. (Local on purpose — quality.py's quantile helper is private
+    to the engine, and this slice stays self-contained in the router.)"""
+    if not values:
+        return None
+    s = sorted(values)
+    pos = (len(s) - 1) * q
+    lo, hi = math.floor(pos), math.ceil(pos)
+    return int(round(s[lo] + (s[hi] - s[lo]) * (pos - lo)))
+
+
+def _latest_frontier_lag_s(db: Session, sid: int, zid: int) -> int | None:
+    """observed_at − max_ts_new of the NEWEST arrival row that brought new hours
+    (rows with n_new == 0 carry no frontier and are skipped). May be NEGATIVE:
+    day-ahead auctions publish hours that lie in the future, so their frontier
+    runs ahead of the wall clock — that is the honest number, not an error."""
+    row = (
+        db.query(IngestArrival.observed_at, IngestArrival.max_ts_new)
+        .filter(
+            IngestArrival.series_id == sid,
+            IngestArrival.zone_id == zid,
+            IngestArrival.max_ts_new.isnot(None),
+        )
+        .order_by(IngestArrival.observed_at.desc())
+        .first()
+    )
+    return int(row[0] - row[1]) if row else None
+
+
+# ─── /summary ─────────────────────────────────────────────────────────────────
+
+
+def _summary_payload(db: Session) -> dict:
+    """The full enabled-zones × charter-series quality matrix. Expensive-ish
+    (one 90-day quality scan, one revision GROUP BY, one arrival point-lookup
+    per emitted cell) → computed at most once per SUMMARY_TTL_S via
+    cached_value; freshness stamps are added per REQUEST, outside the cache
+    (a warm cache must not freeze age_days — marginal/overview convention)."""
+    now = datetime.now(UTC)
+    today = now.date()
+    cut_long = (today - timedelta(days=SUMMARY_LONG_DAYS)).isoformat()
+    cut_short = (today - timedelta(days=SUMMARY_SHORT_DAYS)).isoformat()
+
+    rows = (
+        db.query(
+            QualityDaily.zone,
+            QualityDaily.series_key,
+            QualityDaily.date,
+            QualityDaily.hours_present,
+            QualityDaily.hours_expected,
+            QualityDaily.flags,
+        )
+        .filter(QualityDaily.date >= cut_long)
+        .all()
+    )
+
+    # (zone, series) → per-window accumulators, Python-side (one pass).
+    cells: dict[tuple[str, str], dict] = {}
+    for zone, skey, day, present, expected, flags in rows:
+        if zone not in POWER_ZONES or skey not in _VALID_QUALITY_SERIES:
+            continue  # disabled zone / config drift — not part of the charter matrix
+        c = cells.setdefault(
+            (zone, skey),
+            {"r30": [], "r90": [], "flagged30": 0},
+        )
+        ratio = (present / expected) if expected > 0 else None  # _zone rows carry 0/0
+        if ratio is not None:
+            c["r90"].append(ratio)
+        flagged = bool(flags and flags != "[]")
+        if day >= cut_short:
+            if ratio is not None:
+                c["r30"].append(ratio)
+            if flagged:
+                c["flagged30"] += 1
+
+    # Trailing-30d revision counts per (series, zone), one GROUP BY. observed_at
+    # is unindexed, but the ledger accrues from first deploy (A1) and this runs
+    # at most once per cache TTL behind the heavy guard.
+    cut_epoch_30 = int(now.timestamp()) - SUMMARY_SHORT_DAYS * _DAY_S
+    sid_key = dict(db.query(SeriesDim.id, SeriesDim.key).all())
+    zid_key = dict(db.query(ZoneDim.id, ZoneDim.key).all())
+    rev30: dict[tuple[str, str], int] = {}
+    for sid, zid, n in (
+        db.query(PowerRevision.series_id, PowerRevision.zone_id, func.count())
+        .filter(PowerRevision.observed_at >= cut_epoch_30)
+        .group_by(PowerRevision.series_id, PowerRevision.zone_id)
+        .all()
+    ):
+        skey, zkey = sid_key.get(sid), zid_key.get(zid)
+        if skey is not None and zkey is not None:
+            rev30[(zkey, skey)] = int(n)
+
+    key_sid = {v: k for k, v in sid_key.items()}
+    key_zid = {v: k for k, v in zid_key.items()}
+
+    zones_out = []
+    for zone in POWER_ZONES:  # registry order — deterministic
+        series_out = []
+        for skey in _VALID_QUALITY_SERIES:
+            c = cells.get((zone, skey))
+            if c is None:
+                continue  # zone doesn't carry this series (or no _zone flags) — omit
+            if skey == ZONE_SERIES_KEY:
+                # Zone-level flag rows: no completeness, no series of their own
+                # in the store — revision count / arrival lag don't apply.
+                revisions, lag = None, None
+            else:
+                revisions = rev30.get((zone, skey), 0)
+                sid, zid = key_sid.get(skey), key_zid.get(zone)
+                lag = (
+                    _latest_frontier_lag_s(db, sid, zid)
+                    if sid is not None and zid is not None
+                    else None
+                )
+            series_out.append(
+                {
+                    "series_key": skey,
+                    "completeness_30d": round(sum(c["r30"]) / len(c["r30"]), 4) if c["r30"] else None,
+                    "completeness_90d": round(sum(c["r90"]) / len(c["r90"]), 4) if c["r90"] else None,
+                    "flagged_days_30d": c["flagged30"],
+                    "revisions_30d": revisions,
+                    "arrival_lag_s": lag,
+                }
+            )
+        if series_out:
+            zones_out.append({"zone": zone, "series": series_out})
+
+    # as_of = the newest quality DAY on record (indexed point lookup) — a data
+    # fact, cacheable; age_days/stale are stamped per request from it.
+    latest = db.query(func.max(QualityDaily.date)).scalar()
+    return {
+        "available": bool(zones_out),
+        "zones": zones_out,
+        "windows": {"short_days": SUMMARY_SHORT_DAYS, "long_days": SUMMARY_LONG_DAYS},
+        "series_keys": list(_VALID_QUALITY_SERIES),
+        "as_of": latest,
+        "note": (
+            "Completeness = mean(hours_present/hours_expected) over days WITH quality rows "
+            "in the window; flags describe the published data (see /api/v1/quality/series); "
+            "revisions_30d counts the source's own restatements beyond float noise; "
+            "arrival_lag_s = last fetch's wall-clock minus the newest hour it brought "
+            "(negative for day-ahead series — the auction publishes the future). "
+            f"'{ZONE_SERIES_KEY}' rows are zone-level flags and appear only on flagged days."
+        ),
+    }
+
+
+@router.get("/summary")
+def quality_summary(
+    db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
+    _g: None = Depends(heavy_query_guard),
+):
+    """Data-quality matrix over enabled zones × charter series: trailing 30/90-day
+    completeness, flagged days, restatement counts and latest arrival lag —
+    "here is what the published record looks like", per cell. Descriptive.
+
+    Zone-independent and the heaviest read on this router → one compute per
+    15 min (cached_value) behind heavy_query_guard; freshness is stamped per
+    request so a warm cache can't freeze age_days. The cached dict is never
+    mutated — the response is rebuilt around it."""
+    data = cached_value("quality_summary", lambda: _summary_payload(db), ttl=SUMMARY_TTL_S)
+    return {
+        **data,
+        **freshness_meta(data.get("as_of"), datetime.now(UTC).date(), _QUALITY_MAX_AGE_DAYS),
+    }
+
+
+# ─── /series ──────────────────────────────────────────────────────────────────
+
+
+@router.get("/series")
+def quality_series(
+    series: str = Query(..., description=f"Quality series key ({', '.join(_VALID_QUALITY_SERIES)})"),
+    zone: str = Query(..., description="Bidding zone key, e.g. DE_LU"),
+    days: int = Query(90, ge=1, le=365, description="Trailing window (UTC days)"),
+    db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
+):
+    """Daily quality rows for ONE series+zone, newest first: hours present vs
+    expected plus the decoded rule flags (each flag: rule, affected hours as
+    ISO UTC, detail) — the drill-down behind a /summary cell. Also reports
+    arrival-lag stats over the same window (median + p90 of frontier lag =
+    batch observed_at − newest hour it brought; negative for day-ahead series,
+    whose frontier runs ahead of the clock). Every flag DESCRIBES the source's
+    published output — none of it judges the market.
+
+    Cheap by construction (≤365 indexed quality rows + one indexed arrival
+    range scan bounded by the log's 90-day retention) — rate-limited only, no
+    heavy slot."""
+    _require_quality_series(series)
+    _require_zone(zone)
+    now = datetime.now(UTC)
+    today = now.date()
+    cut_day = (today - timedelta(days=days)).isoformat()
+
+    rows = (
+        db.query(QualityDaily)
+        .filter(
+            QualityDaily.zone == zone,
+            QualityDaily.series_key == series,
+            QualityDaily.date >= cut_day,
+        )
+        .order_by(QualityDaily.date.desc())
+        .all()
+    )
+    data = [
+        {
+            "date": r.date,
+            "hours_present": r.hours_present,
+            "hours_expected": r.hours_expected,
+            "flags": _decode_flags(r.flags),
+        }
+        for r in rows
+    ]
+
+    # Arrival-lag stats over the window. "_zone" is a reserved pseudo-series
+    # with no store series of its own → no arrival rows, honest zeros.
+    sid = db.query(SeriesDim.id).filter(SeriesDim.key == series).scalar()
+    zid = db.query(ZoneDim.id).filter(ZoneDim.key == zone).scalar()
+    lags: list[int] = []
+    if sid is not None and zid is not None:
+        cut_epoch = int(now.timestamp()) - days * _DAY_S
+        lags = [
+            int(obs - mts)
+            for obs, mts in db.query(IngestArrival.observed_at, IngestArrival.max_ts_new)
+            .filter(
+                IngestArrival.series_id == sid,
+                IngestArrival.zone_id == zid,
+                IngestArrival.observed_at >= cut_epoch,
+                IngestArrival.max_ts_new.isnot(None),
+            )
+            .all()
+        ]
+
+    return {
+        "available": bool(data),
+        "series": series,
+        "zone": zone,
+        "days": days,
+        "data": data,
+        "arrival": {
+            "n_batches": len(lags),
+            "median_lag_s": _pctl(lags, 0.5),
+            "p90_lag_s": _pctl(lags, 0.9),
+        },
+        **freshness_meta(rows[0].date if rows else None, today, _QUALITY_MAX_AGE_DAYS),
+    }
+
+
+# ─── /revisions ───────────────────────────────────────────────────────────────
+
+
+@router.get("/revisions")
+def quality_revisions(
+    series: str = Query(..., description="Series key, e.g. load.actual (see /api/v1/series/catalog)"),
+    zone: str = Query(..., description="Bidding zone key, e.g. DE_LU"),
+    days: int = Query(30, ge=1, le=365, description="Trailing window over observed_at (UTC days)"),
+    mature: bool = Query(
+        True,
+        description="true (default): only restatements observed >48h after the hour "
+        "they restate (settled data changed); false: include the normal "
+        "provisional fill-in window too",
+    ),
+    db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
+    _g: None = Depends(heavy_query_guard),
+):
+    """The revision ledger for ONE series+zone: every time the source re-published
+    a different value for an hour it had already published (beyond the float-noise
+    epsilon — see backend/power/hourly_store.py), with old/new value, when the
+    change was observed, and its size in %. Plus a per-hour roll-up of hours
+    restated MORE THAN ONCE. Descriptive: the ledger reports the source's own
+    restatements, it never says the data was "wrong".
+
+    `mature=true` (default) keeps only revisions observed more than 48 h
+    (REVISION_MATURITY_S) after the hour they restate — real changes to settled
+    data, not the routine provisional fill-in of the first couple of days. The ledger is
+    forward-only (accrues from first deploy), so `as_of` here is the newest
+    ingest_arrival.observed_at for this series+zone — the last moment the source
+    was polled and could have restated something — not a per-spec window.
+
+    Heavy-guarded: the per-pair ledger scan is unbounded by retention (the
+    ledger is never pruned — it is the product)."""
+    _require_zone(zone)
+    if series.startswith(REVISION_EXCLUDED_PREFIXES):
+        return {
+            "available": False,
+            "series": series,
+            "zone": zone,
+            "reason": (
+                f"{series!r} is a derived series and is not revision-ledgered: it restates "
+                "whenever its inputs restate, so its ledger would double-count every "
+                "upstream revision. Query the input series instead (e.g. load.actual, "
+                "gen.B16, gen.B18/B19)."
+            ),
+            # inert triple — there is no ledger to be fresh about, and every
+            # response on this router carries the three keys
+            **freshness_meta(None, None, ARRIVAL_STALE_DAYS),
+        }
+    sid = db.query(SeriesDim.id).filter(SeriesDim.key == series).scalar()
+    if sid is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown series {series!r} — see /api/v1/series/catalog for the queryable keys.",
+        )
+    zid = db.query(ZoneDim.id).filter(ZoneDim.key == zone).scalar()
+
+    now = datetime.now(UTC)
+    cut_epoch = int(now.timestamp()) - days * _DAY_S
+    rows: list[PowerRevision] = []
+    if zid is not None:
+        q = (
+            db.query(PowerRevision)
+            .filter(
+                PowerRevision.series_id == sid,
+                PowerRevision.zone_id == zid,
+                PowerRevision.observed_at >= cut_epoch,
+            )
+        )
+        if mature:
+            q = q.filter(PowerRevision.observed_at - PowerRevision.ts_utc > REVISION_MATURITY_S)
+        rows = (
+            q.order_by(PowerRevision.observed_at.desc(), PowerRevision.id.desc())
+            .limit(MAX_REVISION_ROWS + 1)
+            .all()
+        )
+
+    # Honest freshness for a forward-only ledger (module docstring): the newest
+    # arrival for this pair — evidence the source was last POLLED then.
+    last_polled = (
+        db.query(func.max(IngestArrival.observed_at))
+        .filter(IngestArrival.series_id == sid, IngestArrival.zone_id == zid)
+        .scalar()
+        if zid is not None
+        else None
+    )
+    fresh = freshness_meta(_iso(last_polled), now.date(), ARRIVAL_STALE_DAYS)
+
+    if len(rows) > MAX_REVISION_ROWS:
+        return {
+            "available": False,
+            "series": series,
+            "zone": zone,
+            "reason": (
+                f"Window matches more than {MAX_REVISION_ROWS:,} revision rows — narrow `days`. "
+                "This is a per-request cap, not the ledger's extent."
+            ),
+            **fresh,
+        }
+
+    data = [
+        {
+            "ts_utc": _iso(r.ts_utc),
+            "old_value": r.old_value,
+            "new_value": r.new_value,
+            "observed_at": _iso(r.observed_at),
+            "delta_pct": _delta_pct(r.old_value, r.new_value),
+        }
+        for r in rows
+    ]
+
+    # Per-hour roll-up over the SAME filtered rows: hours restated more than
+    # once. `rows` is observed_at-desc, so the first row seen per hour is that
+    # hour's LATEST restatement — its delta is last_change_pct.
+    per_hour: dict[int, list[PowerRevision]] = {}
+    for r in rows:
+        per_hour.setdefault(r.ts_utc, []).append(r)
+    restated = [
+        {
+            "ts_utc": _iso(ts),
+            "n_revisions": len(rs),
+            "last_change_pct": _delta_pct(rs[0].old_value, rs[0].new_value),
+        }
+        for ts, rs in sorted(per_hour.items(), reverse=True)
+        if len(rs) > 1
+    ]
+
+    out = {
+        "available": bool(data),
+        "series": series,
+        "zone": zone,
+        "days": days,
+        "mature": mature,
+        "maturity_threshold_s": REVISION_MATURITY_S,
+        "count": len(data),
+        "data": data,
+        "restated_hours": restated,
+        **fresh,
+    }
+    if not data:
+        out["reason"] = (
+            "No revisions on record for this series+zone in the window. The ledger accrues "
+            "from first deploy (forward-only), and with mature=true the routine provisional "
+            "fill-in is filtered out — a quiet ledger means the source has not restated "
+            "settled data here."
+        )
+    return out

--- a/backend/routes/scoreboard.py
+++ b/backend/routes/scoreboard.py
@@ -1,0 +1,543 @@
+"""Honest-Record forecast scoreboard read API (/api/v1/scoreboard/*) — slice B2.
+
+Public, versioned endpoints over `forecast_score_daily` (the B1 engine in
+backend/power/forecast_score.py): per-(zone, series, UTC-day) error metrics for
+ENTSO-E's published day-ahead forecasts vs the published actuals.
+
+Posture B, said plainly: every number here GRADES a forecast ENTSO-E published.
+OBSYD makes no forecast. The two naive baselines (persistence = actual 24 h ago,
+seasonal = actual 168 h ago) are built from published actuals alone — the
+"no model at all" yardsticks a fair grade needs, not models of ours.
+
+SIGN CONVENTION (declared on the wire as `bias_convention` wherever a bias is
+served): bias = mean(forecast − actual) — positive means the published forecast
+leaned HIGH. The OLDER /api/power/forecast-error endpoint reports the OPPOSITE
+sign (bias_mw = mean(actual − forecast)) and stays unchanged for its readers.
+
+AGGREGATION over daily rows (documented once here, shared by /summary and
+/monthly): day-weighted by `n_hours`, which makes the recombined numbers exact
+per-hour statistics of the window, not means-of-means —
+
+* mae  = Σ(mae_d·n_d) / Σn_d            (the exact window per-hour MAE)
+* bias = Σ(bias_d·n_d) / Σn_d           (the exact window per-hour bias)
+* rmse = sqrt(Σ(rmse_d²·n_d) / Σn_d)    (exact: rmse_d² recovers the day's Σe²)
+* mape = Σ(mape_d·n_d) / Σn_d over days where mape exists (approximate: the
+  day's MAPE subset may be slightly smaller than n_hours — the engine drops
+  hours whose |actual| is under its division floor and does not store that
+  sub-count; load only by design)
+* skill_x = 1 − Σ(mae_d·n_d) / Σ(mae_x_d·n_d), summed ONLY over days whose
+  baseline MAE exists — a day with a NULL baseline drops out of the skill
+  RATIO only, never out of the headline mae. skill > 0 = the published
+  forecast beat the naive baseline; NULL when no day carries the baseline.
+
+Conventions (matching backend/routes/quality.py, the freshest v1 precedent):
+* every handler is `def`, never `async def` — sync-DB routes must run in
+  Starlette's threadpool (repo rule, PR #116);
+* the shared v1 per-IP budget applies (`_rate_limit` from routes/api_v1);
+* /ranking is zone-independent and the heaviest read here → computed once per
+  ~15 min per window (api_guard.cached_value) behind heavy_query_guard, with
+  the freshness triple stamped per REQUEST (a warm cache must not freeze
+  age_days); /profile scans the hourly store on-read → heavy-guarded too;
+* every response carries `as_of`/`age_days`/`stale`; the stale window is the
+  `forecast_scoreboard` freshness spec's (collectors/freshness.py::SPECS),
+  looked up by key so retuning the spec retunes these endpoints;
+* unknown zone/series → HTTP 400 listing the valid values; window/days ranges
+  via Query(ge=, le=) → 422; a valid-but-empty combination is HTTP 200 with
+  `available: false`, never a 404;
+* timestamps on the wire are ISO 8601 UTC; hour-of-day buckets are UTC.
+"""
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from backend.api_guard import cached_value, heavy_query_guard
+from backend.collectors.freshness import SPECS, freshness_meta
+from backend.database import get_db
+from backend.models.energy import ForecastScoreDaily, InstalledCapacity
+from backend.power.forecast_score import FORECAST_PAIRS, score_hours
+from backend.power.hourly_store import read_hourly
+from backend.power.zones import POWER_ZONES
+from backend.routes.api_v1 import _rate_limit  # same v1 per-IP budget — scoreboard IS v1 traffic
+
+router = APIRouter(prefix="/api/v1/scoreboard", tags=["v1"])
+
+#: /summary trailing windows (UTC days) — short / season / year.
+SUMMARY_WINDOW_DAYS = (30, 90, 365)
+
+#: /ranking accepts exactly the summary windows — an enum, not a range, so an
+#: unsupported value is a 400 listing the valid ones (house style for
+#: enumerated params; free ranges get Query(ge=, le=) → 422 instead).
+RANKING_WINDOW_DAYS = (30, 90, 365)
+
+#: /ranking is one all-zones × all-series scan — computed once per window and
+#: served from the keyed TTL cache for 15 min (quality-summary precedent; the
+#: nightly scorer is the only writer, so even 15 min is generous).
+RANKING_TTL_S = 900.0
+
+#: A68 capacity labels backing the capacity-normalized MAE (installed_capacity
+#: stores the READABLE labels from PSR_LABELS — B18/B19/B16 arrive translated).
+WIND_CAPACITY_LABELS = ("Wind Onshore", "Wind Offshore")
+SOLAR_CAPACITY_LABELS = ("Solar",)
+
+#: The wire statement of the bias sign — consumer-facing, attached to every
+#: response that serves a bias (summary, monthly, profile).
+BIAS_CONVENTION = (
+    "bias = mean(forecast - actual) in MW: positive means ENTSO-E's published "
+    "forecast leaned HIGH. NOTE: the older /api/power/forecast-error endpoint "
+    "reports the OPPOSITE sign (bias_mw = mean(actual - forecast))."
+)
+
+#: Stale window for every scoreboard endpoint — the forecast_scoreboard
+#: freshness spec's own max age, looked up by key so spec and API never drift.
+_SCOREBOARD_MAX_AGE_DAYS = int(
+    next(s for s in SPECS if s.key == "forecast_scoreboard").max_age.total_seconds() // 86400
+)
+
+_DAY_S = 86400
+_SERIES_KEYS = tuple(FORECAST_PAIRS)  # load, residual, wind, solar — engine order
+
+
+# ─── shared helpers ───────────────────────────────────────────────────────────
+
+
+def _require_zone(zone: str) -> None:
+    if zone not in POWER_ZONES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown zone {zone!r}. Valid zones: {', '.join(POWER_ZONES)}.",
+        )
+
+
+def _require_series(series: str) -> None:
+    if series not in FORECAST_PAIRS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown scoreboard series {series!r}. Valid: {', '.join(_SERIES_KEYS)}.",
+        )
+
+
+def _aggregate(rows: list[ForecastScoreDaily]) -> dict | None:
+    """Day-weighted aggregate over daily score rows (module docstring math).
+    Raw, unrounded floats — rounding happens once at the response edge. None
+    when no usable row (a row without mae/n_hours is defensive-skipped; the
+    engine never writes one)."""
+    n_total = 0
+    days = 0
+    mae_sum = rmse2_sum = bias_sum = 0.0
+    mape_sum = 0.0
+    mape_n = 0
+    sp_mae = sp_base = 0.0  # persistence-skill numerator/denominator sums
+    ss_mae = ss_base = 0.0  # seasonal-skill sums
+    for r in rows:
+        if r.mae is None or not r.n_hours or r.n_hours <= 0:
+            continue
+        n = r.n_hours
+        days += 1
+        n_total += n
+        mae_sum += r.mae * n
+        bias_sum += (r.bias or 0.0) * n
+        rmse2_sum += (r.rmse or 0.0) ** 2 * n
+        if r.mape is not None:
+            mape_sum += r.mape * n
+            mape_n += n
+        if r.mae_persistence is not None:
+            sp_mae += r.mae * n
+            sp_base += r.mae_persistence * n
+        if r.mae_seasonal is not None:
+            ss_mae += r.mae * n
+            ss_base += r.mae_seasonal * n
+    if days == 0:
+        return None
+    return {
+        "days": days,
+        "n_hours": n_total,
+        "mae": mae_sum / n_total,
+        "rmse": math.sqrt(rmse2_sum / n_total),
+        "bias": bias_sum / n_total,
+        "mape": (mape_sum / mape_n) if mape_n else None,
+        "skill_persistence": (1.0 - sp_mae / sp_base) if sp_base > 0 else None,
+        "skill_seasonal": (1.0 - ss_mae / ss_base) if ss_base > 0 else None,
+    }
+
+
+def _rounded_metrics(agg: dict) -> dict:
+    """The shared metric block, rounded for the wire: MW to 0.1, mape to 0.01
+    (it is a %), skill to 0.001 (a ratio). `mape` is present for every series
+    and honestly null outside load — a stable schema beats a shape-shifting
+    one. Skips the count keys — callers name those themselves."""
+    r = lambda v, nd: round(v, nd) if v is not None else None  # noqa: E731
+    return {
+        "n_hours": agg["n_hours"],
+        "mae": r(agg["mae"], 1),
+        "rmse": r(agg["rmse"], 1),
+        "bias": r(agg["bias"], 1),
+        "mape": r(agg["mape"], 2),
+        "skill_persistence": r(agg["skill_persistence"], 3),
+        "skill_seasonal": r(agg["skill_seasonal"], 3),
+    }
+
+
+# ─── /summary ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/summary")
+def scoreboard_summary(
+    zone: str = Query(..., description="Bidding zone key, e.g. DE_LU"),
+    db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
+):
+    """One zone's forecast report card: per series (load/residual/wind/solar)
+    the trailing 30/90/365-day aggregates — mae/rmse/bias (+mape for load) and
+    skill vs both naive baselines, day-weighted by n_hours (module docstring).
+    Descriptive: grades ENTSO-E's published forecasts, makes none.
+
+    Cheap by construction (≤365 days × 4 series of indexed daily rows for ONE
+    zone) — rate-limited only, no heavy slot."""
+    _require_zone(zone)
+    today = datetime.now(UTC).date()
+    cuts = {w: (today - timedelta(days=w)).isoformat() for w in SUMMARY_WINDOW_DAYS}
+    longest = cuts[max(SUMMARY_WINDOW_DAYS)]
+
+    rows = (
+        db.query(ForecastScoreDaily)
+        .filter(ForecastScoreDaily.zone == zone, ForecastScoreDaily.date >= longest)
+        .all()
+    )
+    per_series: dict[str, dict[int, list[ForecastScoreDaily]]] = {}
+    for r in rows:
+        if r.series not in FORECAST_PAIRS:
+            continue  # config drift — not part of the pair table
+        buckets = per_series.setdefault(r.series, {w: [] for w in SUMMARY_WINDOW_DAYS})
+        for w in SUMMARY_WINDOW_DAYS:
+            if r.date >= cuts[w]:
+                buckets[w].append(r)
+
+    series_out = []
+    for name in _SERIES_KEYS:  # engine order — deterministic
+        buckets = per_series.get(name)
+        if buckets is None:
+            continue  # zone doesn't carry this pair — omit (quality precedent)
+        windows = {}
+        for w in SUMMARY_WINDOW_DAYS:
+            agg = _aggregate(buckets[w])
+            windows[f"{w}d"] = (
+                {"days_covered": agg["days"], **_rounded_metrics(agg)} if agg else None
+            )
+        series_out.append({"series": name, "windows": windows})
+
+    # as_of = the zone's newest scored day on record (indexed point lookup) —
+    # deliberately NOT bounded by the 365d scan, so an anciently-stale zone
+    # still reports WHEN it was last scored instead of a blank.
+    latest = (
+        db.query(func.max(ForecastScoreDaily.date))
+        .filter(ForecastScoreDaily.zone == zone)
+        .scalar()
+    )
+    return {
+        "available": bool(series_out),
+        "zone": zone,
+        "series": series_out,
+        "series_keys": list(_SERIES_KEYS),
+        "windows_days": list(SUMMARY_WINDOW_DAYS),
+        "bias_convention": BIAS_CONVENTION,
+        "note": (
+            "Grades ENTSO-E's own published D-1 forecasts against its published "
+            "actuals — OBSYD forecasts nothing. Aggregates are day-weighted by "
+            "n_hours (exact per-hour window means; rmse recombined quadratically). "
+            "skill_x = 1 - mae/mae_baseline vs persistence (actual 24h ago) and "
+            "seasonal (actual 168h ago); days without the baseline drop out of the "
+            "skill ratio only. mape is load-only by design (wind/solar hit honest "
+            "zeros, residual crosses zero)."
+        ),
+        **freshness_meta(latest, today, _SCOREBOARD_MAX_AGE_DAYS),
+    }
+
+
+# ─── /ranking ─────────────────────────────────────────────────────────────────
+
+
+def _latest_capacity(db: Session) -> dict[tuple[str, str], float]:
+    """(zone, psr label) → A68 capacity_mw at that zone+label's own latest year.
+    One small scan of the annual reference table (37 zones × 3 labels × a few
+    years), reduced in Python — never a per-zone point query."""
+    labels = WIND_CAPACITY_LABELS + SOLAR_CAPACITY_LABELS
+    best: dict[tuple[str, str], tuple[int, float]] = {}
+    for zone, psr, year, cap in (
+        db.query(
+            InstalledCapacity.zone,
+            InstalledCapacity.psr_type,
+            InstalledCapacity.year,
+            InstalledCapacity.capacity_mw,
+        )
+        .filter(InstalledCapacity.psr_type.in_(labels))
+        .all()
+    ):
+        k = (zone, psr)
+        if k not in best or year > best[k][0]:
+            best[k] = (year, cap)
+    return {k: cap for k, (_, cap) in best.items()}
+
+
+def _ranking_payload(db: Session, window: int) -> dict:
+    """The full enabled-zones ranking for one window — one daily-table scan plus
+    one capacity scan, grouped in Python. Cached per window via cached_value;
+    freshness stamps ride each REQUEST, outside the cache."""
+    today = datetime.now(UTC).date()
+    cut = (today - timedelta(days=window)).isoformat()
+    rows = db.query(ForecastScoreDaily).filter(ForecastScoreDaily.date >= cut).all()
+
+    cells: dict[tuple[str, str], list[ForecastScoreDaily]] = {}
+    for r in rows:
+        if r.zone in POWER_ZONES and r.series in FORECAST_PAIRS:
+            cells.setdefault((r.zone, r.series), []).append(r)
+
+    caps = _latest_capacity(db)
+    metric_of = {"load": "mape", "wind": "nmae_pct", "solar": "nmae_pct", "residual": "mae"}
+    series_out: dict[str, dict] = {}
+    any_ranked = False
+
+    for name in _SERIES_KEYS:
+        entries: list[dict] = []
+        for zone in POWER_ZONES:  # registry order in, metric order out
+            agg = _aggregate(cells.get((zone, name), []))
+            if agg is None:
+                continue  # zone never scored for this pair — nothing to rank
+            entry = {
+                "zone": zone,
+                "days_covered": agg["days"],
+                "n_hours": agg["n_hours"],
+                "mae": round(agg["mae"], 1),
+            }
+            if name == "load":
+                entry["mape"] = round(agg["mape"], 2) if agg["mape"] is not None else None
+                entry["_metric"] = agg["mape"]
+            elif name in ("wind", "solar"):
+                labels = WIND_CAPACITY_LABELS if name == "wind" else SOLAR_CAPACITY_LABELS
+                cap = sum(caps.get((zone, lb), 0.0) for lb in labels)
+                if cap > 0:
+                    entry["capacity_mw"] = round(cap, 1)
+                    entry["nmae_pct"] = round(100.0 * agg["mae"] / cap, 2)
+                    entry["_metric"] = agg["mae"] / cap
+                else:
+                    # LISTED, never silently hidden — the absolute MAE is still
+                    # honest, only the cross-zone normalization is impossible.
+                    entry["capacity_mw"] = None
+                    entry["nmae_pct"] = None
+                    entry["_metric"] = None
+                    entry["signposted"] = (
+                        f"no A68 capacity data for {name} in this zone - "
+                        "nMAE not computable, absolute mae shown unranked"
+                    )
+            else:  # residual — plain MW, caveated below
+                entry["_metric"] = agg["mae"]
+            entries.append(entry)
+
+        ranked = sorted((e for e in entries if e["_metric"] is not None),
+                        key=lambda e: e["_metric"])
+        unranked = sorted((e for e in entries if e["_metric"] is None),
+                          key=lambda e: e["zone"])
+        for i, e in enumerate(ranked, start=1):
+            e["rank"] = i
+        for e in unranked:
+            e["rank"] = None
+        for e in entries:
+            e.pop("_metric")
+        any_ranked = any_ranked or bool(entries)
+        block = {"metric": metric_of[name], "ranking": ranked + unranked}
+        if name == "residual":
+            block["caveat"] = (
+                "mae is absolute MW — zones of different size are not comparable "
+                "on it; the ordering is orientation, not a fair cross-zone grade"
+            )
+        series_out[name] = block
+
+    latest = db.query(func.max(ForecastScoreDaily.date)).scalar()
+    return {
+        "available": any_ranked,
+        "window_days": window,
+        "series": series_out,
+        "as_of": latest,
+        "note": (
+            "Grades ENTSO-E's own published D-1 forecasts — OBSYD forecasts nothing. "
+            "Comparable metrics per series: load by MAPE (%); wind/solar by nMAE "
+            "(100 x window MAE / A68 installed capacity of the matching technology, "
+            "each zone+type at its own latest A68 year; wind = onshore + offshore); "
+            "residual by absolute MAE (see caveat). Lower = better; rank 1 = the "
+            "forecast the actuals stayed closest to. Aggregation is day-weighted "
+            "by n_hours, as on /scoreboard/summary."
+        ),
+    }
+
+
+@router.get("/ranking")
+def scoreboard_ranking(
+    window: int = Query(90, description=f"Trailing window in days ({', '.join(map(str, RANKING_WINDOW_DAYS))})"),
+    db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
+    _g: None = Depends(heavy_query_guard),
+):
+    """All enabled zones ranked per series by the comparable metric — which
+    zone's published forecast the actuals stayed closest to. Zones without the
+    A68 capacity a normalization needs are listed unranked with an explicit
+    signpost, never hidden. Descriptive throughout.
+
+    Zone-independent and the heaviest scoreboard read → one compute per window
+    per ~15 min (cached_value) behind heavy_query_guard; freshness is stamped
+    per request so a warm cache can't freeze age_days. The cached dict is never
+    mutated — the response is rebuilt around it."""
+    if window not in RANKING_WINDOW_DAYS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported window {window}. Valid windows (days): "
+                f"{', '.join(map(str, RANKING_WINDOW_DAYS))}."
+            ),
+        )
+    data = cached_value(
+        f"scoreboard_ranking_{window}",
+        lambda: _ranking_payload(db, window),
+        ttl=RANKING_TTL_S,
+    )
+    return {
+        **data,
+        **freshness_meta(data.get("as_of"), datetime.now(UTC).date(), _SCOREBOARD_MAX_AGE_DAYS),
+    }
+
+
+# ─── /monthly ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/monthly")
+def scoreboard_monthly(
+    zone: str = Query(..., description="Bidding zone key, e.g. DE_LU"),
+    series: str = Query(..., description=f"Scoreboard series ({', '.join(_SERIES_KEYS)})"),
+    db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
+):
+    """Calendar-month aggregates (UTC months) for ONE zone+series over the full
+    scored history, oldest first — has the published forecast been getting
+    better or worse? Same day-weighted aggregation and skill definitions as
+    /summary (module docstring).
+
+    Cheap by construction (one zone-indexed scan of a daily table; the output
+    is months × one series) — rate-limited only, no heavy slot."""
+    _require_zone(zone)
+    _require_series(series)
+
+    rows = (
+        db.query(ForecastScoreDaily)
+        .filter(ForecastScoreDaily.zone == zone, ForecastScoreDaily.series == series)
+        .order_by(ForecastScoreDaily.date.asc())
+        .all()
+    )
+    months: dict[str, list[ForecastScoreDaily]] = {}
+    for r in rows:
+        months.setdefault(r.date[:7], []).append(r)  # "YYYY-MM" — UTC calendar month
+
+    data = []
+    for month in sorted(months):
+        agg = _aggregate(months[month])
+        if agg is None:
+            continue
+        data.append({"month": month, "days": agg["days"], **_rounded_metrics(agg)})
+
+    latest = rows[-1].date if rows else None
+    return {
+        "available": bool(data),
+        "zone": zone,
+        "series": series,
+        "data": data,
+        "bias_convention": BIAS_CONVENTION,
+        "note": (
+            "Grades ENTSO-E's own published D-1 forecasts — OBSYD forecasts "
+            "nothing. Months are UTC calendar months, oldest first; aggregation "
+            "is day-weighted by n_hours as on /scoreboard/summary; mape is "
+            "load-only by design."
+        ),
+        **freshness_meta(latest, datetime.now(UTC).date(), _SCOREBOARD_MAX_AGE_DAYS),
+    }
+
+
+# ─── /profile ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/profile")
+def scoreboard_profile(
+    zone: str = Query(..., description="Bidding zone key, e.g. DE_LU"),
+    series: str = Query(..., description=f"Scoreboard series ({', '.join(_SERIES_KEYS)})"),
+    window: int = Query(90, ge=1, le=365, description="Trailing window (UTC days)"),
+    db: Session = Depends(get_db),
+    _rl: None = Depends(_rate_limit),
+    _g: None = Depends(heavy_query_guard),
+):
+    """Forecast error by hour-of-day (0–23 UTC) for ONE zone+series: per bucket
+    the mean absolute error, mean bias and n over the trailing window — does the
+    published forecast miss the morning ramp, the evening peak, the solar noon?
+    Buckets are UTC hours: a zone's local-time pattern appears shifted by its
+    offset. Descriptive: grades ENTSO-E's published forecast, makes none.
+
+    The daily table stores no hourly residuals, so this is computed on-read from
+    the canonical hourly store through the ENGINE's own pieces — FORECAST_PAIRS
+    for the pair alignment (wind's actual = gen.B18+gen.B19 summed, exactly as
+    the nightly scorer does) and score_hours per bucket, so route and scoreboard
+    can never grade different series. Up to a year of hourly rows per side →
+    heavy-guarded; the window cap is the 422-checked Query bound."""
+    _require_zone(zone)
+    _require_series(series)
+
+    now = datetime.now(UTC)
+    end_ts = int(now.timestamp())
+    start_ts = end_ts - window * _DAY_S
+
+    fc_key, actual_keys = FORECAST_PAIRS[series]
+    forecast = dict(read_hourly(db, fc_key, zone, start_ts, end_ts))
+    actual: dict[int, float] = {}
+    for key in actual_keys:
+        for t, v in read_hourly(db, key, zone, start_ts, end_ts):
+            actual[t] = actual.get(t, 0.0) + v
+
+    buckets: dict[int, list[int]] = {}
+    for t in forecast:
+        if t in actual:
+            buckets.setdefault((t % _DAY_S) // 3600, []).append(t)
+
+    hours_out = []
+    newest = None
+    if buckets:
+        newest = max(t for ts in buckets.values() for t in ts)
+        for h in range(24):
+            m = score_hours(forecast, actual, sorted(buckets.get(h, [])))
+            hours_out.append(
+                {
+                    "hour_utc": h,
+                    "n": m["n_hours"] if m else 0,
+                    "mae": round(m["mae"], 1) if m else None,
+                    "bias": round(m["bias"], 1) if m else None,
+                }
+            )
+
+    return {
+        "available": bool(buckets),
+        "zone": zone,
+        "series": series,
+        "window_days": window,
+        "hours": hours_out,
+        "bias_convention": BIAS_CONVENTION,
+        "note": (
+            "Grades ENTSO-E's own published D-1 forecast — OBSYD forecasts "
+            "nothing. hour_utc buckets are UTC hours of day (0-23); local-time "
+            "features (morning ramp, solar noon) appear shifted by the zone's "
+            "offset. n = hours where both forecast and actual exist; empty "
+            "buckets carry honest nulls."
+        ),
+        **freshness_meta(
+            datetime.fromtimestamp(newest, UTC).isoformat() if newest is not None else None,
+            now.date(),
+            _SCOREBOARD_MAX_AGE_DAYS,
+        ),
+    }

--- a/backend/routes/scoreboard.py
+++ b/backend/routes/scoreboard.py
@@ -121,11 +121,12 @@ def _require_series(series: str) -> None:
         )
 
 
-def _aggregate(rows: list[ForecastScoreDaily]) -> dict | None:
+def _aggregate(rows) -> dict | None:
     """Day-weighted aggregate over daily score rows (module docstring math).
-    Raw, unrounded floats — rounding happens once at the response edge. None
-    when no usable row (a row without mae/n_hours is defensive-skipped; the
-    engine never writes one)."""
+    Attribute access only, so it takes ORM entities (summary/monthly) and
+    column Row tuples (the ranking scan) alike. Raw, unrounded floats —
+    rounding happens once at the response edge. None when no usable row (a row
+    without mae/n_hours is defensive-skipped; the engine never writes one)."""
     n_total = 0
     days = 0
     mae_sum = rmse2_sum = bias_sum = 0.0
@@ -289,9 +290,28 @@ def _ranking_payload(db: Session, window: int) -> dict:
     freshness stamps ride each REQUEST, outside the cache."""
     today = datetime.now(UTC).date()
     cut = (today - timedelta(days=window)).isoformat()
-    rows = db.query(ForecastScoreDaily).filter(ForecastScoreDaily.date >= cut).all()
+    # Column tuples, not ORM entities: at 365d × 37 zones × 4 series the full
+    # entity hydration is several-fold dearer than Row named tuples, and the
+    # cached compute pays it in one gulp. Attribute names match the model's, so
+    # _aggregate reads them unchanged. THE ranking is 3 fixed SELECTs (score
+    # scan, capacity scan, max-date) — the budget test pins it.
+    rows = (
+        db.query(
+            ForecastScoreDaily.zone,
+            ForecastScoreDaily.series,
+            ForecastScoreDaily.n_hours,
+            ForecastScoreDaily.mae,
+            ForecastScoreDaily.rmse,
+            ForecastScoreDaily.bias,
+            ForecastScoreDaily.mape,
+            ForecastScoreDaily.mae_persistence,
+            ForecastScoreDaily.mae_seasonal,
+        )
+        .filter(ForecastScoreDaily.date >= cut)
+        .all()
+    )
 
-    cells: dict[tuple[str, str], list[ForecastScoreDaily]] = {}
+    cells: dict[tuple[str, str], list] = {}
     for r in rows:
         if r.zone in POWER_ZONES and r.series in FORECAST_PAIRS:
             cells.setdefault((r.zone, r.series), []).append(r)
@@ -316,6 +336,14 @@ def _ranking_payload(db: Session, window: int) -> dict:
             if name == "load":
                 entry["mape"] = round(agg["mape"], 2) if agg["mape"] is not None else None
                 entry["_metric"] = agg["mape"]
+                if agg["mape"] is None:
+                    # Same honesty as the capacity case: LISTED, with the
+                    # reason. The engine stores no MAPE only when every scored
+                    # hour's |actual| sat under its division floor.
+                    entry["signposted"] = (
+                        "MAPE unavailable for this window - "
+                        "not rankable, absolute mae shown unranked"
+                    )
             elif name in ("wind", "solar"):
                 labels = WIND_CAPACITY_LABELS if name == "wind" else SOLAR_CAPACITY_LABELS
                 cap = sum(caps.get((zone, lb), 0.0) for lb in labels)
@@ -398,6 +426,9 @@ def scoreboard_ranking(
                 f"{', '.join(map(str, RANKING_WINDOW_DAYS))}."
             ),
         )
+    # NB: cached_value serializes COLD computes behind api_guard's one shared
+    # _cache_lock (all keys) — a cold ranking briefly gates other cached keys'
+    # cold paths too. api_guard-design follow-on, noted here, not fixed here.
     data = cached_value(
         f"scoreboard_ranking_{window}",
         lambda: _ranking_payload(db, window),

--- a/backend/scripts/quality_backfill.py
+++ b/backend/scripts/quality_backfill.py
@@ -1,0 +1,69 @@
+"""One-time backfill of quality_daily from the canonical hourly store. No API calls.
+
+Computes the Honest-Record data-quality aggregates (completeness + rule-based
+anomaly flags) per (zone, series, day), using the SAME engine the nightly job
+runs (backend/power/quality.py) — backfill and nightly can never disagree.
+Posture B: every flag describes the published data; nothing here predicts.
+
+Each zone is one pass: a handful of indexed range scans over power_hourly
+(the six QUALITY_SERIES read once over the range ±30 days, plus the zone's
+other gen.* series and border flows), bucketed per day in one pass — no
+strftime table scans, no per-day queries (the rederive_daily lesson). Zones
+with no data in the range write nothing; the engine skips quietly, so the same
+command works on a 3-zone dev DB and the 37-zone prod DB. Idempotent: a rerun
+replaces the rows and retracts what the data no longer supports.
+
+    python -m backend.scripts.quality_backfill --start 2024-01-01
+    python -m backend.scripts.quality_backfill --start 2024-01-01 --end 2026-07-31 --zones DE_LU FR
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timedelta, timezone
+
+from backend.database import SessionLocal
+from backend.power.quality import compute_and_store_range
+from backend.power.zones import POWER_ZONES
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger("quality_backfill")
+
+
+def backfill(start: str, end: str, zones: list[str]) -> None:
+    db = SessionLocal()
+    written = removed = 0
+    try:
+        for zone in zones:
+            try:
+                result = compute_and_store_range(db, zone, start, end)
+            except Exception as exc:
+                db.rollback()
+                logger.error("%s FAILED: %s", zone, exc)
+                continue
+            written += result["written"]
+            removed += result["removed"]
+            logger.info("%s: %d rows written, %d retracted", zone, result["written"], result["removed"])
+    finally:
+        db.close()
+    logger.info("done: %d rows written, %d retracted over %d zones (%s..%s)",
+                written, removed, len(zones), start, end)
+
+
+if __name__ == "__main__":
+    # Default end = yesterday UTC: a day that is not over is not a day (rederive_daily's rule),
+    # and the nightly job owns the trailing window from here on anyway.
+    yesterday = (datetime.now(timezone.utc).date() - timedelta(days=1)).isoformat()
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--start", required=True, help="first UTC day, YYYY-MM-DD")
+    ap.add_argument("--end", default=yesterday, help="last UTC day inclusive (default: yesterday UTC)")
+    ap.add_argument("--zones", nargs="*", default=list(POWER_ZONES))
+    args = ap.parse_args()
+    # A typo'd zone must fail loudly, not no-op: the engine skips unknown zones
+    # quietly by design (that is how a 3-zone dev DB runs the 37-zone command),
+    # so `--zones DELU` would otherwise "succeed" with 0 rows written.
+    unknown = [z for z in args.zones if z not in POWER_ZONES]
+    if unknown:
+        ap.error(f"unknown zone(s): {', '.join(unknown)} — enabled zones: {', '.join(POWER_ZONES)}")
+    backfill(args.start, args.end, args.zones)

--- a/backend/scripts/scoreboard_backfill.py
+++ b/backend/scripts/scoreboard_backfill.py
@@ -1,0 +1,62 @@
+"""One-time backfill of forecast_score_daily from the canonical hourly store. No API calls.
+
+Scores ENTSO-E's published day-ahead forecasts against the published actuals,
+per (zone, series, day), using the SAME engine the nightly job runs
+(backend/power/forecast_score.py) — backfill and nightly can never disagree.
+Posture B: this grades the TSOs' own forecasts; OBSYD forecasts nothing.
+
+Each zone is one pass: 9 indexed range scans over power_hourly (4 forecast +
+5 actual series, resolved by dim id) scored day by day, one commit per zone —
+no strftime table scans, no per-day queries (the rederive_daily lesson). Zones
+with no data in the range write nothing; the engine skips quietly, so the same
+command works on a 3-zone dev DB and the 37-zone prod DB. Idempotent: a rerun
+replaces the rows.
+
+    python -m backend.scripts.scoreboard_backfill --start 2024-01-01
+    python -m backend.scripts.scoreboard_backfill --start 2024-01-01 --end 2026-07-31 --zones DE_LU FR
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timedelta, timezone
+
+from backend.database import SessionLocal
+from backend.power.forecast_score import compute_and_store_range
+from backend.power.zones import POWER_ZONES
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger("scoreboard_backfill")
+
+
+def backfill(start: str, end: str, zones: list[str]) -> None:
+    db = SessionLocal()
+    written = removed = 0
+    try:
+        for zone in zones:
+            try:
+                result = compute_and_store_range(db, zone, start, end)
+            except Exception as exc:
+                db.rollback()
+                logger.error("%s FAILED: %s", zone, exc)
+                continue
+            written += result["written"]
+            removed += result["removed"]
+            logger.info("%s: %d rows written, %d retracted", zone, result["written"], result["removed"])
+    finally:
+        db.close()
+    logger.info("done: %d rows written, %d retracted over %d zones (%s..%s)",
+                written, removed, len(zones), start, end)
+
+
+if __name__ == "__main__":
+    # Default end = yesterday UTC: a day that is not over is not a day (rederive_daily's rule),
+    # and the nightly job owns the trailing window from here on anyway.
+    yesterday = (datetime.now(timezone.utc).date() - timedelta(days=1)).isoformat()
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--start", required=True, help="first UTC day, YYYY-MM-DD")
+    ap.add_argument("--end", default=yesterday, help="last UTC day inclusive (default: yesterday UTC)")
+    ap.add_argument("--zones", nargs="*", default=list(POWER_ZONES))
+    args = ap.parse_args()
+    backfill(args.start, args.end, args.zones)

--- a/backend/scripts/scoreboard_backfill.py
+++ b/backend/scripts/scoreboard_backfill.py
@@ -59,4 +59,10 @@ if __name__ == "__main__":
     ap.add_argument("--end", default=yesterday, help="last UTC day inclusive (default: yesterday UTC)")
     ap.add_argument("--zones", nargs="*", default=list(POWER_ZONES))
     args = ap.parse_args()
+    # A typo'd zone must fail loudly, not no-op: the engine skips unknown zones
+    # quietly by design (that is how a 3-zone dev DB runs the 37-zone command),
+    # so `--zones DELU` would otherwise "succeed" with 0 rows written.
+    unknown = [z for z in args.zones if z not in POWER_ZONES]
+    if unknown:
+        ap.error(f"unknown zone(s): {', '.join(unknown)} — enabled zones: {', '.join(POWER_ZONES)}")
     backfill(args.start, args.end, args.zones)

--- a/backend/signals/detectors/__init__.py
+++ b/backend/signals/detectors/__init__.py
@@ -36,6 +36,10 @@ from backend.signals.detectors.power import (
     detect_price_spikes,
     detect_record_breaks,
 )
+from backend.signals.detectors.quality import (
+    detect_completeness_drops,
+    detect_major_restatements,
+)
 from backend.signals.rules import _upsert_alert
 
 logger = logging.getLogger(__name__)
@@ -47,7 +51,9 @@ logger = logging.getLogger(__name__)
 # Extended 2026-07-12 with the depth-roadmap data: imbalance peaks, day-ahead
 # spikes (both tails), hydro vs seasonal band, fresh all-time records.
 # Extended 2026-07-28 with interconnector saturation (flow at the day-ahead NTC,
-# A61 — NTC-allocated borders only).
+# A61 — NTC-allocated borders only). Extended with the Honest Record's own
+# incidents (slice A4): completeness drops + major restatements from the
+# quality_daily / power_revision transparency tables (detectors/quality.py).
 DETECTORS = [
     detect_gas_balance,
     detect_negative_prices,
@@ -59,6 +65,8 @@ DETECTORS = [
     detect_record_breaks,
     detect_episode_rank,
     detect_interconnector_saturation,
+    detect_completeness_drops,
+    detect_major_restatements,
 ]
 
 

--- a/backend/signals/detectors/quality.py
+++ b/backend/signals/detectors/quality.py
@@ -1,0 +1,293 @@
+"""Data-quality incidents on the anomaly radar — Honest Record slice A4.
+
+The A1/A2 transparency tables (revision ledger, nightly quality aggregates)
+record what the source published; these two detectors surface the days that
+record turns NEWSWORTHY, on the same Alert backbone as every other radar rule —
+zero extra delivery code, same feed, same RSS.
+
+* ``quality_completeness_drop`` — yesterday (the newest finished UTC day) a
+  charter series' published hours collapsed below half, in a zone+series that
+  is normally near-complete. The trailing norm is the guard rail twice over: a
+  chronically thin series is not news, and a freshly deployed / newly enabled
+  zone has no norm yet, so the detector stays silent instead of judging a day
+  against a handful of rows.
+* ``quality_major_restatement`` — the source re-published materially different
+  values for several SETTLED hours of one series within the last 24 h. "Settled"
+  reuses the read-side maturity threshold of /api/v1/quality/revisions
+  (REVISION_MATURITY_S, routes/quality.py): restatements inside the routine
+  provisional fill-in window are not events.
+
+Sibling contract (base.py): DB reads only, cheap enough for the 5-minute
+runner, template text, descriptive never predictive — a low-completeness day
+is hours the source has not (yet) published, a restatement is the source
+revising its own publication; neither says "wrong data" and neither judges the
+market. Both rules FOLD multiple offending series of one zone into a single
+result (worst offender leads the title, every one is named in the detail) —
+the alert backbone dedups on (rule, zone), so per-series results would
+overwrite each other and a warning could mask a critical (the
+interconnector_saturated precedent).
+"""
+
+from __future__ import annotations
+
+import statistics
+from datetime import datetime, timedelta, timezone
+
+from backend.models.energy import PowerRevision, QualityDaily, SeriesDim, ZoneDim
+from backend.power.quality import QUALITY_SERIES
+from backend.power.zones import POWER_ZONES
+from backend.signals.detectors.base import MIN_BASELINE_N, DetectorResult
+
+# ── quality_completeness_drop ─────────────────────────────────────────────────
+#: Yesterday's hours_present/hours_expected below this → a drop worth a look.
+COMPLETENESS_DROP_RATIO = 0.5
+#: … but only where the zone+series is NORMALLY near-complete: trailing mean
+#: completeness (days with quality rows, yesterday excluded) must clear this.
+COMPLETENESS_NORM_MIN = 0.9
+#: Trailing window for that norm, and the minimum days-with-rows before the
+#: norm is trustworthy (MIN_BASELINE_N — the radar's shared "no baseline, no
+#: judgement" floor; this is what keeps the first days after deploy quiet).
+COMPLETENESS_NORM_DAYS = 30
+COMPLETENESS_MIN_NORM_DAYS = MIN_BASELINE_N
+
+
+def detect_completeness_drops(db) -> list[DetectorResult]:
+    """Zones where a normally-complete charter series lost most of yesterday.
+
+    Judges only YESTERDAY (UTC) — today is partial by construction while the
+    day runs. A missing yesterday row is silence, not a drop: either the
+    nightly quality job has not covered the day yet or the series is inactive
+    there, and absence is never turned into a claim (no data → no alert).
+    """
+    yesterday = datetime.now(timezone.utc).date() - timedelta(days=1)
+    y_iso = yesterday.isoformat()
+    cut = (yesterday - timedelta(days=COMPLETENESS_NORM_DAYS)).isoformat()
+
+    # One indexed date-range scan for all zones; QUALITY_SERIES is the charter
+    # list and never contains the reserved "_zone" pseudo-series (its rows carry
+    # hours_expected == 0 and describe zone-level flags, not completeness).
+    rows = (
+        db.query(
+            QualityDaily.zone,
+            QualityDaily.series_key,
+            QualityDaily.date,
+            QualityDaily.hours_present,
+            QualityDaily.hours_expected,
+        )
+        .filter(
+            QualityDaily.date >= cut,
+            QualityDaily.date <= y_iso,
+            QualityDaily.series_key.in_(QUALITY_SERIES),
+        )
+        .all()
+    )
+
+    cells: dict[tuple[str, str], dict] = {}
+    for zone, skey, day, present, expected in rows:
+        if zone not in POWER_ZONES or expected <= 0:
+            continue  # disabled zone (radar speaks only about served zones)
+        c = cells.setdefault((zone, skey), {"today": None, "norm": []})
+        if day == y_iso:
+            c["today"] = (present, expected)
+        else:
+            c["norm"].append(present / expected)
+
+    by_zone: dict[str, list[dict]] = {}
+    for (zone, skey), c in cells.items():
+        if c["today"] is None:
+            continue
+        present, expected = c["today"]
+        if present / expected >= COMPLETENESS_DROP_RATIO:
+            continue
+        norm = c["norm"]
+        if len(norm) < COMPLETENESS_MIN_NORM_DAYS:
+            continue  # no trustworthy norm yet (fresh deploy / new zone)
+        norm_mean = sum(norm) / len(norm)
+        if norm_mean < COMPLETENESS_NORM_MIN:
+            continue  # chronically thin series — its gaps are not news
+        by_zone.setdefault(zone, []).append({
+            "series": skey,
+            "present": present,
+            "expected": expected,
+            "norm_pct": 100.0 * norm_mean,
+        })
+
+    results: list[DetectorResult] = []
+    for zone, entries in sorted(by_zone.items()):
+        # Worst first: fully-missing series lead, then the lowest ratio.
+        entries.sort(key=lambda e: (e["present"] > 0, e["present"] / e["expected"]))
+        worst = entries[0]
+        parts = [
+            f"{e['series']}: {e['present']} of {e['expected']} expected hours "
+            f"on {y_iso} vs a {e['norm_pct']:.0f}% {COMPLETENESS_NORM_DAYS}-day norm"
+            for e in entries
+        ]
+        results.append(
+            DetectorResult(
+                rule="quality_completeness_drop",
+                zone=zone,
+                vertical="power",
+                severity=(
+                    "critical" if any(e["present"] == 0 for e in entries) else "warning"
+                ),
+                title=(
+                    f"{zone}: {worst['series']} — source published "
+                    f"{worst['present']} of {worst['expected']} expected hours"
+                    + (f" (+{len(entries) - 1} more series)" if len(entries) > 1 else "")
+                ),
+                detail=(
+                    "; ".join(parts) + ". Completeness describes the published "
+                    "record for the day — the hours may still arrive with the "
+                    "source's later publications. Descriptive, not a verdict."
+                ),
+                as_of=y_iso,
+            )
+        )
+    return results
+
+
+# ── quality_major_restatement ─────────────────────────────────────────────────
+#: Radar window: restatements OBSERVED within the last 24 h (the feed reports
+#: what changed recently; the full history lives in /api/v1/quality/revisions).
+RESTATE_WINDOW_S = 24 * 3600
+#: An hour counts when |new − old| / max(|old|, floor) exceeds this fraction.
+RESTATE_MIN_FRACTION = 0.20
+#: The floor keeps a previous value near zero (a price crossing 0) from
+#: manufacturing an unbounded percentage; 1.0 in the series' own unit.
+RESTATE_DENOM_FLOOR = 1.0
+#: ≥3 distinct hours of ONE series → warning; ≥12 hours or a ≥50% median
+#: change → critical.
+RESTATE_MIN_HOURS = 3
+RESTATE_CRIT_HOURS = 12
+RESTATE_CRIT_MEDIAN_PCT = 50.0
+
+
+def _recent_revisions(db, cutoff_epoch: int) -> list:
+    """The ledger rows observed at/after `cutoff_epoch`, WITHOUT scanning the
+    (never-pruned) ledger: power_revision is append-only and `observed_at` is
+    the write-time wall clock, so it is nondecreasing in the autoincrement PK.
+    Walking the PK tail backwards and stopping at the first row older than the
+    cutoff reads O(recent rows).
+
+    Why not the (series_id, zone_id, observed_at) index the API reads ride:
+    observed_at is its THIRD column, so it only seeks for a KNOWN series+zone
+    pair (routes/quality.py always has one). This detector cuts across ALL
+    pairs, and a bare observed_at filter would scan the whole table on every
+    5-minute run — the PK tail is the one access path that makes "recent
+    first" cheap without enumerating hundreds of candidate pairs. yield_per
+    keeps the walk streaming (without it the ORM would buffer the full result
+    before the first row)."""
+    out = []
+    q = (
+        db.query(
+            PowerRevision.series_id,
+            PowerRevision.zone_id,
+            PowerRevision.ts_utc,
+            PowerRevision.old_value,
+            PowerRevision.new_value,
+            PowerRevision.observed_at,
+        )
+        .order_by(PowerRevision.id.desc())
+        .yield_per(1000)
+    )
+    for row in q:
+        if row.observed_at < cutoff_epoch:
+            break
+        out.append(row)
+    return out
+
+
+def detect_major_restatements(db) -> list[DetectorResult]:
+    """Zones where the source restated several settled hours of one series in
+    the last 24 h. Distinct hours, not revision rows — an hour revised twice in
+    the window is one restated hour, at its largest observed change."""
+    # Read-side maturity threshold shared with /api/v1/quality/revisions —
+    # imported at call time (the sibling-precedent for routes imports,
+    # detect_hydro_deviations) so the detector module never pulls the FastAPI
+    # router stack in at import time.
+    from backend.routes.quality import REVISION_MATURITY_S
+
+    now = int(datetime.now(timezone.utc).timestamp())
+    recent = _recent_revisions(db, now - RESTATE_WINDOW_S)
+    if not recent:
+        return []
+
+    sid_key = dict(
+        db.query(SeriesDim.id, SeriesDim.key)
+        .filter(SeriesDim.id.in_({r.series_id for r in recent}))
+        .all()
+    )
+    zid_key = dict(
+        db.query(ZoneDim.id, ZoneDim.key)
+        .filter(ZoneDim.id.in_({r.zone_id for r in recent}))
+        .all()
+    )
+
+    # (zone, series) → {hour ts → largest change fraction}; plus the newest
+    # observation per pair for the as_of stamp.
+    hours: dict[tuple[str, str], dict[int, float]] = {}
+    seen_at: dict[tuple[str, str], int] = {}
+    for r in recent:
+        if r.observed_at - r.ts_utc <= REVISION_MATURITY_S:
+            continue  # routine provisional fill-in, not a restatement of settled data
+        zone, skey = zid_key.get(r.zone_id), sid_key.get(r.series_id)
+        if zone is None or skey is None or zone not in POWER_ZONES:
+            continue
+        frac = abs(r.new_value - r.old_value) / max(abs(r.old_value), RESTATE_DENOM_FLOOR)
+        if frac <= RESTATE_MIN_FRACTION:
+            continue
+        pair = (zone, skey)
+        per_hour = hours.setdefault(pair, {})
+        per_hour[r.ts_utc] = max(per_hour.get(r.ts_utc, 0.0), frac)
+        seen_at[pair] = max(seen_at.get(pair, 0), r.observed_at)
+
+    by_zone: dict[str, list[dict]] = {}
+    for (zone, skey), per_hour in hours.items():
+        if len(per_hour) < RESTATE_MIN_HOURS:
+            continue
+        pcts = [100.0 * f for f in per_hour.values()]
+        median = statistics.median(pcts)
+        by_zone.setdefault(zone, []).append({
+            "series": skey,
+            "n_hours": len(per_hour),
+            "median_pct": median,
+            "largest_pct": max(pcts),
+            "critical": len(per_hour) >= RESTATE_CRIT_HOURS
+            or median >= RESTATE_CRIT_MEDIAN_PCT,
+            "observed_at": seen_at[(zone, skey)],
+        })
+
+    results: list[DetectorResult] = []
+    for zone, entries in sorted(by_zone.items()):
+        entries.sort(
+            key=lambda e: (e["critical"], e["n_hours"], e["median_pct"]), reverse=True
+        )
+        worst = entries[0]
+        newest = max(e["observed_at"] for e in entries)
+        parts = [
+            f"{e['n_hours']} hours of {e['series']} restated by a median of "
+            f"{e['median_pct']:.0f}% (largest {e['largest_pct']:.0f}%)"
+            for e in entries
+        ]
+        results.append(
+            DetectorResult(
+                rule="quality_major_restatement",
+                zone=zone,
+                vertical="power",
+                severity="critical" if any(e["critical"] for e in entries) else "warning",
+                title=(
+                    f"{zone}: {worst['n_hours']} settled hours of {worst['series']} "
+                    f"restated (median {worst['median_pct']:.0f}%)"
+                    + (f" (+{len(entries) - 1} more series)" if len(entries) > 1 else "")
+                ),
+                detail=(
+                    "The source re-published different values for hours settled "
+                    "more than 48 h earlier, observed in the last 24 h: "
+                    + "; ".join(parts)
+                    + ". A restatement is the source revising its own "
+                    "publication — described here, not judged."
+                ),
+                as_of=datetime.fromtimestamp(newest, tz=timezone.utc).strftime("%Y-%m-%d"),
+            )
+        )
+    return results

--- a/backend/signals/detectors/quality.py
+++ b/backend/signals/detectors/quality.py
@@ -5,12 +5,14 @@ record what the source published; these two detectors surface the days that
 record turns NEWSWORTHY, on the same Alert backbone as every other radar rule —
 zero extra delivery code, same feed, same RSS.
 
-* ``quality_completeness_drop`` — yesterday (the newest finished UTC day) a
-  charter series' published hours collapsed below half, in a zone+series that
-  is normally near-complete. The trailing norm is the guard rail twice over: a
-  chronically thin series is not news, and a freshly deployed / newly enabled
-  zone has no norm yet, so the detector stays silent instead of judging a day
-  against a handful of rows.
+* ``quality_completeness_drop`` — on the newest finished day the record HOLDS
+  (max quality_daily date ≤ the calendar yesterday; the nightly writer lands
+  the literal yesterday only minutes before midnight, so the calendar date
+  would be a race) a charter series' published hours collapsed below half, in
+  a zone+series that is normally near-complete. The trailing norm is the guard
+  rail twice over: a chronically thin series is not news, and a freshly
+  deployed / newly enabled zone has no norm yet, so the detector stays silent
+  instead of judging a day against a handful of rows.
 * ``quality_major_restatement`` — the source re-published materially different
   values for several SETTLED hours of one series within the last 24 h. "Settled"
   reuses the read-side maturity threshold shared with /api/v1/quality/revisions
@@ -35,7 +37,9 @@ interconnector_saturated precedent).
 from __future__ import annotations
 
 import statistics
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
+
+from sqlalchemy import func
 
 from backend.models.energy import PowerRevision, QualityDaily, SeriesDim, ZoneDim
 from backend.power.quality import QUALITY_SERIES, REVISION_MATURITY_S
@@ -56,16 +60,34 @@ COMPLETENESS_MIN_NORM_DAYS = MIN_BASELINE_N
 
 
 def detect_completeness_drops(db) -> list[DetectorResult]:
-    """Zones where a normally-complete charter series lost most of yesterday.
+    """Zones where a normally-complete charter series lost most of the newest
+    finished day ON RECORD.
 
-    Judges only YESTERDAY (UTC) — today is partial by construction while the
-    day runs. A missing yesterday row is silence, not a drop: either the
-    nightly quality job has not covered the day yet or the series is inactive
-    there, and absence is never turned into a claim (no data → no alert).
+    The anchor is max(quality_daily.date) ≤ the calendar yesterday — NOT the
+    literal calendar yesterday: the nightly quality job (23:55 UTC on day D)
+    first writes day D−1's rows five minutes before "yesterday" rolls over to
+    D, so judging the literal date would race the writer's last five minutes
+    and silently skip the day whenever the job overruns midnight. Anchoring on
+    the newest recorded day gives every quality day a full 24 h detection
+    surface regardless of schedule timing; the backbone's (rule, zone) upsert
+    makes the re-fires idempotent, and as_of carries the anchored day — the
+    day actually judged — so the runner's staleness gate stays honest. Today
+    is never judged (partial by construction while the day runs; the ≤
+    yesterday cap enforces it). No quality rows at all → silence, not a claim
+    (no data → no alert).
     """
     yesterday = datetime.now(timezone.utc).date() - timedelta(days=1)
-    y_iso = yesterday.isoformat()
-    cut = (yesterday - timedelta(days=COMPLETENESS_NORM_DAYS)).isoformat()
+    y_iso = (
+        db.query(func.max(QualityDaily.date))
+        .filter(
+            QualityDaily.date <= yesterday.isoformat(),
+            QualityDaily.series_key.in_(QUALITY_SERIES),
+        )
+        .scalar()
+    )
+    if y_iso is None:
+        return []
+    cut = (date.fromisoformat(y_iso) - timedelta(days=COMPLETENESS_NORM_DAYS)).isoformat()
 
     # One indexed date-range scan for all zones; QUALITY_SERIES is the charter
     # list and never contains the reserved "_zone" pseudo-series (its rows carry

--- a/backend/signals/detectors/quality.py
+++ b/backend/signals/detectors/quality.py
@@ -13,9 +13,13 @@ zero extra delivery code, same feed, same RSS.
   against a handful of rows.
 * ``quality_major_restatement`` — the source re-published materially different
   values for several SETTLED hours of one series within the last 24 h. "Settled"
-  reuses the read-side maturity threshold of /api/v1/quality/revisions
-  (REVISION_MATURITY_S, routes/quality.py): restatements inside the routine
-  provisional fill-in window are not events.
+  reuses the read-side maturity threshold shared with /api/v1/quality/revisions
+  (REVISION_MATURITY_S, canonical home backend/power/quality.py): restatements
+  inside the routine provisional fill-in window are not events. "Materially" is
+  two floors deep: the change must clear an absolute per-series-family floor in
+  the series' own unit BEFORE its percentage is computed — the ledger's write
+  epsilon is only 0.5 units, and a percentage alone would let three 1-MW
+  re-publishes page someone.
 
 Sibling contract (base.py): DB reads only, cheap enough for the 5-minute
 runner, template text, descriptive never predictive — a low-completeness day
@@ -34,7 +38,7 @@ import statistics
 from datetime import datetime, timedelta, timezone
 
 from backend.models.energy import PowerRevision, QualityDaily, SeriesDim, ZoneDim
-from backend.power.quality import QUALITY_SERIES
+from backend.power.quality import QUALITY_SERIES, REVISION_MATURITY_S
 from backend.power.zones import POWER_ZONES
 from backend.signals.detectors.base import MIN_BASELINE_N, DetectorResult
 
@@ -155,11 +159,41 @@ RESTATE_MIN_FRACTION = 0.20
 #: The floor keeps a previous value near zero (a price crossing 0) from
 #: manufacturing an unbounded percentage; 1.0 in the series' own unit.
 RESTATE_DENOM_FLOOR = 1.0
+#: Materiality floor on the CHANGE ITSELF, per series family (longest story
+#: first): the ledger's write epsilon is only 0.5 units (hourly_store.
+#: REVISION_FLOOR), so a 2→3 MW re-publish is ledgered — and against the
+#: percentage machinery above it scores 50% (0→1.5 MW scores 150% via the
+#: denominator floor). Three such hours would page someone about nothing. A
+#: restatement must first be material in the series' OWN unit before its
+#: percentage is worth saying: 50 MW for MW-scale series (well under one
+#: mid-size unit, far above meter jitter), 5 EUR for prices (a sub-5-EUR move
+#: on a settled hour is rounding, not news), 10 units for anything unlisted
+#: (ntc.*, sched.*, imbalance.* …). STEP_JUMP_FLOORS' per-series-floor pattern
+#: (backend/power/quality.py), keyed by prefix because the family is what sets
+#: the unit scale.
+RESTATE_ABS_FLOORS: dict[str, float] = {
+    "load.": 50.0,
+    "gen.": 50.0,
+    "flow.": 50.0,
+    "price.": 5.0,
+}
+RESTATE_ABS_FLOOR_DEFAULT = 10.0
 #: ≥3 distinct hours of ONE series → warning; ≥12 hours or a ≥50% median
 #: change → critical.
 RESTATE_MIN_HOURS = 3
 RESTATE_CRIT_HOURS = 12
 RESTATE_CRIT_MEDIAN_PCT = 50.0
+#: Detail cap: name the top offenders, fold the rest. A backfill burst can
+#: restate dozens of series in one zone at once; the title already folds, and
+#: an unbounded detail would push kilobytes into every feed/RSS render.
+RESTATE_DETAIL_MAX_SERIES = 6
+
+
+def _abs_floor(series_key: str) -> float:
+    for prefix, floor in RESTATE_ABS_FLOORS.items():
+        if series_key.startswith(prefix):
+            return floor
+    return RESTATE_ABS_FLOOR_DEFAULT
 
 
 def _recent_revisions(db, cutoff_epoch: int) -> list:
@@ -201,12 +235,6 @@ def detect_major_restatements(db) -> list[DetectorResult]:
     """Zones where the source restated several settled hours of one series in
     the last 24 h. Distinct hours, not revision rows — an hour revised twice in
     the window is one restated hour, at its largest observed change."""
-    # Read-side maturity threshold shared with /api/v1/quality/revisions —
-    # imported at call time (the sibling-precedent for routes imports,
-    # detect_hydro_deviations) so the detector module never pulls the FastAPI
-    # router stack in at import time.
-    from backend.routes.quality import REVISION_MATURITY_S
-
     now = int(datetime.now(timezone.utc).timestamp())
     recent = _recent_revisions(db, now - RESTATE_WINDOW_S)
     if not recent:
@@ -233,7 +261,10 @@ def detect_major_restatements(db) -> list[DetectorResult]:
         zone, skey = zid_key.get(r.zone_id), sid_key.get(r.series_id)
         if zone is None or skey is None or zone not in POWER_ZONES:
             continue
-        frac = abs(r.new_value - r.old_value) / max(abs(r.old_value), RESTATE_DENOM_FLOOR)
+        delta = abs(r.new_value - r.old_value)
+        if delta < _abs_floor(skey):
+            continue  # immaterial in the series' own unit — no percentage worth saying
+        frac = delta / max(abs(r.old_value), RESTATE_DENOM_FLOOR)
         if frac <= RESTATE_MIN_FRACTION:
             continue
         pair = (zone, skey)
@@ -264,11 +295,14 @@ def detect_major_restatements(db) -> list[DetectorResult]:
         )
         worst = entries[0]
         newest = max(e["observed_at"] for e in entries)
+        shown = entries[:RESTATE_DETAIL_MAX_SERIES]
         parts = [
             f"{e['n_hours']} hours of {e['series']} restated by a median of "
             f"{e['median_pct']:.0f}% (largest {e['largest_pct']:.0f}%)"
-            for e in entries
+            for e in shown
         ]
+        if len(entries) > len(shown):
+            parts.append(f"+{len(entries) - len(shown)} more series")
         results.append(
             DetectorResult(
                 rule="quality_major_restatement",
@@ -281,8 +315,9 @@ def detect_major_restatements(db) -> list[DetectorResult]:
                     + (f" (+{len(entries) - 1} more series)" if len(entries) > 1 else "")
                 ),
                 detail=(
-                    "The source re-published different values for hours settled "
-                    "more than 48 h earlier, observed in the last 24 h: "
+                    f"The source re-published different values for hours settled "
+                    f"more than {REVISION_MATURITY_S // 3600} h earlier, observed "
+                    f"in the last {RESTATE_WINDOW_S // 3600} h: "
                     + "; ".join(parts)
                     + ". A restatement is the source revising its own "
                     "publication — described here, not judged."

--- a/backend/tests/test_anomaly_detectors.py
+++ b/backend/tests/test_anomaly_detectors.py
@@ -349,9 +349,10 @@ def test_run_all_detectors_isolates_failures(db_session, monkeypatch):
 
 
 def test_detector_registry_count(db_session):
-    assert len(DETECTORS) == 10  # gas/negative_prices/dunkelflaute/forced_outages
+    assert len(DETECTORS) == 12  # gas/negative_prices/dunkelflaute/forced_outages
     # + imbalance_extreme/price_spike/hydro_deviation/record_break/episode_rank
     # + interconnector_saturated (day-ahead NTC, A61)
+    # + quality_completeness_drop/quality_major_restatement (Honest Record A4)
 
 
 # ─── flow_anomaly (legacy maritime check) — baseline + onset cure ─────────────

--- a/backend/tests/test_forecast_score.py
+++ b/backend/tests/test_forecast_score.py
@@ -1,0 +1,200 @@
+"""Nightly forecast scoring: per (zone, series, UTC-day) error metrics for
+ENTSO-E's published day-ahead forecasts vs the published actuals.
+
+Posture B: OBSYD grades ENTSO-E's OWN forecasts — it makes none of its own.
+The naive baselines (persistence = actual(t−24h), seasonal = actual(t−168h))
+are built from published actuals alone; they exist so a reader can later judge
+the TSO forecast against "no model at all". Only the baseline MAEs are stored —
+skill is derived at read time.
+
+n semantics (documented + asserted here): `n_hours` counts the hours where BOTH
+forecast and actual exist. MAPE and the baseline MAEs are means over their own
+(possibly smaller) subsets of those hours — MAPE drops hours whose |actual| is
+below the division floor, a baseline MAE drops hours whose lagged actual is
+missing — and each is NULL when its subset is empty. `n_hours` never shrinks
+for either.
+
+Times are epoch-UTC throughout, and the tests read the UTC clock instead of
+hardcoding calendar days (repo rule #111: date.today() made suites fail between
+00–02 local).
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.models.energy import ForecastScoreDaily, PowerHourly, SeriesDim
+from backend.power.forecast_score import (
+    FORECAST_PAIRS,
+    MAPE_ACTUAL_FLOOR_MW,
+    compute_and_store_range,
+    compute_and_store_scores,
+)
+from backend.power.hourly_store import day_hour_ts, upsert_hourly
+
+
+def _day(days_ago: int) -> str:
+    return (datetime.now(timezone.utc).date() - timedelta(days=days_ago)).isoformat()
+
+
+DAY = _day(2)            # the scored day (safely finished)
+PERSIST_DAY = _day(3)    # DAY − 24 h
+SEASONAL_DAY = _day(9)   # DAY − 168 h
+
+
+def _seed_load(db, zone: str = "DE_LU") -> None:
+    """Four hand-checkable hours on DAY, plus the actuals both baselines need.
+
+    errors (forecast − actual): [−10, +10, +20, −40]
+      → mae 20 · rmse √550 · bias −5 (the forecast leaned LOW)
+    persistence |actual(t) − actual(t−24h)|: [10, 10, 20, 40] → 20
+    seasonal    |actual(t) − actual(t−168h)|: [0, 0, 0, 40]   → 10
+    """
+    fc = [(day_hour_ts(DAY, h), v) for h, v in zip((0, 1, 2, 3), (100.0, 200.0, 300.0, 400.0))]
+    ac = [(day_hour_ts(DAY, h), v) for h, v in zip((0, 1, 2, 3), (110.0, 190.0, 280.0, 440.0))]
+    persist = [(day_hour_ts(PERSIST_DAY, h), v) for h, v in zip((0, 1, 2, 3), (100.0, 200.0, 300.0, 400.0))]
+    seasonal = [(day_hour_ts(SEASONAL_DAY, h), v) for h, v in zip((0, 1, 2, 3), (110.0, 190.0, 280.0, 400.0))]
+    upsert_hourly(db, "load.forecast", zone, fc, unit="MW")
+    upsert_hourly(db, "load.actual", zone, ac + persist + seasonal, unit="MW")
+    db.commit()
+
+
+def test_hand_computed_mae_rmse_bias_mape_and_baselines(db_session):
+    _seed_load(db_session)
+    result = compute_and_store_scores(db_session, "DE_LU", DAY)
+    assert result["written"] == 1  # only the load pair has data
+
+    row = (
+        db_session.query(ForecastScoreDaily)
+        .filter_by(zone="DE_LU", series="load", date=DAY)
+        .one()
+    )
+    assert row.n_hours == 4
+    assert row.mae == pytest.approx(20.0)
+    assert row.rmse == pytest.approx(math.sqrt(550.0))
+    # bias = mean(forecast − actual): NEGATIVE = the published forecast leaned LOW.
+    # (The /api/power/forecast-error endpoint reports the opposite sign, unchanged.)
+    assert row.bias == pytest.approx(-5.0)
+    assert row.mape == pytest.approx(100.0 * (10 / 110 + 10 / 190 + 20 / 280 + 40 / 440) / 4)
+    assert row.mae_persistence == pytest.approx(20.0)
+    assert row.mae_seasonal == pytest.approx(10.0)
+
+
+def test_mape_guard_excludes_tiny_actuals_but_mae_keeps_them(db_session):
+    """An hour whose |actual| is under the floor is a division trap (or an ingest
+    artifact), not a percentage — it leaves MAPE but stays in MAE and n_hours."""
+    h0, h1 = day_hour_ts(DAY, 0), day_hour_ts(DAY, 1)
+    upsert_hourly(db_session, "load.forecast", "DE_LU", [(h0, 200.0), (h1, 50.0)], unit="MW")
+    upsert_hourly(
+        db_session, "load.actual", "DE_LU",
+        [(h0, MAPE_ACTUAL_FLOOR_MW), (h1, 0.0)], unit="MW",
+    )
+    db_session.commit()
+    compute_and_store_scores(db_session, "DE_LU", DAY)
+
+    row = db_session.query(ForecastScoreDaily).filter_by(series="load", date=DAY).one()
+    assert row.n_hours == 2
+    assert row.mae == pytest.approx(75.0)          # both hours count: (100 + 50) / 2
+    assert row.mape == pytest.approx(100.0)        # only h0: |200 − 100| / 100
+
+
+def test_baselines_score_only_hours_where_the_lagged_actual_exists(db_session):
+    """No prior-day actual → no persistence term for that hour; no prior-week data
+    at all → mae_seasonal is NULL. n_hours never shrinks for a missing baseline."""
+    upsert_hourly(
+        db_session, "load.forecast", "DE_LU",
+        [(day_hour_ts(DAY, 0), 100.0), (day_hour_ts(DAY, 1), 100.0)], unit="MW",
+    )
+    upsert_hourly(
+        db_session, "load.actual", "DE_LU",
+        [
+            (day_hour_ts(DAY, 0), 110.0),
+            (day_hour_ts(DAY, 1), 130.0),
+            (day_hour_ts(PERSIST_DAY, 0), 140.0),  # hour 1 of DAY−1 is missing
+        ],
+        unit="MW",
+    )
+    db_session.commit()
+    compute_and_store_scores(db_session, "DE_LU", DAY)
+
+    row = db_session.query(ForecastScoreDaily).filter_by(series="load", date=DAY).one()
+    assert row.n_hours == 2
+    assert row.mae_persistence == pytest.approx(30.0)  # |110 − 140|, the one covered hour
+    assert row.mae_seasonal is None
+
+
+def test_wind_actual_is_the_b18_plus_b19_sum(db_session):
+    """There is no wind.actual series — realised wind is gen.B18 + gen.B19,
+    the same derivation the residual ingest and the forecast-error route use."""
+    t = day_hour_ts(DAY, 12)
+    upsert_hourly(db_session, "wind.forecast", "DE_LU", [(t, 10_000.0)], unit="MW")
+    upsert_hourly(db_session, "gen.B18", "DE_LU", [(t, 3_000.0)], unit="MW")
+    upsert_hourly(db_session, "gen.B19", "DE_LU", [(t, 5_000.0)], unit="MW")
+    db_session.commit()
+    compute_and_store_scores(db_session, "DE_LU", DAY)
+
+    row = db_session.query(ForecastScoreDaily).filter_by(series="wind", date=DAY).one()
+    assert row.n_hours == 1
+    assert row.bias == pytest.approx(2_000.0)  # 10 GW promised, 8 GW delivered → leaned HIGH
+    assert row.mae == pytest.approx(2_000.0)
+    assert row.mape is None                    # MAPE is load-only by design
+
+
+def test_recompute_is_idempotent(db_session):
+    _seed_load(db_session)
+    compute_and_store_scores(db_session, "DE_LU", DAY)
+    compute_and_store_scores(db_session, "DE_LU", DAY)
+
+    rows = (
+        db_session.query(ForecastScoreDaily)
+        .filter_by(zone="DE_LU", series="load", date=DAY)
+        .all()
+    )
+    assert len(rows) == 1, "recompute replaces the row, never duplicates it"
+    assert rows[0].n_hours == 4
+    assert rows[0].mae == pytest.approx(20.0)
+
+
+def test_zone_with_no_data_writes_nothing_and_does_not_crash(db_session):
+    result = compute_and_store_scores(db_session, "FR", DAY)
+    assert result == {"written": 0, "removed": 0}
+    assert db_session.query(ForecastScoreDaily).count() == 0
+
+
+def test_recompute_retracts_a_day_the_data_no_longer_supports(db_session):
+    """Episodes doctrine: a row a later revision of the data no longer supports
+    disappears, rather than sitting in the scoreboard forever."""
+    _seed_load(db_session)
+    compute_and_store_scores(db_session, "DE_LU", DAY)
+    assert db_session.query(ForecastScoreDaily).filter_by(series="load", date=DAY).count() == 1
+
+    sid = db_session.query(SeriesDim.id).filter_by(key="load.forecast").scalar()
+    db_session.query(PowerHourly).filter(PowerHourly.series_id == sid).delete()
+    db_session.commit()
+
+    result = compute_and_store_scores(db_session, "DE_LU", DAY)
+    assert result["removed"] == 1
+    assert db_session.query(ForecastScoreDaily).filter_by(series="load", date=DAY).count() == 0
+
+
+def test_range_scores_each_day_and_skips_days_without_both_sides(db_session):
+    """PERSIST_DAY/SEASONAL_DAY carry actuals but no forecast — they feed the
+    baselines, they do not get scored themselves."""
+    _seed_load(db_session)
+    result = compute_and_store_range(db_session, "DE_LU", SEASONAL_DAY, DAY)
+    assert result["written"] == 1
+
+    dates = [r.date for r in db_session.query(ForecastScoreDaily).filter_by(series="load").all()]
+    assert dates == [DAY]
+
+
+def test_routes_share_the_canonical_pair_table():
+    """The forecast-error route must import THE pair table, not carry a copy —
+    a drifted copy would grade a different forecast than the scoreboard stores."""
+    from backend.routes import power as power_routes
+
+    assert power_routes.FORECAST_PAIRS is FORECAST_PAIRS
+    assert set(FORECAST_PAIRS) == {"load", "residual", "wind", "solar"}

--- a/backend/tests/test_power_overview.py
+++ b/backend/tests/test_power_overview.py
@@ -27,9 +27,11 @@ def test_overview_empty_is_unavailable(db_session):
 
 def test_overview_returns_seeded_zone_with_state(db_session):
     # One day of price + grid for DE_LU is enough for load_power_situation to be "available".
-    db_session.add(PowerPriceDaily(date="2026-07-02", zone="DE_LU", mean_price=71.0,
+    # Seed relative to the UTC clock — a fixed date ages out of the freshness window (#111).
+    recent = (datetime.now(timezone.utc).date() - timedelta(days=1)).isoformat()
+    db_session.add(PowerPriceDaily(date=recent, zone="DE_LU", mean_price=71.0,
                                    min_price=40.0, max_price=95.0, negative_hours=0))
-    db_session.add(PowerGrid(date="2026-07-02", zone="DE_LU", load_mw=55000.0,
+    db_session.add(PowerGrid(date=recent, zone="DE_LU", load_mw=55000.0,
                              wind_mw=8000.0, solar_mw=6000.0, residual_mw=41000.0))
     db_session.commit()
 

--- a/backend/tests/test_quality_api.py
+++ b/backend/tests/test_quality_api.py
@@ -1,0 +1,378 @@
+"""/api/v1/quality/* — the Honest-Record read API (slice A3).
+
+Covers: summary matrix shape + hand-computed completeness/flag/revision/lag
+math, the per-series drill-down (flags decoded, day cap, arrival stats), the
+revision ledger (maturity filter both ways, delta_pct, per-hour roll-up),
+helpful 400s on bad params, honest available:false on valid-but-empty
+combinations, and the v1 guard stack (shared rate budget, heavy slots).
+
+Posture B: every asserted field describes what the SOURCE published/restated.
+Times read the UTC clock, never date.today() (repo rule #111).
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api_guard import _reset_coverage_cache
+from backend.auth.ratelimit import reset_limits
+from backend.database import get_db
+from backend.main import app
+from backend.models.energy import IngestArrival, PowerRevision, QualityDaily
+from backend.power.hourly_store import resolve_series_id, resolve_zone_id, upsert_hourly
+
+NOW = datetime.now(UTC)
+NOW_S = int(NOW.timestamp())
+_H = 3600
+_D = 86400
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    reset_limits()
+    _reset_coverage_cache()  # keyed cache is process-global — quality_summary would leak
+    yield
+    app.dependency_overrides.clear()
+    reset_limits()
+    _reset_coverage_cache()
+
+
+def _client(db) -> TestClient:
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _day(days_ago: int) -> str:
+    return (NOW.date() - timedelta(days=days_ago)).isoformat()
+
+
+def _q(db, zone, series_key, day, present, expected, flags=None):
+    db.add(QualityDaily(zone=zone, series_key=series_key, date=day,
+                        hours_present=present, hours_expected=expected,
+                        flags=json.dumps(flags or [])))
+
+
+def _ids(db, series: str, zone: str) -> tuple[int, int]:
+    sid, zid = resolve_series_id(db, series), resolve_zone_id(db, zone)
+    db.commit()
+    return sid, zid
+
+
+FLAG = {"rule": "zero_run", "hours": [], "detail": {"longest_run_hours": 6}}
+
+
+# ─── /summary ─────────────────────────────────────────────────────────────────
+
+
+def test_summary_completeness_and_flag_math(db_session):
+    # 30d window: 24/24 and 12/24 → 0.75; 90d adds a 24/24 day at d60 → 0.8333
+    _q(db_session, "DE_LU", "load.actual", _day(1), 24, 24)
+    _q(db_session, "DE_LU", "load.actual", _day(2), 12, 24, flags=[FLAG])
+    _q(db_session, "DE_LU", "load.actual", _day(60), 24, 24)
+    _q(db_session, "DE_LU", "load.actual", _day(100), 0, 24)  # outside 90d — ignored
+    db_session.commit()
+
+    body = _client(db_session).get("/api/v1/quality/summary").json()
+    assert body["available"] is True
+    assert [z["zone"] for z in body["zones"]] == ["DE_LU"]
+    (cell,) = body["zones"][0]["series"]  # only the carried series appears
+    assert cell["series_key"] == "load.actual"
+    assert cell["completeness_30d"] == pytest.approx(0.75)
+    assert cell["completeness_90d"] == pytest.approx(0.8333, abs=1e-4)
+    assert cell["flagged_days_30d"] == 1
+    assert cell["revisions_30d"] == 0
+    # freshness triple, stamped per request: newest quality day is yesterday
+    assert body["as_of"] == _day(1)
+    assert body["age_days"] == 1
+    assert body["stale"] is False
+
+
+def test_summary_revision_count_and_arrival_lag(db_session):
+    _q(db_session, "DE_LU", "load.actual", _day(1), 24, 24)
+    sid, zid = _ids(db_session, "load.actual", "DE_LU")
+    ts = NOW_S // _H * _H - 5 * _D
+    # 3 revisions inside 30d, 1 outside — only the 3 count
+    for i, obs in enumerate((NOW_S - _D, NOW_S - 2 * _D, NOW_S - 3 * _D, NOW_S - 31 * _D)):
+        db_session.add(PowerRevision(series_id=sid, zone_id=zid, ts_utc=ts + i * _H,
+                                     old_value=100.0, new_value=200.0, observed_at=obs))
+    # newest arrival brought nothing new (no frontier) — the lag must come from
+    # the newest arrival that DID bring new hours: lag exactly 1h
+    db_session.add(IngestArrival(series_id=sid, zone_id=zid, observed_at=NOW_S - 50,
+                                 n_new=0, n_changed=0, min_ts_new=None, max_ts_new=None))
+    db_session.add(IngestArrival(series_id=sid, zone_id=zid, observed_at=NOW_S - 100,
+                                 n_new=4, n_changed=0, min_ts_new=ts,
+                                 max_ts_new=NOW_S - 100 - _H))
+    db_session.commit()
+
+    (cell,) = _client(db_session).get("/api/v1/quality/summary").json()["zones"][0]["series"]
+    assert cell["revisions_30d"] == 3
+    assert cell["arrival_lag_s"] == _H
+
+
+def test_summary_zone_flag_cell_carries_no_completeness(db_session):
+    _q(db_session, "DE_LU", "_zone", _day(1), 0, 0,
+       flags=[{"rule": "gen_below_load_exports", "hours": [], "detail": {}}])
+    db_session.commit()
+    (cell,) = _client(db_session).get("/api/v1/quality/summary").json()["zones"][0]["series"]
+    assert cell["series_key"] == "_zone"
+    assert cell["completeness_30d"] is None and cell["completeness_90d"] is None
+    assert cell["flagged_days_30d"] == 1
+    assert cell["revisions_30d"] is None and cell["arrival_lag_s"] is None
+
+
+def test_summary_empty_is_honest(db_session):
+    body = _client(db_session).get("/api/v1/quality/summary").json()
+    assert body["available"] is False
+    assert body["zones"] == []
+    assert body["as_of"] is None and body["stale"] is False  # inert, not a crash
+
+
+def test_summary_is_cached_and_stamped_per_request(db_session, monkeypatch):
+    """The matrix computes once per TTL; the freshness triple must ride each
+    REQUEST (a warm cache must not freeze age_days — marginal/overview rule)."""
+    import backend.routes.quality as q
+
+    _q(db_session, "DE_LU", "load.actual", _day(1), 24, 24)
+    db_session.commit()
+    calls = {"n": 0}
+    orig = q._summary_payload
+
+    def counting(db):
+        calls["n"] += 1
+        return orig(db)
+
+    monkeypatch.setattr(q, "_summary_payload", counting)
+    c = _client(db_session)
+    first = c.get("/api/v1/quality/summary").json()
+    second = c.get("/api/v1/quality/summary").json()
+    assert calls["n"] == 1  # second hit served from the keyed cache
+    assert first["zones"] == second["zones"]
+    assert "age_days" in second and "stale" in second
+
+
+# ─── /series ──────────────────────────────────────────────────────────────────
+
+
+def test_series_rows_newest_first_flags_decoded(db_session):
+    from backend.power.hourly_store import day_hour_ts
+
+    flagged_hour = day_hour_ts(_day(2), 23)
+    _q(db_session, "DE_LU", "load.actual", _day(2), 18, 24,
+       flags=[{"rule": "zero_run", "hours": [flagged_hour], "detail": {"longest_run_hours": 6}}])
+    _q(db_session, "DE_LU", "load.actual", _day(1), 24, 24)
+    db_session.commit()
+
+    body = _client(db_session).get(
+        "/api/v1/quality/series?series=load.actual&zone=DE_LU").json()
+    assert body["available"] is True
+    assert [r["date"] for r in body["data"]] == [_day(1), _day(2)]  # newest first
+    flag = body["data"][1]["flags"][0]
+    assert flag["rule"] == "zero_run"
+    assert flag["hours"] == [f"{_day(2)}T23:00:00+00:00"]  # epoch → ISO at the edge
+    assert flag["detail"] == {"longest_run_hours": 6}
+    assert body["as_of"] == _day(1)
+
+
+def test_series_day_window_filters_and_caps(db_session):
+    _q(db_session, "DE_LU", "load.actual", _day(10), 24, 24)
+    _q(db_session, "DE_LU", "load.actual", _day(100), 24, 24)
+    db_session.commit()
+    c = _client(db_session)
+    body = c.get("/api/v1/quality/series?series=load.actual&zone=DE_LU&days=30").json()
+    assert [r["date"] for r in body["data"]] == [_day(10)]
+    # cap: days > 365 is a validation error, not a silent clamp
+    assert c.get("/api/v1/quality/series?series=load.actual&zone=DE_LU&days=400").status_code == 422
+
+
+def test_series_arrival_median_and_p90(db_session):
+    _q(db_session, "DE_LU", "load.actual", _day(1), 24, 24)
+    sid, zid = _ids(db_session, "load.actual", "DE_LU")
+    for i, lag in enumerate((_H, 2 * _H, 3 * _H)):
+        obs = NOW_S - 1000 - i
+        db_session.add(IngestArrival(series_id=sid, zone_id=zid, observed_at=obs,
+                                     n_new=1, n_changed=0,
+                                     min_ts_new=obs - lag, max_ts_new=obs - lag))
+    db_session.commit()
+    arrival = _client(db_session).get(
+        "/api/v1/quality/series?series=load.actual&zone=DE_LU").json()["arrival"]
+    assert arrival["n_batches"] == 3
+    assert arrival["median_lag_s"] == 2 * _H
+    # p90 over [3600, 7200, 10800]: pos 1.8 → 7200 + 0.8·3600 = 10080
+    assert arrival["p90_lag_s"] == 10080
+
+
+def test_series_bad_params_are_helpful_400s(db_session):
+    c = _client(db_session)
+    r = c.get("/api/v1/quality/series?series=hack&zone=DE_LU")
+    assert r.status_code == 400
+    assert "load.actual" in r.json()["detail"]  # lists the valid keys
+    r = c.get("/api/v1/quality/series?series=load.actual&zone=NOPE")
+    assert r.status_code == 400
+    assert "DE_LU" in r.json()["detail"]  # lists the valid zones
+
+
+def test_series_valid_but_empty_is_available_false(db_session):
+    body = _client(db_session).get(
+        "/api/v1/quality/series?series=load.actual&zone=FR").json()
+    assert body["available"] is False
+    assert body["data"] == []
+    assert body["arrival"] == {"n_batches": 0, "median_lag_s": None, "p90_lag_s": None}
+
+
+# ─── /revisions ───────────────────────────────────────────────────────────────
+
+
+def test_revisions_maturity_filter_both_ways(db_session):
+    sid, zid = _ids(db_session, "load.actual", "DE_LU")
+    settled = NOW_S // _H * _H - 5 * _D  # restated 5 days after the hour → mature
+    fresh = NOW_S // _H * _H - _H       # restated ~1h after the hour → fill-in
+    db_session.add(PowerRevision(series_id=sid, zone_id=zid, ts_utc=settled,
+                                 old_value=100.0, new_value=120.0, observed_at=NOW_S - 100))
+    db_session.add(PowerRevision(series_id=sid, zone_id=zid, ts_utc=fresh,
+                                 old_value=50.0, new_value=60.0, observed_at=NOW_S - 50))
+    db_session.commit()
+    c = _client(db_session)
+
+    body = c.get("/api/v1/quality/revisions?series=load.actual&zone=DE_LU").json()
+    assert body["mature"] is True and body["maturity_threshold_s"] == 48 * 3600
+    assert body["count"] == 1
+    row = body["data"][0]
+    assert row["old_value"] == 100.0 and row["new_value"] == 120.0
+    assert row["delta_pct"] == pytest.approx(20.0)
+    assert row["ts_utc"] == datetime.fromtimestamp(settled, UTC).isoformat()
+
+    body = c.get("/api/v1/quality/revisions?series=load.actual&zone=DE_LU&mature=false").json()
+    assert body["count"] == 2  # fill-in included on request
+
+
+def test_revisions_rollup_counts_multiply_restated_hours(db_session):
+    sid, zid = _ids(db_session, "load.actual", "DE_LU")
+    hour = NOW_S // _H * _H - 5 * _D
+    other = hour + _H
+    db_session.add(PowerRevision(series_id=sid, zone_id=zid, ts_utc=hour,
+                                 old_value=100.0, new_value=110.0, observed_at=NOW_S - 2000))
+    db_session.add(PowerRevision(series_id=sid, zone_id=zid, ts_utc=hour,
+                                 old_value=110.0, new_value=130.0, observed_at=NOW_S - 1000))
+    db_session.add(PowerRevision(series_id=sid, zone_id=zid, ts_utc=other,
+                                 old_value=200.0, new_value=250.0, observed_at=NOW_S - 1500))
+    db_session.commit()
+
+    body = _client(db_session).get(
+        "/api/v1/quality/revisions?series=load.actual&zone=DE_LU").json()
+    assert body["count"] == 3
+    (roll,) = body["restated_hours"]  # only the twice-restated hour rolls up
+    assert roll["ts_utc"] == datetime.fromtimestamp(hour, UTC).isoformat()
+    assert roll["n_revisions"] == 2
+    # last change: 110 → 130 = +18.18% of the previously published value
+    assert roll["last_change_pct"] == pytest.approx(18.18, abs=0.01)
+
+
+def test_revisions_delta_pct_null_when_old_value_zero(db_session):
+    sid, zid = _ids(db_session, "gen.B16", "DE_LU")
+    db_session.add(PowerRevision(series_id=sid, zone_id=zid,
+                                 ts_utc=NOW_S // _H * _H - 5 * _D,
+                                 old_value=0.0, new_value=5.0, observed_at=NOW_S - 10))
+    db_session.commit()
+    body = _client(db_session).get(
+        "/api/v1/quality/revisions?series=gen.B16&zone=DE_LU").json()
+    assert body["data"][0]["delta_pct"] is None  # no honest % of a zero base
+
+
+def test_revisions_ride_the_real_write_path(db_session):
+    """upsert_hourly twice with a moved value → the ledger row the endpoint
+    serves, mature because the hour lies 5 days back."""
+    ts = NOW_S // _H * _H - 5 * _D
+    upsert_hourly(db_session, "load.actual", "DE_LU", [(ts, 100.0)], unit="MW")
+    upsert_hourly(db_session, "load.actual", "DE_LU", [(ts, 200.0)], unit="MW")
+
+    body = _client(db_session).get(
+        "/api/v1/quality/revisions?series=load.actual&zone=DE_LU").json()
+    assert body["available"] is True and body["count"] == 1
+    assert body["data"][0]["delta_pct"] == pytest.approx(100.0)
+    assert body["as_of"] is not None  # arrival log = last time the source was polled
+    assert body["age_days"] == 0 and body["stale"] is False
+
+
+def test_revisions_bad_params_are_helpful_400s(db_session):
+    c = _client(db_session)
+    r = c.get("/api/v1/quality/revisions?series=hack&zone=DE_LU")
+    assert r.status_code == 400
+    assert "series/catalog" in r.json()["detail"]  # points at the queryable keys
+    r = c.get("/api/v1/quality/revisions?series=hack&zone=NOPE")
+    assert r.status_code == 400
+    assert "DE_LU" in r.json()["detail"]
+
+
+def test_revisions_derived_series_get_an_honest_reason(db_session):
+    body = _client(db_session).get(
+        "/api/v1/quality/revisions?series=residual.actual&zone=DE_LU").json()
+    assert body["available"] is False
+    assert "not revision-ledgered" in body["reason"]
+
+
+def test_revisions_row_cap_refuses_instead_of_truncating(db_session, monkeypatch):
+    """More rows than the cap → available:false with a narrow-the-window reason
+    (a truncated ledger is a wrong ledger), never a silent cut."""
+    import backend.routes.quality as q
+
+    monkeypatch.setattr(q, "MAX_REVISION_ROWS", 2)
+    sid, zid = _ids(db_session, "load.actual", "DE_LU")
+    hour = NOW_S // _H * _H - 5 * _D
+    for i in range(3):
+        db_session.add(PowerRevision(series_id=sid, zone_id=zid, ts_utc=hour + i * _H,
+                                     old_value=100.0, new_value=120.0,
+                                     observed_at=NOW_S - 100 - i))
+    db_session.commit()
+    body = _client(db_session).get(
+        "/api/v1/quality/revisions?series=load.actual&zone=DE_LU").json()
+    assert body["available"] is False
+    assert "narrow" in body["reason"]
+    assert "stale" in body  # the triple rides even the refusal
+
+
+def test_revisions_valid_but_empty_is_available_false(db_session):
+    upsert_hourly(db_session, "load.actual", "DE_LU",
+                  [(NOW_S // _H * _H - 5 * _D, 100.0)], unit="MW")  # series known, no restatement
+    body = _client(db_session).get(
+        "/api/v1/quality/revisions?series=load.actual&zone=DE_LU").json()
+    assert body["available"] is False
+    assert body["data"] == [] and body["restated_hours"] == []
+    assert "reason" in body
+    assert body["as_of"] is not None  # the source WAS polled — that much is on record
+
+
+# ─── guard stack ──────────────────────────────────────────────────────────────
+
+
+def test_quality_shares_the_v1_rate_budget(db_session, monkeypatch):
+    """All three endpoints draw from the same per-IP v1 bucket as /series."""
+    import backend.routes.api_v1 as v1
+
+    monkeypatch.setattr(v1, "RATE_PER_MIN", 2)
+    c = _client(db_session)
+    assert c.get("/api/v1/quality/summary").status_code == 200
+    assert c.get("/api/v1/quality/series?series=load.actual&zone=DE_LU").status_code == 200
+    assert c.get("/api/v1/quality/revisions?series=x&zone=DE_LU").status_code == 429
+
+
+def test_summary_and_revisions_hold_a_heavy_slot(db_session):
+    """Drained semaphore → fail-fast 503 for the guarded reads; the light
+    per-series drill-down still answers."""
+    import backend.api_guard as guard
+
+    upsert_hourly(db_session, "load.actual", "DE_LU", [(NOW_S // _H * _H, 1.0)], unit="MW")
+    c = _client(db_session)
+    acquired = [guard._heavy_sem.acquire(blocking=False)
+                for _ in range(guard.HEAVY_QUERY_SLOTS)]
+    try:
+        assert all(acquired)
+        assert c.get("/api/v1/quality/summary").status_code == 503
+        assert c.get("/api/v1/quality/revisions?series=load.actual&zone=DE_LU").status_code == 503
+        assert c.get("/api/v1/quality/series?series=load.actual&zone=DE_LU").status_code == 200
+    finally:
+        for ok in acquired:
+            if ok:
+                guard._heavy_sem.release()

--- a/backend/tests/test_quality_api.py
+++ b/backend/tests/test_quality_api.py
@@ -24,10 +24,20 @@ from backend.main import app
 from backend.models.energy import IngestArrival, PowerRevision, QualityDaily
 from backend.power.hourly_store import resolve_series_id, resolve_zone_id, upsert_hourly
 
+# Rebound per TEST by the _clock fixture below — the endpoints read the live
+# clock, so a suite that imports before UTC midnight and asserts after it must
+# not do its day math from a frozen import-time NOW (repo rule #111's flake class).
 NOW = datetime.now(UTC)
 NOW_S = int(NOW.timestamp())
 _H = 3600
 _D = 86400
+
+
+@pytest.fixture(autouse=True)
+def _clock():
+    global NOW, NOW_S
+    NOW = datetime.now(UTC)
+    NOW_S = int(NOW.timestamp())
 
 
 @pytest.fixture(autouse=True)
@@ -130,6 +140,42 @@ def test_summary_empty_is_honest(db_session):
     assert body["as_of"] is None and body["stale"] is False  # inert, not a crash
 
 
+def test_summary_payload_select_budget(db_session):
+    """The matrix must stay a fixed handful of queries — never O(cells) point
+    lookups (test_bulk_uses_fixed_query_count pattern). Budget: quality scan,
+    two dim reads, revision GROUP BY, frontier join, max-date + headroom."""
+    from sqlalchemy import event
+
+    import backend.routes.quality as q
+
+    for zone in ("DE_LU", "FR"):
+        for series in ("load.actual", "gen.B16"):
+            _q(db_session, zone, series, _day(1), 24, 24)
+            sid, zid = _ids(db_session, series, zone)
+            db_session.add(IngestArrival(series_id=sid, zone_id=zid, observed_at=NOW_S - 100,
+                                         n_new=1, n_changed=0, min_ts_new=NOW_S - 100 - _H,
+                                         max_ts_new=NOW_S - 100 - _H))
+            db_session.add(PowerRevision(series_id=sid, zone_id=zid,
+                                         ts_utc=NOW_S // _H * _H - 5 * _D,
+                                         old_value=1.0, new_value=3.0, observed_at=NOW_S - 50))
+    db_session.commit()
+
+    statements = []
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            statements.append(statement)
+
+    engine = db_session.get_bind()
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        payload = q._summary_payload(db_session)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+    assert len(payload["zones"]) == 2  # the seed actually exercised the matrix
+    assert len(statements) <= 8, f"{len(statements)} SELECTs — summary regressed to per-cell reads"
+
+
 def test_summary_is_cached_and_stamped_per_request(db_session, monkeypatch):
     """The matrix computes once per TTL; the freshness triple must ride each
     REQUEST (a warm cache must not freeze age_days — marginal/overview rule)."""
@@ -174,6 +220,19 @@ def test_series_rows_newest_first_flags_decoded(db_session):
     assert flag["hours"] == [f"{_day(2)}T23:00:00+00:00"]  # epoch → ISO at the edge
     assert flag["detail"] == {"longest_run_hours": 6}
     assert body["as_of"] == _day(1)
+
+
+def test_series_corrupt_flags_row_degrades_visibly(db_session):
+    """A row whose flags JSON won't parse yields a `_decode_error` flag for THAT
+    row — never a 500 that hides the healthy rows around it."""
+    db_session.add(QualityDaily(zone="DE_LU", series_key="load.actual", date=_day(2),
+                                hours_present=24, hours_expected=24, flags="{not json"))
+    _q(db_session, "DE_LU", "load.actual", _day(1), 24, 24)
+    db_session.commit()
+    body = _client(db_session).get(
+        "/api/v1/quality/series?series=load.actual&zone=DE_LU").json()
+    assert len(body["data"]) == 2  # the healthy row still served
+    assert body["data"][1]["flags"] == [{"rule": "_decode_error", "hours": [], "detail": {}}]
 
 
 def test_series_day_window_filters_and_caps(db_session):

--- a/backend/tests/test_quality_detectors.py
+++ b/backend/tests/test_quality_detectors.py
@@ -1,0 +1,286 @@
+"""Honest-Record slice A4 — data-quality incidents on the anomaly-radar backbone.
+
+Two curated detectors (backend/signals/detectors/quality.py) surface what the
+A1/A2 transparency tables recorded, as radar alerts:
+
+* quality_completeness_drop — yesterday's published hours collapsed for a
+  series that is normally near-complete (quality_daily),
+* quality_major_restatement — the source restated several settled hours of one
+  series in the last 24 h (power_revision ledger).
+
+Same contract as every sibling in test_anomaly_detectors.py: DB reads only,
+descriptive template text, one alert per (rule, zone) — multiple offending
+series in a zone FOLD into one result (the interconnector_saturated precedent),
+and no data → no alert, never a fabricated calm. All clocks UTC (#111).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from backend.models.alerts import Alert
+from backend.models.energy import PowerRevision, QualityDaily
+from backend.power.hourly_store import resolve_series_id, resolve_zone_id
+from backend.signals.detectors import DETECTORS, run_all_detectors
+from backend.signals.detectors.quality import (
+    detect_completeness_drops,
+    detect_major_restatements,
+)
+
+
+def _utc_yesterday():
+    return datetime.now(timezone.utc).date() - timedelta(days=1)
+
+
+def _seed_quality(
+    db,
+    zone="DE_LU",
+    series="load.actual",
+    *,
+    yesterday_present=4,
+    expected=24,
+    norm_days=30,
+    norm_present=24,
+):
+    """`norm_days` full prior days then yesterday with `yesterday_present` hours.
+    yesterday_present=None seeds only the norm (no row for yesterday)."""
+    y = _utc_yesterday()
+    for o in range(1, norm_days + 1):
+        db.add(QualityDaily(
+            zone=zone, series_key=series, date=(y - timedelta(days=o)).isoformat(),
+            hours_present=norm_present, hours_expected=expected, flags="[]",
+        ))
+    if yesterday_present is not None:
+        db.add(QualityDaily(
+            zone=zone, series_key=series, date=y.isoformat(),
+            hours_present=yesterday_present, hours_expected=expected, flags="[]",
+        ))
+    db.commit()
+
+
+def _seed_revisions(
+    db,
+    zone="DE_LU",
+    series="load.actual",
+    *,
+    hours=3,
+    pct=30.0,
+    observed_ago_h=1,
+    hour_age_h=120,
+    old=1000.0,
+):
+    """`hours` distinct restated hours of one series+zone: each hour is
+    `hour_age_h` old (mature at 120 h > the 48 h threshold), observed
+    `observed_ago_h` ago, moved by `pct` percent of the old value. Anchored to
+    the top of the hour so two seeding calls hit the SAME hour timestamps."""
+    sid = resolve_series_id(db, series)
+    zid = resolve_zone_id(db, zone)
+    now = int(
+        datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0).timestamp()
+    )
+    observed = now - observed_ago_h * 3600
+    for i in range(hours):
+        db.add(PowerRevision(
+            series_id=sid, zone_id=zid,
+            ts_utc=now - hour_age_h * 3600 - i * 3600,
+            old_value=old, new_value=old * (1.0 + pct / 100.0),
+            observed_at=observed,
+        ))
+    db.commit()
+
+
+# ─── quality_completeness_drop ────────────────────────────────────────────────
+
+
+def test_completeness_drop_fires(db_session):
+    _seed_quality(db_session, yesterday_present=4)
+    results = detect_completeness_drops(db_session)
+    assert len(results) == 1
+    r = results[0]
+    assert r.rule == "quality_completeness_drop"
+    assert r.zone == "DE_LU" and r.vertical == "power" and r.severity == "warning"
+    assert "load.actual" in r.title
+    assert "4 of 24" in r.title, "yesterday's count vs the expectation, in the headline"
+    assert "100%" in r.detail, "the 30-day norm travels in the detail"
+    assert r.as_of == _utc_yesterday().isoformat()
+
+
+def test_completeness_critical_at_zero_hours(db_session):
+    _seed_quality(db_session, yesterday_present=0)
+    r = detect_completeness_drops(db_session)[0]
+    assert r.severity == "critical"
+    assert "0 of 24" in r.title
+
+
+def test_completeness_weak_norm_suppressed(db_session):
+    # A series that is chronically half-complete dropping further is not news —
+    # the ≥90% trailing norm is the whole point of the rule.
+    _seed_quality(db_session, yesterday_present=4, norm_present=12)
+    assert detect_completeness_drops(db_session) == []
+
+
+def test_completeness_new_zone_guard(db_session):
+    # 3 prior perfect days are not a norm (MIN_BASELINE_N discipline): right
+    # after a deploy / a newly enabled zone the detector stays silent instead of
+    # judging yesterday against a handful of days.
+    _seed_quality(db_session, yesterday_present=2, norm_days=3)
+    assert detect_completeness_drops(db_session) == []
+
+
+def test_completeness_above_threshold_suppressed(db_session):
+    _seed_quality(db_session, yesterday_present=13)  # 54% — above the 50% bar
+    assert detect_completeness_drops(db_session) == []
+
+
+def test_completeness_missing_yesterday_row_is_silence(db_session):
+    # No quality row for yesterday (nightly job not run yet / series inactive)
+    # → nothing to describe → no alert. Absence is never turned into a claim.
+    _seed_quality(db_session, yesterday_present=None)
+    assert detect_completeness_drops(db_session) == []
+
+
+def test_completeness_no_data_no_alerts(db_session):
+    assert detect_completeness_drops(db_session) == []
+
+
+def test_completeness_folds_series_per_zone(db_session):
+    """The backbone dedups on (rule, zone): two dropped series in one zone must
+    come back as ONE result — worst offender leads the title, both are named."""
+    _seed_quality(db_session, series="load.actual", yesterday_present=0)   # critical
+    _seed_quality(db_session, series="gen.B16", yesterday_present=5)       # warning
+    results = detect_completeness_drops(db_session)
+    assert len(results) == 1, "one result per zone — the backbone's dedup key"
+    r = results[0]
+    assert r.severity == "critical", "the worst series sets the zone's severity"
+    assert "load.actual" in r.title and "+1 more" in r.title
+    assert "load.actual" in r.detail and "gen.B16" in r.detail
+
+
+def test_completeness_two_zones_two_results(db_session):
+    _seed_quality(db_session, zone="DE_LU", yesterday_present=4)
+    _seed_quality(db_session, zone="FR", yesterday_present=0)
+    results = detect_completeness_drops(db_session)
+    assert {r.zone for r in results} == {"DE_LU", "FR"}
+
+
+def test_completeness_disabled_zone_suppressed(db_session):
+    # ES is in the registry but not in the test env's enabled zones — the radar
+    # only speaks about zones the product serves.
+    _seed_quality(db_session, zone="ES", yesterday_present=0)
+    assert detect_completeness_drops(db_session) == []
+
+
+def test_completeness_ignores_unfinished_today(db_session):
+    # TODAY is always partial while the day runs; only YESTERDAY (the newest
+    # finished UTC day) is ever judged.
+    y = _utc_yesterday()
+    _seed_quality(db_session, yesterday_present=24)
+    db_session.add(QualityDaily(
+        zone="DE_LU", series_key="load.actual", date=(y + timedelta(days=1)).isoformat(),
+        hours_present=6, hours_expected=24, flags="[]",
+    ))
+    db_session.commit()
+    assert detect_completeness_drops(db_session) == []
+
+
+# ─── quality_major_restatement ────────────────────────────────────────────────
+
+
+def test_restatement_fires_at_three_hours(db_session):
+    _seed_revisions(db_session, hours=3, pct=30.0)
+    results = detect_major_restatements(db_session)
+    assert len(results) == 1
+    r = results[0]
+    assert r.rule == "quality_major_restatement"
+    assert r.zone == "DE_LU" and r.vertical == "power" and r.severity == "warning"
+    assert "load.actual" in r.title and "3" in r.title
+    assert "30%" in r.detail, "the median change travels"
+
+
+def test_restatement_two_hours_silent(db_session):
+    _seed_revisions(db_session, hours=2, pct=30.0)
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_small_changes_silent(db_session):
+    _seed_revisions(db_session, hours=6, pct=10.0)  # below the 20% bar
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_critical_at_twelve_hours(db_session):
+    _seed_revisions(db_session, hours=12, pct=30.0)
+    assert detect_major_restatements(db_session)[0].severity == "critical"
+
+
+def test_restatement_critical_at_median_50pct(db_session):
+    _seed_revisions(db_session, hours=3, pct=60.0)
+    assert detect_major_restatements(db_session)[0].severity == "critical"
+
+
+def test_restatement_immature_fill_in_silent(db_session):
+    # Restated hours only 12h old — the normal provisional fill-in window
+    # (REVISION_MATURITY_S read-side threshold, routes/quality.py), not news.
+    _seed_revisions(db_session, hours=6, pct=30.0, hour_age_h=12)
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_old_observation_silent(db_session):
+    # Observed three days ago — outside the 24h radar window (the on-site feed
+    # is "what changed recently", not the ledger's history).
+    _seed_revisions(db_session, hours=6, pct=30.0, observed_ago_h=72, hour_age_h=240)
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_counts_distinct_hours_not_rows(db_session):
+    # Two revisions of the SAME hour are one restated hour, not two.
+    _seed_revisions(db_session, hours=2, pct=30.0)
+    _seed_revisions(db_session, hours=2, pct=40.0)  # same two hours, revised again
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_folds_series_per_zone(db_session):
+    _seed_revisions(db_session, series="load.actual", hours=12, pct=30.0)  # critical
+    _seed_revisions(db_session, series="gen.B16", hours=3, pct=25.0)       # warning
+    results = detect_major_restatements(db_session)
+    assert len(results) == 1, "one result per zone — the backbone's dedup key"
+    r = results[0]
+    assert r.severity == "critical"
+    assert "load.actual" in r.title and "+1 more" in r.title
+    assert "load.actual" in r.detail and "gen.B16" in r.detail
+
+
+def test_restatement_disabled_zone_suppressed(db_session):
+    _seed_revisions(db_session, zone="ES", hours=6, pct=30.0)
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_no_data_no_alerts(db_session):
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_zero_old_value_uses_floor(db_session):
+    # |new−old| is measured against max(|old|, floor) — an old value of exactly
+    # 0 must not divide-by-zero or manufacture an infinite percentage.
+    _seed_revisions(db_session, hours=3, pct=0.0, old=0.0)
+    for r in db_session.query(PowerRevision).all():
+        r.new_value = 5.0
+    db_session.commit()
+    results = detect_major_restatements(db_session)
+    assert len(results) == 1  # 5.0 against the 1.0 floor = 500% — still finite
+
+
+# ─── registry + runner integration ────────────────────────────────────────────
+
+
+def test_quality_detectors_are_registered(db_session):
+    assert detect_completeness_drops in DETECTORS
+    assert detect_major_restatements in DETECTORS
+
+
+def test_runner_surfaces_quality_alerts(db_session):
+    _seed_quality(db_session, yesterday_present=4)
+    _seed_revisions(db_session, hours=3, pct=30.0)
+    run_all_detectors(db_session)
+    rules = {a.rule: a for a in db_session.query(Alert).all()}
+    assert "quality_completeness_drop" in rules
+    assert "quality_major_restatement" in rules
+    assert rules["quality_completeness_drop"].vertical == "power"
+    assert rules["quality_completeness_drop"].zone == "DE_LU"

--- a/backend/tests/test_quality_detectors.py
+++ b/backend/tests/test_quality_detectors.py
@@ -141,6 +141,32 @@ def test_completeness_no_data_no_alerts(db_session):
     assert detect_completeness_drops(db_session) == []
 
 
+def test_completeness_exactly_half_suppressed(db_session):
+    # 12/24 is exactly the 0.5 ratio — the bar is strictly below.
+    _seed_quality(db_session, yesterday_present=12)
+    assert detect_completeness_drops(db_session) == []
+
+
+def test_completeness_norm_exactly_090_fires(db_session):
+    # 9/10 on every prior day → the trailing mean sits exactly at the 0.90
+    # threshold, which is inclusive (a 90%-complete series IS the near-complete
+    # case the rule exists for).
+    _seed_quality(db_session, yesterday_present=4, expected=10, norm_present=9)
+    assert len(detect_completeness_drops(db_session)) == 1
+
+
+def test_completeness_13_norm_days_silent(db_session):
+    # One day short of MIN_BASELINE_N — not a norm yet.
+    _seed_quality(db_session, yesterday_present=4, norm_days=13)
+    assert detect_completeness_drops(db_session) == []
+
+
+def test_completeness_14_norm_days_fires(db_session):
+    # Exactly MIN_BASELINE_N days of rows — the norm becomes trustworthy.
+    _seed_quality(db_session, yesterday_present=4, norm_days=14)
+    assert len(detect_completeness_drops(db_session)) == 1
+
+
 def test_completeness_folds_series_per_zone(db_session):
     """The backbone dedups on (rule, zone): two dropped series in one zone must
     come back as ONE result — worst offender leads the title, both are named."""
@@ -217,7 +243,7 @@ def test_restatement_critical_at_median_50pct(db_session):
 
 def test_restatement_immature_fill_in_silent(db_session):
     # Restated hours only 12h old — the normal provisional fill-in window
-    # (REVISION_MATURITY_S read-side threshold, routes/quality.py), not news.
+    # (REVISION_MATURITY_S read-side threshold, backend/power/quality.py), not news.
     _seed_revisions(db_session, hours=6, pct=30.0, hour_age_h=12)
     assert detect_major_restatements(db_session) == []
 
@@ -256,15 +282,89 @@ def test_restatement_no_data_no_alerts(db_session):
     assert detect_major_restatements(db_session) == []
 
 
+def test_restatement_maturity_boundary_is_strict(db_session):
+    """Exactly 48h between the hour and its observation is still fill-in (the
+    /revisions API's strict >, mirrored); one second beyond is settled data."""
+    from backend.power.quality import REVISION_MATURITY_S
+
+    sid = resolve_series_id(db_session, "load.actual")
+    zid = resolve_zone_id(db_session, "DE_LU")
+    now = int(datetime.now(timezone.utc).timestamp())
+    for i in range(3):
+        ts = now - REVISION_MATURITY_S - 2 * 3600 - i * 3600
+        db_session.add(PowerRevision(
+            series_id=sid, zone_id=zid, ts_utc=ts,
+            old_value=1000.0, new_value=1300.0,
+            observed_at=ts + REVISION_MATURITY_S,  # exactly at the threshold
+        ))
+    db_session.commit()
+    assert detect_major_restatements(db_session) == []
+
+    for r in db_session.query(PowerRevision).all():
+        r.observed_at += 1  # one second beyond — now mature
+    db_session.commit()
+    assert len(detect_major_restatements(db_session)) == 1
+
+
+def test_restatement_fraction_boundary_is_strict(db_session):
+    # Exactly 20% of the old value (1000→1200, well past the materiality
+    # floor) — the bar is "exceeds", not "meets".
+    _seed_revisions(db_session, hours=3, pct=20.0)
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_detail_caps_series_list(db_session):
+    # A backfill burst can restate many series of one zone at once; the detail
+    # names the top offenders and folds the rest instead of growing unbounded.
+    for i in range(8):
+        _seed_revisions(db_session, series=f"gen.B{i:02d}", hours=3 + i, pct=30.0)
+    r = detect_major_restatements(db_session)[0]
+    assert r.detail.count("hours of gen.B") == 6, "top offenders only"
+    assert "+2 more series" in r.detail
+    assert "gen.B07" in r.title, "the most-restated series leads"
+
+
 def test_restatement_zero_old_value_uses_floor(db_session):
-    # |new−old| is measured against max(|old|, floor) — an old value of exactly
-    # 0 must not divide-by-zero or manufacture an infinite percentage.
+    # The percentage is measured against max(|old|, floor) — an old value of
+    # exactly 0 must not divide-by-zero or manufacture an infinite percentage.
+    # new=200 clears the load.* materiality floor (50 MW), so only the
+    # denominator is under test here.
     _seed_revisions(db_session, hours=3, pct=0.0, old=0.0)
     for r in db_session.query(PowerRevision).all():
-        r.new_value = 5.0
+        r.new_value = 200.0
     db_session.commit()
     results = detect_major_restatements(db_session)
-    assert len(results) == 1  # 5.0 against the 1.0 floor = 500% — still finite
+    assert len(results) == 1  # 200 against the 1.0 denominator floor — finite, fires
+
+
+def test_restatement_downward_fires(db_session):
+    # Downward corrections are the COMMON real case (provisional generation
+    # revised down); the magnitude must be signless.
+    _seed_revisions(db_session, hours=3, pct=-30.0)
+    r = detect_major_restatements(db_session)[0]
+    assert r.severity == "warning" and "30%" in r.detail
+
+
+def test_restatement_immaterial_absolute_change_silent(db_session):
+    # 2→3 MW is 50% against the denominator floor but one megawatt of movement
+    # — the ledger's 0.5-unit write epsilon lets it through, the load.* 50 MW
+    # materiality floor must not. Percentages only get a voice once the change
+    # is material in the series' own unit.
+    _seed_revisions(db_session, hours=3, pct=50.0, old=2.0)
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_immaterial_price_change_silent(db_session):
+    # 2→3 EUR is 50% but one euro — below the price.* 5 EUR floor.
+    _seed_revisions(db_session, series="price.dayahead", hours=3, pct=50.0, old=2.0)
+    assert detect_major_restatements(db_session) == []
+
+
+def test_restatement_material_price_change_fires(db_session):
+    # 40→52 EUR: 12 EUR clears the price.* floor, 30% clears the fraction bar.
+    _seed_revisions(db_session, series="price.dayahead", hours=3, pct=30.0, old=40.0)
+    r = detect_major_restatements(db_session)[0]
+    assert r.severity == "warning" and "price.dayahead" in r.title
 
 
 # ─── registry + runner integration ────────────────────────────────────────────

--- a/backend/tests/test_quality_detectors.py
+++ b/backend/tests/test_quality_detectors.py
@@ -39,10 +39,12 @@ def _seed_quality(
     expected=24,
     norm_days=30,
     norm_present=24,
+    days_ago=1,
 ):
-    """`norm_days` full prior days then yesterday with `yesterday_present` hours.
-    yesterday_present=None seeds only the norm (no row for yesterday)."""
-    y = _utc_yesterday()
+    """`norm_days` full prior days then the anchor day (`days_ago` before today,
+    default yesterday) with `yesterday_present` hours. yesterday_present=None
+    seeds only the norm (no row for the anchor day)."""
+    y = datetime.now(timezone.utc).date() - timedelta(days=days_ago)
     for o in range(1, norm_days + 1):
         db.add(QualityDaily(
             zone=zone, series_key=series, date=(y - timedelta(days=o)).isoformat(),
@@ -131,10 +133,26 @@ def test_completeness_above_threshold_suppressed(db_session):
 
 
 def test_completeness_missing_yesterday_row_is_silence(db_session):
-    # No quality row for yesterday (nightly job not run yet / series inactive)
-    # → nothing to describe → no alert. Absence is never turned into a claim.
+    # No quality row for yesterday (nightly job not run yet): the detector
+    # anchors on the newest recorded day instead — here that day is fully
+    # complete, so silence. Absence is never turned into a claim.
     _seed_quality(db_session, yesterday_present=None)
     assert detect_completeness_drops(db_session) == []
+
+
+def test_completeness_fires_without_a_yesterday_row(db_session):
+    """The race the anchor exists for: the nightly quality job (23:55 UTC on
+    day D) writes day D−1's rows minutes before "yesterday" rolls over to D —
+    for almost all of day D the literal calendar yesterday has no row yet (and
+    a job overrun past midnight would skip it entirely). The newest recorded
+    day ≤ yesterday is what gets judged, with an honest as_of."""
+    two_days_ago = (datetime.now(timezone.utc).date() - timedelta(days=2)).isoformat()
+    _seed_quality(db_session, yesterday_present=4, days_ago=2)  # no yesterday row at all
+    results = detect_completeness_drops(db_session)
+    assert len(results) == 1
+    r = results[0]
+    assert "4 of 24" in r.title
+    assert r.as_of == two_days_ago, "as_of names the day actually judged"
 
 
 def test_completeness_no_data_no_alerts(db_session):

--- a/backend/tests/test_quality_engine.py
+++ b/backend/tests/test_quality_engine.py
@@ -1,0 +1,402 @@
+"""Nightly data-quality aggregates: completeness + rule-based anomaly flags
+per (zone, series, UTC day), persisted in quality_daily.
+
+Posture B: every flag DESCRIBES the published data (solar at night, a zero-run
+in load, an 8-IQR step) — nothing here predicts. Per rule there is one
+synthetic-positive and one boundary-negative case; conservatism is the design
+constraint (a false positive costs exactly the trust the product exists for).
+
+Times are epoch-UTC throughout, and the tests read the UTC clock instead of
+hardcoding calendar days (repo rule #111: date.today() made suites fail between
+00–02 local).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import backend.models  # noqa: F401 — registers vessel/alert tables run_retention touches
+from backend.models.energy import IngestArrival, PowerHourly, PowerRevision, QualityDaily, SeriesDim
+from backend.power.hourly_store import day_hour_ts, upsert_hourly
+from backend.power.quality import (
+    QUALITY_SERIES,
+    ZONE_SERIES_KEY,
+    compute_and_store_quality,
+    compute_and_store_range,
+)
+
+
+def _day(days_ago: int) -> str:
+    return (datetime.now(timezone.utc).date() - timedelta(days=days_ago)).isoformat()
+
+
+DAY = _day(2)  # the examined day (safely finished)
+
+
+def _row(db, series_key: str, zone: str = "DE_LU", day: str = DAY) -> QualityDaily:
+    return db.query(QualityDaily).filter_by(zone=zone, series_key=series_key, date=day).one()
+
+
+def _flags(row: QualityDaily) -> list[dict]:
+    return json.loads(row.flags)
+
+
+def _rules(row: QualityDaily) -> set[str]:
+    return {f["rule"] for f in _flags(row)}
+
+
+def _seed_hours(db, series: str, zone: str, day: str, values: dict[int, float], unit="MW"):
+    upsert_hourly(db, series, zone, [(day_hour_ts(day, h), v) for h, v in values.items()], unit=unit)
+
+
+# ── Completeness ──────────────────────────────────────────────────────────────
+
+def test_completeness_counts_present_hours_of_24(db_session):
+    _seed_hours(db_session, "load.actual", "DE_LU", DAY, {h: 1000.0 for h in range(20)})
+    db_session.commit()
+    result = compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert result["written"] == 1  # only load.actual has data
+
+    row = _row(db_session, "load.actual")
+    assert row.hours_present == 20
+    assert row.hours_expected == 24
+    assert _flags(row) == []
+
+
+def test_qh_series_expects_96_intervals(db_session):
+    day_start = day_hour_ts(DAY, 0)
+    points = [(day_start + i * 900, 50.0) for i in range(90)]  # 90 of 96 quarter-hours
+    upsert_hourly(db_session, "price.dayahead.qh", "DE_LU", points, unit="EUR/MWh")
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+
+    row = _row(db_session, "price.dayahead.qh")
+    assert row.hours_present == 90
+    assert row.hours_expected == 96
+
+
+def test_empty_day_gets_zero_row_only_with_surrounding_activity(db_session):
+    """Activity within 30 days → the gap is information (hours_present=0).
+    Series with no data anywhere stay silent — the zone doesn't carry them."""
+    _seed_hours(db_session, "load.actual", "DE_LU", _day(5), {10: 900.0})
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+
+    row = _row(db_session, "load.actual")
+    assert row.hours_present == 0
+    assert row.hours_expected == 24
+    assert _flags(row) == []
+    # the other five series have no data at all → no rows, no noise
+    assert db_session.query(QualityDaily).count() == 1
+
+
+def test_no_row_when_activity_is_beyond_the_30_day_window(db_session):
+    _seed_hours(db_session, "load.actual", "DE_LU", _day(40), {10: 900.0})
+    db_session.commit()
+    result = compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert result == {"written": 0, "removed": 0}
+    assert db_session.query(QualityDaily).count() == 0
+
+
+def test_zone_with_no_data_writes_nothing_and_does_not_crash(db_session):
+    result = compute_and_store_quality(db_session, "FR", DAY)
+    assert result == {"written": 0, "removed": 0}
+    assert db_session.query(QualityDaily).count() == 0
+
+
+# ── pv_at_night ───────────────────────────────────────────────────────────────
+
+def test_pv_at_night_flags_solar_inside_the_dark_window(db_session):
+    # day max 4000 → 1% = 40 → floor 50 governs; 300 MW at 23:00 UTC is a flag
+    _seed_hours(db_session, "gen.B16", "DE_LU", DAY, {12: 4000.0, 23: 300.0})
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+
+    flags = _flags(_row(db_session, "gen.B16"))
+    assert [f["rule"] for f in flags] == ["pv_at_night"]
+    assert flags[0]["hours"] == [day_hour_ts(DAY, 23)]
+    assert flags[0]["detail"] == {"max_mw": 300.0, "threshold_mw": 50.0}
+
+
+def test_pv_at_night_boundary_values_do_not_flag(db_session):
+    # 1% of a 60 GW day = 600 MW: exactly 600 at night is NOT above the threshold
+    _seed_hours(db_session, "gen.B16", "DE_LU", DAY, {12: 60000.0, 23: 600.0})
+    # exactly the 50 MW floor is NOT above it either
+    _seed_hours(db_session, "gen.B16", "FR", DAY, {12: 100.0, 22: 50.0})
+    # 21:00 UTC is OUTSIDE the conservative window — high values there are dusk, not night
+    _seed_hours(db_session, "gen.B16", "NL", DAY, {12: 8000.0, 21: 5000.0})
+    db_session.commit()
+    for zone in ("DE_LU", "FR", "NL"):
+        compute_and_store_quality(db_session, zone, DAY)
+        assert _flags(_row(db_session, "gen.B16", zone=zone)) == []
+
+
+# ── zero_run ──────────────────────────────────────────────────────────────────
+
+def test_zero_run_flags_six_consecutive_zero_load_hours(db_session):
+    values = {h: 0.0 for h in range(6)} | {h: 1000.0 for h in range(6, 24)}
+    _seed_hours(db_session, "load.actual", "DE_LU", DAY, values)
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+
+    flags = [f for f in _flags(_row(db_session, "load.actual")) if f["rule"] == "zero_run"]
+    assert len(flags) == 1
+    assert flags[0]["hours"] == [day_hour_ts(DAY, h) for h in range(6)]
+    assert flags[0]["detail"] == {"longest_run_hours": 6}
+
+
+def test_zero_run_five_hours_is_below_the_bar(db_session):
+    values = {h: 0.0 for h in range(5)} | {h: 1000.0 for h in range(5, 24)}
+    _seed_hours(db_session, "load.actual", "DE_LU", DAY, values)
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert "zero_run" not in _rules(_row(db_session, "load.actual"))
+
+
+def test_zero_run_never_applies_to_prices(db_session):
+    """Zero (and negative) PRICES are real market outcomes — six zero price
+    hours must produce no flag of any kind (the 50 EUR recovery step is also
+    under the 100 EUR floor)."""
+    values = {h: 0.0 for h in range(6)} | {h: 50.0 for h in range(6, 24)}
+    _seed_hours(db_session, "price.dayahead", "DE_LU", DAY, values, unit="EUR/MWh")
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert _flags(_row(db_session, "price.dayahead")) == []
+
+
+# ── step_jump ─────────────────────────────────────────────────────────────────
+
+def _seed_alternating_load(db, days_ago_from: int, days_ago_to: int, except_hours: dict[int, float] | None = None):
+    """1000/1100 alternating hours over [days_ago_from..days_ago_to] — trailing
+    deltas of ±100 → IQR 200 → step threshold max(8·200, 500) = 1600."""
+    points = []
+    for days_ago in range(days_ago_from, days_ago_to - 1, -1):
+        day = _day(days_ago)
+        for h in range(24):
+            v = 1000.0 if h % 2 == 0 else 1100.0
+            if days_ago == days_ago_to and except_hours and h in except_hours:
+                v = except_hours[h]
+            points.append((day_hour_ts(day, h), v))
+    upsert_hourly(db, "load.actual", "DE_LU", points, unit="MW")
+    db.commit()
+
+
+def test_step_jump_flags_a_spike_far_beyond_the_series_own_iqr(db_session):
+    _seed_alternating_load(db_session, 32, 2, except_hours={12: 9000.0})
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+
+    flags = [f for f in _flags(_row(db_session, "load.actual")) if f["rule"] == "step_jump"]
+    assert len(flags) == 1
+    # the spike enters at hour 12 and leaves at hour 13 — both deltas flag
+    assert flags[0]["hours"] == [day_hour_ts(DAY, 12), day_hour_ts(DAY, 13)]
+    assert flags[0]["detail"]["threshold"] == pytest.approx(1600.0)
+    assert flags[0]["detail"]["max_abs_delta"] == pytest.approx(7900.0)
+
+
+def test_step_jump_exactly_at_threshold_does_not_flag(db_session):
+    # hour 11 is 1100; hours 12..23 at 2700 give one delta of exactly 8×IQR = 1600
+    _seed_alternating_load(db_session, 32, 2, except_hours={h: 2700.0 for h in range(12, 24)})
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert "step_jump" not in _rules(_row(db_session, "load.actual"))
+
+
+def test_step_jump_absolute_floor_guards_series_without_history(db_session):
+    """No trailing deltas → IQR 0 → the absolute floor governs: 400 MW stays
+    quiet, 600 MW flags (load floor 500)."""
+    _seed_hours(db_session, "load.actual", "DE_LU", DAY, {0: 1000.0, 1: 1400.0})
+    _seed_hours(db_session, "load.actual", "FR", DAY, {0: 1000.0, 1: 1600.0})
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+    compute_and_store_quality(db_session, "FR", DAY)
+
+    assert "step_jump" not in _rules(_row(db_session, "load.actual"))
+    fr_flags = [f for f in _flags(_row(db_session, "load.actual", zone="FR")) if f["rule"] == "step_jump"]
+    assert fr_flags and fr_flags[0]["detail"]["threshold"] == pytest.approx(500.0)
+
+
+def test_step_jump_price_floor_is_100_eur(db_session):
+    _seed_hours(db_session, "price.dayahead", "DE_LU", DAY, {0: 10.0, 1: 160.0}, unit="EUR/MWh")
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+
+    flags = [f for f in _flags(_row(db_session, "price.dayahead")) if f["rule"] == "step_jump"]
+    assert flags and flags[0]["detail"]["threshold"] == pytest.approx(100.0)
+
+
+# ── gen_below_load_exports (zone-level, series_key "_zone") ──────────────────
+
+def _seed_balance(db, zone: str, gen_mw: float, load_mw: float = 1000.0, export_mw: float | None = 100.0):
+    _seed_hours(db, "load.actual", zone, DAY, {h: load_mw for h in range(24)})
+    _seed_hours(db, "gen.B01", zone, DAY, {h: gen_mw for h in range(24)})
+    if export_mw is not None:
+        # zone is the storing (FROM) side: positive = zone exports
+        _seed_hours(db, "flow.XX", zone, DAY, {h: export_mw for h in range(24)})
+    db.commit()
+
+
+def test_gen_below_load_exports_flags_a_covered_zone_with_a_deficit(db_session):
+    # gen 16800 vs load 24000 + exports 2400: coverage gate 0.7 ≥ 0.6 passes,
+    # 16800 < 0.9 × 26400 → flag
+    _seed_balance(db_session, "DE_LU", gen_mw=700.0)
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+
+    row = _row(db_session, ZONE_SERIES_KEY)
+    assert row.hours_present == 0 and row.hours_expected == 0
+    (flag,) = _flags(row)
+    assert flag["rule"] == "gen_below_load_exports"
+    assert flag["hours"] == []
+    assert flag["detail"]["gen_mwh"] == pytest.approx(16800.0)
+    assert flag["detail"]["load_mwh"] == pytest.approx(24000.0)
+    assert flag["detail"]["net_export_mwh"] == pytest.approx(2400.0)
+    assert flag["detail"]["deficit_pct"] == pytest.approx(36.4)
+
+    # retraction: the feed heals (gen now covers supply) → the _zone row disappears
+    _seed_hours(db_session, "gen.B01", "DE_LU", DAY, {h: 1200.0 for h in range(24)})
+    db_session.commit()
+    result = compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert result["removed"] == 1
+    assert db_session.query(QualityDaily).filter_by(series_key=ZONE_SERIES_KEY).count() == 0
+
+
+def test_gen_below_load_exports_exempts_structurally_under_covered_zones(db_session):
+    # gen/load 0.4 < coverage_min_ratio 0.6 — the SE4-shaped structural gap
+    # (or a genuine net importer) is exempt, coverage.py's fail-safe doctrine
+    _seed_balance(db_session, "DE_LU", gen_mw=400.0)
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert db_session.query(QualityDaily).filter_by(series_key=ZONE_SERIES_KEY).count() == 0
+
+
+def test_gen_below_load_exports_boundary_at_ninety_percent_does_not_flag(db_session):
+    # gen 23760 == exactly 0.9 × (24000 + 2400) → within tolerance, no flag
+    _seed_balance(db_session, "DE_LU", gen_mw=990.0)
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert db_session.query(QualityDaily).filter_by(series_key=ZONE_SERIES_KEY).count() == 0
+
+
+def test_gen_below_load_exports_needs_flow_data(db_session):
+    """Without border flows an unmeasured import is indistinguishable from a
+    deficit — a healthy importer would flag every day. No flows, no flag."""
+    _seed_balance(db_session, "DE_LU", gen_mw=700.0, export_mw=None)
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert db_session.query(QualityDaily).filter_by(series_key=ZONE_SERIES_KEY).count() == 0
+
+
+# ── Recompute discipline ──────────────────────────────────────────────────────
+
+def test_recompute_is_idempotent(db_session):
+    _seed_hours(db_session, "load.actual", "DE_LU", DAY, {h: 1000.0 for h in range(24)})
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+
+    rows = db_session.query(QualityDaily).filter_by(zone="DE_LU", series_key="load.actual", date=DAY).all()
+    assert len(rows) == 1, "recompute replaces the row, never duplicates it"
+    assert rows[0].hours_present == 24
+
+
+def test_recompute_retracts_a_day_the_data_no_longer_supports(db_session):
+    """Episodes doctrine: a row a later revision of the data no longer supports
+    disappears, rather than sitting in the record forever."""
+    _seed_hours(db_session, "load.actual", "DE_LU", DAY, {h: 1000.0 for h in range(24)})
+    db_session.commit()
+    compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert db_session.query(QualityDaily).count() == 1
+
+    sid = db_session.query(SeriesDim.id).filter_by(key="load.actual").scalar()
+    db_session.query(PowerHourly).filter(PowerHourly.series_id == sid).delete()
+    db_session.commit()
+
+    result = compute_and_store_quality(db_session, "DE_LU", DAY)
+    assert result["removed"] == 1
+    assert db_session.query(QualityDaily).count() == 0
+
+
+def test_range_covers_each_day(db_session):
+    for day in (_day(4), _day(3), DAY):
+        _seed_hours(db_session, "load.actual", "DE_LU", day, {h: 1000.0 for h in range(24)})
+    db_session.commit()
+    result = compute_and_store_range(db_session, "DE_LU", _day(4), DAY)
+    assert result["written"] == 3
+
+    dates = [r.date for r in db_session.query(QualityDaily).order_by(QualityDaily.date).all()]
+    assert dates == [_day(4), _day(3), DAY]
+
+
+def test_quality_series_config_matches_the_task_charter():
+    assert QUALITY_SERIES == (
+        "load.actual", "price.dayahead", "price.dayahead.qh",
+        "gen.B16", "gen.B18", "gen.B19",
+    )
+
+
+# ── Retention (ingest_arrival pruning, A1's TODO) ────────────────────────────
+
+async def test_retention_prunes_old_arrivals_keeps_recent_and_never_touches_revisions(
+    db_session, monkeypatch
+):
+    import backend.collectors.retention as retention_mod
+
+    now = int(datetime.now(timezone.utc).timestamp())
+    old = now - 100 * 86400
+    recent = now - 86400
+    db_session.add(IngestArrival(series_id=1, zone_id=1, observed_at=old, n_new=1, n_changed=0))
+    db_session.add(IngestArrival(series_id=1, zone_id=1, observed_at=recent, n_new=1, n_changed=0))
+    # the revision ledger is the product — even a 100-day-old row must survive
+    db_session.add(PowerRevision(series_id=1, zone_id=1, ts_utc=old,
+                                 old_value=1.0, new_value=2.0, observed_at=old))
+    db_session.commit()
+
+    # run_retention binds SessionLocal at import time and is not in conftest's
+    # consumer list — point it at this test's engine explicitly.
+    factory = sessionmaker(autocommit=False, autoflush=False, bind=db_session.get_bind())
+    monkeypatch.setattr(retention_mod, "SessionLocal", factory)
+    await retention_mod.run_retention()
+
+    db_session.expire_all()
+    assert [r.observed_at for r in db_session.query(IngestArrival).all()] == [recent]
+    assert db_session.query(PowerRevision).count() == 1
+
+
+# ── Wiring: scheduler job + freshness spec ───────────────────────────────────
+
+class _RecordingScheduler:
+    """Stands in for the module-global AsyncIOScheduler: records add_job calls."""
+
+    def __init__(self):
+        self.jobs: dict[str, object] = {}
+
+    def add_job(self, func, trigger, *, id, **kwargs):  # noqa: A002 - mirrors APScheduler
+        assert id not in self.jobs, f"duplicate scheduler job id: {id}"
+        self.jobs[id] = (func, trigger)
+
+    def start(self):
+        pass
+
+
+def test_quality_nightly_registered_between_episodes_and_scoreboard(monkeypatch):
+    import backend.collectors.scheduler as sched_mod
+
+    rec = _RecordingScheduler()
+    monkeypatch.setattr(sched_mod, "scheduler", rec)
+    sched_mod.start_scheduler()
+
+    func, trigger = rec.jobs["quality_nightly"]
+    assert func is sched_mod._run_quality_nightly
+    assert str(trigger) == "cron[hour='23', minute='55']"
+    # the nightly derived-table chain keeps its order: records → episodes → quality → scoreboard
+    assert str(rec.jobs["episodes_nightly"][1]) == "cron[hour='23', minute='50']"
+    assert str(rec.jobs["forecast_scoreboard_nightly"][1]) == "cron[hour='23', minute='58']"
+
+
+def test_quality_daily_freshness_spec_watches_the_nightly_recompute():
+    from backend.collectors.freshness import SPECS
+
+    spec = next((s for s in SPECS if s.key == "quality_daily"), None)
+    assert spec is not None, "quality_daily must be freshness-monitored"
+    assert spec.model is QualityDaily
+    assert spec.column == "updated_at"
+    assert spec.max_age == timedelta(days=2)

--- a/backend/tests/test_quality_engine.py
+++ b/backend/tests/test_quality_engine.py
@@ -129,8 +129,11 @@ def test_pv_at_night_boundary_values_do_not_flag(db_session):
     _seed_hours(db_session, "gen.B16", "FR", DAY, {12: 100.0, 22: 50.0})
     # 21:00 UTC is OUTSIDE the conservative window — high values there are dusk, not night
     _seed_hours(db_session, "gen.B16", "NL", DAY, {12: 8000.0, 21: 5000.0})
+    # …and so is 01:00 UTC, the first hour past the window's pre-dawn end
+    # (Finnish midsummer sunrise ~00:54 UTC is exactly why the window stops there)
+    _seed_hours(db_session, "gen.B16", "BE", DAY, {12: 8000.0, 1: 5000.0})
     db_session.commit()
-    for zone in ("DE_LU", "FR", "NL"):
+    for zone in ("DE_LU", "FR", "NL", "BE"):
         compute_and_store_quality(db_session, zone, DAY)
         assert _flags(_row(db_session, "gen.B16", zone=zone)) == []
 
@@ -216,6 +219,15 @@ def test_step_jump_absolute_floor_guards_series_without_history(db_session):
     assert "step_jump" not in _rules(_row(db_session, "load.actual"))
     fr_flags = [f for f in _flags(_row(db_session, "load.actual", zone="FR")) if f["rule"] == "step_jump"]
     assert fr_flags and fr_flags[0]["detail"]["threshold"] == pytest.approx(500.0)
+
+
+def test_every_step_jump_wired_series_has_a_floor():
+    """The delta pass reads its floor from STEP_JUMP_FLOORS — wiring a series
+    into step_jump without one would KeyError at 23:55 UTC, not in review."""
+    from backend.power.quality import QUALITY_RULES, STEP_JUMP_FLOORS, rule_step_jump
+
+    wired = {key for key, rules in QUALITY_RULES.items() if rule_step_jump in rules}
+    assert wired <= set(STEP_JUMP_FLOORS)
 
 
 def test_step_jump_price_floor_is_100_eur(db_session):

--- a/backend/tests/test_revision_ledger.py
+++ b/backend/tests/test_revision_ledger.py
@@ -11,6 +11,7 @@ from backend.models.energy import IngestArrival, PowerRevision
 from backend.power.hourly_store import (
     REVISION_FLOOR,
     REVISION_REL_TOL,
+    read_hourly,
     resolve_series_id,
     resolve_zone_id,
     upsert_hourly,
@@ -101,7 +102,7 @@ def test_change_below_relative_epsilon_is_not_a_revision(db_session):
     upsert_hourly(db_session, "load.actual", "DE_LU", [(BASE, 60_000.0)])
     upsert_hourly(db_session, "load.actual", "DE_LU", [(BASE, 60_040.0)])  # Δ=40 ≤ 60
     assert db_session.query(PowerRevision).count() == 0
-    upsert_hourly(db_session, "load.actual", "DE_LU", [(BASE, 60_100.0)])  # Δ=60 vs 60_040 → > 60.04? no: 60 ≤ 60.04
+    upsert_hourly(db_session, "load.actual", "DE_LU", [(BASE, 60_100.0)])  # Δ=60 ≤ 60.04 (0.1% of 60_040) → below relative epsilon
     assert db_session.query(PowerRevision).count() == 0
     upsert_hourly(db_session, "load.actual", "DE_LU", [(BASE, 61_000.0)])  # Δ=900 > 60.1
     assert db_session.query(PowerRevision).count() == 1
@@ -140,6 +141,23 @@ def test_mixed_batch_counts_new_and_changed(db_session):
     assert a.n_new == 1
     assert a.n_changed == 1
     assert a.min_ts_new == a.max_ts_new == BASE + 2 * H
+
+
+def test_duplicate_ts_in_batch_diffs_last_wins(db_session):
+    # A batch carrying the same hour twice is diffed against the LAST value —
+    # mirroring what the ON CONFLICT upsert leaves behind. Here the last value
+    # equals the stored one, so nothing is a revision.
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(BASE, 50.0)])
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(BASE, 99.0), (BASE, 50.0)])
+    assert db_session.query(PowerRevision).count() == 0
+    assert read_hourly(db_session, "price.dayahead", "DE_LU") == [(BASE, 50.0)]
+
+
+def test_duplicate_new_ts_counts_once(db_session):
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(BASE, 99.0), (BASE, 50.0)])
+    a = db_session.query(IngestArrival).one()
+    assert a.n_new == 1
+    assert a.min_ts_new == a.max_ts_new == BASE
 
 
 def test_ledger_issues_bounded_selects_per_batch(db_session):

--- a/backend/tests/test_revision_ledger.py
+++ b/backend/tests/test_revision_ledger.py
@@ -1,0 +1,167 @@
+"""Revision ledger + arrival log (Honest Record slice A1): every batch through
+the single hourly write path records what changed (power_revision) and what
+arrived (ingest_arrival). Silent capture only — no API/UI in this slice."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import event
+
+from backend.models.energy import IngestArrival, PowerRevision
+from backend.power.hourly_store import (
+    REVISION_FLOOR,
+    REVISION_REL_TOL,
+    resolve_series_id,
+    resolve_zone_id,
+    upsert_hourly,
+)
+
+H = 3600
+BASE = 1_700_000_000  # arbitrary fixed epoch (matches test_hourly_store convention)
+
+
+def _now_ts() -> int:
+    return int(datetime.now(timezone.utc).timestamp())
+
+
+def test_fresh_insert_logs_one_arrival_and_no_revisions(db_session):
+    pts = [(BASE + i * H, 100.0 + i) for i in range(24)]
+    upsert_hourly(db_session, "load.actual", "DE_LU", pts, unit="MW")
+
+    assert db_session.query(PowerRevision).count() == 0
+    arrivals = db_session.query(IngestArrival).all()
+    assert len(arrivals) == 1  # one row per batch, not per point
+    a = arrivals[0]
+    assert a.series_id == resolve_series_id(db_session, "load.actual")
+    assert a.zone_id == resolve_zone_id(db_session, "DE_LU")
+    assert a.n_new == 24
+    assert a.n_changed == 0
+    assert a.min_ts_new == BASE
+    assert a.max_ts_new == BASE + 23 * H
+    # observed_at is the UTC wall clock at ingest (frontier lag = observed_at − max_ts_new).
+    assert abs(a.observed_at - _now_ts()) < 60
+
+
+def test_identical_reupsert_logs_arrival_with_zero_counts(db_session):
+    pts = [(BASE, 50.0), (BASE + H, 60.0)]
+    upsert_hourly(db_session, "price.dayahead", "FR", pts)
+    upsert_hourly(db_session, "price.dayahead", "FR", pts)
+
+    assert db_session.query(PowerRevision).count() == 0
+    arrivals = db_session.query(IngestArrival).order_by(IngestArrival.id).all()
+    # A no-change batch STILL logs an arrival row: it is evidence the source was
+    # fetched (later slices read arrival cadence as fetch health), and dropping
+    # it would make "no row" ambiguous between "never polled" and "polled, same".
+    assert len(arrivals) == 2
+    a = arrivals[1]
+    assert a.n_new == 0
+    assert a.n_changed == 0
+    assert a.min_ts_new is None
+    assert a.max_ts_new is None
+
+
+def test_all_none_batch_logs_nothing(db_session):
+    # None values are skipped before the batch forms → empty batch → no arrival.
+    upsert_hourly(db_session, "solar.forecast", "DE_LU", [(BASE, None), (BASE + H, None)])
+    assert db_session.query(IngestArrival).count() == 0
+    assert db_session.query(PowerRevision).count() == 0
+
+
+def test_change_beyond_epsilon_writes_revision(db_session):
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(BASE, 50.0), (BASE + H, 60.0)])
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(BASE, 55.0)])
+
+    revs = db_session.query(PowerRevision).all()
+    assert len(revs) == 1
+    r = revs[0]
+    assert r.series_id == resolve_series_id(db_session, "price.dayahead")
+    assert r.zone_id == resolve_zone_id(db_session, "DE_LU")
+    assert r.ts_utc == BASE
+    assert r.old_value == 50.0
+    assert r.new_value == 55.0
+    assert abs(r.observed_at - _now_ts()) < 60
+
+    a = db_session.query(IngestArrival).order_by(IngestArrival.id).all()[-1]
+    assert a.n_new == 0
+    assert a.n_changed == 1
+
+
+def test_change_below_absolute_floor_is_not_a_revision(db_session):
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(BASE, 50.0)])
+    # |Δ| = 0.3 ≤ max(FLOOR=0.5, 0.001·50) → float noise, not a revision.
+    assert abs(50.3 - 50.0) <= max(REVISION_FLOOR, REVISION_REL_TOL * 50.0)
+    upsert_hourly(db_session, "price.dayahead", "DE_LU", [(BASE, 50.3)])
+    assert db_session.query(PowerRevision).count() == 0
+    a = db_session.query(IngestArrival).order_by(IngestArrival.id).all()[-1]
+    assert a.n_changed == 0
+
+
+def test_change_below_relative_epsilon_is_not_a_revision(db_session):
+    # Large magnitudes: the 0.1% relative term dominates the 0.5 floor.
+    upsert_hourly(db_session, "load.actual", "DE_LU", [(BASE, 60_000.0)])
+    upsert_hourly(db_session, "load.actual", "DE_LU", [(BASE, 60_040.0)])  # Δ=40 ≤ 60
+    assert db_session.query(PowerRevision).count() == 0
+    upsert_hourly(db_session, "load.actual", "DE_LU", [(BASE, 60_100.0)])  # Δ=60 vs 60_040 → > 60.04? no: 60 ≤ 60.04
+    assert db_session.query(PowerRevision).count() == 0
+    upsert_hourly(db_session, "load.actual", "DE_LU", [(BASE, 61_000.0)])  # Δ=900 > 60.1
+    assert db_session.query(PowerRevision).count() == 1
+
+
+def test_residual_series_change_is_not_revision_ledgered(db_session):
+    # Derived series restate whenever their inputs restate — ledgering them would
+    # double-count every upstream revision. Arrival rows are still written.
+    upsert_hourly(db_session, "residual.load", "DE_LU", [(BASE, 30_000.0)])
+    upsert_hourly(db_session, "residual.load", "DE_LU", [(BASE, 20_000.0)])
+    assert db_session.query(PowerRevision).count() == 0
+    assert db_session.query(IngestArrival).count() == 2
+
+
+def test_new_row_is_arrival_not_revision(db_session):
+    upsert_hourly(db_session, "load.actual", "NL", [(BASE, 1.0)])
+    upsert_hourly(db_session, "load.actual", "NL", [(BASE + H, 2.0)])  # new hour only
+    assert db_session.query(PowerRevision).count() == 0
+    a = db_session.query(IngestArrival).order_by(IngestArrival.id).all()[-1]
+    assert a.n_new == 1
+    assert a.min_ts_new == a.max_ts_new == BASE + H
+
+
+def test_mixed_batch_counts_new_and_changed(db_session):
+    upsert_hourly(db_session, "price.dayahead", "NL", [(BASE, 50.0), (BASE + H, 60.0)])
+    # One real change, one unchanged, one new hour.
+    upsert_hourly(
+        db_session,
+        "price.dayahead",
+        "NL",
+        [(BASE, 40.0), (BASE + H, 60.0), (BASE + 2 * H, 70.0)],
+    )
+    revs = db_session.query(PowerRevision).all()
+    assert [(r.ts_utc, r.old_value, r.new_value) for r in revs] == [(BASE, 50.0, 40.0)]
+    a = db_session.query(IngestArrival).order_by(IngestArrival.id).all()[-1]
+    assert a.n_new == 1
+    assert a.n_changed == 1
+    assert a.min_ts_new == a.max_ts_new == BASE + 2 * H
+
+
+def test_ledger_issues_bounded_selects_per_batch(db_session):
+    """The diff read must be ONE indexed SELECT per batch — a month-sized backfill
+    batch must not degrade to per-row lookups (budget mirrors
+    test_power_overview.test_bulk_uses_fixed_query_count)."""
+    month = [(BASE + i * H, float(i)) for i in range(744)]
+    upsert_hourly(db_session, "load.actual", "DE_LU", month)  # seed
+
+    statements = []
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            statements.append(statement)
+
+    engine = db_session.get_bind()
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        # Re-upsert with every value shifted → 744 revisions, still bounded SELECTs.
+        upsert_hourly(db_session, "load.actual", "DE_LU", [(ts, v + 10.0) for ts, v in month])
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+    # 2 dim resolves + 1 diff read (+ headroom for driver chatter).
+    assert len(statements) <= 5, f"{len(statements)} SELECTs — ledger regressed to per-row reads"
+    assert db_session.query(PowerRevision).count() == 744

--- a/backend/tests/test_scoreboard_api.py
+++ b/backend/tests/test_scoreboard_api.py
@@ -193,15 +193,23 @@ def test_bias_positive_when_forecast_leans_high_end_to_end(db_session):
 def test_ranking_load_by_mape(db_session):
     _score(db_session, "DE_LU", "load", _day(1), mae=500.0, mape=5.0)
     _score(db_session, "FR", "load", _day(1), mae=900.0, mape=2.0)  # bigger MW, better %
+    _score(db_session, "NL", "load", _day(1), mae=100.0, mape=None)  # no stored MAPE
     db_session.commit()
     body = _client(db_session).get("/api/v1/scoreboard/ranking").json()
     assert body["available"] is True
     assert body["window_days"] == 90
     load = body["series"]["load"]
     assert load["metric"] == "mape"
-    assert [(e["zone"], e["rank"]) for e in load["ranking"]] == [("FR", 1), ("DE_LU", 2)]
+    assert [(e["zone"], e["rank"]) for e in load["ranking"]] == [
+        ("FR", 1), ("DE_LU", 2), ("NL", None)]
     assert load["ranking"][0]["mape"] == pytest.approx(2.0)
     assert load["ranking"][0]["days_covered"] == 1
+    # NULL-MAPE zones are signposted like the missing-capacity case — listed,
+    # with the reason, never a bare null
+    nl = load["ranking"][2]
+    assert nl["mape"] is None
+    assert "MAPE unavailable" in nl["signposted"]
+    assert nl["mae"] == pytest.approx(100.0)  # the absolute number still served
 
 
 def test_ranking_nmae_math_and_capacity_signposting(db_session):
@@ -257,7 +265,10 @@ def test_ranking_window_filters_and_validates(db_session):
     assert "30" in r.json()["detail"] and "365" in r.json()["detail"]  # lists valid windows
 
 
-def test_ranking_is_cached_per_window_and_stamped_per_request(db_session, monkeypatch):
+def test_ranking_is_cached_per_window_and_restamped_per_request(db_session, monkeypatch):
+    """The payload computes once per TTL per window, but the freshness triple
+    must be re-derived from the LIVE clock on every request — a warm cache
+    that freezes age_days would misreport staleness for up to 15 minutes."""
     import backend.routes.scoreboard as sb
 
     _score(db_session, "DE_LU", "load", _day(1), mape=3.0)
@@ -272,12 +283,57 @@ def test_ranking_is_cached_per_window_and_stamped_per_request(db_session, monkey
     monkeypatch.setattr(sb, "_ranking_payload", counting)
     c = _client(db_session)
     first = c.get("/api/v1/scoreboard/ranking").json()
+    assert calls["n"] == 1
+    assert first["stale"] is False  # as_of is yesterday, window is 2 days
+
+    # Jump the handler's clock 3 days: the SAME cached payload must come back
+    # with a provably different, live-derived stamp — not the frozen one.
+    real_dt = sb.datetime
+
+    class _Warped(real_dt):
+        @classmethod
+        def now(cls, tz=None):
+            return real_dt.now(tz) + timedelta(days=3)
+
+    monkeypatch.setattr(sb, "datetime", _Warped)
     second = c.get("/api/v1/scoreboard/ranking").json()
-    assert calls["n"] == 1  # second hit served from the keyed cache
+    assert calls["n"] == 1  # served warm — the payload was NOT recomputed
     assert first["series"] == second["series"]
-    assert "age_days" in second and "stale" in second  # triple rides each request
+    assert second["age_days"] == first["age_days"] + 3  # restamped from the live clock
+    assert second["stale"] is True  # > the 2-day forecast_scoreboard window
     c.get("/api/v1/scoreboard/ranking?window=30")
     assert calls["n"] == 2  # each window is its own cache entry
+
+
+def test_ranking_payload_select_budget(db_session):
+    """The ranking must stay a fixed handful of queries — one score scan, one
+    capacity scan, one max-date — never per-zone/per-cell point reads
+    (test_summary_payload_select_budget pattern from the quality suite)."""
+    from sqlalchemy import event
+
+    import backend.routes.scoreboard as sb
+
+    for zone in ("DE_LU", "FR"):
+        _score(db_session, zone, "load", _day(1), mape=3.0)
+        _score(db_session, zone, "wind", _day(1))
+        _cap(db_session, zone, "Wind Onshore", 10000.0)
+    db_session.commit()
+
+    statements = []
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            statements.append(statement)
+
+    engine = db_session.get_bind()
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        payload = sb._ranking_payload(db_session, 90)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+    assert payload["available"] is True  # the seed actually exercised the matrix
+    assert len(payload["series"]["load"]["ranking"]) == 2
+    assert len(statements) <= 4, f"{len(statements)} SELECTs — ranking regressed to per-zone reads"
 
 
 # ─── /monthly ─────────────────────────────────────────────────────────────────

--- a/backend/tests/test_scoreboard_api.py
+++ b/backend/tests/test_scoreboard_api.py
@@ -1,0 +1,424 @@
+"""/api/v1/scoreboard/* — the Honest-Record forecast scoreboard read API (B2).
+
+Covers: per-zone summary window math (day-weighted by n_hours, hand-computed,
+incl. the NULL-baseline drop-out from the skill ratio only), the cross-zone
+ranking (load MAPE / wind+solar capacity-normalized MAE with seeded A68
+capacity and honest signposting when a zone has none / residual plain-MAE
+caveat), monthly bucketing across a calendar boundary, the on-read hour-of-day
+profile riding the REAL engine path (FORECAST_PAIRS + score_hours over the
+hourly store), the bias sign convention (table convention: forecast − actual,
+declared on the wire), helpful 400s, honest available:false, and the v1 guard
+stack (shared rate budget, heavy slots, per-window ranking cache).
+
+Posture B: every asserted number GRADES a forecast ENTSO-E published — OBSYD
+forecasts nothing. Times read the UTC clock, never date.today() (repo rule #111).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api_guard import _reset_coverage_cache
+from backend.auth.ratelimit import reset_limits
+from backend.database import get_db
+from backend.main import app
+from backend.models.energy import ForecastScoreDaily, InstalledCapacity
+from backend.power.forecast_score import compute_and_store_scores
+from backend.power.hourly_store import day_hour_ts, upsert_hourly
+
+# Rebound per TEST by the _clock fixture below — the endpoints read the live
+# clock, so a suite that imports before UTC midnight and asserts after it must
+# not do its day math from a frozen import-time NOW (repo rule #111's flake class).
+NOW = datetime.now(UTC)
+NOW_S = int(NOW.timestamp())
+_H = 3600
+_D = 86400
+
+
+@pytest.fixture(autouse=True)
+def _clock():
+    global NOW, NOW_S
+    NOW = datetime.now(UTC)
+    NOW_S = int(NOW.timestamp())
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    reset_limits()
+    _reset_coverage_cache()  # keyed cache is process-global — the ranking would leak
+    yield
+    app.dependency_overrides.clear()
+    reset_limits()
+    _reset_coverage_cache()
+
+
+def _client(db) -> TestClient:
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _day(days_ago: int) -> str:
+    return (NOW.date() - timedelta(days=days_ago)).isoformat()
+
+
+def _score(db, zone, series, day, *, n=24, mae=100.0, rmse=120.0, bias=10.0,
+           mape=None, mae_p=150.0, mae_s=200.0):
+    db.add(ForecastScoreDaily(zone=zone, series=series, date=day, n_hours=n,
+                              mae=mae, rmse=rmse, bias=bias, mape=mape,
+                              mae_persistence=mae_p, mae_seasonal=mae_s))
+
+
+def _cap(db, zone, psr, mw, year=2025):
+    db.add(InstalledCapacity(zone=zone, year=year, psr_type=psr, capacity_mw=mw))
+
+
+# ─── /summary ─────────────────────────────────────────────────────────────────
+
+
+def test_summary_window_math_day_weighted(db_session):
+    """Hand-computed 30/90/365 aggregates. Day-weighted by n_hours: mae/bias are
+    exact per-hour window means, rmse recombines quadratically, and a day whose
+    baseline MAE is NULL drops out of the SKILL ratio only (its mae still
+    counts in the headline mae)."""
+    _score(db_session, "DE_LU", "load", _day(1), n=24, mae=100.0, rmse=100.0,
+           bias=10.0, mape=2.0, mae_p=200.0, mae_s=250.0)
+    _score(db_session, "DE_LU", "load", _day(40), n=12, mae=200.0, rmse=200.0,
+           bias=-20.0, mape=4.0, mae_p=250.0, mae_s=None)  # NULL seasonal baseline
+    _score(db_session, "DE_LU", "load", _day(200), n=24, mae=50.0, rmse=50.0,
+           bias=0.0, mape=1.0, mae_p=100.0, mae_s=100.0)
+    db_session.commit()
+
+    body = _client(db_session).get("/api/v1/scoreboard/summary?zone=DE_LU").json()
+    assert body["available"] is True
+    assert body["zone"] == "DE_LU"
+    (cell,) = body["series"]  # only the carried series appears
+    assert cell["series"] == "load"
+
+    w30 = cell["windows"]["30d"]
+    assert w30["days_covered"] == 1 and w30["n_hours"] == 24
+    assert w30["mae"] == pytest.approx(100.0)
+    assert w30["rmse"] == pytest.approx(100.0)
+    assert w30["bias"] == pytest.approx(10.0)
+    assert w30["mape"] == pytest.approx(2.0)
+    assert w30["skill_persistence"] == pytest.approx(0.5)    # 1 − 100/200
+    assert w30["skill_seasonal"] == pytest.approx(0.6)       # 1 − 100/250
+
+    w90 = cell["windows"]["90d"]
+    assert w90["days_covered"] == 2 and w90["n_hours"] == 36
+    assert w90["mae"] == pytest.approx(133.3, abs=0.05)      # (100·24+200·12)/36
+    assert w90["rmse"] == pytest.approx(141.4, abs=0.05)     # sqrt((100²·24+200²·12)/36)
+    assert w90["bias"] == pytest.approx(0.0)                 # (10·24 − 20·12)/36
+    assert w90["mape"] == pytest.approx(2.67, abs=0.01)      # (2·24+4·12)/36
+    # skill vs persistence uses BOTH days: 1 − 4800/7800
+    assert w90["skill_persistence"] == pytest.approx(0.385, abs=1e-3)
+    # NULL-baseline day drops out of the seasonal ratio ONLY → same as 30d
+    assert w90["skill_seasonal"] == pytest.approx(0.6)
+
+    w365 = cell["windows"]["365d"]
+    assert w365["days_covered"] == 3 and w365["n_hours"] == 60
+    assert w365["mae"] == pytest.approx(100.0)               # 6000/60
+    assert w365["mape"] == pytest.approx(2.0)                # 120/60
+    assert w365["skill_persistence"] == pytest.approx(0.412, abs=1e-3)  # 1 − 6000/10200
+
+    # freshness triple, keyed to the forecast_scoreboard spec (2d window)
+    assert body["as_of"] == _day(1)
+    assert body["age_days"] == 1
+    assert body["stale"] is False
+    # the sign convention is declared on the wire, table convention
+    assert "mean(forecast - actual)" in body["bias_convention"]
+    assert "forecast-error" in body["bias_convention"]  # warns about the old route
+
+
+def test_summary_lists_only_carried_series_but_names_all(db_session):
+    _score(db_session, "DE_LU", "wind", _day(40), mape=None)
+    db_session.commit()
+    body = _client(db_session).get("/api/v1/scoreboard/summary?zone=DE_LU").json()
+    assert [c["series"] for c in body["series"]] == ["wind"]
+    assert body["series_keys"] == ["load", "residual", "wind", "solar"]
+    windows = body["series"][0]["windows"]
+    assert windows["30d"] is None  # a window with no scored days is honest null
+    assert windows["90d"]["days_covered"] == 1
+    # wind carries no MAPE by design — the field is present and honestly null
+    assert windows["90d"]["mape"] is None
+
+
+def test_summary_valid_but_empty_zone_is_available_false(db_session):
+    body = _client(db_session).get("/api/v1/scoreboard/summary?zone=FR").json()
+    assert body["available"] is False
+    assert body["series"] == []
+    assert body["as_of"] is None and body["stale"] is False  # inert, not a crash
+
+
+def test_summary_bad_zone_is_helpful_400(db_session):
+    r = _client(db_session).get("/api/v1/scoreboard/summary?zone=NOPE")
+    assert r.status_code == 400
+    assert "DE_LU" in r.json()["detail"]
+
+
+# ─── sign convention (through the real engine) ────────────────────────────────
+
+
+def test_bias_positive_when_forecast_leans_high_end_to_end(db_session):
+    """Seed forecast = actual + 50 in the hourly store, score it through the
+    REAL engine (compute_and_store_scores), and assert the summary reports
+    bias +50 — the TABLE convention (forecast − actual), opposite of the old
+    /api/power/forecast-error route. The profile (which reads the hourly store
+    directly through the engine's score_hours) must agree."""
+    for h in range(4):
+        ts = day_hour_ts(_day(5), h)
+        upsert_hourly(db_session, "load.forecast", "DE_LU", [(ts, 10050.0)], unit="MW")
+        upsert_hourly(db_session, "load.actual", "DE_LU", [(ts, 10000.0)], unit="MW")
+    compute_and_store_scores(db_session, "DE_LU", _day(5))
+
+    c = _client(db_session)
+    body = c.get("/api/v1/scoreboard/summary?zone=DE_LU").json()
+    (cell,) = body["series"]
+    assert cell["series"] == "load"
+    assert cell["windows"]["30d"]["bias"] == pytest.approx(50.0)  # positive = leaned HIGH
+    assert "mean(forecast - actual)" in body["bias_convention"]
+
+    prof = c.get("/api/v1/scoreboard/profile?zone=DE_LU&series=load").json()
+    assert prof["available"] is True
+    covered = [row for row in prof["hours"] if row["n"] > 0]
+    assert len(covered) == 4
+    assert all(row["bias"] == pytest.approx(50.0) for row in covered)
+    assert "mean(forecast - actual)" in prof["bias_convention"]
+
+
+# ─── /ranking ─────────────────────────────────────────────────────────────────
+
+
+def test_ranking_load_by_mape(db_session):
+    _score(db_session, "DE_LU", "load", _day(1), mae=500.0, mape=5.0)
+    _score(db_session, "FR", "load", _day(1), mae=900.0, mape=2.0)  # bigger MW, better %
+    db_session.commit()
+    body = _client(db_session).get("/api/v1/scoreboard/ranking").json()
+    assert body["available"] is True
+    assert body["window_days"] == 90
+    load = body["series"]["load"]
+    assert load["metric"] == "mape"
+    assert [(e["zone"], e["rank"]) for e in load["ranking"]] == [("FR", 1), ("DE_LU", 2)]
+    assert load["ranking"][0]["mape"] == pytest.approx(2.0)
+    assert load["ranking"][0]["days_covered"] == 1
+
+
+def test_ranking_nmae_math_and_capacity_signposting(db_session):
+    # wind capacity: DE_LU onshore+offshore summed, each at its own latest year
+    _cap(db_session, "DE_LU", "Wind Onshore", 90000.0, year=2024)  # stale year — must lose
+    _cap(db_session, "DE_LU", "Wind Onshore", 20000.0, year=2025)
+    _cap(db_session, "DE_LU", "Wind Offshore", 5000.0, year=2025)
+    _cap(db_session, "FR", "Wind Onshore", 10000.0, year=2025)
+    _cap(db_session, "DE_LU", "Solar", 10000.0, year=2025)
+    _score(db_session, "DE_LU", "wind", _day(1), mae=500.0)   # 100·500/25000 = 2.0 %
+    _score(db_session, "FR", "wind", _day(1), mae=300.0)      # 100·300/10000 = 3.0 %
+    _score(db_session, "NL", "wind", _day(1), mae=100.0)      # no A68 capacity seeded
+    _score(db_session, "DE_LU", "solar", _day(1), mae=250.0)  # 100·250/10000 = 2.5 %
+    db_session.commit()
+
+    body = _client(db_session).get("/api/v1/scoreboard/ranking").json()
+    wind = body["series"]["wind"]
+    assert wind["metric"] == "nmae_pct"
+    assert [(e["zone"], e["rank"]) for e in wind["ranking"]] == [
+        ("DE_LU", 1), ("FR", 2), ("NL", None)]  # listed, never silently hidden
+    de, fr, nl = wind["ranking"]
+    assert de["nmae_pct"] == pytest.approx(2.0)
+    assert de["capacity_mw"] == pytest.approx(25000.0)  # 2025 values, onshore+offshore
+    assert fr["nmae_pct"] == pytest.approx(3.0)
+    assert nl["nmae_pct"] is None and nl["capacity_mw"] is None
+    assert "no A68 capacity" in nl["signposted"]
+    assert nl["mae"] == pytest.approx(100.0)  # the absolute number still served
+
+    solar = body["series"]["solar"]
+    assert solar["ranking"][0]["nmae_pct"] == pytest.approx(2.5)
+
+
+def test_ranking_residual_plain_mae_with_caveat(db_session):
+    _score(db_session, "DE_LU", "residual", _day(1), mae=800.0)
+    _score(db_session, "FR", "residual", _day(1), mae=400.0)
+    db_session.commit()
+    res = _client(db_session).get("/api/v1/scoreboard/ranking").json()["series"]["residual"]
+    assert res["metric"] == "mae"
+    assert [(e["zone"], e["rank"]) for e in res["ranking"]] == [("FR", 1), ("DE_LU", 2)]
+    assert "not" in res["caveat"] and "MW" in res["caveat"]  # cross-zone comparability caveat
+
+
+def test_ranking_window_filters_and_validates(db_session):
+    _score(db_session, "DE_LU", "load", _day(50), mape=3.0)
+    db_session.commit()
+    c = _client(db_session)
+    assert c.get("/api/v1/scoreboard/ranking").json()["available"] is True  # 90d default
+    body = c.get("/api/v1/scoreboard/ranking?window=30").json()
+    assert body["available"] is False  # the only row lies outside 30d
+    assert body["series"]["load"]["ranking"] == []
+    r = c.get("/api/v1/scoreboard/ranking?window=7")
+    assert r.status_code == 400
+    assert "30" in r.json()["detail"] and "365" in r.json()["detail"]  # lists valid windows
+
+
+def test_ranking_is_cached_per_window_and_stamped_per_request(db_session, monkeypatch):
+    import backend.routes.scoreboard as sb
+
+    _score(db_session, "DE_LU", "load", _day(1), mape=3.0)
+    db_session.commit()
+    calls = {"n": 0}
+    orig = sb._ranking_payload
+
+    def counting(db, window):
+        calls["n"] += 1
+        return orig(db, window)
+
+    monkeypatch.setattr(sb, "_ranking_payload", counting)
+    c = _client(db_session)
+    first = c.get("/api/v1/scoreboard/ranking").json()
+    second = c.get("/api/v1/scoreboard/ranking").json()
+    assert calls["n"] == 1  # second hit served from the keyed cache
+    assert first["series"] == second["series"]
+    assert "age_days" in second and "stale" in second  # triple rides each request
+    c.get("/api/v1/scoreboard/ranking?window=30")
+    assert calls["n"] == 2  # each window is its own cache entry
+
+
+# ─── /monthly ─────────────────────────────────────────────────────────────────
+
+
+def test_monthly_buckets_on_utc_calendar_months(db_session):
+    _score(db_session, "DE_LU", "load", "2026-05-31", n=24, mae=100.0, rmse=100.0,
+           bias=10.0, mape=2.0, mae_p=200.0, mae_s=None)
+    _score(db_session, "DE_LU", "load", "2026-06-01", n=12, mae=200.0, rmse=200.0,
+           bias=-20.0, mape=4.0, mae_p=250.0, mae_s=250.0)
+    _score(db_session, "DE_LU", "load", "2026-06-15", n=24, mae=50.0, rmse=50.0,
+           bias=0.0, mape=1.0, mae_p=None, mae_s=100.0)
+    db_session.commit()
+
+    body = _client(db_session).get(
+        "/api/v1/scoreboard/monthly?zone=DE_LU&series=load").json()
+    assert body["available"] is True
+    may, june = body["data"]  # oldest first — a chart-ready history
+    assert may["month"] == "2026-05" and may["days"] == 1
+    assert may["mae"] == pytest.approx(100.0)
+    assert may["skill_persistence"] == pytest.approx(0.5)  # 1 − 100/200
+    assert may["skill_seasonal"] is None                   # only baseline row is NULL
+
+    assert june["month"] == "2026-06" and june["days"] == 2 and june["n_hours"] == 36
+    assert june["mae"] == pytest.approx(100.0)             # (200·12+50·24)/36
+    assert june["bias"] == pytest.approx(-6.7)             # (−20·12+0·24)/36, wire-rounded 0.1
+    assert june["mape"] == pytest.approx(2.0)              # (4·12+1·24)/36
+    # persistence: only the 06-01 row carries the baseline → 1 − 2400/3000
+    assert june["skill_persistence"] == pytest.approx(0.2)
+    # seasonal: 06-01 and 06-15 → 1 − 3600/(250·12+100·24) = 1 − 3600/5400
+    assert june["skill_seasonal"] == pytest.approx(0.333, abs=1e-3)
+
+    assert body["as_of"] == "2026-06-15"
+    assert body["stale"] is True  # months old — honestly stale
+    assert "mean(forecast - actual)" in body["bias_convention"]
+
+
+def test_monthly_bad_params_and_empty(db_session):
+    c = _client(db_session)
+    r = c.get("/api/v1/scoreboard/monthly?zone=DE_LU&series=hack")
+    assert r.status_code == 400
+    assert "load" in r.json()["detail"]  # lists the valid series keys
+    r = c.get("/api/v1/scoreboard/monthly?zone=NOPE&series=load")
+    assert r.status_code == 400
+    assert "DE_LU" in r.json()["detail"]
+    body = c.get("/api/v1/scoreboard/monthly?zone=FR&series=load").json()
+    assert body["available"] is False and body["data"] == []
+
+
+# ─── /profile ─────────────────────────────────────────────────────────────────
+
+
+def test_profile_hour_of_day_math_via_engine(db_session):
+    """Two days of seeded hourly pairs → per-UTC-hour buckets through the real
+    engine scoring (score_hours): h0 has errors +100 and −100 (mae 100, bias 0),
+    h1 has a single +50."""
+    upsert_hourly(db_session, "load.forecast", "DE_LU",
+                  [(day_hour_ts(_day(3), 0), 10100.0), (day_hour_ts(_day(3), 1), 10050.0),
+                   (day_hour_ts(_day(2), 0), 9900.0)], unit="MW")
+    upsert_hourly(db_session, "load.actual", "DE_LU",
+                  [(day_hour_ts(_day(3), 0), 10000.0), (day_hour_ts(_day(3), 1), 10000.0),
+                   (day_hour_ts(_day(2), 0), 10000.0)], unit="MW")
+
+    body = _client(db_session).get(
+        "/api/v1/scoreboard/profile?zone=DE_LU&series=load").json()
+    assert body["available"] is True
+    assert body["window_days"] == 90
+    assert [row["hour_utc"] for row in body["hours"]] == list(range(24))
+    h0, h1 = body["hours"][0], body["hours"][1]
+    assert h0["n"] == 2 and h0["mae"] == pytest.approx(100.0) and h0["bias"] == pytest.approx(0.0)
+    assert h1["n"] == 1 and h1["mae"] == pytest.approx(50.0) and h1["bias"] == pytest.approx(50.0)
+    assert body["hours"][5] == {"hour_utc": 5, "n": 0, "mae": None, "bias": None}
+    assert "UTC" in body["note"]  # hour-of-day is UTC, said on the wire
+    # as_of = the newest scored hour, ISO 8601 UTC
+    assert body["as_of"] == datetime.fromtimestamp(day_hour_ts(_day(2), 0), UTC).isoformat()
+
+
+def test_profile_wind_sums_the_two_actual_gen_series(db_session):
+    """The wind pair's actual is gen.B18+gen.B19 summed — FORECAST_PAIRS is the
+    single source of that alignment and the profile must ride it."""
+    ts = day_hour_ts(_day(2), 12)
+    upsert_hourly(db_session, "wind.forecast", "DE_LU", [(ts, 800.0)], unit="MW")
+    upsert_hourly(db_session, "gen.B18", "DE_LU", [(ts, 300.0)], unit="MW")
+    upsert_hourly(db_session, "gen.B19", "DE_LU", [(ts, 400.0)], unit="MW")
+
+    body = _client(db_session).get(
+        "/api/v1/scoreboard/profile?zone=DE_LU&series=wind").json()
+    h12 = body["hours"][12]
+    assert h12["n"] == 1
+    assert h12["bias"] == pytest.approx(100.0)  # 800 − (300+400), forecast leaned high
+    assert h12["mae"] == pytest.approx(100.0)
+
+
+def test_profile_param_validation(db_session):
+    c = _client(db_session)
+    assert c.get("/api/v1/scoreboard/profile?zone=DE_LU&series=load&window=400").status_code == 422
+    assert c.get("/api/v1/scoreboard/profile?zone=DE_LU&series=load&window=0").status_code == 422
+    r = c.get("/api/v1/scoreboard/profile?zone=DE_LU&series=hack")
+    assert r.status_code == 400
+    assert "load" in r.json()["detail"]
+    r = c.get("/api/v1/scoreboard/profile?zone=NOPE&series=load")
+    assert r.status_code == 400
+    assert "DE_LU" in r.json()["detail"]
+
+
+def test_profile_valid_but_empty_is_available_false(db_session):
+    body = _client(db_session).get(
+        "/api/v1/scoreboard/profile?zone=FR&series=load").json()
+    assert body["available"] is False
+    assert body["hours"] == []
+    assert body["as_of"] is None and body["stale"] is False
+
+
+# ─── guard stack ──────────────────────────────────────────────────────────────
+
+
+def test_scoreboard_shares_the_v1_rate_budget(db_session, monkeypatch):
+    import backend.routes.api_v1 as v1
+
+    monkeypatch.setattr(v1, "RATE_PER_MIN", 2)
+    c = _client(db_session)
+    assert c.get("/api/v1/scoreboard/summary?zone=DE_LU").status_code == 200
+    assert c.get("/api/v1/scoreboard/monthly?zone=DE_LU&series=load").status_code == 200
+    assert c.get("/api/v1/scoreboard/ranking").status_code == 429
+
+
+def test_ranking_and_profile_hold_a_heavy_slot(db_session):
+    """Drained semaphore → fail-fast 503 for the guarded reads; the light
+    single-zone reads still answer."""
+    import backend.api_guard as guard
+
+    c = _client(db_session)
+    acquired = [guard._heavy_sem.acquire(blocking=False)
+                for _ in range(guard.HEAVY_QUERY_SLOTS)]
+    try:
+        assert all(acquired)
+        assert c.get("/api/v1/scoreboard/ranking").status_code == 503
+        assert c.get("/api/v1/scoreboard/profile?zone=DE_LU&series=load").status_code == 503
+        assert c.get("/api/v1/scoreboard/summary?zone=DE_LU").status_code == 200
+        assert c.get("/api/v1/scoreboard/monthly?zone=DE_LU&series=load").status_code == 200
+    finally:
+        for ok in acquired:
+            if ok:
+                guard._heavy_sem.release()

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,7 +25,8 @@ Rate limit: the ~120 req/min/IP budget applies to **every** `/api/v1` endpoint �
 data (`/series`, `/genmix`, `/snapshot`), reference (`/meta`, `/zones`, `/status`,
 `/capacity`, `/units`, `/series/catalog`) and the `/badge/*.svg` widgets alike.
 On top of that, the heavier scans — `/series`, `/genmix`, `/snapshot`,
-`/series/catalog`, `/status`, `/quality/summary`, `/quality/revisions` and
+`/series/catalog`, `/status`, `/quality/summary`, `/quality/revisions`,
+`/scoreboard/ranking`, `/scoreboard/profile` and
 `/api/power/units/history` — share a concurrency
 guard: at most 8 heavy queries run at once server-wide; an excess request gets an
 immediate HTTP 503 with a retry message rather than queueing.
@@ -138,6 +139,63 @@ unrecoverable), so `as_of` here is the newest arrival-log timestamp for the
 series+zone: the last moment the source was polled and could have restated
 something. All `/quality/*` responses carry `as_of`/`age_days`/`stale`, and all
 timestamps are ISO 8601 UTC like the rest of `/api/v1`.
+
+### The forecast scoreboard — `/api/v1/scoreboard/*`
+
+OBSYD **grades ENTSO-E's own published D-1 forecasts** (load, wind, solar, and
+the derived residual = load − wind − solar) against ENTSO-E's published actuals
+— it makes no forecast of its own. The two yardsticks are naive baselines built
+from published actuals alone: *persistence* (actual 24 h ago) and *seasonal*
+(actual 168 h ago); `skill_x = 1 − mae/mae_x` — positive means the published
+forecast beat the naive baseline.
+
+**Bias sign convention** (declared on the wire as `bias_convention`):
+`bias = mean(forecast − actual)` in MW — **positive = the published forecast
+leaned HIGH**. The older `/api/power/forecast-error` endpoint reports the
+**opposite** sign (`bias_mw = mean(actual − forecast)`) and stays unchanged for
+its readers.
+
+Aggregates over daily rows are **day-weighted by `n_hours`** (exact per-hour
+window means; rmse recombined quadratically); days whose baseline MAE is NULL
+drop out of the skill ratio only, never out of the headline mae. `mape` exists
+for `load` only (wind/solar hit honest zeros at night, residual crosses zero).
+All `/scoreboard/*` responses carry `as_of`/`age_days`/`stale`.
+
+### `GET /api/v1/scoreboard/summary`
+One zone's report card: per carried series (`load`/`residual`/`wind`/`solar`)
+the trailing **30/90/365-day** aggregates — `days_covered`, `n_hours`, `mae`,
+`rmse`, `bias`, `mape` (load), `skill_persistence`, `skill_seasonal`.
+`?zone=` *(required)* — unknown zones are HTTP 400 listing the valid keys; a
+zone with no scored days is HTTP 200 with `available:false`.
+
+### `GET /api/v1/scoreboard/ranking`
+All enabled zones ranked per series by the **comparable** metric, best (lowest
+error) first: `load` by MAPE (%); `wind`/`solar` by **nMAE** (100 × window MAE
+÷ A68 installed capacity of the matching technology — wind = onshore +
+offshore, each zone+type at its own latest A68 year); `residual` by absolute
+MAE with an explicit `caveat` (absolute MW — zones of different size are not
+comparable on it). Zones with scored days but **no A68 capacity** for the
+technology are listed unranked (`nmae_pct: null`, `rank: null`) with a
+`signposted` reason — never silently hidden. `?window=` one of `30|90|365`
+days (default 90; anything else is HTTP 400 listing the valid windows).
+Computed once per ~15 min per window (cached), heavy-guarded.
+
+### `GET /api/v1/scoreboard/monthly`
+UTC calendar-month aggregates for ONE zone+series over the full scored history,
+oldest first — has the published forecast been getting better or worse? Each
+row: `month` (`YYYY-MM`), `days`, `n_hours`, `mae`, `rmse`, `bias`, `mape`
+(load), `skill_persistence`, `skill_seasonal`. `?zone=&series=` *(both
+required)* — bad values are HTTP 400 listing the valid keys.
+
+### `GET /api/v1/scoreboard/profile`
+Forecast error by **hour of day (0–23, UTC)** for ONE zone+series over a
+trailing window: per bucket the mean absolute error, mean `bias` and `n`.
+Computed on-read from the canonical hourly store through the scoring engine's
+own pair table (wind's actual = `gen.B18`+`gen.B19` summed), so it can never
+grade different series than the scoreboard. Buckets are UTC — a zone's
+local-time features (morning ramp, solar noon) appear shifted by its offset.
+`?zone=&series=&window=` (`window` 1–365 days, default 90; out-of-range is
+HTTP 422). Heavy-guarded.
 
 ## Series keys
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,7 +25,8 @@ Rate limit: the ~120 req/min/IP budget applies to **every** `/api/v1` endpoint �
 data (`/series`, `/genmix`, `/snapshot`), reference (`/meta`, `/zones`, `/status`,
 `/capacity`, `/units`, `/series/catalog`) and the `/badge/*.svg` widgets alike.
 On top of that, the heavier scans — `/series`, `/genmix`, `/snapshot`,
-`/series/catalog`, `/status` and `/api/power/units/history` — share a concurrency
+`/series/catalog`, `/status`, `/quality/summary`, `/quality/revisions` and
+`/api/power/units/history` — share a concurrency
 guard: at most 8 heavy queries run at once server-wide; an excess request gets an
 immediate HTTP 503 with a retry message rather than queueing.
 "Nothing found" (unknown series, empty window) is HTTP 200 with
@@ -87,6 +88,52 @@ Sources, licenses, attribution, enabled zones, available series, disclaimer.
 ### `GET /api/v1/status`
 Honest data coverage: per-zone and per-source freshness (measured on the data's own
 delivery date), and an overall `healthy` flag. "Here is exactly what is fresh and what is stale."
+
+### `GET /api/v1/quality/summary`
+The Honest-Record matrix over enabled zones × charter series (`load.actual`,
+`price.dayahead`, `price.dayahead.qh`, `gen.B16`/`B18`/`B19`, plus the reserved
+zone-level key `_zone`): per cell the trailing-30d/90d completeness (mean
+`hours_present/hours_expected` over days WITH quality rows), flagged days (30d),
+restatement count (30d) and the latest arrival lag in seconds (last fetch's
+wall-clock minus the newest hour it brought — **negative** for day-ahead series,
+whose frontier runs ahead of the clock). Series a zone doesn't carry are omitted;
+`_zone` cells appear only on flagged days. Computed once per ~15 min (cached),
+heavy-guarded. Descriptive: every number states what the source published.
+
+### `GET /api/v1/quality/series`
+Daily quality rows for ONE series+zone, newest first — the drill-down behind a
+summary cell — plus arrival-lag stats (median + p90) over the same window.
+
+| Param | Default | Notes |
+|-------|---------|-------|
+| `series` | *(required)* | one of the charter keys above, or `_zone` (zone-level flags) — anything else is HTTP 400 listing the valid keys |
+| `zone` | *(required)* | enabled bidding zone key — unknown zones are HTTP 400 listing the valid keys |
+| `days` | 90 | trailing window, max 365 |
+
+Each row: `date`, `hours_present`, `hours_expected`, `flags` (decoded list —
+`rule`, affected `hours` as ISO UTC, `detail`). Flags describe the published
+data (`zero_run`, `pv_at_night`, `step_jump`, `gen_below_load_exports`), never
+the market. A valid-but-empty combination is HTTP 200 with `available:false`.
+
+### `GET /api/v1/quality/revisions`
+The revision ledger for ONE series+zone: every time the source re-published a
+different value for an hour it had already published (beyond a float-noise
+epsilon), with `old_value`/`new_value`, `observed_at` and `delta_pct` — plus
+`restated_hours`, a roll-up of hours restated more than once
+(`n_revisions`, `last_change_pct`). Heavy-guarded, row-capped (20k/request).
+
+| Param | Default | Notes |
+|-------|---------|-------|
+| `series` | *(required)* | any catalog series key (see `/series/catalog`); derived `residual.*` series are not ledgered and answer `available:false` with the reason |
+| `zone` | *(required)* | enabled bidding zone key |
+| `days` | 30 | trailing window over `observed_at`, max 365 |
+| `mature` | `true` | `true`: only restatements observed >48 h after the hour they restate (settled data changed); `false`: include the routine provisional fill-in too |
+
+The ledger is forward-only (accrues from first deploy — history before that is
+unrecoverable), so `as_of` here is the newest arrival-log timestamp for the
+series+zone: the last moment the source was polled and could have restated
+something. All `/quality/*` responses carry `as_of`/`age_days`/`stale`, and all
+timestamps are ISO 8601 UTC like the rest of `/api/v1`.
 
 ## Series keys
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -115,6 +115,9 @@ Each row: `date`, `hours_present`, `hours_expected`, `flags` (decoded list —
 `rule`, affected `hours` as ISO UTC, `detail`). Flags describe the published
 data (`zero_run`, `pv_at_night`, `step_jump`, `gen_below_load_exports`), never
 the market. A valid-but-empty combination is HTTP 200 with `available:false`.
+Note: the arrival-lag stats ride the arrival log, which is pruned to a trailing
+90 days — with `days` > 90 the quality rows cover the full window but the lag
+stats remain bounded by that retention.
 
 ### `GET /api/v1/quality/revisions`
 The revision ledger for ONE series+zone: every time the source re-published a

--- a/docs/API.md
+++ b/docs/API.md
@@ -120,7 +120,11 @@ The revision ledger for ONE series+zone: every time the source re-published a
 different value for an hour it had already published (beyond a float-noise
 epsilon), with `old_value`/`new_value`, `observed_at` and `delta_pct` — plus
 `restated_hours`, a roll-up of hours restated more than once
-(`n_revisions`, `last_change_pct`). Heavy-guarded, row-capped (20k/request).
+(`n_revisions`, `last_change_pct`). `delta_pct` divides by the *absolute*
+previous value, so its sign is always the direction of movement (a negative
+price restated further down is a negative delta, not a sign flip). The roll-up
+is computed over the rows the `mature` filter left — toggling `mature` changes
+`restated_hours` too. Heavy-guarded, row-capped (20k/request).
 
 | Param | Default | Notes |
 |-------|---------|-------|

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import { MAP_FALLBACK } from './components/MapFallback'
 import DurationCurvePanel from './components/DurationCurvePanel'
 import MeritOrderScatter from './components/MeritOrderScatter'
 import MarginalTechPanel from './components/MarginalTechPanel'
+import ForecastScoreboardPanel from './components/ForecastScoreboardPanel'
 import GenMixHistoryPanel from './components/GenMixHistoryPanel'
 import TrendsPanel from './components/TrendsPanel'
 import ErrorBoundary from './components/ErrorBoundary'
@@ -766,6 +767,11 @@ function Dashboard() {
             <div className="mt-3">
               <ErrorBoundary name="marginal-tech">
                 <MarginalTechPanel zone={energyZone} />
+              </ErrorBoundary>
+            </div>
+            <div className="mt-3">
+              <ErrorBoundary name="forecast-scoreboard">
+                <ForecastScoreboardPanel zone={energyZone} />
               </ErrorBoundary>
             </div>
             <div className="mt-3">

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,8 @@ import CompactView from './components/CompactView'
 import AlertsPanel from './components/AlertsPanel'
 import SeriesExplorer from './components/SeriesExplorer'
 import CoveragePanel from './components/CoveragePanel'
+import DataQualityPanel from './components/DataQualityPanel'
+import RevisionsLedgerPanel from './components/RevisionsLedgerPanel'
 import EuropeDesk from './components/EuropeDesk'
 import { MAP_FALLBACK } from './components/MapFallback'
 import DurationCurvePanel from './components/DurationCurvePanel'
@@ -805,6 +807,12 @@ function Dashboard() {
             </ErrorBoundary>
             <ErrorBoundary name="coverage">
               <CoveragePanel />
+            </ErrorBoundary>
+            <ErrorBoundary name="data-quality">
+              <DataQualityPanel />
+            </ErrorBoundary>
+            <ErrorBoundary name="revisions-ledger">
+              <RevisionsLedgerPanel />
             </ErrorBoundary>
           </div>
         )}

--- a/frontend/src/components/CoveragePanel.jsx
+++ b/frontend/src/components/CoveragePanel.jsx
@@ -26,11 +26,22 @@ export default function CoveragePanel() {
           <span className="font-mono text-xs text-neutral-500 tracking-wider">DATA COVERAGE</span>
           <InfoPopover text="Exactly what is fresh and what is stale right now, per zone and source — measured on the DATA's own delivery date, not the write timestamp. The transparency answer to a black-box feed: we show our gaps." />
         </div>
-        {data && (
-          <span className={`font-mono text-[10px] font-bold ${data.healthy ? 'text-green-400' : 'text-amber-400'}`}>
-            {data.fresh_count}/{data.total} fresh
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {data && (
+            <span className={`font-mono text-[10px] font-bold ${data.healthy ? 'text-green-400' : 'text-amber-400'}`}>
+              {data.fresh_count}/{data.total} fresh
+            </span>
+          )}
+          {/* Cross-panel link to the quality matrix below — same
+              getElementById + scrollIntoView idiom as the Borders chip. */}
+          <button
+            onClick={() => document.getElementById('panel-data-quality')?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+            className="font-mono text-[9px] tracking-wider border border-border rounded px-1.5 py-0.5 text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+            title="Completeness, quality flags, restatements and arrival lag per zone × series — further down this tab"
+          >
+            DATA QUALITY ↓
+          </button>
+        </div>
       </div>
 
       {loading && (

--- a/frontend/src/components/DataQualityPanel.jsx
+++ b/frontend/src/components/DataQualityPanel.jsx
@@ -1,0 +1,305 @@
+import { useMemo, useState } from 'react'
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import useZones from '../hooks/useZones'
+
+const API = '/api'
+
+// The reserved zone-level pseudo-series (backend/power/quality.py::ZONE_SERIES_KEY):
+// cross-series rule flags only — completeness / revisions / lag are null by contract.
+const ZONE_SERIES_KEY = '_zone'
+
+// Human labels for the charter series (backend/power/quality.py::QUALITY_SERIES —
+// a stable config tuple, mirrored here like the fuel labels in utils/fuels.js).
+const SERIES_LABELS = {
+  'load.actual': 'Load (actual)',
+  'price.dayahead': 'Day-ahead price',
+  'price.dayahead.qh': 'Day-ahead price · 15-min',
+  'gen.B16': 'Solar generation',
+  'gen.B18': 'Wind offshore generation',
+  'gen.B19': 'Wind onshore generation',
+  [ZONE_SERIES_KEY]: 'zone-level checks',
+}
+
+const seriesLabel = (key) => SERIES_LABELS[key] || key
+
+// Initial zone-row cap — 37 zones in prod would push the ledger below the fold.
+const INITIAL_ZONE_ROWS = 12
+
+// Humanize an arrival lag in seconds. Negative = the data runs AHEAD of the
+// wall clock (day-ahead auctions publish future hours) — honest, not an error.
+function humanLag(s) {
+  if (s == null) return '—'
+  const a = Math.abs(s)
+  const mag = a < 60 ? `${Math.round(a)} s`
+    : a < 3600 ? `${Math.round(a / 60)} min`
+    : a < 86400 ? `${(a / 3600).toFixed(1)} h`
+    : `${(a / 86400).toFixed(1)} d`
+  return `${mag} ${s >= 0 ? 'behind' : 'ahead'}`
+}
+
+const fmtPct = (r) => (r == null ? '—' : `${(r * 100).toFixed(1)}%`)
+
+// Same emerald/amber/orange ladder as BordersPanel's convergenceColor — a hue
+// already means "how complete/coupled" elsewhere on the desk.
+function completenessTone(r) {
+  if (r == null) return { text: 'text-neutral-700', bar: 'bg-neutral-700' }
+  if (r >= 0.99) return { text: 'text-emerald-400', bar: 'bg-emerald-400' }
+  if (r >= 0.95) return { text: 'text-amber-400', bar: 'bg-amber-400' }
+  return { text: 'text-orange-400', bar: 'bg-orange-400' }
+}
+
+// Tiny inline completeness bar — a styled div, deliberately not a chart lib.
+function CompletenessBar({ ratio }) {
+  const tone = completenessTone(ratio)
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="inline-block w-12 h-1 rounded bg-white/10 overflow-hidden shrink-0">
+        {ratio != null && (
+          <span className={`block h-full ${tone.bar}`} style={{ width: `${Math.min(100, ratio * 100)}%` }} />
+        )}
+      </span>
+      <span className={`num ${tone.text}`}>{fmtPct(ratio)}</span>
+    </span>
+  )
+}
+
+// Structured ⓘ legend — BordersLegend's <dl> pattern. The API's `note` string
+// is never rendered raw here (repo rule); the long-form prose lives in
+// HOW TO READ on the EUROPE tab.
+function QualityLegend() {
+  const rows = [
+    ['Completeness', 'mean of hours published ÷ hours expected per UTC day (24 hourly, 96 quarter-hour), over the trailing 30/90 days with quality rows. A statement about the published record, not the market.'],
+    ['Worst series', 'the series with the lowest 30-day completeness in the zone.'],
+    ['Flags', 'days a rule flagged the published data (solar reported at night, load flatlining at exact zero, an hourly step 8× the series’ own month). Each flag describes the feed.'],
+    ['Revisions', 'hours the source re-published with a DIFFERENT value in the last 30 days, beyond float noise — the source revising its own publication.'],
+    ['Arrival', 'newest fetch’s wall clock minus the newest hour it delivered. Negative (“ahead”) for day-ahead series — the auction publishes the future.'],
+    ['zone-level checks', 'flags needing several series at once (e.g. generation below load while the zone exports). No completeness, revisions or lag of their own.'],
+  ]
+  return (
+    <div className="space-y-2">
+      <dl className="space-y-1.5">
+        {rows.map(([term, def]) => (
+          <div key={term} className="grid grid-cols-[86px_1fr] gap-x-2">
+            <dt className="text-cyan-glow/90">{term}</dt>
+            <dd className="text-neutral-400 leading-snug">{def}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="pt-1 border-t border-border/40 text-neutral-500">
+        Descriptive throughout — a low day is hours the source has not (yet) published,
+        never a judgement. Full definitions: HOW TO READ on the EUROPE tab.
+      </div>
+    </div>
+  )
+}
+
+// Per-series breakdown under an expanded zone row.
+function SeriesBreakdown({ series }) {
+  return (
+    <table className="w-full font-mono text-[10px]">
+      <thead>
+        <tr className="text-[8px] text-neutral-600 uppercase tracking-wider">
+          <th className="text-left px-2 py-1">Series</th>
+          <th className="text-left px-2 py-1" title="Mean daily completeness, trailing 30 days">30d</th>
+          <th className="text-right px-2 py-1" title="Mean daily completeness, trailing 90 days">90d</th>
+          <th className="text-right px-2 py-1" title="Days with at least one quality flag, trailing 30 days">Flags 30d</th>
+          <th className="text-right px-2 py-1" title="Source restatements beyond float noise, trailing 30 days">Rev 30d</th>
+          <th className="text-right px-2 py-1" title="Latest fetch's wall clock minus the newest hour it delivered">Arrival</th>
+        </tr>
+      </thead>
+      <tbody>
+        {series.map((s) => {
+          const isZoneRow = s.series_key === ZONE_SERIES_KEY
+          return (
+            <tr key={s.series_key} className="border-t border-border/30">
+              <td className={`px-2 py-1 ${isZoneRow ? 'text-neutral-500 italic' : 'text-neutral-400'}`}>
+                {seriesLabel(s.series_key)}
+              </td>
+              {isZoneRow ? (
+                // Zone-level pseudo-series: flags only — the other columns are
+                // null by contract, shown as em-dashes, never as zeros.
+                <>
+                  <td className="px-2 py-1 text-neutral-700">—</td>
+                  <td className="px-2 py-1 text-right text-neutral-700">—</td>
+                  <td className="px-2 py-1 text-right text-neutral-300 num">{s.flagged_days_30d}</td>
+                  <td className="px-2 py-1 text-right text-neutral-700">—</td>
+                  <td className="px-2 py-1 text-right text-neutral-700">—</td>
+                </>
+              ) : (
+                <>
+                  <td className="px-2 py-1"><CompletenessBar ratio={s.completeness_30d} /></td>
+                  <td className={`px-2 py-1 text-right num ${completenessTone(s.completeness_90d).text}`}>{fmtPct(s.completeness_90d)}</td>
+                  <td className={`px-2 py-1 text-right num ${s.flagged_days_30d > 0 ? 'text-neutral-300' : 'text-neutral-600'}`}>{s.flagged_days_30d}</td>
+                  <td className={`px-2 py-1 text-right num ${s.revisions_30d > 0 ? 'text-neutral-300' : 'text-neutral-600'}`}>{s.revisions_30d ?? '—'}</td>
+                  <td className="px-2 py-1 text-right text-neutral-500">{humanLag(s.arrival_lag_s)}</td>
+                </>
+              )}
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+}
+
+/**
+ * The quality matrix over GET /api/v1/quality/summary: per zone, how complete
+ * the published record is (30/90d), which series lags worst, how often rules
+ * flagged the published data, how often the source restated values, and how
+ * far behind the wall clock the newest data arrived. One summary row per zone,
+ * expandable to the per-series breakdown. Worst completeness floats to the top.
+ *
+ * Posture B: every cell describes what the SOURCE published / restated — a low
+ * completeness day is hours not (yet) published, never "wrong data".
+ */
+export default function DataQualityPanel() {
+  const { data, loading, error } = useFetchWithError(`${API}/v1/quality/summary`)
+  const { zones: zoneList } = useZones()
+  const [expanded, setExpanded] = useState(() => new Set())
+  const [showAll, setShowAll] = useState(false)
+
+  const zoneLabel = (key) => zoneList.find((z) => z.key === key)?.label || key
+
+  // Zone summary rows, worst 30d completeness first (problems float up).
+  const rows = useMemo(() => {
+    const zones = data?.zones || []
+    return zones
+      .map((z) => {
+        const real = z.series.filter((s) => s.series_key !== ZONE_SERIES_KEY)
+        const with30 = real.filter((s) => s.completeness_30d != null)
+        const mean30 = with30.length
+          ? with30.reduce((acc, s) => acc + s.completeness_30d, 0) / with30.length
+          : null
+        const worst = with30.length
+          ? with30.reduce((acc, s) => (s.completeness_30d < acc.completeness_30d ? s : acc))
+          : null
+        const flags30 = z.series.reduce((acc, s) => acc + (s.flagged_days_30d || 0), 0)
+        const revs30 = real.reduce((acc, s) => acc + (s.revisions_30d || 0), 0)
+        const lags = real.map((s) => s.arrival_lag_s).filter((v) => v != null)
+        // "Worst" = numerically greatest = most behind the clock. A zone whose
+        // every series runs ahead (day-ahead) honestly shows "ahead".
+        const worstLag = lags.length ? Math.max(...lags) : null
+        return { zone: z.zone, series: z.series, mean30, worst, flags30, revs30, worstLag }
+      })
+      .sort((a, b) => (a.mean30 ?? 2) - (b.mean30 ?? 2))
+  }, [data])
+
+  const visible = showAll ? rows : rows.slice(0, INITIAL_ZONE_ROWS)
+
+  const toggle = (zone) =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(zone)) next.delete(zone)
+      else next.add(zone)
+      return next
+    })
+
+  return (
+    <Panel
+      id="data-quality"
+      title="DATA QUALITY · COMPLETENESS & FLAGS"
+      info={<QualityLegend />}
+      infoWide
+      freshness={data}
+      headerRight={
+        data?.available && (
+          <span className="font-mono text-[9px] text-neutral-600">
+            {rows.length} zones · last {data?.windows?.short_days ?? 30}/{data?.windows?.long_days ?? 90}d
+          </span>
+        )
+      }
+    >
+      {loading && !data && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">Loading quality matrix…</div>
+      )}
+      {!loading && error && !data && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-red-400">Fetch error — retrying on next refresh.</div>
+      )}
+      {data && !data.available && (
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-500">
+          No quality aggregates on record yet — the nightly quality job writes one row per zone, series and UTC day.
+        </div>
+      )}
+      {data?.available && (
+        <>
+          <div className="px-2 py-2 overflow-x-auto">
+            <table className="w-full font-mono text-[11px]">
+              <thead>
+                <tr className="text-[9px] text-neutral-600 uppercase tracking-wider">
+                  <th className="text-left px-2 py-1">Zone</th>
+                  <th className="text-left px-2 py-1" title="Mean 30-day completeness across this zone's series">Completeness 30d</th>
+                  <th className="text-left px-2 py-1" title="The series with the lowest 30-day completeness">Worst series</th>
+                  <th className="text-right px-2 py-1" title="Flagged days across all series, trailing 30 days">Flags</th>
+                  <th className="text-right px-2 py-1" title="Source restatements across all series, trailing 30 days">Rev</th>
+                  <th className="text-right px-2 py-1" title="Worst (most behind) latest arrival lag across this zone's series">Arrival</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visible.map((r) => {
+                  const isOpen = expanded.has(r.zone)
+                  return (
+                    <RowGroup key={r.zone} row={r} isOpen={isOpen} onToggle={() => toggle(r.zone)} zoneLabel={zoneLabel} />
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+          {rows.length > INITIAL_ZONE_ROWS && (
+            <div className="px-4 pb-2">
+              <button
+                onClick={() => setShowAll((v) => !v)}
+                className="font-mono text-[9px] tracking-wider border border-border rounded px-1.5 py-0.5 text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+              >
+                {showAll ? 'show fewer' : `show all ${rows.length} zones`}
+              </button>
+            </div>
+          )}
+          <div className="px-4 py-2 border-t border-border font-mono text-[9px] text-neutral-700">
+            What the published record looks like, per zone × series — descriptive, never a judgement.
+            Public at GET /api/v1/quality/summary.
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}
+
+// One zone's summary row + (when open) its per-series breakdown row.
+function RowGroup({ row, isOpen, onToggle, zoneLabel }) {
+  return (
+    <>
+      <tr
+        onClick={onToggle}
+        className="border-t border-border/30 cursor-pointer hover:bg-white/[0.03]"
+        title={isOpen ? 'Collapse per-series breakdown' : 'Expand per-series breakdown'}
+      >
+        <td className="px-2 py-1.5 text-neutral-300 whitespace-nowrap">
+          <span className="text-neutral-600 mr-1.5">{isOpen ? '▾' : '▸'}</span>
+          {zoneLabel(row.zone)}
+        </td>
+        <td className="px-2 py-1.5"><CompletenessBar ratio={row.mean30} /></td>
+        <td className="px-2 py-1.5 text-neutral-500 whitespace-nowrap">
+          {row.worst ? (
+            <>
+              {seriesLabel(row.worst.series_key)}{' '}
+              <span className={completenessTone(row.worst.completeness_30d).text}>
+                {fmtPct(row.worst.completeness_30d)}
+              </span>
+            </>
+          ) : '—'}
+        </td>
+        <td className={`px-2 py-1.5 text-right num ${row.flags30 > 0 ? 'text-neutral-300' : 'text-neutral-600'}`}>{row.flags30}</td>
+        <td className={`px-2 py-1.5 text-right num ${row.revs30 > 0 ? 'text-neutral-300' : 'text-neutral-600'}`}>{row.revs30}</td>
+        <td className="px-2 py-1.5 text-right text-neutral-500 whitespace-nowrap">{humanLag(row.worstLag)}</td>
+      </tr>
+      {isOpen && (
+        <tr className="border-t border-border/20">
+          <td colSpan={6} className="px-2 pb-2 pt-1 bg-white/[0.02]">
+            <SeriesBreakdown series={row.series} />
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/DataQualityPanel.jsx
+++ b/frontend/src/components/DataQualityPanel.jsx
@@ -2,26 +2,9 @@ import { useMemo, useState } from 'react'
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import useZones from '../hooks/useZones'
+import { ZONE_SERIES_KEY, qualitySeriesLabel as seriesLabel } from '../utils/qualitySeries'
 
 const API = '/api'
-
-// The reserved zone-level pseudo-series (backend/power/quality.py::ZONE_SERIES_KEY):
-// cross-series rule flags only — completeness / revisions / lag are null by contract.
-const ZONE_SERIES_KEY = '_zone'
-
-// Human labels for the charter series (backend/power/quality.py::QUALITY_SERIES —
-// a stable config tuple, mirrored here like the fuel labels in utils/fuels.js).
-const SERIES_LABELS = {
-  'load.actual': 'Load (actual)',
-  'price.dayahead': 'Day-ahead price',
-  'price.dayahead.qh': 'Day-ahead price · 15-min',
-  'gen.B16': 'Solar generation',
-  'gen.B18': 'Wind offshore generation',
-  'gen.B19': 'Wind onshore generation',
-  [ZONE_SERIES_KEY]: 'zone-level checks',
-}
-
-const seriesLabel = (key) => SERIES_LABELS[key] || key
 
 // Initial zone-row cap — 37 zones in prod would push the ledger below the fold.
 const INITIAL_ZONE_ROWS = 12
@@ -130,8 +113,12 @@ function SeriesBreakdown({ series }) {
                 <>
                   <td className="px-2 py-1"><CompletenessBar ratio={s.completeness_30d} /></td>
                   <td className={`px-2 py-1 text-right num ${completenessTone(s.completeness_90d).text}`}>{fmtPct(s.completeness_90d)}</td>
+                  {/* No null-guards on this branch: for real series the API
+                      contract makes flags AND revisions plain ints (nulls exist
+                      only on the _zone branch above) — guarding one but not the
+                      other would just imply a contract that isn't there. */}
                   <td className={`px-2 py-1 text-right num ${s.flagged_days_30d > 0 ? 'text-neutral-300' : 'text-neutral-600'}`}>{s.flagged_days_30d}</td>
-                  <td className={`px-2 py-1 text-right num ${s.revisions_30d > 0 ? 'text-neutral-300' : 'text-neutral-600'}`}>{s.revisions_30d ?? '—'}</td>
+                  <td className={`px-2 py-1 text-right num ${s.revisions_30d > 0 ? 'text-neutral-300' : 'text-neutral-600'}`}>{s.revisions_30d}</td>
                   <td className="px-2 py-1 text-right text-neutral-500">{humanLag(s.arrival_lag_s)}</td>
                 </>
               )}
@@ -159,7 +146,10 @@ export default function DataQualityPanel() {
   const [expanded, setExpanded] = useState(() => new Set())
   const [showAll, setShowAll] = useState(false)
 
-  const zoneLabel = (key) => zoneList.find((z) => z.key === key)?.label || key
+  // key→label Map built once per zone-list load — a find() per row per render
+  // would rescan the 37-entry list for every visible zone.
+  const zoneLabels = useMemo(() => new Map(zoneList.map((z) => [z.key, z.label || z.key])), [zoneList])
+  const zoneLabel = (key) => zoneLabels.get(key) || key
 
   // Zone summary rows, worst 30d completeness first (problems float up).
   const rows = useMemo(() => {

--- a/frontend/src/components/ForecastErrorStrip.jsx
+++ b/frontend/src/components/ForecastErrorStrip.jsx
@@ -41,8 +41,28 @@ export default function ForecastErrorStrip({ zone = 'DE_LU' }) {
 
   return (
     <div className="px-4 py-2 border-t border-border/30 space-y-0.5">
-      <div className="font-mono text-[9px] text-neutral-600 tracking-wider uppercase">
-        Forecast vs actual · last 7 days · published TSO forecast, not ours
+      <div className="flex items-center justify-between gap-2">
+        <div className="font-mono text-[9px] text-neutral-600 tracking-wider uppercase">
+          Forecast vs actual · last 7 days · published TSO forecast, not ours
+        </div>
+        {/* Cross-tab jump via the URL hash: App.jsx's hashchange listener is the
+            existing deep-link mechanism that switches the active tab for any hash
+            matching a TAB key — no prop threading through PowerLoadForecastPanel
+            needed. The delayed scroll waits for the ANALYTICS panels to mount;
+            if they haven't yet, scrollIntoView on a missing node is a no-op and
+            the user still lands on the right tab. */}
+        <a
+          href="#analytics"
+          onClick={() => {
+            setTimeout(() => {
+              document.getElementById('panel-forecast-scoreboard')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            }, 250)
+          }}
+          className="shrink-0 font-mono text-[9px] tracking-wider border border-border rounded px-1.5 py-0.5 text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+          title="Open the full forecast scoreboard on the ANALYTICS tab — MAE/RMSE/bias, skill vs naive baselines, all-zone ranking"
+        >
+          full scoreboard →
+        </a>
       </div>
       <Line label="Load" err={load} />
       <Line label="Wind" err={wind} />

--- a/frontend/src/components/ForecastScoreboardPanel.jsx
+++ b/frontend/src/components/ForecastScoreboardPanel.jsx
@@ -1,0 +1,349 @@
+import { useMemo, useState } from 'react'
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import useZones from '../hooks/useZones'
+import { POLL_SLOW_MS } from '../utils/poll'
+
+const API = '/api'
+
+// Display labels for the four graded series (engine order — the backend's
+// FORECAST_PAIRS; each /summary response confirms it via series_keys).
+const SERIES_LABEL = { load: 'Load', residual: 'Residual load', wind: 'Wind', solar: 'Solar' }
+const SERIES_ORDER = ['load', 'residual', 'wind', 'solar']
+
+// /summary ships all three windows in one response (client-side toggle);
+// /ranking takes the window as a param — each is its own cached server compute.
+const ZONE_WINDOWS = ['30d', '90d', '365d']
+const RANK_WINDOWS = [30, 90, 365]
+
+// Ranked rows shown per ranking table before "show all" — signposted zones are
+// ALWAYS appended below regardless (listed, never hidden — the API's posture).
+const INITIAL_RANK_ROWS = 10
+
+// Fallback title for the bias columns, used only until /summary delivers the
+// API's own bias_convention string (which rides on title= attrs, never popovers).
+const BIAS_TITLE_FALLBACK =
+  'bias = mean(forecast − actual) in MW: positive = the published forecast leaned high'
+
+// Segmented toggle idiom shared with CapturePanel / GasBalancePanel.
+function ToggleBtn({ id, label, view, setView }) {
+  return (
+    <button
+      type="button"
+      onClick={() => setView(id)}
+      className={`font-mono text-[9px] tracking-wider px-2 py-0.5 rounded border transition-colors ${
+        view === id ? 'text-cyan-glow border-cyan-glow/50 bg-cyan-glow/5' : 'text-neutral-600 border-border hover:text-neutral-400'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+// MW to 0–1 decimals (repo number convention): whole MW normally, one decimal
+// only when the value is small enough that rounding would erase it.
+const fmtMW = (v) => (v == null ? '—' : Math.abs(v) < 10 ? v.toFixed(1) : Math.round(v).toLocaleString('en-US'))
+const fmtBias = (v) => (v == null ? '—' : `${v > 0 ? '+' : ''}${fmtMW(v)}`)
+const fmtPct1 = (v) => (v == null ? '—' : `${v.toFixed(1)}%`)
+
+// Skill vs a naive baseline, as the compact phrase — signed %, colored by sign.
+function SkillCell({ skill }) {
+  if (skill == null) {
+    return <span className="text-neutral-700" title="No day in this window carries this baseline">—</span>
+  }
+  const pct = Math.abs(skill * 100).toFixed(1)
+  if (skill > 0) return <span className="text-emerald-400">beats naive by {pct}%</span>
+  if (skill < 0) return <span className="text-orange-400">trails naive by {pct}%</span>
+  return <span className="text-neutral-500">matches naive</span>
+}
+
+// Structured ⓘ legend — BordersLegend's <dl> pattern. The API's `note` /
+// `bias_convention` strings are never rendered raw in this popover (repo rule);
+// the long-form prose lives in HOW TO READ on the EUROPE tab.
+function ScoreboardLegend() {
+  const rows = [
+    ['MAE', 'mean absolute error (MW) — the typical hourly miss, direction ignored.'],
+    ['RMSE', 'root-mean-square error (MW) — punishes big misses harder; RMSE well above MAE = spiky errors.'],
+    ['Bias', 'mean(forecast − actual) in MW — positive = the published forecast leaned high.'],
+    ['MAPE', 'the miss as % of the actual — load only by design (wind/solar hit honest zeros, residual crosses zero).'],
+    ['nMAE', 'MAE as % of installed capacity (A68; wind = onshore + offshore) — comparable across fleet sizes.'],
+    ['beats naive', 'skill = 1 − MAE/MAE_naive vs persistence (same hour yesterday) and seasonal (same hour last week) — both built from published actuals alone. Positive = the published forecast beat the no-model yardstick.'],
+    ['n=', 'days (and hours) both forecast and actual existed — every score states its sample.'],
+  ]
+  return (
+    <div className="space-y-2">
+      <dl className="space-y-1.5">
+        {rows.map(([term, def]) => (
+          <div key={term} className="grid grid-cols-[74px_1fr] gap-x-2">
+            <dt className="text-cyan-glow/90">{term}</dt>
+            <dd className="text-neutral-400 leading-snug">{def}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="pt-1 border-t border-border/40 text-neutral-500">
+        Grades ENTSO-E&rsquo;s own published D-1 forecasts — OBSYD makes no forecasts.
+        Full definitions: HOW TO READ on the EUROPE tab.
+      </div>
+    </div>
+  )
+}
+
+// One zone's report card at one window — per series MAE/RMSE/bias (+MAPE for
+// load) and skill vs both naive baselines. Tables and styled divs only.
+function ZoneTable({ data, window, biasTitle }) {
+  const byKey = Object.fromEntries((data.series ?? []).map((s) => [s.series, s]))
+  const keys = data.series_keys?.length ? data.series_keys : SERIES_ORDER
+  return (
+    <div className="px-2 pt-2 overflow-x-auto">
+      <table className="w-full font-mono text-[10px]">
+        <thead>
+          <tr className="text-[8px] text-neutral-600 uppercase tracking-wider">
+            <th className="text-left px-2 py-1">Series</th>
+            <th className="text-right px-2 py-1" title="Mean absolute error over the window (MW)">MAE MW</th>
+            <th className="text-right px-2 py-1" title="Root-mean-square error over the window (MW)">RMSE MW</th>
+            <th className="text-right px-2 py-1" title={biasTitle}>Bias MW</th>
+            <th className="text-right px-2 py-1" title="Mean absolute percentage error — load only by design">MAPE</th>
+            <th className="text-left px-2 py-1" title="Skill vs persistence: the actual at the same hour yesterday as the naive forecast">vs persistence</th>
+            <th className="text-left px-2 py-1" title="Skill vs seasonal: the actual at the same hour last week as the naive forecast">vs seasonal</th>
+            <th className="text-right px-2 py-1" title="Days covered in this window (scored hours on hover)">n</th>
+          </tr>
+        </thead>
+        <tbody>
+          {keys.map((k) => {
+            const s = byKey[k]
+            const w = s?.windows?.[window]
+            if (!s || !w) {
+              // Absent series / empty window: named and explained, never a
+              // silently missing row.
+              return (
+                <tr key={k} className="border-t border-border/30 text-neutral-700">
+                  <td className="px-2 py-1.5 text-neutral-600">{SERIES_LABEL[k] ?? k}</td>
+                  <td colSpan={7} className="px-2 py-1.5 text-[9px]">
+                    {!s ? 'not scored — this zone does not carry the forecast/actual pair' : 'no scored days in this window'}
+                  </td>
+                </tr>
+              )
+            }
+            return (
+              <tr key={k} className="border-t border-border/30">
+                <td className="px-2 py-1.5 text-neutral-300 whitespace-nowrap">{SERIES_LABEL[k] ?? k}</td>
+                <td className="px-2 py-1.5 text-right num text-neutral-300">{fmtMW(w.mae)}</td>
+                <td className="px-2 py-1.5 text-right num text-neutral-400">{fmtMW(w.rmse)}</td>
+                <td className="px-2 py-1.5 text-right num text-neutral-300" title={biasTitle}>{fmtBias(w.bias)}</td>
+                <td className="px-2 py-1.5 text-right num text-neutral-400">
+                  {k === 'load' ? fmtPct1(w.mape) : <span className="text-neutral-700" title="MAPE is load-only by design">—</span>}
+                </td>
+                <td className="px-2 py-1.5 whitespace-nowrap"><SkillCell skill={w.skill_persistence} /></td>
+                <td className="px-2 py-1.5 whitespace-nowrap"><SkillCell skill={w.skill_seasonal} /></td>
+                <td className="px-2 py-1.5 text-right num text-neutral-500 whitespace-nowrap" title={`${w.n_hours} scored hours`}>
+                  n={w.days_covered}d
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// One series' cross-zone ranking table. The API delivers ranked rows first
+// (best = lowest error) and signposted rows last (rank: null) — signposted
+// zones stay visible below the cap, greyed, with the reason in the row (body
+// text; the ⓘ popover stays API-string-free).
+function RankingTable({ name, block, zoneLabel, currentZone }) {
+  const [showAll, setShowAll] = useState(false)
+  const rows = block?.ranking ?? []
+  const ranked = rows.filter((r) => r.rank != null)
+  const signposted = rows.filter((r) => r.rank == null)
+  const visible = showAll ? ranked : ranked.slice(0, INITIAL_RANK_ROWS)
+  const metric = block?.metric
+  const metricHead = metric === 'mape' ? 'MAPE' : metric === 'nmae_pct' ? 'nMAE' : 'MAE MW'
+  const showMaeCol = metric !== 'mae' // absolute MW context beside the % metric
+  const cols = 4 + (showMaeCol ? 1 : 0)
+
+  const metricCell = (r) => {
+    if (metric === 'mape') return fmtPct1(r.mape)
+    if (metric === 'nmae_pct') {
+      return (
+        <span title={r.capacity_mw != null ? `${fmtMW(r.mae)} MW MAE ÷ ${fmtMW(r.capacity_mw)} MW installed (A68)` : undefined}>
+          {fmtPct1(r.nmae_pct)}
+        </span>
+      )
+    }
+    return fmtMW(r.mae)
+  }
+
+  return (
+    <div className="border border-border/40 rounded">
+      <div className="px-2 py-1.5 border-b border-border/30">
+        <span className="font-mono text-[9px] text-neutral-400 uppercase tracking-wider">
+          {SERIES_LABEL[name] ?? name} · ranked by {metricHead}
+        </span>
+        {block?.caveat && (
+          <div className="font-mono text-[9px] text-neutral-600 leading-snug pt-0.5">{block.caveat}</div>
+        )}
+      </div>
+      <div className="px-1 py-1 overflow-x-auto">
+        <table className="w-full font-mono text-[10px]">
+          <thead>
+            <tr className="text-[8px] text-neutral-600 uppercase tracking-wider">
+              <th className="text-right px-2 py-1" title="Rank 1 = the published forecast the actuals stayed closest to">#</th>
+              <th className="text-left px-2 py-1">Zone</th>
+              <th className="text-right px-2 py-1">{metricHead}</th>
+              {showMaeCol && <th className="text-right px-2 py-1" title="Absolute window MAE (MW), for scale">MAE MW</th>}
+              <th className="text-right px-2 py-1" title="Days covered in this window (scored hours on hover)">n</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((r) => {
+              const isCurrent = r.zone === currentZone
+              return (
+                <tr key={r.zone} className={`border-t border-border/30 ${isCurrent ? 'bg-white/[0.03]' : ''}`}>
+                  <td className="px-2 py-1 text-right num text-neutral-500">{r.rank}</td>
+                  <td className={`px-2 py-1 whitespace-nowrap ${isCurrent ? 'text-cyan-glow' : 'text-neutral-300'}`}>{zoneLabel(r.zone)}</td>
+                  <td className="px-2 py-1 text-right num text-neutral-300">{metricCell(r)}</td>
+                  {showMaeCol && <td className="px-2 py-1 text-right num text-neutral-500">{fmtMW(r.mae)}</td>}
+                  <td className="px-2 py-1 text-right num text-neutral-600 whitespace-nowrap" title={`${r.n_hours} scored hours`}>{r.days_covered}d</td>
+                </tr>
+              )
+            })}
+            {signposted.map((r) => (
+              <tr key={r.zone} className="border-t border-border/30 text-neutral-600">
+                <td className="px-2 py-1 text-right">—</td>
+                <td className="px-2 py-1 whitespace-nowrap">{zoneLabel(r.zone)}</td>
+                <td colSpan={cols - 2} className="px-2 py-1 text-[9px] leading-snug">
+                  MAE {fmtMW(r.mae)} MW · {r.signposted}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {ranked.length > INITIAL_RANK_ROWS && (
+        <div className="px-2 pb-1.5">
+          <button
+            onClick={() => setShowAll((v) => !v)}
+            className="font-mono text-[9px] tracking-wider border border-border rounded px-1.5 py-0.5 text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+          >
+            {showAll ? 'show fewer' : `show all ${ranked.length} ranked`}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The forecast scoreboard over GET /api/v1/scoreboard/{summary,ranking}:
+ * grades ENTSO-E's own published D-1 forecasts (load / residual / wind /
+ * solar) against its published actuals — OBSYD makes no forecasts. ZONE view
+ * is one zone's report card at 30/90/365 days; RANKING view orders all zones
+ * per series by the comparable metric (load: MAPE; wind/solar: nMAE % of A68
+ * installed capacity; residual: absolute MAE, caveated). Zones a
+ * normalization can't cover are listed signposted, never hidden.
+ */
+export default function ForecastScoreboardPanel({ zone = 'DE_LU' }) {
+  const [view, setView] = useState('zone')
+  const [zoneWindow, setZoneWindow] = useState('30d')
+  const [rankWindow, setRankWindow] = useState(90)
+
+  const { zones: zoneList } = useZones()
+  const zoneLabels = useMemo(() => new Map(zoneList.map((z) => [z.key, z.label || z.key])), [zoneList])
+  const zoneLabel = (key) => zoneLabels.get(key) || key
+
+  // Summary is cheap (rate-limited only) and drives the default view → always
+  // fetched. Ranking is heavy-guarded server-side → fetched only while shown
+  // (the hook's null-url idle); all request state lives in the URL (#115).
+  const { data: sum, loading: sumLoading, error: sumError } = useFetchWithError(
+    `${API}/v1/scoreboard/summary?zone=${zone}`, { deps: [zone], pollMs: POLL_SLOW_MS },
+  )
+  const { data: rank, loading: rankLoading, error: rankError } = useFetchWithError(
+    view === 'ranking' ? `${API}/v1/scoreboard/ranking?window=${rankWindow}` : null,
+    { deps: [view, rankWindow], pollMs: POLL_SLOW_MS },
+  )
+
+  const active = view === 'ranking' ? rank : sum
+  // The API's own sign statement rides on title= attrs only — never a popover.
+  const biasTitle = sum?.bias_convention || BIAS_TITLE_FALLBACK
+
+  return (
+    <Panel
+      id="forecast-scoreboard"
+      title={view === 'ranking' ? 'FORECAST SCOREBOARD · ALL ZONES' : `FORECAST SCOREBOARD · ${zoneLabel(zone)}`}
+      info={<ScoreboardLegend />}
+      infoWide
+      freshness={active}
+      collapsible
+      headerRight={
+        <div className="flex items-center gap-1">
+          <ToggleBtn id="zone" label="ZONE" view={view} setView={setView} />
+          <ToggleBtn id="ranking" label="RANKING" view={view} setView={setView} />
+        </div>
+      }
+    >
+      {view === 'zone' && (
+        <>
+          <div className="flex items-center justify-between px-4 pt-2.5">
+            <div className="flex items-center gap-1">
+              {ZONE_WINDOWS.map((w) => (
+                <ToggleBtn key={w} id={w} label={w.toUpperCase()} view={zoneWindow} setView={setZoneWindow} />
+              ))}
+            </div>
+            <span className="font-mono text-[9px] text-neutral-600 hidden sm:inline">trailing UTC days · D-1 forecast vs actual</span>
+          </div>
+          {sumLoading && !sum && (
+            <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">Loading scoreboard…</div>
+          )}
+          {!sumLoading && sumError && !sum && (
+            <div className="px-4 py-6 text-center font-mono text-[10px] text-red-400">Fetch error — retrying on next refresh.</div>
+          )}
+          {sum && !sum.available && (
+            <div className="px-4 py-4 font-mono text-[10px] text-neutral-500">
+              No forecast scores exist yet for this zone — the nightly scorer writes one row per zone,
+              series and UTC day once both the published forecast and the published actual exist.
+            </div>
+          )}
+          {sum?.available && <ZoneTable data={sum} window={zoneWindow} biasTitle={biasTitle} />}
+        </>
+      )}
+
+      {view === 'ranking' && (
+        <>
+          <div className="flex items-center justify-between px-4 pt-2.5">
+            <div className="flex items-center gap-1">
+              {RANK_WINDOWS.map((w) => (
+                <ToggleBtn key={w} id={w} label={`${w}D`} view={rankWindow} setView={setRankWindow} />
+              ))}
+            </div>
+            <span className="font-mono text-[9px] text-neutral-600 hidden sm:inline">lower error = better · rank 1 = closest to actuals</span>
+          </div>
+          {rankLoading && !rank && (
+            <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">Loading ranking…</div>
+          )}
+          {!rankLoading && rankError && !rank && (
+            <div className="px-4 py-6 text-center font-mono text-[10px] text-red-400">Fetch error — retrying on next refresh.</div>
+          )}
+          {rank && !rank.available && (
+            <div className="px-4 py-4 font-mono text-[10px] text-neutral-500">
+              No forecast scores exist yet in this window — the nightly scorer has not graded any zone here.
+            </div>
+          )}
+          {rank?.available && (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 px-3 pt-3 pb-1">
+              {SERIES_ORDER.filter((k) => rank.series?.[k]).map((k) => (
+                <RankingTable key={k} name={k} block={rank.series[k]} zoneLabel={zoneLabel} currentZone={zone} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      <div className="px-4 py-2 mt-2 border-t border-border font-mono text-[9px] text-neutral-700">
+        Grades ENTSO-E&rsquo;s own published D-1 forecasts against its published actuals — OBSYD makes no
+        forecasts. Naive yardsticks built from published actuals alone: persistence = same hour yesterday,
+        seasonal = same hour last week. Public at GET /api/v1/scoreboard/summary + /ranking.
+      </div>
+    </Panel>
+  )
+}

--- a/frontend/src/components/ForecastScoreboardPanel.jsx
+++ b/frontend/src/components/ForecastScoreboardPanel.jsx
@@ -213,7 +213,8 @@ function RankingTable({ name, block, zoneLabel, currentZone }) {
                 <td className="px-2 py-1 text-right">—</td>
                 <td className="px-2 py-1 whitespace-nowrap">{zoneLabel(r.zone)}</td>
                 <td colSpan={cols - 2} className="px-2 py-1 text-[9px] leading-snug">
-                  MAE {fmtMW(r.mae)} MW · {r.signposted}
+                  MAE {fmtMW(r.mae)} MW ·{' '}
+                  <span title={`${r.n_hours} scored hours`}>n={r.days_covered}d</span> · {r.signposted}
                 </td>
               </tr>
             ))}
@@ -331,7 +332,10 @@ export default function ForecastScoreboardPanel({ zone = 'DE_LU' }) {
           )}
           {rank?.available && (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 px-3 pt-3 pb-1">
-              {SERIES_ORDER.filter((k) => rank.series?.[k]).map((k) => (
+              {/* Order by the known series first, then anything new the API adds —
+                  a fifth backend series must appear here without a frontend edit. */}
+              {[...SERIES_ORDER.filter((k) => rank.series?.[k]),
+                ...Object.keys(rank.series ?? {}).filter((k) => !SERIES_ORDER.includes(k))].map((k) => (
                 <RankingTable key={k} name={k} block={rank.series[k]} zoneLabel={zoneLabel} currentZone={zone} />
               ))}
             </div>

--- a/frontend/src/components/HowToRead.jsx
+++ b/frontend/src/components/HowToRead.jsx
@@ -20,6 +20,17 @@ const TERMS = [
   ['SCHED vs physical', 'which record a border is read from. SCHED = ENTSO-E’s scheduled commercial exchanges, resolved per bidding zone (the only grain that can see DK1 vs DK2); physical = the metered country-level flow.'],
 ]
 
+// The Honest-Record vocabulary (EXPLORE tab's DATA QUALITY + REVISIONS LEDGER
+// panels). Every term describes what the SOURCE published or restated — none
+// of it judges the data or the market.
+const QUALITY_TERMS = [
+  ['Completeness', 'the share of a UTC day’s expected intervals the source actually published (24 for hourly series, 96 for 15-min series), averaged over a 30/90-day window. A low day is hours the source has not (yet) published — a statement about the record, not the market.'],
+  ['Revision / restatement', 'the source re-published a DIFFERENT value for an hour it had already published, beyond float noise. “Mature” = observed more than 48 h after the hour it restates — settled data changed, not the routine provisional fill-in sources run for a day or two.'],
+  ['Arrival lag', 'the wall-clock gap between when a fetch arrived and the newest hour it delivered. Negative (“ahead”) for day-ahead series — the auction publishes tomorrow’s hours, so the data runs ahead of the clock.'],
+  ['Quality flag', 'a rule-based description of odd published data: solar reported in the dead of night, load flatlining at exact zero, an hourly step 8× larger than the series’ own trailing month. Each flag describes the feed, never the market.'],
+  ['Zone-level checks', 'quality checks that need several series at once — e.g. total generation below load while the zone exports. They appear as their own “zone-level checks” row, only on flagged days, with no completeness or lag of their own.'],
+]
+
 export default function HowToRead() {
   return (
     <Panel id="how-to-read" title="NEW HERE? HOW TO READ THIS" collapsible defaultCollapsed={true}>
@@ -31,6 +42,15 @@ export default function HowToRead() {
         </p>
         <dl className="space-y-2">
           {TERMS.map(([term, def]) => (
+            <div key={term} className="grid grid-cols-1 sm:grid-cols-[160px_1fr] gap-x-3 gap-y-0.5">
+              <dt className="font-mono text-[11px] text-cyan-glow/90">{term}</dt>
+              <dd className="font-mono text-[11px] text-neutral-400 leading-snug">{def}</dd>
+            </div>
+          ))}
+        </dl>
+        <div className="pt-2 border-t border-border/40 font-mono text-[10px] text-neutral-500 tracking-wider">DATA QUALITY</div>
+        <dl className="space-y-2">
+          {QUALITY_TERMS.map(([term, def]) => (
             <div key={term} className="grid grid-cols-1 sm:grid-cols-[160px_1fr] gap-x-3 gap-y-0.5">
               <dt className="font-mono text-[11px] text-cyan-glow/90">{term}</dt>
               <dd className="font-mono text-[11px] text-neutral-400 leading-snug">{def}</dd>

--- a/frontend/src/components/HowToRead.jsx
+++ b/frontend/src/components/HowToRead.jsx
@@ -31,6 +31,18 @@ const QUALITY_TERMS = [
   ['Zone-level checks', 'quality checks that need several series at once — e.g. total generation below load while the zone exports. They appear as their own “zone-level checks” row, only on flagged days, with no completeness or lag of their own.'],
 ]
 
+// The forecast-scoreboard vocabulary (ANALYTICS tab). OBSYD grades ENTSO-E's
+// own published D-1 forecasts against its published actuals — it makes no
+// forecasts of its own, and every score states its sample.
+const SCOREBOARD_TERMS = [
+  ['What is graded', 'ENTSO-E’s own published day-ahead forecasts for load, residual load, wind and solar, compared against the actuals the same source later published. OBSYD makes no forecasts — it reports how the official ones fared.'],
+  ['MAE / RMSE', 'mean absolute error: the typical hourly miss in MW, direction ignored. RMSE punishes large misses harder — RMSE well above MAE means the errors are spiky, not steady.'],
+  ['Bias', 'mean(forecast − actual) in MW. Positive = the published forecast leaned high on average, negative = it leaned low. (The older forecast-error strip on the POWER tab states the same number with the opposite sign convention.)'],
+  ['MAPE / nMAE', 'the miss as a percentage. MAPE (% of the actual) works for load only — wind and solar hit honest zeros overnight, residual load crosses zero. Wind/solar rank by nMAE instead: MAE as % of the zone’s installed capacity (ENTSO-E A68), so a 500 MW miss in a 60 GW fleet doesn’t read like one in a 5 GW fleet.'],
+  ['Skill vs naive', '1 − MAE/MAE_naive against two no-model yardsticks built from published actuals alone: persistence (the actual at the same hour yesterday) and seasonal (same hour last week). Positive = the published forecast beat the yardstick; a forecast that trails persistence added no information that day.'],
+  ['n=', 'every score names the days (and hours) it is computed over — a 30-day skill over 6 days of data says so.'],
+]
+
 export default function HowToRead() {
   return (
     <Panel id="how-to-read" title="NEW HERE? HOW TO READ THIS" collapsible defaultCollapsed={true}>
@@ -51,6 +63,15 @@ export default function HowToRead() {
         <div className="pt-2 border-t border-border/40 font-mono text-[10px] text-neutral-500 tracking-wider">DATA QUALITY</div>
         <dl className="space-y-2">
           {QUALITY_TERMS.map(([term, def]) => (
+            <div key={term} className="grid grid-cols-1 sm:grid-cols-[160px_1fr] gap-x-3 gap-y-0.5">
+              <dt className="font-mono text-[11px] text-cyan-glow/90">{term}</dt>
+              <dd className="font-mono text-[11px] text-neutral-400 leading-snug">{def}</dd>
+            </div>
+          ))}
+        </dl>
+        <div className="pt-2 border-t border-border/40 font-mono text-[10px] text-neutral-500 tracking-wider">FORECAST SCOREBOARD</div>
+        <dl className="space-y-2">
+          {SCOREBOARD_TERMS.map(([term, def]) => (
             <div key={term} className="grid grid-cols-1 sm:grid-cols-[160px_1fr] gap-x-3 gap-y-0.5">
               <dt className="font-mono text-[11px] text-cyan-glow/90">{term}</dt>
               <dd className="font-mono text-[11px] text-neutral-400 leading-snug">{def}</dd>

--- a/frontend/src/components/RevisionsLedgerPanel.jsx
+++ b/frontend/src/components/RevisionsLedgerPanel.jsx
@@ -1,0 +1,242 @@
+import { useState } from 'react'
+import Panel from './Panel'
+import useFetchWithError from '../hooks/useFetchWithError'
+import useZones from '../hooks/useZones'
+
+const API = '/api'
+
+// The charter series the quality engine tracks (backend/power/quality.py::
+// QUALITY_SERIES — a stable config tuple, so a mirrored list beats a fetch).
+// The zone-level pseudo-series is deliberately absent: it has no store series
+// of its own, so there is nothing for the ledger to restate.
+const QUALITY_SERIES = [
+  { key: 'load.actual', label: 'Load (actual)' },
+  { key: 'price.dayahead', label: 'Day-ahead price' },
+  { key: 'price.dayahead.qh', label: 'Day-ahead price · 15-min' },
+  { key: 'gen.B16', label: 'Solar generation' },
+  { key: 'gen.B18', label: 'Wind offshore generation' },
+  { key: 'gen.B19', label: 'Wind onshore generation' },
+]
+
+// Raw-ledger display cap — the API can return up to 20k rows per window and a
+// 20k-row DOM table helps nobody. The roll-up above the table is uncapped.
+const MAX_RAW_ROWS = 200
+
+// "2026-08-01T13:00:00+00:00" → "2026-08-01 13:00" (always UTC on this desk).
+const fmtUtc = (iso) => (iso ? iso.slice(0, 16).replace('T', ' ') : '—')
+
+// Signed percentage, 1 decimal. delta_pct is null when the old value was
+// exactly 0 (no honest percentage exists) — shown as an em-dash, never 0.0%.
+const fmtDeltaPct = (v) => (v == null ? '—' : `${v > 0 ? '+' : ''}${v.toFixed(1)}%`)
+
+const fmtVal = (v) => (v == null ? '—' : Number(v).toFixed(1))
+
+// Structured ⓘ legend — BordersLegend's <dl> pattern. API `reason` strings are
+// shown verbatim in the panel body's empty state (they are written for humans),
+// but never rendered raw inside this popover (repo rule).
+function RevisionsLegend() {
+  const rows = [
+    ['Revision', 'the source re-published a DIFFERENT value for an hour it had already published, beyond a float-noise epsilon. The ledger records old → new, when the change was observed, and its size.'],
+    ['Mature', 'observed more than 48 h after the hour it restates — settled data changed. The default view; the toggle adds the routine provisional fill-in window (sources routinely re-publish actuals for a day or two).'],
+    ['Restated >1×', 'hours the source restated more than once inside the window; "last change" is the newest restatement’s size.'],
+    ['Δ%', 'new − old as a share of |old| — the sign is the direction of movement, even across negative prices.'],
+    ['Freshness', 'the last time this source was polled for this zone — the newest moment a restatement could have been observed. The ledger accrues forward from first deploy and is never pruned.'],
+  ]
+  return (
+    <div className="space-y-2">
+      <dl className="space-y-1.5">
+        {rows.map(([term, def]) => (
+          <div key={term} className="grid grid-cols-[86px_1fr] gap-x-2">
+            <dt className="text-cyan-glow/90">{term}</dt>
+            <dd className="text-neutral-400 leading-snug">{def}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="pt-1 border-t border-border/40 text-neutral-500">
+        Descriptive: the ledger reports the source’s own restatements — it never says
+        the data was “wrong”. Full definitions: HOW TO READ on the EUROPE tab.
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The revision ledger over GET /api/v1/quality/revisions: every time the
+ * source re-published a different value for an hour it had already published,
+ * for one series × zone. Headline counts, the restated-more-than-once roll-up,
+ * and the raw old→new rows behind a toggle.
+ *
+ * Posture B: a restatement is the source revising its own publication — the
+ * ledger describes it, it never calls the data wrong.
+ */
+export default function RevisionsLedgerPanel() {
+  const [series, setSeries] = useState('price.dayahead')
+  const [zone, setZone] = useState('DE_LU')
+  const [mature, setMature] = useState(true) // true = settled-data restatements only (API default)
+  const [showRaw, setShowRaw] = useState(false)
+  const { zones } = useZones()
+
+  // Selector state lives in the URL → useFetchWithError invalidates `data` on
+  // every change (the #115 zone-coherence rule: never show stale other-pair data).
+  const url = `${API}/v1/quality/revisions?series=${encodeURIComponent(series)}&zone=${encodeURIComponent(zone)}&mature=${mature}`
+  const { data, loading, error } = useFetchWithError(url, { deps: [series, zone, mature] })
+
+  const rows = data?.data ?? []
+  const restated = data?.restated_hours ?? []
+  // /revisions' as_of is a full ISO datetime (newest poll for this pair); the
+  // header chip renders delivery DATES desk-wide, so trim to the UTC date.
+  const freshness = data ? { ...data, as_of: data.as_of ? data.as_of.slice(0, 10) : null } : null
+
+  return (
+    <Panel
+      id="revisions-ledger"
+      title="REVISIONS LEDGER · SOURCE RESTATEMENTS"
+      info={<RevisionsLegend />}
+      infoWide
+      freshness={freshness}
+      headerRight={
+        data?.available && (
+          <span className="font-mono text-[9px] text-neutral-600">
+            last {data.days}d
+          </span>
+        )
+      }
+    >
+      <div className="flex flex-wrap items-center gap-1.5 px-4 py-2.5 border-b border-border/50">
+        <select
+          value={series}
+          onChange={(e) => setSeries(e.target.value)}
+          className="font-mono text-[11px] bg-[#0a0a12] border border-border rounded px-2 py-1 text-neutral-300"
+          title="Series whose ledger to show"
+        >
+          {QUALITY_SERIES.map((s) => (
+            <option key={s.key} value={s.key}>{s.label}</option>
+          ))}
+        </select>
+        <select
+          value={zone}
+          onChange={(e) => setZone(e.target.value)}
+          className="font-mono text-[11px] bg-[#0a0a12] border border-border rounded px-2 py-1 text-neutral-300"
+          title="Bidding zone"
+        >
+          {zones.map((z) => (
+            <option key={z.key} value={z.key}>{z.label || z.key}</option>
+          ))}
+        </select>
+        <button
+          onClick={() => setMature((m) => !m)}
+          className={`font-mono text-[9px] px-2 py-0.5 rounded border ${
+            !mature
+              ? 'text-amber-300 border-amber-400/40 bg-amber-400/10'
+              : 'text-neutral-500 border-border hover:text-neutral-300'
+          }`}
+          title="Also show restatements observed within 48 h of the hour — the routine provisional fill-in window sources re-publish in for a day or two"
+        >
+          include provisional fill-ins
+        </button>
+      </div>
+
+      {loading && !data && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-neutral-600 animate-pulse">Loading ledger…</div>
+      )}
+      {!loading && error && !data && (
+        <div className="px-4 py-6 text-center font-mono text-[10px] text-red-400">Fetch error — retrying on next refresh.</div>
+      )}
+      {data && !data.available && (
+        // The API's reason strings are written for humans (empty forward-only
+        // ledger, derived series, over-cap window) — shown verbatim.
+        <div className="px-4 py-4 font-mono text-[10px] text-neutral-500 leading-relaxed">
+          {data.reason || 'No revisions on record for this selection.'}
+        </div>
+      )}
+      {data?.available && (
+        <>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-1 px-4 py-3">
+            <span className="font-mono text-[11px] text-neutral-300">
+              <span className="num text-cyan-glow">{data.count}</span> revision{data.count === 1 ? '' : 's'} in {data.days}d
+              <span className="text-neutral-600"> · {mature ? 'settled data only (observed >48 h after the hour)' : 'incl. provisional fill-ins'}</span>
+            </span>
+            <span className="font-mono text-[11px] text-neutral-300">
+              <span className={`num ${restated.length > 0 ? 'text-amber-400' : 'text-neutral-500'}`}>{restated.length}</span>{' '}
+              hour{restated.length === 1 ? '' : 's'} restated more than once
+            </span>
+          </div>
+
+          {restated.length > 0 && (
+            <div className="px-2 pb-2 overflow-x-auto">
+              <table className="w-full font-mono text-[10px]">
+                <thead>
+                  <tr className="text-[8px] text-neutral-600 uppercase tracking-wider">
+                    <th className="text-left px-2 py-1" title="The delivery hour the source restated (UTC)">Hour (UTC)</th>
+                    <th className="text-right px-2 py-1" title="How many times this hour was restated inside the window">Revisions</th>
+                    <th className="text-right px-2 py-1" title="Size of the newest restatement, as % of the value it replaced">Last change</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {restated.map((h) => (
+                    <tr key={h.ts_utc} className="border-t border-border/30">
+                      <td className="px-2 py-1 text-neutral-400 num">{fmtUtc(h.ts_utc)}</td>
+                      <td className="px-2 py-1 text-right text-neutral-300 num">{h.n_revisions}</td>
+                      {/* Direction is not a valence — a restatement up is not "good",
+                          so no green/red here; the sign carries the direction. */}
+                      <td className={`px-2 py-1 text-right num ${h.last_change_pct == null ? 'text-neutral-600' : 'text-neutral-300'}`}>
+                        {fmtDeltaPct(h.last_change_pct)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <div className="px-4 pb-2">
+            <button
+              onClick={() => setShowRaw((v) => !v)}
+              className="font-mono text-[9px] tracking-wider border border-border rounded px-1.5 py-0.5 text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+            >
+              {showRaw ? '▾ hide individual revisions' : `▸ show individual revisions (${data.count})`}
+            </button>
+          </div>
+          {showRaw && (
+            <div className="px-2 pb-2 overflow-x-auto">
+              <table className="w-full font-mono text-[10px]">
+                <thead>
+                  <tr className="text-[8px] text-neutral-600 uppercase tracking-wider">
+                    <th className="text-left px-2 py-1" title="The delivery hour the restatement applies to (UTC)">Hour (UTC)</th>
+                    <th className="text-right px-2 py-1" title="Previously published value → re-published value">Old → new</th>
+                    <th className="text-right px-2 py-1" title="new − old as % of |old|">Δ%</th>
+                    <th className="text-right px-2 py-1" title="When the restatement was observed at our fetch (UTC)">Observed (UTC)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.slice(0, MAX_RAW_ROWS).map((r, i) => (
+                    <tr key={`${r.ts_utc}-${r.observed_at}-${i}`} className="border-t border-border/30">
+                      <td className="px-2 py-1 text-neutral-400 num">{fmtUtc(r.ts_utc)}</td>
+                      <td className="px-2 py-1 text-right text-neutral-300 num whitespace-nowrap">
+                        {fmtVal(r.old_value)} <span className="text-neutral-600">→</span> {fmtVal(r.new_value)}
+                      </td>
+                      <td className={`px-2 py-1 text-right num ${r.delta_pct == null ? 'text-neutral-600' : 'text-neutral-300'}`}>
+                        {fmtDeltaPct(r.delta_pct)}
+                      </td>
+                      <td className="px-2 py-1 text-right text-neutral-500 num">{fmtUtc(r.observed_at)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {rows.length > MAX_RAW_ROWS && (
+                <div className="px-2 py-1 font-mono text-[9px] text-neutral-600">
+                  Showing the newest {MAX_RAW_ROWS} of {rows.length} — the full ledger is public at GET /api/v1/quality/revisions.
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="px-4 py-2 border-t border-border font-mono text-[9px] text-neutral-700">
+            Every value the source re-published differently, per series × zone — the source revising
+            its own publication. Public at GET /api/v1/quality/revisions.
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/frontend/src/components/RevisionsLedgerPanel.jsx
+++ b/frontend/src/components/RevisionsLedgerPanel.jsx
@@ -2,21 +2,12 @@ import { useState } from 'react'
 import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import useZones from '../hooks/useZones'
+// The shared charter list (mirrors backend QUALITY_SERIES). The zone-level
+// pseudo-series is deliberately not offered here: it has no store series of
+// its own, so there is nothing for the ledger to restate.
+import { QUALITY_SERIES } from '../utils/qualitySeries'
 
 const API = '/api'
-
-// The charter series the quality engine tracks (backend/power/quality.py::
-// QUALITY_SERIES — a stable config tuple, so a mirrored list beats a fetch).
-// The zone-level pseudo-series is deliberately absent: it has no store series
-// of its own, so there is nothing for the ledger to restate.
-const QUALITY_SERIES = [
-  { key: 'load.actual', label: 'Load (actual)' },
-  { key: 'price.dayahead', label: 'Day-ahead price' },
-  { key: 'price.dayahead.qh', label: 'Day-ahead price · 15-min' },
-  { key: 'gen.B16', label: 'Solar generation' },
-  { key: 'gen.B18', label: 'Wind offshore generation' },
-  { key: 'gen.B19', label: 'Wind onshore generation' },
-]
 
 // Raw-ledger display cap — the API can return up to 20k rows per window and a
 // 20k-row DOM table helps nobody. The roll-up above the table is uncapped.
@@ -76,10 +67,11 @@ export default function RevisionsLedgerPanel() {
   const [showRaw, setShowRaw] = useState(false)
   const { zones } = useZones()
 
-  // Selector state lives in the URL → useFetchWithError invalidates `data` on
-  // every change (the #115 zone-coherence rule: never show stale other-pair data).
+  // All selector state lives in the URL, so the url IS the dependency —
+  // useFetchWithError invalidates `data` on every change (the #115
+  // zone-coherence rule: never show stale other-pair data).
   const url = `${API}/v1/quality/revisions?series=${encodeURIComponent(series)}&zone=${encodeURIComponent(zone)}&mature=${mature}`
-  const { data, loading, error } = useFetchWithError(url, { deps: [series, zone, mature] })
+  const { data, loading, error } = useFetchWithError(url)
 
   const rows = data?.data ?? []
   const restated = data?.restated_hours ?? []

--- a/frontend/src/utils/qualitySeries.js
+++ b/frontend/src/utils/qualitySeries.js
@@ -1,0 +1,26 @@
+// The Honest-Record charter series, shared by the EXPLORE tab's quality panels.
+// Mirrors backend/power/quality.py::QUALITY_SERIES (+ ZONE_SERIES_KEY) — a
+// stable config tuple, so a mirrored list beats a fetch (fuels.js precedent:
+// one module is the single frontend home for these keys and their labels).
+
+// The reserved zone-level pseudo-series: cross-series rule flags only —
+// completeness / revisions / lag are null by contract, and it has no store
+// series of its own, so the revision ledger never carries it.
+export const ZONE_SERIES_KEY = '_zone'
+
+// Ordered as the backend tuple orders them (registry order, deterministic).
+export const QUALITY_SERIES = [
+  { key: 'load.actual', label: 'Load (actual)' },
+  { key: 'price.dayahead', label: 'Day-ahead price' },
+  { key: 'price.dayahead.qh', label: 'Day-ahead price · 15-min' },
+  { key: 'gen.B16', label: 'Solar generation' },
+  { key: 'gen.B18', label: 'Wind offshore generation' },
+  { key: 'gen.B19', label: 'Wind onshore generation' },
+]
+
+const LABELS = {
+  ...Object.fromEntries(QUALITY_SERIES.map((s) => [s.key, s.label])),
+  [ZONE_SERIES_KEY]: 'zone-level checks',
+}
+
+export const qualitySeriesLabel = (key) => LABELS[key] || key


### PR DESCRIPTION
## What

OBSYD now documents the official record's own behavior — and publicly grades the official forecasts. 19 commits, built subagent-driven with two-stage reviews per slice plus a final whole-branch review (verdict: READY TO MERGE). Suite 1267 → **1392 passed** (+125 tests), ruff clean, `npm run build` green.

### A — Provenance layer ("honest about its own data", now structural)
- **Revision ledger + arrival log** (`power_revision`, `ingest_arrival`) hooked into the single hourly write path: every restatement (old→new, observed_at) and every fetch recorded, one indexed SELECT per batch, epsilon guard against float noise, derived series excluded. Forward-only from deploy.
- **Nightly quality aggregates** (`quality_daily`): completeness vs expected intervals (24/96) + rule flags — PV at night (astronomy-argued UTC window), load zero-runs, 8×IQR step jumps, generation < load+exports (coverage-gated, fail-safe). 23:55 UTC job, trailing 10 days.
- **Public API** `GET /api/v1/quality/{summary,series,revisions}` with the v1 guard stack, SELECT-budget-pinned summary, 48h read-time maturity filter on revisions.
- **Radar integration**: completeness drops vs a zone's own 30d norm + major mature restatements → anomaly feed + RSS. Detector anchors on the newest recorded day (final review caught a 5-minute scheduler race that would have silenced it in prod).
- **EXPLORE panels**: DATA QUALITY matrix + REVISIONS LEDGER.

### B — Forecast scoreboard (grades ENTSO-E's published D-1 forecasts; OBSYD makes none)
- **Nightly scoring** (`forecast_score_daily`): MAE/RMSE/bias (MAPE load-only) per zone × series × day for load/residual/wind/solar, plus persistence & seasonal-naive baseline MAEs built from actuals alone. 23:58 UTC job.
- **Public API** `GET /api/v1/scoreboard/{summary,ranking,monthly,profile}`: day-weighted exact aggregation, read-time skill, wind/solar ranked by capacity-normalized nMAE (A68), zones without capacity signposted, never hidden; bias convention declared on the wire.
- **ANALYTICS panel**: zone report card + all-zone ranking, cross-tab link from the forecast-error strip.

### Verification
- 1392 passed / 1 skipped, zero failures; ruff clean; build green.
- Local visual smoke (Playwright, 3-zone dev DB): all panels render real data — completeness bars, honest STALE chips, FR leads load ranking at 1.5% MAPE, signposting works.
- Deploy: new tables via `create_all` (no migration needed; `init_db` runs before scheduler start). Post-deploy one-time backfills: `quality_backfill` + `scoreboard_backfill` over 37 zones.

Market rationale (research-backed, plan `lass-uns-das-genauer-rosy-sparkle.md`): provenance/reliability is what Montel/Electricity Maps/Yes Energy monetize, openmod has asked for it since 2017, ENTSO-E revises 18.3% of events without metadata, and no free tool does any of it. Forecast benchmarking is a gridstatus Enterprise app and academically unserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)