### PR TITLE
Redesign foundations: ink-blue accent, serif/mono tokens, theme-aware charts (A of 3)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@deck.gl/extensions": "^9.2.10",
         "@deck.gl/layers": "^9.2.10",
         "@deck.gl/react": "^9.2.10",
+        "@fontsource-variable/source-serif-4": "^5.3.0",
         "@tailwindcss/vite": "^4.2.1",
         "deck.gl": "^9.2.10",
         "lightweight-charts": "^5.1.0",
@@ -1391,6 +1392,15 @@
       "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@fontsource-variable/source-serif-4": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/source-serif-4/-/source-serif-4-5.3.0.tgz",
+      "integrity": "sha512-9vch9WqxjaaA+1o9Ur8pOgIGbCYLjRReOUel23A6lOpD1syptgjtkORevvNmldJ5kGXQL29onQUqI5Ltz0s3bQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@deck.gl/extensions": "^9.2.10",
     "@deck.gl/layers": "^9.2.10",
     "@deck.gl/react": "^9.2.10",
+    "@fontsource-variable/source-serif-4": "^5.3.0",
     "@tailwindcss/vite": "^4.2.1",
     "deck.gl": "^9.2.10",
     "lightweight-charts": "^5.1.0",

--- a/frontend/scripts/screenshot-sweep.mjs
+++ b/frontend/scripts/screenshot-sweep.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Visual-regression sweep: full-page screenshots of every reachable surface in
+// both themes, for before/after eyeballing around design passes.
+//
+// Usage:
+//   node scripts/screenshot-sweep.mjs [base-url] [--out dir]
+//   (default base http://localhost:5199, default out screenshots/sweep;
+//    pass https://obsyd.dev to sweep production)
+// Needs playwright-core resolvable; set CHROMIUM_PATH to a Chrome/Chromium
+// binary if no bundled browser is installed (same contract as
+// verify-zone-coherence.mjs).
+
+import { mkdirSync } from 'fs'
+import { join } from 'path'
+import { exit, argv, env } from 'process'
+
+const args = argv.slice(2)
+const outIdx = args.indexOf('--out')
+const OUT = outIdx !== -1 ? args[outIdx + 1] : 'screenshots/sweep'
+const BASE = args.find((a, i) => !a.startsWith('--') && i !== outIdx + 1) || 'http://localhost:5199'
+
+// App routes wait for the desk shell (#desk-nav) + a settle for async panels;
+// static routes only need the network to go quiet.
+const ROUTES = [
+  { path: '/', name: 'landing', app: false },
+  { path: '/docs', name: 'docs', app: false },
+  { path: '/impressum', name: 'impressum', app: false },
+  { path: '/datenschutz', name: 'datenschutz', app: false },
+  { path: '/app#europe', name: 'tab-europe', app: true },
+  { path: '/app#energy', name: 'tab-power', app: true },
+  { path: '/app#analytics', name: 'tab-analytics', app: true },
+  { path: '/app#gas', name: 'tab-gas', app: true },
+  { path: '/app#explore', name: 'tab-explore', app: true },
+  { path: '/app#alerts', name: 'tab-alerts', app: true },
+]
+
+let chromium
+try {
+  ({ chromium } = await import('playwright-core'))
+} catch {
+  console.error('playwright-core not resolvable — npm i --no-save playwright-core')
+  exit(2)
+}
+
+mkdirSync(OUT, { recursive: true })
+const browser = await chromium.launch(
+  env.CHROMIUM_PATH ? { executablePath: env.CHROMIUM_PATH } : {},
+)
+
+for (const theme of ['light', 'dark']) {
+  const ctx = await browser.newContext({ viewport: { width: 1500, height: 1000 } })
+  // Pin the theme and force every collapsible panel open so sweeps compare
+  // full content, not whatever collapse state localStorage happens to hold.
+  await ctx.addInitScript((t) => {
+    localStorage.setItem('obsyd-theme', t)
+    localStorage.setItem('obsyd-panel-how-to-read', '0')
+  }, theme)
+  const page = await ctx.newPage()
+  for (const r of ROUTES) {
+    const file = join(OUT, `${r.name}-${theme}.png`)
+    try {
+      await page.goto(`${BASE}${r.path}`, { waitUntil: 'domcontentloaded', timeout: 60000 })
+      if (r.app) {
+        await page.waitForSelector('#desk-nav', { timeout: 30000 })
+        await page.waitForTimeout(4000)
+      } else {
+        await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {})
+        await page.waitForTimeout(500)
+      }
+      await page.screenshot({ path: file, fullPage: true })
+      console.log(`ok   ${file}`)
+    } catch (e) {
+      console.error(`FAIL ${file} — ${e.message.split('\n')[0]}`)
+    }
+  }
+  await ctx.close()
+}
+
+await browser.close()
+console.log(`\nSweep complete → ${OUT}`)

--- a/frontend/src/components/BalancingPanel.jsx
+++ b/frontend/src/components/BalancingPanel.jsx
@@ -12,15 +12,14 @@ import {
   Tooltip,
   ReferenceLine,
 } from 'recharts'
