### PR TITLE
Pace the live flows sweep — Energy-Charts started rate-limiting it

### DIFF
--- a/backend/power/energy_charts_flows.py
+++ b/backend/power/energy_charts_flows.py
@@ -57,6 +57,17 @@ CACHE_THROTTLE_SECONDS = 2.0
 RATE_LIMIT_ATTEMPTS = 6
 RATE_LIMIT_BASE_SECONDS = 30.0
 
+# The LIVE path needs the same discipline, scaled down: since ~2026-08-04 the
+# API 429s the tail of the ~20-country intraday sweep when the requests go out
+# back-to-back (958 warnings in one day of prod logs), which silently starved
+# GR/BG/HR/SI/SK/FI/CH of same-day flows. One second between countries plus a
+# short bounded backoff clears it; the backfill constants above are too heavy
+# for a 30-minute scheduler job (worst case 6 attempts × 30 s·2^n per country
+# would hold the job for minutes).
+LIVE_THROTTLE_SECONDS = 1.0
+LIVE_RATE_LIMIT_ATTEMPTS = 3
+LIVE_RATE_LIMIT_BASE_SECONDS = 5.0
+
 # Energy-Charts country names -> OBSYD zone codes.
 # "Germany" maps to DE_LU because the DE ENTSO-E bidding zone is the DE-LU
 # combined zone; Energy-Charts /cbpf for country=de covers this zone.
@@ -324,29 +335,38 @@ def _month_windows(start: date, end: date) -> list[tuple[date, date]]:
     return windows
 
 
-async def _fetch_with_rate_limit(country_code: str, start_iso: str, end_iso: str) -> dict:
-    """fetch_cbpf with HTTP-429 backoff for the backfill path.
+async def _fetch_with_rate_limit(
+    country_code: str,
+    start_iso: str,
+    end_iso: str,
+    *,
+    attempts: int = RATE_LIMIT_ATTEMPTS,
+    base_seconds: float = RATE_LIMIT_BASE_SECONDS,
+) -> dict:
+    """fetch_cbpf with HTTP-429 backoff (defaults = the heavy backfill profile).
 
     A month-sweep is hundreds of requests; without honouring the rate limit the
     2026-07-12 run "completed" in 20 s having skipped almost every country-month
     (ingest_cbpf logs per-country failures as warnings, so nothing retried).
-    Non-429 errors propagate immediately.
+    The live path passes the LIVE_* profile — bounded so a 30-minute scheduler
+    job can never hang for minutes on one country. Non-429 errors propagate
+    immediately.
     """
-    for attempt in range(RATE_LIMIT_ATTEMPTS):
+    for attempt in range(attempts):
         try:
             return await fetch_cbpf(country_code, start_iso, end_iso)
         except httpx.HTTPStatusError as exc:
             resp = exc.response
-            if resp is None or resp.status_code != 429 or attempt == RATE_LIMIT_ATTEMPTS - 1:
+            if resp is None or resp.status_code != 429 or attempt == attempts - 1:
                 raise
             retry_after = resp.headers.get("Retry-After", "")
             try:
                 wait = float(retry_after)
             except ValueError:
-                wait = RATE_LIMIT_BASE_SECONDS * (2**attempt)
+                wait = base_seconds * (2**attempt)
             logger.warning(
                 "energy_charts_flows: 429 for %s %s..%s — backing off %.0fs (attempt %d/%d)",
-                country_code, start_iso, end_iso, wait, attempt + 1, RATE_LIMIT_ATTEMPTS,
+                country_code, start_iso, end_iso, wait, attempt + 1, attempts,
             )
             await asyncio.sleep(wait)
     raise AssertionError("unreachable")  # loop always returns or raises
@@ -364,13 +384,24 @@ async def _fetch_range(
 
     Live path (use_cache=False): one direct request for the exact range — the
     scheduler's small rolling windows change intraday and must not be cached.
+    Since ~2026-08-04 the API 429s back-to-back sweeps, so the live request
+    rides the bounded LIVE_* backoff and is followed by a short pause that
+    spaces the per-country loop in ingest_cbpf.
     Backfill path (use_cache=True): month-chunked through raw_cache so a crashed
     or re-run backfill never re-hits the API. Only COMPLETED months are written
     to the cache — a current-month blob would freeze mid-month and starve later
     re-runs of the month's remainder.
     """
     if not use_cache:
-        return [await fetch_cbpf(country_code, start_date.isoformat(), end_date.isoformat())]
+        payload = await _fetch_with_rate_limit(
+            country_code,
+            start_date.isoformat(),
+            end_date.isoformat(),
+            attempts=LIVE_RATE_LIMIT_ATTEMPTS,
+            base_seconds=LIVE_RATE_LIMIT_BASE_SECONDS,
+        )
+        await asyncio.sleep(LIVE_THROTTLE_SECONDS)
+        return [payload]
 
     today = datetime.now(timezone.utc).date()
     payloads: list[dict] = []

--- a/backend/tests/test_energy_charts_flows.py
+++ b/backend/tests/test_energy_charts_flows.py
@@ -38,6 +38,14 @@ def _clear_dependency_overrides():
     app.dependency_overrides.clear()
 
 