-import { fmtTs, CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fmtTs, CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
 // Colors mirror the house up/secondary convention (PowerGridPanel's
 // wind/solar pair, PowerLoadForecastPanel's actual/forecast pair): the
-// established default price-line cyan for the first series, amber for the
+// established default price-line accent for the first series, amber for the
 // second. Direction is never color-alone — arrows + a legend carry identity too.
-const COLOR_UP = '#22d3ee'
 const COLOR_DOWN = '#fbbf24'
 
 function zoneLabel(zone) {
@@ -55,8 +54,8 @@ function fmtDirPrice(price, direction) {
   return `${arrow} ${sign}€${Math.abs(price).toFixed(1)}`.trim()
 }
 
-function dirColor(direction) {
-  return direction === 'down' ? COLOR_DOWN : direction === 'up' ? COLOR_UP : '#a3a3a3'
+function dirColor(direction, accent) {
+  return direction === 'down' ? COLOR_DOWN : direction === 'up' ? accent : '#a3a3a3'
 }
 
 const HOUR_MS = 60 * 60 * 1000
@@ -90,6 +89,7 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
     deps: [zone, product],
     pollMs: POLL_SLOW_MS,
   })
+  const ct = useChartTheme()
 
   // A transient poll failure must not blank a chart that already has good (if
   // slightly stale) data — mirrors LiveNowPanel/PowerSituationHeader.
@@ -147,7 +147,7 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
         <div className="flex items-center gap-2">
           <ProductToggle product={product} onChange={setProduct} />
           {data?.available && latest?.price != null && (
-            <span className="font-mono text-[10px] font-bold" style={{ color: dirColor(latest.direction) }}>
+            <span className="font-mono text-[10px] font-bold" style={{ color: dirColor(latest.direction, ct.accent) }}>
               {fmtDirPrice(latest.price, latest.direction)}
             </span>
           )}
@@ -183,11 +183,11 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
                 <XAxis
                   dataKey="t"
                   tickFormatter={fmtTs}
-                  tick={{ fontSize: 9, fill: '#525252' }}
+                  tick={ct.tick}
                   minTickGap={60}
                 />
                 <YAxis
-                  tick={{ fontSize: 9, fill: '#525252' }}
+                  tick={ct.tick}
                   width={44}
                   tickFormatter={(v) => `${v}`}
                 />
@@ -211,9 +211,9 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
                   type="stepAfter"
                   dataKey="up"
                   name="up-regulation"
-                  stroke={COLOR_UP}
+                  stroke={ct.accent}
                   strokeWidth={1}
-                  dot={{ r: 1.5, strokeWidth: 0, fill: COLOR_UP }}
+                  dot={{ r: 1.5, strokeWidth: 0, fill: ct.accent }}
                   isAnimationActive={false}
                 />
                 <Line
@@ -228,7 +228,7 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
               </LineChart>
             </ResponsiveContainer>
             <div className="flex items-center justify-center gap-4 mt-1 font-mono text-[8px] text-neutral-600">
-              <span style={{ color: COLOR_UP }}>▬ up-regulation (↑)</span>
+              <span style={{ color: ct.accent }}>▬ up-regulation (↑)</span>
               <span style={{ color: COLOR_DOWN }}>▬ down-regulation (↓)</span>
             </div>
           </div>

--- a/frontend/src/components/BordersPanel.jsx
+++ b/frontend/src/components/BordersPanel.jsx
@@ -5,7 +5,7 @@ import { POLL_SLOW_MS } from '../utils/poll'
 import {
   ResponsiveContainer, ComposedChart, Line, Bar, XAxis, YAxis, Tooltip, ReferenceLine, CartesianGrid,
 } from 'recharts'
-import { fmtTs, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtTs, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -70,6 +70,7 @@ function SpreadChart({ a, b }) {
   const { data, loading } = useFetchWithError(
     `${API}/power/spread?a=${a}&b=${b}&days=14`, { deps: [a, b] },
   )
+  const ct = useChartTheme()
   if (loading && !data) {
     return <div className="px-4 py-6 font-mono text-[10px] text-neutral-600 animate-pulse">Loading border…</div>
   }
@@ -92,10 +93,10 @@ function SpreadChart({ a, b }) {
       </div>
       <ResponsiveContainer width="100%" height={180}>
         <ComposedChart data={rows} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-          <XAxis dataKey="x" tickFormatter={fmtTs} tick={{ fontSize: 8, fill: '#737373' }} minTickGap={70} />
-          <YAxis yAxisId="s" tick={{ fontSize: 8, fill: '#737373' }} width={40} />
-          <YAxis yAxisId="f" orientation="right" tick={{ fontSize: 8, fill: '#525252' }} width={34} />
+          <CartesianGrid {...ct.grid} />
+          <XAxis dataKey="x" tickFormatter={fmtTs} tick={ct.tick} minTickGap={70} />
+          <YAxis yAxisId="s" tick={ct.tick} width={40} />
+          <YAxis yAxisId="f" orientation="right" tick={ct.tick} width={34} />
           <ReferenceLine yAxisId="s" y={0} stroke="#444" />
           <Tooltip
             contentStyle={CHART_TOOLTIP_STYLE}

--- a/frontend/src/components/CapacityPricePanel.jsx
+++ b/frontend/src/components/CapacityPricePanel.jsx
@@ -11,7 +11,7 @@ import {
   YAxis,
   Tooltip,
 } from 'recharts'
-import { fmtTs, CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fmtTs, CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -20,8 +20,8 @@ const API = '/api'
 // BalancingPanel's own up/down convention (cyan/amber) so the two capacity+activation panels
 // share one mental model; mFRR gets its own cool/warm pair so all 5 lines stay distinguishable.
 const PRODUCTS = [
-  { key: 'fcr', label: 'FCR', color: '#e5e5e5' },
-  { key: 'afrr_pos', label: 'aFRR ↑', color: '#22d3ee' },
+  { key: 'fcr', label: 'FCR', color: 'ink' },
+  { key: 'afrr_pos', label: 'aFRR ↑', color: 'accent' },
   { key: 'afrr_neg', label: 'aFRR ↓', color: '#fbbf24' },
   { key: 'mfrr_pos', label: 'mFRR ↑', color: '#e879f9' },
   { key: 'mfrr_neg', label: 'mFRR ↓', color: '#a3e635' },
@@ -64,6 +64,8 @@ export default function CapacityPricePanel({ zone = 'DE_LU' }) {
     deps: [zone],
     pollMs: POLL_SLOW_MS,
   })
+  const ct = useChartTheme()
+  const resolveColor = (c) => (c === 'accent' ? ct.accent : c === 'ink' ? ct.ink : c)
 
   // A transient poll failure must not blank a chart that already has good (if slightly
   // stale) data — mirrors BalancingPanel/LiveNowPanel.
@@ -144,11 +146,11 @@ export default function CapacityPricePanel({ zone = 'DE_LU' }) {
                 <XAxis
                   dataKey="t"
                   tickFormatter={fmtTs}
-                  tick={{ fontSize: 9, fill: '#525252' }}
+                  tick={ct.tick}
                   minTickGap={60}
                 />
                 <YAxis
-                  tick={{ fontSize: 9, fill: '#525252' }}
+                  tick={ct.tick}
                   width={44}
                   tickFormatter={(v) => `${v}`}
                 />
@@ -167,7 +169,7 @@ export default function CapacityPricePanel({ zone = 'DE_LU' }) {
                     type="stepAfter"
                     dataKey={p.key}
                     name={p.label}
-                    stroke={p.color}
+                    stroke={resolveColor(p.color)}
                     strokeWidth={1.25}
                     dot={false}
                     hide={hidden.has(p.key)}
@@ -182,7 +184,7 @@ export default function CapacityPricePanel({ zone = 'DE_LU' }) {
                   key={p.key}
                   onClick={() => toggle(p.key)}
                   className="transition-opacity"
-                  style={{ color: p.color, opacity: hidden.has(p.key) ? 0.35 : 1 }}
+                  style={{ color: resolveColor(p.color), opacity: hidden.has(p.key) ? 0.35 : 1 }}
                   title={hidden.has(p.key) ? `Show ${p.label}` : `Hide ${p.label}`}
                 >
                   ▬ {p.label}

--- a/frontend/src/components/CapturePanel.jsx
+++ b/frontend/src/components/CapturePanel.jsx
@@ -5,7 +5,7 @@ import { POLL_SLOW_MS } from '../utils/poll'
 import {
   ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine, Legend,
 } from 'recharts'
-import { CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 import { fuelColor } from '../utils/fuels'
 
 const API = '/api'
@@ -41,6 +41,7 @@ function readStrikeParam() {
  * it per bidding zone.
  */
 export default function CapturePanel({ zone = 'DE_LU' }) {
+  const ct = useChartTheme()
   const { data, loading, error } = useFetchWithError(
     `${API}/power/capture?zone=${zone}&months=36`, { deps: [zone], pollMs: POLL_SLOW_MS },
   )
@@ -229,9 +230,9 @@ export default function CapturePanel({ zone = 'DE_LU' }) {
               </div>
               <ResponsiveContainer width="100%" height={170}>
                 <LineChart data={chart} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-                  <XAxis dataKey="month" tick={{ fontSize: 8, fill: '#737373' }} minTickGap={40} />
-                  <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={34}
+                  <CartesianGrid {...ct.grid} />
+                  <XAxis dataKey="month" tick={ct.tick} minTickGap={40} />
+                  <YAxis tick={ct.tick} width={34}
                     tickFormatter={(v) => chartMode === 'price' ? `€${v.toFixed(0)}` : `×${v.toFixed(1)}`} />
                   {chartMode === 'vf' ? (
                     // Baseload itself. Everything below this line earned less than the base product.

--- a/frontend/src/components/CrossBorderFlowPanel.jsx
+++ b/frontend/src/components/CrossBorderFlowPanel.jsx
@@ -13,18 +13,17 @@ import {
   Tooltip,
   ReferenceLine,
 } from 'recharts'
-import { fmtDate, fmtTs, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, fmtTs, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
-// Color palette: green = export, orange = import, neutral = near-zero
-const COLOR_EXPORT = '#22d3ee'  // cyan – net exporter
+// Color palette: accent = export, orange = import, neutral = near-zero
 const COLOR_IMPORT = '#fb923c'  // orange – net importer
 const COLOR_ZERO   = '#94a3b8'  // slate – near-zero or missing
 
-function borderColor(netMw) {
+function borderColor(netMw, accent) {
   if (netMw == null) return COLOR_ZERO
-  if (netMw > 0) return COLOR_EXPORT
+  if (netMw > 0) return accent  // net exporter
   if (netMw < 0) return COLOR_IMPORT
   return COLOR_ZERO
 }
@@ -39,8 +38,9 @@ function zoneLabel(zone) {
 // Each border = one sparkline + headline bar. Grain-agnostic: `spark` is
 // [{x, net_mw}] with x either a date string (daily) or an ISO timestamp (hourly).
 function BorderRow({ label, netMw, direction, spark, xFormatter, utilPct = null }) {
+  const ct = useChartTheme()
   const absGW = netMw != null ? Math.abs(netMw / 1000).toFixed(2) : '—'
-  const color = borderColor(netMw)
+  const color = borderColor(netMw, ct.accent)
 
   // Bar width: scale relative to ±10 GW max visible (more borders → larger range)
   const MAX_BAR_GW = 10
@@ -195,7 +195,7 @@ export default function CrossBorderFlowPanel({ zone = 'DE_LU' }) {
       id="cross-border-flows"
       freshness={data}
       title={`CROSS-BORDER FLOWS · ${zl}`}
-      info={`Net physical electricity flows across ${zl}'s real interconnectors with its neighbours — sorted by magnitude. Positive = net export in the shown direction. Green = net exporter, orange = net importer. DAILY shows daily means over the selected window; HOURLY shows the last 72 hours from the canonical hourly store. Source: Fraunhofer ISE Energy-Charts (CC BY 4.0).`}
+      info={`Net physical electricity flows across ${zl}'s real interconnectors with its neighbours — sorted by magnitude. Positive = net export in the shown direction. Blue = net exporter, orange = net importer. DAILY shows daily means over the selected window; HOURLY shows the last 72 hours from the canonical hourly store. Source: Fraunhofer ISE Energy-Charts (CC BY 4.0).`}
       collapsible
       headerRight={
         <div className="flex items-center gap-2">

--- a/frontend/src/components/DurationCurvePanel.jsx
+++ b/frontend/src/components/DurationCurvePanel.jsx
@@ -7,18 +7,19 @@ import PanelTakeaway from './PanelTakeaway'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 const MAX_POINTS = 2000
 
 const METRICS = {
-  price: { key: 'price.dayahead', label: 'Day-ahead price', unit: '€/MWh', scale: 1, color: '#22d3ee' },
+  price: { key: 'price.dayahead', label: 'Day-ahead price', unit: '€/MWh', scale: 1, color: 'accent' },
   residual: { key: 'residual.actual', label: 'Residual load', unit: 'GW', scale: 1 / 1000, color: '#a78bfa' },
 }
 
 export default function DurationCurvePanel({ zone = 'DE_LU' }) {
   const [metric, setMetric] = useState('price')
+  const ct = useChartTheme()
   const { range } = useViewState()
   const m = METRICS[metric]
   const start = rangeStart(range)
@@ -81,14 +82,14 @@ export default function DurationCurvePanel({ zone = 'DE_LU' }) {
         <div className="px-2 pt-2 pb-1">
           <ResponsiveContainer width="100%" height={200}>
             <AreaChart data={curve} margin={{ top: 5, right: 12, left: 0, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-              <XAxis dataKey="pct" tick={{ fontSize: 8, fill: '#737373' }} unit="%" type="number" domain={[0, 100]} />
-              <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={40} />
+              <CartesianGrid {...ct.grid} />
+              <XAxis dataKey="pct" tick={ct.tick} unit="%" type="number" domain={[0, 100]} />
+              <YAxis tick={ct.tick} width={40} />
               {metric === 'price' && <ReferenceLine y={0} stroke="#444" />}
               <Tooltip {...CHART_TOOLTIP_PROPS}
                 labelFormatter={(p) => `${p}% of hours`}
                 formatter={(v) => [`${Number(v).toFixed(1)} ${m.unit}`, m.label]} />
-              <Area type="monotone" dataKey="v" stroke={m.color} fill={m.color} fillOpacity={0.08} strokeWidth={1.5} dot={false} />
+              <Area type="monotone" dataKey="v" stroke={m.color === 'accent' ? ct.accent : m.color} fill={m.color === 'accent' ? ct.accent : m.color} fillOpacity={0.08} strokeWidth={1.5} dot={false} />
             </AreaChart>
           </ResponsiveContainer>
           <div className="px-2 font-mono text-[8px] text-neutral-700">x = % of hours in range (sorted high→low)</div>

--- a/frontend/src/components/GasBalancePanel.jsx
+++ b/frontend/src/components/GasBalancePanel.jsx
@@ -7,7 +7,7 @@ import {
   ResponsiveContainer, AreaChart, Area, LineChart, Line,
   XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 import TrackRecordBadge from './TrackRecordBadge'
 
 const API = '/api'
@@ -40,6 +40,7 @@ export default function GasBalancePanel() {
   const { range } = useViewState()
   const { data, loading, error } = useFetchWithError(`${API}/gas/balance?days=${rangeDays(range)}`, { deps: [range] })
   const [view, setView] = useState('residual') // 'residual' | 'decomp'
+  const ct = useChartTheme()
 
   if (error)
     return (
@@ -99,23 +100,23 @@ export default function GasBalancePanel() {
             {view === 'residual' && rows.length > 1 && (
               <ResponsiveContainer width="100%" height={140}>
                 <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
-                  <XAxis dataKey="date" tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
-                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={34} />
+                  <CartesianGrid {...ct.grid} />
+                  <XAxis dataKey="date" tick={ct.tick} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
+                  <YAxis tick={ct.tick} width={34} />
                   <Tooltip contentStyle={CHART_TOOLTIP_STYLE} formatter={(v) => [`${Math.round(v).toLocaleString()} GWh`, 'residual']} labelFormatter={fmtDate} />
                   <ReferenceLine y={0} stroke="#444" />
-                  <Area type="monotone" dataKey="residual" stroke="#22d3ee" fill="#22d3ee" fillOpacity={0.05} strokeWidth={1.5} dot={<FlagDot />} activeDot={{ r: 3 }} />
+                  <Area type="monotone" dataKey="residual" stroke={ct.accent} fill={ct.accent} fillOpacity={0.05} strokeWidth={1.5} dot={<FlagDot />} activeDot={{ r: 3 }} />
                 </AreaChart>
               </ResponsiveContainer>
             )}
             {view === 'decomp' && rows.length > 1 && (
               <ResponsiveContainer width="100%" height={140}>
                 <LineChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
-                  <XAxis dataKey="date" tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
-                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={34} />
+                  <CartesianGrid {...ct.grid} />
+                  <XAxis dataKey="date" tick={ct.tick} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
+                  <YAxis tick={ct.tick} width={34} />
                   <Tooltip contentStyle={CHART_TOOLTIP_STYLE} formatter={(v, name) => [`${Math.round(v).toLocaleString()} GWh`, name]} labelFormatter={fmtDate} />
-                  <Line type="monotone" dataKey="implied_delta" name="implied ΔStorage" stroke="#22d3ee" strokeWidth={1.5} dot={false} />
+                  <Line type="monotone" dataKey="implied_delta" name="implied ΔStorage" stroke={ct.accent} strokeWidth={1.5} dot={false} />
                   <Line type="monotone" dataKey="actual_delta" name="actual ΔStorage" stroke="#94a3b8" strokeWidth={1.5} strokeDasharray="4 3" dot={false} />
                 </LineChart>
               </ResponsiveContainer>

--- a/frontend/src/components/GasDemandPanel.jsx
+++ b/frontend/src/components/GasDemandPanel.jsx
@@ -5,7 +5,7 @@ import { rangeDays } from '../utils/ranges'
 import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -41,6 +41,7 @@ export default function GasDemandPanel() {
   const { range } = useViewState()
   const demand = useFetchWithError(`${API}/gas/demand?days=${rangeDays(range)}`, { deps: [range] })
   const power = useFetchWithError(`${API}/gas/power-burn?days=${rangeDays(range)}`, { deps: [range] })
+  const ct = useChartTheme()
 
   const loading = demand.loading || power.loading
   const error = demand.error // demand is the required source; power may be unavailable
@@ -97,9 +98,9 @@ export default function GasDemandPanel() {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={70}>
                 <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
-                  <XAxis dataKey="date" tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
-                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={28} />
+                  <CartesianGrid {...ct.grid} />
+                  <XAxis dataKey="date" tick={ct.tick} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
+                  <YAxis tick={ct.tick} width={28} />
                   <Tooltip contentStyle={CHART_TOOLTIP_STYLE} formatter={(v, name) => [`${Math.round(v).toLocaleString()} GWh`, name]} labelFormatter={fmtDate} />
                   <Area type="monotone" dataKey="power" stackId="1" stroke="#a78bfa" fill="#a78bfa" fillOpacity={0.15} strokeWidth={1} dot={false} />
                   <Area type="monotone" dataKey="heat" stackId="1" stroke="#22d3ee" fill="#22d3ee" fillOpacity={0.12} strokeWidth={1} dot={false} />

--- a/frontend/src/components/GasStorageCountriesPanel.jsx
+++ b/frontend/src/components/GasStorageCountriesPanel.jsx
@@ -6,7 +6,7 @@ import { rangeDays } from '../utils/ranges'
 import {
   ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -27,6 +27,7 @@ export default function GasStorageCountriesPanel() {
   const { data, loading, error } = useFetchWithError(
     `${API}/gas/storage/countries?days=${rangeDays(range)}`, { deps: [range] },
   )
+  const ct = useChartTheme()
 
   if (error) {
     return (
@@ -105,7 +106,7 @@ export default function GasStorageCountriesPanel() {
                               className="h-1.5 rounded-sm"
                               style={{
                                 width: `${Math.max(0, Math.min(100, pct))}%`,
-                                background: pct < 30 ? '#fb923c' : '#22d3ee',
+                                background: pct < 30 ? '#fb923c' : ct.accent,
                                 opacity: 0.75,
                               }}
                             />
@@ -137,14 +138,14 @@ export default function GasStorageCountriesPanel() {
               </div>
               <ResponsiveContainer width="100%" height={130}>
                 <LineChart data={shown} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-                  <XAxis dataKey="date" tickFormatter={fmtDate} tick={{ fontSize: 8, fill: '#737373' }} minTickGap={50} />
-                  <YAxis domain={[0, 100]} tick={{ fontSize: 8, fill: '#737373' }} width={30}
+                  <CartesianGrid {...ct.grid} />
+                  <XAxis dataKey="date" tickFormatter={fmtDate} tick={ct.tick} minTickGap={50} />
+                  <YAxis domain={[0, 100]} tick={ct.tick} width={30}
                     tickFormatter={(v) => `${v}%`} />
                   <ReferenceLine y={30} stroke="#fb923c" strokeDasharray="4 4" strokeOpacity={0.4} />
                   <Tooltip contentStyle={CHART_TOOLTIP_STYLE} labelFormatter={fmtDate}
                     formatter={(v) => [v == null ? '—' : `${Number(v).toFixed(1)}%`, 'fill']} />
-                  <Line type="monotone" dataKey="fill_pct" stroke="#22d3ee" strokeWidth={1.4}
+                  <Line type="monotone" dataKey="fill_pct" stroke={ct.accent} strokeWidth={1.4}
                     dot={false} connectNulls isAnimationActive={false} />
                 </LineChart>
               </ResponsiveContainer>

--- a/frontend/src/components/GasStoragePanel.jsx
+++ b/frontend/src/components/GasStoragePanel.jsx
@@ -5,13 +5,14 @@ import { rangeDays } from '../utils/ranges'
 import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
 export default function GasStoragePanel() {
   const { range } = useViewState()
   const { data, loading, error } = useFetchWithError(`${API}/gas/storage?days=${rangeDays(range)}`, { deps: [range] })
+  const ct = useChartTheme()
 
   if (error)
     return (
@@ -53,11 +54,11 @@ export default function GasStoragePanel() {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={70}>
                 <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
-                  <XAxis dataKey="date" tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
-                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={24} domain={[0, 100]} />
+                  <CartesianGrid {...ct.grid} />
+                  <XAxis dataKey="date" tick={ct.tick} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
+                  <YAxis tick={ct.tick} width={24} domain={[0, 100]} />
                   <Tooltip contentStyle={CHART_TOOLTIP_STYLE} formatter={(v) => [`${Number(v).toFixed(1)}%`, 'Fill']} labelFormatter={fmtDate} />
-                  <Area type="monotone" dataKey="fill_pct" stroke="#22d3ee" fill="#22d3ee" fillOpacity={0.06} strokeWidth={1.5} dot={false} />
+                  <Area type="monotone" dataKey="fill_pct" stroke={ct.accent} fill={ct.accent} fillOpacity={0.06} strokeWidth={1.5} dot={false} />
                 </AreaChart>
               </ResponsiveContainer>
             </div>

--- a/frontend/src/components/GasSupplyPanel.jsx
+++ b/frontend/src/components/GasSupplyPanel.jsx
@@ -5,7 +5,7 @@ import { rangeDays } from '../utils/ranges'
 import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -21,6 +21,7 @@ function Stat({ label, value }) {
 export default function GasSupplyPanel() {
   const { range } = useViewState()
   const { data, loading, error } = useFetchWithError(`${API}/gas/supply?days=${rangeDays(range)}`, { deps: [range] })
+  const ct = useChartTheme()
 
   if (error)
     return (
@@ -62,11 +63,11 @@ export default function GasSupplyPanel() {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={70}>
                 <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
-                  <XAxis dataKey="date" tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
-                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={28} />
+                  <CartesianGrid {...ct.grid} />
+                  <XAxis dataKey="date" tick={ct.tick} tickFormatter={fmtDate} interval="preserveStartEnd" minTickGap={60} />
+                  <YAxis tick={ct.tick} width={28} />
                   <Tooltip contentStyle={CHART_TOOLTIP_STYLE} formatter={(v) => [`${Math.round(v).toLocaleString()} GWh`, 'supply']} labelFormatter={fmtDate} />
-                  <Area type="monotone" dataKey="supply_gwh" stroke="#22d3ee" fill="#22d3ee" fillOpacity={0.06} strokeWidth={1.5} dot={false} />
+                  <Area type="monotone" dataKey="supply_gwh" stroke={ct.accent} fill={ct.accent} fillOpacity={0.06} strokeWidth={1.5} dot={false} />
                 </AreaChart>
               </ResponsiveContainer>
             </div>

--- a/frontend/src/components/GenMixHistoryPanel.jsx
+++ b/frontend/src/components/GenMixHistoryPanel.jsx
@@ -6,12 +6,13 @@ import Panel from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 import { fuelColor, sortFuels } from '../utils/fuels'
 
 const API = '/api'
 
 export default function GenMixHistoryPanel({ zone = 'DE_LU' }) {
+  const ct = useChartTheme()
   const { range } = useViewState()
   // Monthly buckets need >= 1y to be meaningful, so a short global range floors here.
   const start = rangeStart(range, 365)
@@ -53,9 +54,9 @@ export default function GenMixHistoryPanel({ zone = 'DE_LU' }) {
         <div className="px-2 pt-2 pb-1">
           <ResponsiveContainer width="100%" height={260}>
             <AreaChart data={chart} margin={{ top: 5, right: 12, left: 0, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-              <XAxis dataKey="t" tick={{ fontSize: 8, fill: '#737373' }} minTickGap={30} />
-              <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={34} unit="" />
+              <CartesianGrid {...ct.grid} />
+              <XAxis dataKey="t" tick={ct.tick} minTickGap={30} />
+              <YAxis tick={ct.tick} width={34} unit="" />
               <Tooltip {...CHART_TOOLTIP_PROPS} formatter={(v, n) => [`${Number(v).toFixed(1)} GW`, n]} />
               <Legend wrapperStyle={{ fontSize: 8, fontFamily: 'monospace' }} iconSize={7} />
               {fuels.map((f) => (

--- a/frontend/src/components/GenerationMixPanel.jsx
+++ b/frontend/src/components/GenerationMixPanel.jsx
@@ -6,7 +6,7 @@ import { rangeDays, rangeStart } from '../utils/ranges'
 import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 import { fuelColor, sortFuels } from '../utils/fuels'
 
 const API = '/api'
@@ -15,6 +15,7 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
   const { range } = useViewState()
   const url = `${API}/power/generation-mix?days=${rangeDays(range)}&zone=${zone}`
   const { data, loading, error } = useFetchWithError(url, { deps: [zone, range], pollMs: POLL_SLOW_MS })
+  const ct = useChartTheme()
 
   if (error)
     return (
@@ -100,16 +101,16 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={160}>
                 <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <CartesianGrid {...ct.grid} />
                   <XAxis
                     dataKey="date"
-                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     tickFormatter={fmtDate}
                     interval="preserveStartEnd"
                     minTickGap={60}
                   />
                   <YAxis
-                    tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     width={36}
                     tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
                   />

--- a/frontend/src/components/ImbalancePanel.jsx
+++ b/frontend/src/components/ImbalancePanel.jsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
   ReferenceLine,
 } from 'recharts'
-import { fmtTs, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtTs, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -52,6 +52,7 @@ export default function ImbalancePanel({ zone = 'DE_LU' }) {
     deps: [zone, res],
     pollMs: POLL_SLOW_MS,
   })
+  const ct = useChartTheme()
 
   const zl = zoneLabel(zone)
 
@@ -111,11 +112,11 @@ export default function ImbalancePanel({ zone = 'DE_LU' }) {
                 <XAxis
                   dataKey="x"
                   tickFormatter={fmtTs}
-                  tick={{ fontSize: 9, fill: '#525252' }}
+                  tick={ct.tick}
                   minTickGap={60}
                 />
                 <YAxis
-                  tick={{ fontSize: 9, fill: '#525252' }}
+                  tick={ct.tick}
                   width={44}
                   tickFormatter={(v) => `${v}`}
                 />
@@ -128,7 +129,7 @@ export default function ImbalancePanel({ zone = 'DE_LU' }) {
                 <Line
                   type="stepAfter"
                   dataKey="price"
-                  stroke="#22d3ee"
+                  stroke={ct.accent}
                   strokeWidth={1}
                   dot={false}
                   isAnimationActive={false}

--- a/frontend/src/components/LiveCharts.jsx
+++ b/frontend/src/components/LiveCharts.jsx
@@ -15,7 +15,7 @@ const CORE = ['DE_LU', 'FR', 'NL', 'BE', 'ES', 'AT']
 const MAX_COMPARE = 3
 
 const SECTIONS = [
-  { key: 'prices', label: 'Prices', kind: 'series', series: 'price.dayahead', unit: '€/MWh', scale: 1, color: '#22d3ee' },
+  { key: 'prices', label: 'Prices', kind: 'series', series: 'price.dayahead', unit: '€/MWh', scale: 1, color: 'accent' },
   { key: 'mix', label: 'Fuel Mix', kind: 'mix' },
   { key: 'load', label: 'Load', kind: 'series', series: 'load.actual', unit: 'GW', scale: 1 / 1000, color: '#a78bfa' },
   { key: 'residual', label: 'Residual', kind: 'series', series: 'residual.actual', unit: 'GW', scale: 1 / 1000, color: '#f59e0b' },

--- a/frontend/src/components/LiveNowPanel.jsx
+++ b/frontend/src/components/LiveNowPanel.jsx
@@ -6,7 +6,7 @@ import { POLL_FAST_MS } from '../utils/poll'
 import {
   ResponsiveContainer, ComposedChart, Area, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
-import { fmtHour, fmtTs, CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fmtHour, fmtTs, CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 import { fuelColor, fuelLabel, sortFuels } from '../utils/fuels'
 
 const API = '/api'
@@ -43,6 +43,7 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
   const [view, setView] = useState('generation')
   const url = `${API}/power/live?zone=${zone}`
   const { data, loading, error } = useFetchWithError(url, { deps: [zone], pollMs: POLL_FAST_MS })
+  const ct = useChartTheme()
 
   // A transient poll failure must not blank a chart that already has good (if
   // slightly stale) data — mirrors PowerSituationHeader/OutagePanel/GenMixHistoryPanel.
@@ -157,15 +158,15 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={200}>
                 <ComposedChart data={genRows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <CartesianGrid {...ct.grid} />
                   <XAxis
                     dataKey="hour"
                     tickFormatter={fmtHour}
-                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     interval={2}
                   />
                   <YAxis
-                    tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     width={36}
                     tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
                   />
@@ -193,7 +194,7 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
                     type="monotone"
                     dataKey="load"
                     name="load"
-                    stroke="#e5e7eb"
+                    stroke={ct.ink}
                     strokeWidth={1.5}
                     dot={false}
                     isAnimationActive={false}
@@ -202,7 +203,7 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
                     type="monotone"
                     dataKey="load_fc"
                     name="load forecast"
-                    stroke="#e5e7eb"
+                    stroke={ct.ink}
                     strokeDasharray="4 3"
                     strokeWidth={1}
                     dot={false}
@@ -225,21 +226,21 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={160}>
                 <ComposedChart data={priceRows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <CartesianGrid {...ct.grid} />
                   <XAxis
                     dataKey="hour"
                     tickFormatter={fmtHour}
-                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     interval={2}
                   />
-                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={36} />
+                  <YAxis tick={ct.tick} width={36} />
                   <ReferenceLine y={0} stroke="#2a2a3a" strokeDasharray="2 2" />
                   {nowHour != null && (
                     <ReferenceLine
                       x={nowHour}
-                      stroke="#22d3ee"
+                      stroke={ct.accent}
                       strokeDasharray="3 3"
-                      label={{ value: 'now', position: 'insideTop', fill: '#22d3ee', fontSize: 9 }}
+                      label={{ value: 'now', position: 'insideTop', fill: ct.accent, fontSize: 9 }}
                     />
                   )}
                   <Tooltip
@@ -250,8 +251,8 @@ export default function LiveNowPanel({ zone = 'DE_LU' }) {
                   <Area
                     type="stepAfter"
                     dataKey="price"
-                    stroke="#22d3ee"
-                    fill="#22d3ee"
+                    stroke={ct.accent}
+                    fill={ct.accent}
                     fillOpacity={0.08}
                     strokeWidth={1.5}
                     dot={<NegativeHourDot />}

--- a/frontend/src/components/MeritOrderScatter.jsx
+++ b/frontend/src/components/MeritOrderScatter.jsx
@@ -7,12 +7,13 @@ import PanelTakeaway from './PanelTakeaway'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 const MAX_POINTS = 4000
 
 export default function MeritOrderScatter({ zone = 'DE_LU' }) {
+  const ct = useChartTheme()
   const { range } = useViewState()
   const start = rangeStart(range)
 
@@ -71,14 +72,14 @@ export default function MeritOrderScatter({ zone = 'DE_LU' }) {
         <div className="px-2 pt-2 pb-1">
           <ResponsiveContainer width="100%" height={220}>
             <ScatterChart margin={{ top: 5, right: 12, left: 0, bottom: 12 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-              <XAxis type="number" dataKey="x" name="Residual" unit=" GW" tick={{ fontSize: 8, fill: '#737373' }}
+              <CartesianGrid {...ct.grid} />
+              <XAxis type="number" dataKey="x" name="Residual" unit=" GW" tick={ct.tick}
                 label={{ value: 'Residual load (GW)', position: 'insideBottom', offset: -4, fontSize: 8, fill: '#737373' }} />
-              <YAxis type="number" dataKey="y" name="Price" unit=" €" tick={{ fontSize: 8, fill: '#737373' }} width={40} />
+              <YAxis type="number" dataKey="y" name="Price" unit=" €" tick={ct.tick} width={40} />
               <ReferenceLine y={0} stroke="#444" />
               <Tooltip {...CHART_TOOLTIP_PROPS} cursor={{ strokeDasharray: '3 3' }}
                 formatter={(v, n) => [n === 'Price' ? `${Number(v).toFixed(1)} €/MWh` : `${Number(v).toFixed(1)} GW`, n]} />
-              <Scatter data={points} fill="#22d3ee" fillOpacity={0.35} />
+              <Scatter data={points} fill={ct.accent} fillOpacity={0.35} />
             </ScatterChart>
           </ResponsiveContainer>
         </div>

--- a/frontend/src/components/MiniMixCard.jsx
+++ b/frontend/src/components/MiniMixCard.jsx
@@ -3,7 +3,7 @@ import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianG
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 import { fuelColor, sortFuels } from '../utils/fuels'
 
 const API = '/api'
@@ -11,6 +11,7 @@ const API = '/api'
 // Compact stacked generation mix per zone for the Live grid (Fuel Mix section).
 // Daily resolution, floored to 90d so the stack has shape; GW.
 export default function MiniMixCard({ title, zone, height = 120 }) {
+  const ct = useChartTheme()
   const { range } = useViewState()
   const start = rangeStart(range, 90)
   const url = `${API}/v1/genmix?zone=${zone}&start=${start}&resolution=daily`
@@ -43,9 +44,9 @@ export default function MiniMixCard({ title, zone, height = 120 }) {
         <div className="px-1 py-2">
           <ResponsiveContainer width="100%" height={height}>
             <AreaChart data={chart} margin={{ top: 5, right: 8, left: 0, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-              <XAxis dataKey="t" tick={{ fontSize: 8, fill: '#737373' }} minTickGap={30} />
-              <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={30} />
+              <CartesianGrid {...ct.grid} />
+              <XAxis dataKey="t" tick={ct.tick} minTickGap={30} />
+              <YAxis tick={ct.tick} width={30} />
               <Tooltip {...CHART_TOOLTIP_PROPS} formatter={(v, n) => [`${Number(v).toFixed(1)} GW`, n]} />
               {fuels.map((f) => (
                 <Area key={f} type="monotone" dataKey={f} stackId="1" stroke={fuelColor(f)} fill={fuelColor(f)} fillOpacity={0.6} strokeWidth={0.5} />

--- a/frontend/src/components/PowerDayAheadPanel.jsx
+++ b/frontend/src/components/PowerDayAheadPanel.jsx
@@ -7,7 +7,7 @@ import { rangeDays, rangeStart } from '../utils/ranges'
 import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
-import { fmtDate, fmtHour, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, fmtHour, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -29,6 +29,7 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
   // so the hourly view is a smoothed picture of what the market actually cleared.
   const { data: qhData } = useFetchWithError(`${API}/power/day-ahead/hourly?zone=${zone}&resolution=qh`, { deps: [zone] })
   const [view, setView] = useState('daily')
+  const ct = useChartTheme()
 
   if (error)
     return (
@@ -135,13 +136,13 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={120}>
                 <AreaChart data={qh} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <CartesianGrid {...ct.grid} />
                   <XAxis
                     dataKey="time"
-                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     interval={7}
                   />
-                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={30} />
+                  <YAxis tick={ct.tick} width={30} />
                   <Tooltip
                     contentStyle={CHART_TOOLTIP_STYLE}
                     formatter={(v) => [`${Number(v).toFixed(1)} €/MWh`, '15-min']}
@@ -152,12 +153,12 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
                   <Area
                     type="stepAfter"
                     dataKey="price"
-                    stroke="#22d3ee"
-                    fill="#22d3ee"
+                    stroke={ct.accent}
+                    fill={ct.accent}
                     fillOpacity={0.06}
                     strokeWidth={1}
                     dot={false}
-                    activeDot={{ r: 3, fill: '#22d3ee' }}
+                    activeDot={{ r: 3, fill: ct.accent }}
                   />
                 </AreaChart>
               </ResponsiveContainer>
@@ -166,14 +167,14 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={120}>
                 <AreaChart data={hourly} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <CartesianGrid {...ct.grid} />
                   <XAxis
                     dataKey="hour"
                     tickFormatter={fmtHour}
-                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     interval={2}
                   />
-                  <YAxis tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }} width={30} />
+                  <YAxis tick={ct.tick} width={30} />
                   <Tooltip
                     contentStyle={CHART_TOOLTIP_STYLE}
                     formatter={(v) => [`${Number(v).toFixed(1)} €/MWh`, 'Hourly']}
@@ -182,12 +183,12 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
                   <Area
                     type="monotone"
                     dataKey="price"
-                    stroke="#22d3ee"
-                    fill="#22d3ee"
+                    stroke={ct.accent}
+                    fill={ct.accent}
                     fillOpacity={0.06}
                     strokeWidth={1.5}
                     dot={false}
-                    activeDot={{ r: 3, fill: '#22d3ee' }}
+                    activeDot={{ r: 3, fill: ct.accent }}
                   />
                 </AreaChart>
               </ResponsiveContainer>
@@ -197,16 +198,16 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
               <div className="px-2 py-2">
                 <ResponsiveContainer width="100%" height={70}>
                   <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                    <CartesianGrid {...ct.grid} />
                     <XAxis
                       dataKey="date"
-                      tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                      tick={ct.tick}
                       tickFormatter={fmtDate}
                       interval="preserveStartEnd"
                       minTickGap={60}
                     />
                     <YAxis
-                      tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                      tick={ct.tick}
                       width={30}
                     />
                     <Tooltip
@@ -217,12 +218,12 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
                     <Area
                       type="monotone"
                       dataKey="close"
-                      stroke="#22d3ee"
-                      fill="#22d3ee"
+                      stroke={ct.accent}
+                      fill={ct.accent}
                       fillOpacity={0.06}
                       strokeWidth={1.5}
                       dot={<NegativeDot />}
-                      activeDot={{ r: 3, fill: '#22d3ee' }}
+                      activeDot={{ r: 3, fill: ct.accent }}
                     />
                   </AreaChart>
                 </ResponsiveContainer>

--- a/frontend/src/components/PowerGridPanel.jsx
+++ b/frontend/src/components/PowerGridPanel.jsx
@@ -6,13 +6,12 @@ import { rangeDays, rangeStart } from '../utils/ranges'
 import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 import TrackRecordBadge from './TrackRecordBadge'
 
 const API = '/api'
 
 // Color palette for the stacked areas
-const COLOR_WIND   = '#22d3ee' // cyan
 const COLOR_SOLAR  = '#fbbf24' // amber
 const COLOR_RESID  = '#94a3b8' // slate (dispatchable)
 const COLOR_DUNKEL = '#f87171' // red-400
@@ -27,6 +26,7 @@ export default function PowerGridPanel({ zone = 'DE_LU' }) {
   const { range } = useViewState()
   const url = `${API}/power/grid?days=${rangeDays(range)}&zone=${zone}`
   const { data, loading, error } = useFetchWithError(url, { deps: [zone, range], pollMs: POLL_SLOW_MS })
+  const ct = useChartTheme()
 
   if (error)
     return (
@@ -49,7 +49,7 @@ export default function PowerGridPanel({ zone = 'DE_LU' }) {
     : null
 
   const isDunkel = latest?.dunkelflaute === true
-  const headerColor = isDunkel ? COLOR_DUNKEL : '#22d3ee'
+  const headerColor = isDunkel ? COLOR_DUNKEL : ct.accent
 
   // Readable label: prefer what the API returns, fall back to zone prop
   const zoneLabel = data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)
@@ -109,16 +109,16 @@ export default function PowerGridPanel({ zone = 'DE_LU' }) {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={120}>
                 <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <CartesianGrid {...ct.grid} />
                   <XAxis
                     dataKey="date"
-                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     tickFormatter={fmtDate}
                     interval="preserveStartEnd"
                     minTickGap={60}
                   />
                   <YAxis
-                    tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     width={36}
                     tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
                   />
@@ -133,8 +133,8 @@ export default function PowerGridPanel({ zone = 'DE_LU' }) {
                     dataKey="wind_mw"
                     name="wind"
                     stackId="load"
-                    stroke={COLOR_WIND}
-                    fill={COLOR_WIND}
+                    stroke={ct.accent}
+                    fill={ct.accent}
                     fillOpacity={0.18}
                     strokeWidth={1}
                     dot={false}
@@ -167,7 +167,7 @@ export default function PowerGridPanel({ zone = 'DE_LU' }) {
 
               {/* Legend */}
               <div className="flex items-center justify-center gap-4 mt-1 font-mono text-[8px] text-neutral-600">
-                <span style={{ color: COLOR_WIND }}>▬ wind</span>
+                <span style={{ color: ct.accent }}>▬ wind</span>
                 <span style={{ color: COLOR_SOLAR }}>▬ solar</span>
                 <span style={{ color: COLOR_RESID }}>▬ residual (dispatchable)</span>
                 <span style={{ color: COLOR_DUNKEL }}>● Dunkelflaute</span>

--- a/frontend/src/components/PowerLoadForecastPanel.jsx
+++ b/frontend/src/components/PowerLoadForecastPanel.jsx
@@ -5,12 +5,12 @@ import useFetchWithError from '../hooks/useFetchWithError'
 import {
   ResponsiveContainer, LineChart, Line, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid,
 } from 'recharts'
-import { fmtDate, fmtHour, CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fmtDate, fmtHour, CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
 const COLOR_FORECAST = '#a78bfa' // violet — the forward view
-const COLOR_ACTUAL = '#22d3ee'   // cyan — realised
+// realised/actual series uses the theme accent (ct.accent)
 
 export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
   const url = `${API}/power/load-forecast?days=30&zone=${zone}`
@@ -19,6 +19,7 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
   // Fetched alongside; the toggle swaps which series is charted.
   const { data: hourlyData } = useFetchWithError(`${API}/power/load-forecast/hourly?zone=${zone}`, { deps: [zone] })
   const [view, setView] = useState('daily')
+  const ct = useChartTheme()
 
   if (error)
     return (
@@ -71,7 +72,7 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
       id="power-load-forecast"
       freshness={data}
       title="LOAD FORECAST vs ACTUAL // ENTSO-E"
-      info="ENTSO-E day-ahead forecasts (processType A01): total load (A65) and wind+solar (A69). The headline is tomorrow's RESIDUAL load = load − wind − solar — the demand dispatchable plants must cover, and the quantity that most drives the day-ahead price. DAILY view tracks the load forecast (violet) vs realised (cyan) — the gap is the forecast error. HOURLY view shows tomorrow's residual shape (evening ramp, midday solar trough, Dunkelflaute windows). Descriptive — higher residual tends to firm prices, but this is not a price call."
+      info="ENTSO-E day-ahead forecasts (processType A01): total load (A65) and wind+solar (A69). The headline is tomorrow's RESIDUAL load = load − wind − solar — the demand dispatchable plants must cover, and the quantity that most drives the day-ahead price. DAILY view tracks the load forecast (violet) vs realised (blue) — the gap is the forecast error. HOURLY view shows tomorrow's residual shape (evening ramp, midday solar trough, Dunkelflaute windows). Descriptive — higher residual tends to firm prices, but this is not a price call."
       collapsible
       headerRight={<span className="font-mono text-[9px] text-neutral-600">ENTSO-E</span>}
     >
@@ -134,9 +135,9 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
           <div className="px-2 pt-2 pb-1">
             <ResponsiveContainer width="100%" height={160}>
               <AreaChart data={hourly} margin={{ top: 5, right: 10, bottom: 5, left: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-                <XAxis dataKey="hour" tickFormatter={fmtHour} tick={{ fontSize: 8, fill: '#737373' }} interval={2} />
-                <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={34} unit="" />
+                <CartesianGrid {...ct.grid} />
+                <XAxis dataKey="hour" tickFormatter={fmtHour} tick={ct.tick} interval={2} />
+                <YAxis tick={ct.tick} width={34} unit="" />
                 <Tooltip {...CHART_TOOLTIP_PROPS} labelFormatter={(h) => `${fmtHour(h)} UTC`}
                   formatter={(v, n) => [v != null ? `${Number(v).toFixed(1)} GW` : '—',
                     { residual: 'Residual', load: 'Load', wind: 'Wind', solar: 'Solar' }[n] ?? n]} />
@@ -151,13 +152,13 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
           <div className="px-2 pt-3 pb-1">
             <ResponsiveContainer width="100%" height={180}>
               <LineChart data={chart} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-                <XAxis dataKey="date" tickFormatter={fmtDate} tick={{ fontSize: 9, fill: '#737373' }} minTickGap={24} />
-                <YAxis tick={{ fontSize: 9, fill: '#737373' }} width={34} domain={['auto', 'auto']} unit="" />
+                <CartesianGrid {...ct.grid} />
+                <XAxis dataKey="date" tickFormatter={fmtDate} tick={ct.tick} minTickGap={24} />
+                <YAxis tick={ct.tick} width={34} domain={['auto', 'auto']} unit="" />
                 <Tooltip {...CHART_TOOLTIP_PROPS} labelFormatter={fmtDate}
                   formatter={(v, n) => [v != null ? `${v.toFixed(1)} GW` : '—', n === 'forecast' ? 'Forecast' : 'Actual']} />
                 <Line type="monotone" dataKey="forecast" stroke={COLOR_FORECAST} dot={false} strokeWidth={1.5} connectNulls />
-                <Line type="monotone" dataKey="actual" stroke={COLOR_ACTUAL} dot={false} strokeWidth={1.5} connectNulls />
+                <Line type="monotone" dataKey="actual" stroke={ct.accent} dot={false} strokeWidth={1.5} connectNulls />
               </LineChart>
             </ResponsiveContainer>
           </div>

--- a/frontend/src/components/PriceTicker.jsx
+++ b/frontend/src/components/PriceTicker.jsx
@@ -5,8 +5,8 @@ import { useState, useEffect } from 'react'
 // `unit` is mandatory context, not decoration: TTF quotes in EUR/MWh while
 // Henry-Hub NG quotes in USD/MMBtu — bare numbers side by side are unreadable.
 const TICKERS = [
-  { key: 'TTF', label: 'TTF', unit: '€/MWh', color: 'text-pink-400' },
-  { key: 'NG', label: 'NG', unit: '$/MMBtu', color: 'text-purple-400' },
+  { key: 'TTF', label: 'TTF', unit: '€/MWh' },
+  { key: 'NG', label: 'NG', unit: '$/MMBtu' },
 ]
 
 export default function PriceTicker() {
@@ -53,7 +53,7 @@ export default function PriceTicker() {
           <div key={t.key} className="flex items-center gap-1 shrink-0">
             {i > 0 && <span className="text-neutral-800 mx-1">|</span>}
             <span className="font-mono text-[10px] text-neutral-500">{t.label}</span>
-            <span className={`font-mono text-xs font-bold ${t.color}`}>
+            <span className="num text-xs font-bold text-neutral-200">
               {price != null ? price.toFixed(2) : '--'}
             </span>
             <span className="font-mono text-[9px] text-neutral-600">{t.unit}</span>

--- a/frontend/src/components/ProductsPanel.jsx
+++ b/frontend/src/components/ProductsPanel.jsx
@@ -4,7 +4,7 @@ import { POLL_SLOW_MS } from '../utils/poll'
 import {
   ResponsiveContainer, ComposedChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -19,6 +19,7 @@ export default function ProductsPanel({ zone = 'DE_LU' }) {
   const { data, loading, error } = useFetchWithError(
     `${API}/power/products?zone=${zone}&days=30`, { deps: [zone], pollMs: POLL_SLOW_MS },
   )
+  const ct = useChartTheme()
 
   if (error) {
     return (
@@ -73,9 +74,9 @@ export default function ProductsPanel({ zone = 'DE_LU' }) {
           <div className="px-2 pt-3">
             <ResponsiveContainer width="100%" height={170}>
               <ComposedChart data={chart} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-                <XAxis dataKey="date" tickFormatter={fmtDate} tick={{ fontSize: 8, fill: '#737373' }} minTickGap={50} />
-                <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={40} />
+                <CartesianGrid {...ct.grid} />
+                <XAxis dataKey="date" tickFormatter={fmtDate} tick={ct.tick} minTickGap={50} />
+                <YAxis tick={ct.tick} width={40} />
                 <ReferenceLine y={0} stroke="#444" />
                 <Tooltip
                   contentStyle={CHART_TOOLTIP_STYLE}
@@ -86,7 +87,7 @@ export default function ProductsPanel({ zone = 'DE_LU' }) {
                   dot={false} isAnimationActive={false} />
                 <Line type="monotone" dataKey="peak" name="peak" stroke="#fbbf24" strokeWidth={1.4}
                   dot={false} connectNulls={false} isAnimationActive={false} />
-                <Line type="monotone" dataKey="off" name="off-peak" stroke="#22d3ee" strokeWidth={1}
+                <Line type="monotone" dataKey="off" name="off-peak" stroke={ct.accent} strokeWidth={1}
                   dot={false} isAnimationActive={false} />
               </ComposedChart>
             </ResponsiveContainer>

--- a/frontend/src/components/SeriesExplorer.jsx
+++ b/frontend/src/components/SeriesExplorer.jsx
@@ -6,7 +6,7 @@ import { InfoPopover } from './Panel'
 import useFetchWithError from '../hooks/useFetchWithError'
 import useSeriesFrame, { MAX_SERIES_ROWS } from '../hooks/useSeriesFrame'
 import { useViewState } from '../context/ViewStateContext'
-import { CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 const DEFAULT_SERIES = 'price.dayahead'
@@ -16,7 +16,7 @@ const DEFAULT_RESOLUTION = 'daily'
 // when a sibling row is removed. Row 0/1 keep the original Explorer's
 // cyan/violet; the rest reuse ZoneCompareChart's pink/green/indigo plus the
 // old Δ-spread amber, so a hue already means something elsewhere on the desk.
-const ROW_COLORS = ['#22d3ee', '#a78bfa', '#f472b6', '#4ade80', '#fbbf24', '#818cf8']
+const ROW_COLORS = ['accent', '#a78bfa', '#f472b6', '#4ade80', '#fbbf24', '#818cf8']
 
 // Module-level (stable reference) fallbacks for before the catalog loads.
 const FALLBACK_SERIES = [{ key: DEFAULT_SERIES, unit: 'EUR/MWh', label: 'Day-ahead price · hourly', group: 'price' }]
@@ -198,6 +198,9 @@ function SeriesPicker({ value, onChange, seriesList, groups }) {
 
 export default function SeriesExplorer() {
   const { zone, setZone, range } = useViewState()  // primary zone + range = the global spine
+  const ct = useChartTheme()
+  // Row 0's 'accent' sentinel resolves per theme; the rest are literal hexes.
+  const resolveColor = (c) => (c === 'accent' ? ct.accent : c)
 
   // Parsed ONCE at mount: either the current `rows=` format, or a legacy
   // `s=`/`vs=` link (old shared Explorer URLs) — never both. `primaryZone` is
@@ -376,7 +379,7 @@ export default function SeriesExplorer() {
       <div className="px-4 py-2.5 border-b border-border/50 space-y-1.5">
         {rows.map((row, i) => (
           <div key={row.id} className="flex flex-wrap items-center gap-1.5">
-            <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ background: ROW_COLORS[i % ROW_COLORS.length] }} />
+            <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ background: resolveColor(ROW_COLORS[i % ROW_COLORS.length]) }} />
             <SeriesPicker
               value={row.series}
               onChange={(key) => (i === 0 ? setPrimarySeries(key) : updateExtraRow(i - 1, { series: key }))}
@@ -476,7 +479,7 @@ export default function SeriesExplorer() {
               ) : (
                 visibleRows.map((r) => (
                   <span key={r.key} className="flex items-center gap-1">
-                    <span className="inline-block w-2 h-0.5" style={{ background: r.color }} />
+                    <span className="inline-block w-2 h-0.5" style={{ background: resolveColor(r.color) }} />
                     <span>{rowLabel(r, seriesList, zoneList)}{r.unit ? ` (${r.unit})` : ''}</span>
                     {r.error && (
                       <span className="text-red-400" title={r.error}>fetch error</span>
@@ -492,11 +495,11 @@ export default function SeriesExplorer() {
             </div>
             <ResponsiveContainer width="100%" height={220}>
               <LineChart data={showSpread ? spreadFrame : frame} margin={{ top: 5, right: 12, left: 0, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-                <XAxis dataKey="t" tickFormatter={fmtT} tick={{ fontSize: 8, fill: '#737373' }} minTickGap={40} />
-                <YAxis yAxisId="left" tick={{ fontSize: 8, fill: '#737373' }} width={44} domain={['auto', 'auto']} />
+                <CartesianGrid {...ct.grid} />
+                <XAxis dataKey="t" tickFormatter={fmtT} tick={ct.tick} minTickGap={40} />
+                <YAxis yAxisId="left" tick={ct.tick} width={44} domain={['auto', 'auto']} />
                 {!showSpread && rightUnit && (
-                  <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 8, fill: '#737373' }} width={44} domain={['auto', 'auto']} />
+                  <YAxis yAxisId="right" orientation="right" tick={ct.tick} width={44} domain={['auto', 'auto']} />
                 )}
                 <Tooltip {...CHART_TOOLTIP_PROPS} labelFormatter={fmtT}
                   formatter={(v, name) => {
@@ -511,7 +514,7 @@ export default function SeriesExplorer() {
                   </>
                 ) : (
                   visibleRows.map((r) => (
-                    <Line key={r.key} yAxisId={r.axis} type="monotone" dataKey={r.key} stroke={r.color} dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />
+                    <Line key={r.key} yAxisId={r.axis} type="monotone" dataKey={r.key} stroke={resolveColor(r.color)} dot={false} strokeWidth={1.4} connectNulls isAnimationActive={false} />
                   ))
                 )}
               </LineChart>

--- a/frontend/src/components/SparkCalculatorPanel.jsx
+++ b/frontend/src/components/SparkCalculatorPanel.jsx
@@ -5,7 +5,7 @@ import { POLL_SLOW_MS } from '../utils/poll'
 import {
   ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -48,6 +48,7 @@ export default function SparkCalculatorPanel({ zone = 'DE_LU' }) {
   const { data, loading, error } = useFetchWithError(
     url, { deps: [zone, efficiency], pollMs: POLL_SLOW_MS },
   )
+  const ct = useChartTheme()
 
   // The slider's displayed position: whatever the user chose, else the backend's own default
   // once it's known, else a placeholder while the very first request is in flight.
@@ -151,10 +152,10 @@ export default function SparkCalculatorPanel({ zone = 'DE_LU' }) {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={160}>
                 <LineChart data={rows} margin={{ top: 4, right: 8, bottom: 2, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-                  <XAxis dataKey="date" tick={{ fontSize: 8, fill: '#737373' }}
+                  <CartesianGrid {...ct.grid} />
+                  <XAxis dataKey="date" tick={ct.tick}
                     tickFormatter={fmtDate} minTickGap={50} />
-                  <YAxis tick={{ fontSize: 8, fill: '#737373' }} width={34} />
+                  <YAxis tick={ct.tick} width={34} />
                   <ReferenceLine y={0} stroke="#525252" strokeDasharray="4 4" />
                   <Tooltip
                     {...CHART_TOOLTIP_PROPS}

--- a/frontend/src/components/SparkSpreadPanel.jsx
+++ b/frontend/src/components/SparkSpreadPanel.jsx
@@ -5,7 +5,7 @@ import { rangeDays } from '../utils/ranges'
 import {
   ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine,
 } from 'recharts'
-import { fmtDate, CHART_TOOLTIP_STYLE } from '../utils/chart'
+import { fmtDate, CHART_TOOLTIP_STYLE, useChartTheme } from '../utils/chart'
 import TrackRecordBadge from './TrackRecordBadge'
 
 const API = '/api'
@@ -15,6 +15,7 @@ export default function SparkSpreadPanel({ zone = 'DE_LU' }) {
   const { data, loading, error } = useFetchWithError(
     `${API}/power/spark-spread?days=${rangeDays(range)}&zone=${zone}`, { deps: [zone, range] },
   )
+  const ct = useChartTheme()
   const zoneLabel = data?.zone === 'DE_LU' ? 'DE-LU' : (data?.zone ?? zone)
 
   // The spark-spread route is public now; a 401/403 shouldn't occur, but treat
@@ -107,16 +108,16 @@ export default function SparkSpreadPanel({ zone = 'DE_LU' }) {
             <div className="px-2 py-2">
               <ResponsiveContainer width="100%" height={120}>
                 <AreaChart data={rows} margin={{ top: 5, right: 5, bottom: 5, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e1e2e" />
+                  <CartesianGrid {...ct.grid} />
                   <XAxis
                     dataKey="date"
-                    tick={{ fontSize: 8, fill: '#555', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     tickFormatter={fmtDate}
                     interval="preserveStartEnd"
                     minTickGap={60}
                   />
                   <YAxis
-                    tick={{ fontSize: 8, fill: '#55556688', fontFamily: 'monospace' }}
+                    tick={ct.tick}
                     width={30}
                   />
                   <Tooltip

--- a/frontend/src/components/TrendsPanel.jsx
+++ b/frontend/src/components/TrendsPanel.jsx
@@ -7,11 +7,12 @@ import PanelTakeaway from './PanelTakeaway'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_PROPS } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
 export default function TrendsPanel({ zone = 'DE_LU' }) {
+  const ct = useChartTheme()
   const { range } = useViewState()
   // Monthly aggregates need >= 1y to be meaningful, so a short global range floors here.
   const start = rangeStart(range, 365)
@@ -88,10 +89,10 @@ export default function TrendsPanel({ zone = 'DE_LU' }) {
         <div className="px-2 pt-2 pb-1">
           <ResponsiveContainer width="100%" height={220}>
             <ComposedChart data={rows} margin={{ top: 5, right: 6, left: 0, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-              <XAxis dataKey="t" tick={{ fontSize: 8, fill: '#737373' }} minTickGap={30} />
-              <YAxis yAxisId="l" tick={{ fontSize: 8, fill: '#737373' }} width={30} />
-              <YAxis yAxisId="r" orientation="right" tick={{ fontSize: 8, fill: '#737373' }} width={30} unit="%" domain={[0, 100]} />
+              <CartesianGrid {...ct.grid} />
+              <XAxis dataKey="t" tick={ct.tick} minTickGap={30} />
+              <YAxis yAxisId="l" tick={ct.tick} width={30} />
+              <YAxis yAxisId="r" orientation="right" tick={ct.tick} width={30} unit="%" domain={[0, 100]} />
               <Tooltip {...CHART_TOOLTIP_PROPS}
                 formatter={(v, n) => [n === 'renewShare' ? `${v}%` : v, n === 'negHours' ? 'Neg-price h' : 'Renewables']} />
               <Legend wrapperStyle={{ fontSize: 8, fontFamily: 'monospace' }} iconSize={7} />

--- a/frontend/src/components/ZoneCompareChart.jsx
+++ b/frontend/src/components/ZoneCompareChart.jsx
@@ -3,7 +3,7 @@ import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianG
 import useFetchWithError from '../hooks/useFetchWithError'
 import { useViewState } from '../context/ViewStateContext'
 import { rangeStart } from '../utils/ranges'
-import { CHART_TOOLTIP_PROPS, fmtDate } from '../utils/chart'
+import { CHART_TOOLTIP_PROPS, fmtDate, useChartTheme } from '../utils/chart'
 
 const API = '/api'
 
@@ -29,7 +29,8 @@ function fmtHourAxis(iso) {
 // per-request row cap). One request per zone, well inside the cap.
 const HOURLY_LOOKBACK_DAYS = 3
 
-export default function ZoneCompareChart({ title, series, zone, compare = [], unit, scale = 1, color = '#22d3ee', labelFor, resolution = 'daily' }) {
+export default function ZoneCompareChart({ title, series, zone, compare = [], unit, scale = 1, color = 'accent', labelFor, resolution = 'daily' }) {
+  const ct = useChartTheme()
   const { range } = useViewState()
   const hourly = resolution === 'hourly'
   const start = hourly
@@ -76,7 +77,7 @@ export default function ZoneCompareChart({ title, series, zone, compare = [], un
 
   const loading = responses.slice(0, zones.length).some((r) => r.loading)
   const failedZones = zones.filter((z, i) => responses[i].error && !responses[i].data)
-  const colorOf = (z, i) => (i === 0 ? color : COMPARE_COLORS[(i - 1) % COMPARE_COLORS.length])
+  const colorOf = (z, i) => (i === 0 ? (color === 'accent' ? ct.accent : color) : COMPARE_COLORS[(i - 1) % COMPARE_COLORS.length])
   const label = (z) => (labelFor ? labelFor(z) : z)
 
   return (
@@ -134,9 +135,9 @@ export default function ZoneCompareChart({ title, series, zone, compare = [], un
         <div className="px-1 py-2">
           <ResponsiveContainer width="100%" height={280}>
             <LineChart data={rows} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
-              <XAxis dataKey="t" tickFormatter={fmtAxis} tick={{ fontSize: 9, fill: '#737373' }} minTickGap={hourly ? 60 : 40} />
-              <YAxis tick={{ fontSize: 9, fill: '#737373' }} width={40} domain={['auto', 'auto']} />
+              <CartesianGrid {...ct.grid} />
+              <XAxis dataKey="t" tickFormatter={fmtAxis} tick={ct.tick} minTickGap={hourly ? 60 : 40} />
+              <YAxis tick={ct.tick} width={40} domain={['auto', 'auto']} />
               <Tooltip
                 {...CHART_TOOLTIP_PROPS}
                 labelFormatter={fmtAxis}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,11 @@
 @import "tailwindcss";
 
 @theme {
-  /* Accent is a de-neoned teal (was neon cyan #00e5ff). Token name kept — ~350
-     `*-cyan-glow` usages flip from here; html.light overrides it darker for white. */
-  --color-cyan-glow: #2dd4bf;
+  /* Accent is an academic ink-blue (2026-08 institutional redesign; was teal
+     #2dd4bf, before that neon cyan #00e5ff). Token name kept — ~350
+     `*-cyan-glow` usages flip from here; html.light overrides it darker for white.
+     Dark value is a lifted, slightly desaturated step of the light ink-blue. */
+  --color-cyan-glow: #7aa5e8;
   --color-green-glow: #34d399;
   --color-surface: #0f1115;
   --color-surface-light: #171a21;
@@ -13,6 +15,12 @@
      so this token stays the single lever — pointing it at the sans flips the whole
      app from one place. Numbers stay column-aligned via tabular-nums on body. */
   --font-mono: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  /* Display serif for headlines, document h2s and the desk's narrative lede —
+     bundled Source Serif 4 variable (OFL, self-hosted via @fontsource, no CDN). */
+  --font-serif: "Source Serif 4 Variable", Georgia, "Times New Roman", serif;
+  /* REAL monospace — code blocks, .num data cells, chart axis ticks. System
+     stack, zero bytes shipped. (--font-mono is the sans lever, not actual mono.) */
+  --font-code: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
 }
 
 .scrollbar-hidden { scrollbar-width: none; }
@@ -30,13 +38,18 @@
 .text-\[11px\] { font-size: 13px; line-height: 1.5; }
 .text-\[12px\] { font-size: 13px; line-height: 1.5; }
 
-/* Softer, more modern corners app-wide; pills keep rounded-full. */
-.rounded { border-radius: 0.5rem; }
+/* Squarer corners app-wide (institutional, not app-y); pills keep rounded-full. */
+.rounded { border-radius: 0.375rem; }
 
 /* Obsyd identity: crisp monospace + tabular figures for DATA values on the sans UI
    (a clean-UI + terminal-numbers signature that reads more "analyst desk" than
    an all-round sans). Applied via `.num` to numeric cells/values. */
-.num { font-family: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, monospace; font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
+.num { font-family: var(--font-code); font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
+
+/* Section labels: small caps instead of letterspaced ALL-CAPS eyebrows. Applied
+   to UPPERCASE source strings — font-variant-caps restyles without changing
+   textContent, so text-matching harnesses (verify-zone-coherence) stay green. */
+.smallcaps { font-variant-caps: all-small-caps; letter-spacing: 0.04em; }
 
 body {
   margin: 0;
@@ -62,14 +75,14 @@ body {
    the rules below then handle the hardcoded neutral/near-black utilities and the
    recharts gridlines that don't read from tokens. */
 html.light {
-  --color-cyan-glow: #0d9488;   /* de-neoned teal, readable on white */
-  --color-green-glow: #16a34a;
+  --color-cyan-glow: #1d4ed8;   /* academic ink-blue, 6.7:1 on white */
+  --color-green-glow: #15803d;  /* darkened for white (was #16a34a at 3.3:1) */
   --color-surface: #ffffff;
-  --color-surface-light: #f1f3f7;
-  --color-border: #e5e7eb;
+  --color-surface-light: #f3f3f1;  /* warmed */
+  --color-border: #e5e4e0;         /* warmed */
 }
 html.light body {
-  background-color: #f6f7f9;
+  background-color: #fbfbfa;  /* paper, not cool gray */
   color: #111827;
 }
 /* Neutral text scale, inverted for a light background. */
@@ -88,10 +101,14 @@ html.light .bg-\[\#06060a\] { background-color: #ffffff; }
 html.light .bg-neutral-800 { background-color: #eef1f6; }
 html.light .bg-neutral-900 { background-color: #f3f4f7; }
 /* Light-palette accents that are too pale on white → darker equivalents. */
-html.light .text-cyan-300 { color: #0f766e; }
-html.light .text-cyan-400 { color: #0d9488; }
+html.light .text-cyan-300 { color: #1e40af; }
+html.light .text-cyan-400 { color: #1d4ed8; }
 html.light .text-violet-300 { color: #6d28d9; }
 html.light .text-amber-300 { color: #b45309; }
+/* Semantic state text (C/E/S vocabulary) — the raw Tailwind values fail contrast
+   on white (yellow-400 ~1.8:1, red-400 ~3:1). Hues stay, ink darkens. */
+html.light .text-yellow-400 { color: #a16207; }
+html.light .text-red-400 { color: #dc2626; }
 /* Chart gridlines are drawn with a white-alpha stroke (invisible on white). */
 html.light .recharts-cartesian-grid line { stroke: #0000000f; }
 /* Recharts tooltips carry a dark inline contentStyle → force light in light theme. */

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import '@fontsource-variable/source-serif-4'
 import './index.css'
 import App from './App.jsx'
 import { ModeProvider } from './context/ModeContext.jsx'

--- a/frontend/src/utils/chart.js
+++ b/frontend/src/utils/chart.js
@@ -1,5 +1,42 @@
 // Shared chart helpers for the EU gas panels.
 
+import { useTheme } from '../context/ThemeContext'
+
+// Real monospace for axis ticks (mirrors index.css --font-code; SVG text can't
+// read CSS custom properties as attribute values, so the stack is repeated here).
+const CODE_FONT = "ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, Consolas, monospace"
+
+// Theme-aware chart neutrals. Recharts axes/grids take inline SVG props, which
+// CSS (and therefore the html.light overrides) cannot reach — so the values live
+// here as plain objects and components re-render on theme change via the hook.
+// Per the dataviz method: grid hairline + recessive (one step off the surface),
+// tick text in muted ink tokens (never a series color), real mono tabular digits.
+// `accent` is the single-series stroke matching --color-cyan-glow per theme
+// (inline SVG attrs can't resolve var(--…) either).
+export const CHART_THEME = {
+  dark: {
+    grid: { stroke: '#262a33', strokeOpacity: 0.6, vertical: false },
+    tick: { fontSize: 10, fill: '#8b8fa3', fontFamily: CODE_FONT },
+    axisLine: { stroke: '#262a33' },
+    accent: '#7aa5e8',
+    ink: '#e5e7eb',
+  },
+  light: {
+    grid: { stroke: '#e9e8e4', vertical: false },
+    tick: { fontSize: 10, fill: '#6b7280', fontFamily: CODE_FONT },
+    axisLine: { stroke: '#d9d8d3' },
+    accent: '#1d4ed8',
+    ink: '#374151',
+  },
+}
+
+// Usage: const ct = useChartTheme()
+//   <CartesianGrid {...ct.grid} /> · tick={ct.tick} · axisLine={ct.axisLine}
+export function useChartTheme() {
+  const { theme } = useTheme()
+  return CHART_THEME[theme === 'light' ? 'light' : 'dark']
+}
+
 // Delivery-date labels are UTC dates. Without an explicit timeZone the browser
 // renders UTC midnight in local time, which shifts every label a day backwards
 // for viewers west of UTC.


### PR DESCRIPTION
## Why

Owner verdict: the site reads as generic "vibe-coded" SaaS. Approved direction: academic-institutional (FRED / Our World in Data frame), light-first, serif/sans pairing, provenance-forward — across landing, /docs and the desk. This is **pass A of three** (B = landing/docs/legal rewrite, C = desk chrome + provenance); each pass leaves prod coherent.

## What

- **Accent**: teal → academic ink-blue via the `--color-cyan-glow` token (`#1d4ed8` light 6.7:1, `#7aa5e8` dark 7.5:1); green darkened for white; light surfaces warmed to paper; `.rounded` 0.5→0.375rem app-wide (273 usages).
- **Type tokens**: `--font-serif` (Source Serif 4 variable, self-hosted via @fontsource — no CDN) + `--font-code` (real system mono); `.num` now real mono; new `.smallcaps` utility (styles UPPERCASE strings without changing textContent — zone-coherence harness stays green).
- **C/E/S light-theme contrast**: `text-yellow-400`→`#a16207`, `text-red-400`→`#dc2626` on white (were 1.8:1 / 3:1).
- **Theme-aware charts**: `CHART_THEME` + `useChartTheme()` in `utils/chart.js`; 27 reachable chart files swept — hard-coded `#1e1e2e`/`#ffffff10` grids, 8px `#555` ticks and `#22d3ee` neon strokes → `ct.grid`/`ct.tick`/`ct.accent`/`ct.ink`. Ticks now 10px real mono tabular. Module-level color configs use an `'accent'`/`'ink'` sentinel resolved at render.
- **Untouched by design**: `fuels.js` (CVD-validated), powermap `palettes.js`, embeds (theme-immune), series-identity + semantic colors, dormant components, layout/density.
- **New**: `scripts/screenshot-sweep.mjs` — 20-shot before/after sweep (6 tabs + 4 static routes × 2 themes).

## Verification

- Build clean; lint delta 0 (same 25 pre-existing problems as main).
- `verify-zone-coherence.mjs` against the built bundle: ALL PASS.
- 20/20 sweep screenshots captured and eyeballed in both themes against the pre-change baseline: accent coherent everywhere, fuel colors pixel-identical, semantic amber/red/violet intact, PowerMap/embeds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbYecg1KBfMZRFb6wRWX8s