+@pytest.fixture(autouse=True)
+def _zero_live_pacing(monkeypatch):
+    """Zero the live-path pacing so tests stay instant — the pacing behavior
+    itself is exercised by its own dedicated tests below."""
+    monkeypatch.setattr(flows, "LIVE_THROTTLE_SECONDS", 0.0)
+    monkeypatch.setattr(flows, "LIVE_RATE_LIMIT_BASE_SECONDS", 0.0)
+
+
 # ─── helpers ─────────────────────────────────────────────────────────────────
 
 _TODAY = date.today()
@@ -312,6 +320,99 @@ async def test_ingest_fetch_failure_graceful(db_session):
 
     # At least the DE borders were written
     assert result["written"] >= 1
+
+
+def _real_429():
+    """A 429 that carries a response object — the shape the live API actually
+    raises (response=None short-circuits the backoff by design)."""
+    import httpx
+
+    req = httpx.Request("GET", "https://api.energy-charts.info/cbpf")
+    return httpx.HTTPStatusError("429", request=req, response=httpx.Response(429, request=req))
+
+
+@pytest.mark.asyncio
+async def test_live_path_retries_a_real_429_then_succeeds(db_session):
+    """The live sweep retries a genuine 429 instead of dropping the country —
+    the failure that starved the sweep's tail of same-day flows since 2026-08-04."""
+    import httpx
+
+    from backend.power.energy_charts_flows import ingest_cbpf
+
+    day = "2026-06-01"
+    de_payload = _make_payload({"France": [2.0] * 96}, base_ts=1780272000)
+    calls = {"de": 0}
+
+    async def mock_fetch(country, start, end):
+        if country == "de":
+            calls["de"] += 1
+            if calls["de"] == 1:
+                raise _real_429()
+            return de_payload
+        raise httpx.HTTPStatusError("skip", request=None, response=None)
+
+    with patch("backend.power.energy_charts_flows.fetch_cbpf", side_effect=mock_fetch):
+        result = await ingest_cbpf(db_session, [day])
+
+    assert calls["de"] == 2  # one 429, one success
+    assert result["written"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_live_path_gives_up_after_bounded_attempts(db_session):
+    """Persistent 429s stop after LIVE_RATE_LIMIT_ATTEMPTS and the ingest
+    continues — a 30-minute scheduler job must never hang on one country."""
+    import httpx
+
+    from backend.power.energy_charts_flows import ingest_cbpf
+
+    calls = {"de": 0}
+
+    async def mock_fetch(country, start, end):
+        if country == "de":
+            calls["de"] += 1
+            raise _real_429()
+        raise httpx.HTTPStatusError("skip", request=None, response=None)
+
+    with patch("backend.power.energy_charts_flows.fetch_cbpf", side_effect=mock_fetch):
+        result = await ingest_cbpf(db_session, ["2026-06-01"])
+
+    assert calls["de"] == flows.LIVE_RATE_LIMIT_ATTEMPTS
+    assert result["written"] == 0  # nothing landed, nothing crashed
+
+
+@pytest.mark.asyncio
+async def test_live_path_paces_the_country_sweep(db_session, monkeypatch):
+    """Each successful live fetch is followed by one LIVE_THROTTLE_SECONDS pause
+    — the spacing that keeps the ~20-country sweep under the API's rate limit."""
+    import httpx
+
+    from backend.power.energy_charts_flows import ingest_cbpf
+
+    monkeypatch.setattr(flows, "LIVE_THROTTLE_SECONDS", 0.123)
+
+    class _RecordingAsyncio:
+        def __init__(self):
+            self.sleeps = []
+
+        async def sleep(self, seconds):
+            self.sleeps.append(seconds)
+
+    fake = _RecordingAsyncio()
+    monkeypatch.setattr(flows, "asyncio", fake)
+
+    de_payload = _make_payload({"France": [2.0] * 96}, base_ts=1780272000)
+
+    async def mock_fetch(country, start, end):
+        if country == "de":
+            return de_payload
+        raise httpx.HTTPStatusError("skip", request=None, response=None)
+
+    with patch("backend.power.energy_charts_flows.fetch_cbpf", side_effect=mock_fetch):
+        await ingest_cbpf(db_session, ["2026-06-01"])
+
+    # Exactly one pause per SUCCESSFUL fetch (failed countries raise before it).
+    assert fake.sleeps.count(0.123) == 1
 
 
 # ─── route tests ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Since ~2026-08-04 Energy-Charts 429s back-to-back `/cbpf` requests (0 on Aug 1-3, 88 on Aug 4, 728 on Aug 5 in prod logs — a server-side tightening, nothing in our deploys touches this collector). The tail of the ~20-country intraday sweep (GR/BG/HR/SI/SK/FI/CH) silently lost same-day flows while the freshness probe stayed green on an early country.

Fix mirrors the PR #142 precedent: the live path now uses the existing 429-backoff wrapper with a bounded LIVE profile (3 attempts, 5 s base — the backfill's 6×30s·2^n would hold a 30-minute job for minutes) plus a 1 s pause after each successful fetch to space the sweep (+~20 s per cycle, irrelevant at 30-min cadence).

Tests: real-429-retry (429 with response object — `response=None` short-circuits by design, existing tests unaffected), bounded give-up, sweep pacing. Suite: 1395 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)