### PR TITLE
Redesign desk: calm chrome, one staleness vocabulary, visible provenance (C of 3)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -117,6 +117,22 @@ const DEFAULT_TAB = 'europe'
 // Page heading per section ("Live monitoring" title on the content).
 const PAGE_TITLES = { europe: 'Live monitoring', energy: 'Power', analytics: 'Analytics', gas: 'Gas', explore: 'Data explorer', alerts: 'Alerts' }
 
+// Desk footer: the provenance + citability line that used to live only on the
+// marketing pages — sources, DOI, API, and the path to the reading guide.
+function DeskFooter({ onHowToRead }) {
+  return (
+    <div className="mt-6 px-4 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 font-mono text-[9px] text-neutral-600">
+      <span>Sources: ENTSO-E Transparency · Fraunhofer Energy-Charts (CC BY 4.0) · GIE</span>
+      <span>·</span>
+      <a href="/#cite" className="hover:text-cyan-glow">Cite this desk — DOI 10.5281/zenodo.21699869</a>
+      <span>·</span>
+      <a href="/docs" className="hover:text-cyan-glow">API docs</a>
+      <span>·</span>
+      <button onClick={onHowToRead} className="hover:text-cyan-glow">How to read this desk</button>
+    </div>
+  )
+}
+
 function Disclaimer() {
   return (
     <footer className="mt-4 mb-4 px-4 text-center font-mono text-[9px] text-neutral-700 leading-relaxed max-w-2xl mx-auto">
@@ -358,7 +374,7 @@ function Dashboard() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="border border-red-500/30 bg-red-500/5 p-6 max-w-md">
-          <div className="text-red-400 font-mono text-xs mb-2">// CONNECTION ERROR</div>
+          <div className="text-red-400 font-mono text-xs mb-2 smallcaps">CONNECTION ERROR</div>
           <div className="text-red-300 font-mono text-sm">{error}</div>
           <div className="text-neutral-500 font-mono text-xs mt-3">
             The data API is not responding — usually temporary. Self-hosting? Check that the
@@ -745,7 +761,7 @@ function Dashboard() {
         {activeTab === 'analytics' && (
           <>
             <div className="mb-2">
-              <span className="font-mono text-[10px] text-neutral-600 tracking-wider">// ANALYTICS · deep history · {energyZone}</span>
+              <span className="font-mono text-[10px] text-neutral-600 smallcaps">ANALYTICS · deep history · {energyZone}</span>
             </div>
             <ErrorBoundary name="duration-curve">
               <DurationCurvePanel zone={energyZone} />
@@ -855,6 +871,12 @@ function Dashboard() {
       </div>
 
         {/* ===== FOOTER ===== */}
+        <DeskFooter
+          onHowToRead={() => {
+            goToTab('europe')
+            setTimeout(() => scrollToSection('panel-how-to-read'), 150)
+          }}
+        />
         <Disclaimer />
       </main>
 

--- a/frontend/src/components/BalancingPanel.jsx
+++ b/frontend/src/components/BalancingPanel.jsx
@@ -133,6 +133,7 @@ export default function BalancingPanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A84 · aFRR/mFRR balancing energy prices"
       id="power-balancing"
       freshness={data}
       title={`BALANCING · ${zl}`}

--- a/frontend/src/components/BordersPanel.jsx
+++ b/frontend/src/components/BordersPanel.jsx
@@ -178,6 +178,7 @@ export default function BordersPanel({ focus }) {
 
   return (
     <Panel
+      source="ENTSO-E A44 spreads · A61 NTC · Fraunhofer Energy-Charts flows (CC BY 4.0)"
       id="power-borders"
       title="BORDERS · PRICE CONVERGENCE & CONGESTION"
       info={<BordersLegend eps={data?.coupled_eps_eur} />}

--- a/frontend/src/components/CapacityPricePanel.jsx
+++ b/frontend/src/components/CapacityPricePanel.jsx
@@ -105,6 +105,7 @@ export default function CapacityPricePanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A15 · balancing capacity tenders"
       id="power-capacity-prices"
       freshness={data}
       title={`CAPACITY PRICES · ${zl}`}

--- a/frontend/src/components/CrossBorderFlowPanel.jsx
+++ b/frontend/src/components/CrossBorderFlowPanel.jsx
@@ -192,6 +192,7 @@ export default function CrossBorderFlowPanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="Fraunhofer Energy-Charts (CC BY 4.0)"
       id="cross-border-flows"
       freshness={data}
       title={`CROSS-BORDER FLOWS · ${zl}`}

--- a/frontend/src/components/FreshnessCaption.jsx
+++ b/frontend/src/components/FreshnessCaption.jsx
@@ -19,20 +19,26 @@
  * `age_days` is optional throughout: /power/overview rows carry `stale` and
  * `as_of` but no age, and "STALE · nulld" is worse than an unqualified STALE.
  */
+// The ONE stale badge — same vocabulary wherever a lagging feed is flagged
+// (panel headers, the situation hero's per-metric tags, the overview matrix).
+export function StaleChip({ asOf, ageDays, dense = false, className = '' }) {
+  return (
+    <span
+      className={`shrink-0 font-mono tracking-wide text-orange-400 border border-orange-500/30 rounded ${
+        dense ? 'text-[8px] px-1 py-px' : 'text-[9px] px-1.5 py-0.5'
+      } ${className}`}
+      title={`Latest data ${asOf ?? 'unknown'} (UTC)${ageDays != null ? ` — ${ageDays}d old` : ''}, this feed may be stalled`}
+    >
+      STALE{ageDays != null ? ` · ${ageDays}d` : ''}
+    </span>
+  )
+}
+
 export default function FreshnessCaption({ meta, dense = false }) {
   if (!meta?.as_of) return null
 
   if (meta.stale) {
-    return (
-      <span
-        className={`shrink-0 font-mono tracking-wide text-orange-400 border border-orange-500/30 rounded ${
-          dense ? 'text-[8px] px-1 py-px' : 'text-[9px] px-1.5 py-0.5'
-        }`}
-        title={`Latest data ${meta.as_of} (UTC)${meta.age_days != null ? ` — ${meta.age_days}d old` : ''}, this feed may be stalled`}
-      >
-        STALE{meta.age_days != null ? ` · ${meta.age_days}d` : ''}
-      </span>
-    )
+    return <StaleChip asOf={meta.as_of} ageDays={meta.age_days} dense={dense} />
   }
 
   return (

--- a/frontend/src/components/GasBalancePanel.jsx
+++ b/frontend/src/components/GasBalancePanel.jsx
@@ -58,6 +58,7 @@ export default function GasBalancePanel() {
 
   return (
     <Panel
+      source="GIE AGSI · ENTSOG · ENTSO-E power burn"
       id="gas-balance"
       freshness={data}
       title="EU GAS BALANCE · RESIDUAL"

--- a/frontend/src/components/GenerationMixPanel.jsx
+++ b/frontend/src/components/GenerationMixPanel.jsx
@@ -53,6 +53,7 @@ export default function GenerationMixPanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A75 · actual generation per production type"
       id="generation-mix"
       freshness={data}
       title={`GENERATION MIX · ${zoneLabel}`}

--- a/frontend/src/components/HydroReservoirPanel.jsx
+++ b/frontend/src/components/HydroReservoirPanel.jsx
@@ -70,6 +70,7 @@ export default function HydroReservoirPanel({ zone = null }) {
 
   return (
     <Panel
+      source="ENTSO-E A72 · weekly reservoir filling"
       id="hydro-reservoirs"
       title={zone == null ? 'HYDRO RESERVOIRS · WEEKLY FILLING' : `HYDRO RESERVOIR · ${zones[0]?.zone_label ?? zone}`}
       freshness={data}

--- a/frontend/src/components/ImbalancePanel.jsx
+++ b/frontend/src/components/ImbalancePanel.jsx
@@ -82,6 +82,7 @@ export default function ImbalancePanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A85 · imbalance settlement prices"
       id="power-imbalance"
       freshness={data}
       title={`IMBALANCE PRICE · ${zl}`}

--- a/frontend/src/components/OutagePanel.jsx
+++ b/frontend/src/components/OutagePanel.jsx
@@ -81,6 +81,7 @@ export default function OutagePanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A77 · generation unavailability"
       id="power-outages"
       title={`${view === 'transmission' ? 'TRANSMISSION' : 'GENERATION'} OUTAGES · ${zoneLabel}`}
       freshness={data}

--- a/frontend/src/components/Panel.jsx
+++ b/frontend/src/components/Panel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 
 import FreshnessCaption from './FreshnessCaption'
+import Provenance from './Provenance'
 
 export function InfoPopover({ text, wide = false }) {
   const [open, setOpen] = useState(false)
@@ -62,7 +63,7 @@ function ApiChip({ downloadUrl }) {
   return (
     <button
       onClick={copy}
-      className={`font-mono text-[9px] tracking-wider border rounded px-1.5 py-0.5 transition-colors ${
+      className={`font-code text-[9px] tracking-wider border rounded px-1.5 py-0.5 transition-colors ${
         copied
           ? 'text-cyan-glow border-cyan-glow/40'
           : 'text-neutral-500 border-border hover:text-cyan-glow hover:border-cyan-glow/40'
@@ -74,7 +75,7 @@ function ApiChip({ downloadUrl }) {
   )
 }
 
-export default function Panel({ id, title, info, infoWide = false, collapsible = false, defaultCollapsed = false, expandSignal, headerRight, downloadUrl, freshness, children }) {
+export default function Panel({ id, title, info, infoWide = false, collapsible = false, defaultCollapsed = false, expandSignal, headerRight, downloadUrl, freshness, source, children }) {
   const [collapsed, setCollapsed] = useState(() => {
     if (!collapsible) return false
     try {
@@ -111,7 +112,7 @@ export default function Panel({ id, title, info, infoWide = false, collapsible =
         }`}
       >
         <div className="flex items-center gap-2 min-w-0">
-          <span className="font-mono text-[11px] font-semibold text-neutral-300 truncate">
+          <span className="font-mono text-[12px] font-medium smallcaps text-neutral-400 truncate">
             {title}
           </span>
           {info && <InfoPopover text={info} wide={infoWide} />}
@@ -123,7 +124,7 @@ export default function Panel({ id, title, info, infoWide = false, collapsible =
               <a
                 href={downloadUrl}
                 onClick={(e) => e.stopPropagation()}
-                className="font-mono text-[9px] tracking-wider border border-border rounded px-1.5 py-0.5 text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
+                className="font-code text-[9px] tracking-wider border border-border rounded px-1.5 py-0.5 text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
                 title="Download this panel's data as CSV (the same URL serves JSON or Parquet via format=)"
               >
                 ↓ CSV
@@ -144,6 +145,11 @@ export default function Panel({ id, title, info, infoWide = false, collapsible =
         </div>
       </div>
       {!collapsed && children}
+      {/* Visible provenance line (was buried in ⓘ popovers) — pass the exact
+          source claim, e.g. "ENTSO-E A44 · day-ahead auction". */}
+      {!collapsed && source && (
+        <Provenance source={source} className="px-4 py-1.5 border-t border-border/40" />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/PowerDayAheadPanel.jsx
+++ b/frontend/src/components/PowerDayAheadPanel.jsx
@@ -58,6 +58,7 @@ export default function PowerDayAheadPanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A44 · day-ahead auction prices"
       id="power-day-ahead"
       freshness={data}
       title={`POWER DAY-AHEAD · ${zoneLabel}`}

--- a/frontend/src/components/PowerGridPanel.jsx
+++ b/frontend/src/components/PowerGridPanel.jsx
@@ -56,6 +56,7 @@ export default function PowerGridPanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A65 load · A75 generation"
       id="power-grid"
       freshness={data}
       title={`RESIDUAL LOAD · ${zoneLabel}`}

--- a/frontend/src/components/PowerLoadForecastPanel.jsx
+++ b/frontend/src/components/PowerLoadForecastPanel.jsx
@@ -69,6 +69,7 @@ export default function PowerLoadForecastPanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A65/A69 · published day-ahead forecasts"
       id="power-load-forecast"
       freshness={data}
       title="LOAD FORECAST vs ACTUAL // ENTSO-E"

--- a/frontend/src/components/PowerOverviewMatrix.jsx
+++ b/frontend/src/components/PowerOverviewMatrix.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { InfoPopover } from './Panel'
+import { StaleChip } from './FreshnessCaption'
 import useFetchWithError from '../hooks/useFetchWithError'
 import { POLL_FAST_MS } from '../utils/poll'
 import { ZONE_STATE, STATE_ORDER, zColor, metricGlossary } from '../utils/zoneState'
@@ -145,7 +146,7 @@ export default function PowerOverviewMatrix({ selectedZone, onSelect, compact = 
                   <td className={`${edgeX} py-2 text-neutral-200 whitespace-nowrap`}>
                     {z.zone_label}
                     {sel && <span className="text-cyan-glow"> ‹</span>}
-                    {z.stale && <span className="text-orange-400/70 text-[8px]"> stale</span>}
+                    {z.stale && <StaleChip asOf={z.as_of} dense className="ml-1" />}
                   </td>
                   {/* Compact swaps the word for the dot + its letter. The letter
                       is the accessibility carrier (colour alone fails red-green

--- a/frontend/src/components/PowerSituationHeader.jsx
+++ b/frontend/src/components/PowerSituationHeader.jsx
@@ -3,6 +3,8 @@ import { POLL_FAST_MS } from '../utils/poll'
 import { InfoPopover } from './Panel'
 import PanelTakeaway from './PanelTakeaway'
 import ReferenceBand from './ReferenceBand'
+import { StaleChip } from './FreshnessCaption'
+import { ZONE_STATE } from '../utils/zoneState'
 import { zPhrase, residualPhrase } from '../utils/takeaway'
 
 const API = '/api'
@@ -18,27 +20,16 @@ const stateLegend = (baselineDays) =>
   'ELEVATED: ≥2σ, or a Dunkelflaute (wind+solar under 15% of load AND in the bottom 2% of this zone\'s own same-month record) / negative-price flag. ' +
   'CALM: within ~2σ and no flags.'
 
-// Descriptive desk state → colour. Posture B: this is "how far from normal",
-// not a forecast. CALM / ELEVATED / STRESSED come straight from the backend.
-const STATE_STYLE = {
-  CALM: { text: 'text-green-glow', dot: 'bg-green-glow', border: 'border-green-500/30' },
-  ELEVATED: { text: 'text-yellow-400', dot: 'bg-yellow-400', border: 'border-yellow-500/30' },
-  STRESSED: { text: 'text-red-400', dot: 'bg-red-400', border: 'border-red-500/30' },
-}
+// Descriptive desk state → colour comes from the ONE canonical map in
+// utils/zoneState.js (this file used to carry a private duplicate).
 
 // Per-component age tag: each metric carries its own freshness so a fresh
 // day-ahead price can never make a days-old residual/renewables figure look
-// current (the backend flags each block separately).
+// current (the backend flags each block separately). Shared StaleChip so the
+// desk speaks one staleness vocabulary.
 function StaleTag({ comp }) {
   if (!comp?.stale) return null
-  return (
-    <span
-      className="font-mono text-[8px] tracking-wide text-orange-400 border border-orange-500/30 rounded px-1 py-px ml-1.5 align-middle"
-      title={`Latest data ${comp.as_of} — this series may be stalled`}
-    >
-      {comp.age_days}d old
-    </span>
-  )
+  return <StaleChip asOf={comp.as_of} ageDays={comp.age_days} dense className="ml-1.5 align-middle" />
 }
 
 function Metric({ label, value, sub, color, band, comp }) {
@@ -71,7 +62,7 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
   if (error && !data) {
     return (
       <div className="border border-red-500/20 bg-surface rounded px-4 py-3">
-        <div className="font-mono text-[10px] text-red-400">POWER SITUATION // FETCH ERROR</div>
+        <div className="font-mono text-[10px] text-red-400 smallcaps">POWER SITUATION · FETCH ERROR</div>
       </div>
     )
   }
@@ -90,7 +81,7 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
   if (!data?.available) {
     return (
       <div className="border border-border bg-surface rounded px-4 py-5">
-        <div className="font-mono text-[10px] text-neutral-600 tracking-wider">// POWER SITUATION</div>
+        <div className="font-mono text-[10px] text-neutral-600 smallcaps">POWER SITUATION</div>
         <div className="font-mono text-xs text-neutral-500 mt-2">
           No power data for {data?.zone_label || zone} yet — check back shortly.
         </div>
@@ -98,7 +89,7 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
     )
   }
 
-  const st = STATE_STYLE[data.state] || STATE_STYLE.CALM
+  const st = ZONE_STATE[data.state] || ZONE_STATE.CALM
   const { price, grid, spark, flags = [] } = data
 
   const priceColor = price.z != null && Math.abs(price.z) >= 2 ? st.text : 'text-neutral-200'
@@ -114,7 +105,7 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
       {/* Header bar: label + zone + state */}
       <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
         <div className="flex items-center gap-2 min-w-0">
-          <span className="font-mono text-[10px] text-neutral-500 tracking-wider">// POWER SITUATION</span>
+          <span className="font-mono text-[10px] text-neutral-500 smallcaps">POWER SITUATION</span>
           <span className="font-mono text-[10px] text-cyan-glow px-1.5 py-0.5 border border-cyan-glow/20 rounded">
             {data.zone_label}
           </span>
@@ -129,14 +120,7 @@ export default function PowerSituationHeader({ zone = 'DE_LU' }) {
             (() => {
               const worst = Math.max(
                 ...[price, grid, spark].filter((c) => c?.stale).map((c) => c.age_days ?? 0), 0)
-              return (
-                <span
-                  className="font-mono text-[9px] tracking-wide text-orange-400 border border-orange-500/30 rounded px-1 py-0.5"
-                  title="At least one series is lagging — see the metric tags below"
-                >
-                  STALE · {worst}d
-                </span>
-              )
+              return <StaleChip asOf={data.as_of} ageDays={worst} />
             })()
           ) : (
             data.as_of && <span className="font-mono text-[9px] text-neutral-600 hidden sm:inline">{data.as_of}</span>

--- a/frontend/src/components/ProductsPanel.jsx
+++ b/frontend/src/components/ProductsPanel.jsx
@@ -46,6 +46,7 @@ export default function ProductsPanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A44 · derived base/peak products"
       id="power-products"
       title={`BASE / PEAK · ${data?.zone_label ?? zone}`}
       info={data?.note || 'Base, Peak and Off-peak on the CET delivery day.'}

--- a/frontend/src/components/RecordChip.jsx
+++ b/frontend/src/components/RecordChip.jsx
@@ -36,7 +36,7 @@ export default function RecordChip({ zone = 'DE_LU' }) {
 
   return (
     <div className="border border-yellow-500/30 bg-yellow-500/5 rounded px-3 py-2 flex flex-wrap items-center gap-x-3 gap-y-1">
-      <span className="font-mono text-[9px] font-bold tracking-widest text-yellow-400">⚡ NEW RECORD</span>
+      <span className="font-mono text-[10px] font-semibold smallcaps text-yellow-400">NEW RECORD</span>
       {fresh.slice(0, 2).map((r) => (
         <span key={`${r.series}-${r.kind}`} className="font-mono text-[10px] text-neutral-300">
           {fmt(r)}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -22,6 +22,18 @@ function Icon({ name }) {
   }
 }
 
+// Utility-row icons in the same linear style as the nav <Icon/>s — replaces
+// the ☾/☀/⚙ pictographs (the last emoji-adjacent glyphs in the shell).
+function UtilIcon({ name }) {
+  const p = { width: 12, height: 12, viewBox: '0 0 16 16', fill: 'none', stroke: 'currentColor', strokeWidth: 1.4, strokeLinecap: 'round', strokeLinejoin: 'round', style: { display: 'inline-block', verticalAlign: '-1px' } }
+  switch (name) {
+    case 'moon': return (<svg {...p}><path d="M13.5 9.8A5.7 5.7 0 016.2 2.5a5.7 5.7 0 107.3 7.3z" /></svg>)
+    case 'sun': return (<svg {...p}><circle cx="8" cy="8" r="3" /><line x1="8" y1="1.5" x2="8" y2="3" /><line x1="8" y1="13" x2="8" y2="14.5" /><line x1="1.5" y1="8" x2="3" y2="8" /><line x1="13" y1="8" x2="14.5" y2="8" /><line x1="3.5" y1="3.5" x2="4.6" y2="4.6" /><line x1="11.4" y1="11.4" x2="12.5" y2="12.5" /><line x1="3.5" y1="12.5" x2="4.6" y2="11.4" /><line x1="11.4" y1="4.6" x2="12.5" y2="3.5" /></svg>)
+    case 'sliders': return (<svg {...p}><line x1="2.5" y1="5" x2="13.5" y2="5" /><line x1="2.5" y1="11" x2="13.5" y2="11" /><circle cx="6" cy="5" r="1.6" fill="currentColor" stroke="none" /><circle cx="10" cy="11" r="1.6" fill="currentColor" stroke="none" /></svg>)
+    default: return null
+  }
+}
+
 function StatusDot({ label, ok }) {
   return (
     <div className="flex items-center gap-1.5 font-mono text-[10px]">
@@ -49,7 +61,7 @@ function SidebarContent({ tabs, activeTab, onNavigate, onOpenPalette, onOpenSett
   return (
     <div className="flex flex-col h-full">
       <div className="px-4 py-4 border-b border-border">
-        <a href="/" title="Back to the landing page" className="block font-mono text-lg font-bold tracking-widest text-cyan-glow hover:opacity-80 transition-opacity">OBSYD</a>
+        <a href="/" title="Back to the landing page" className="block font-serif smallcaps text-xl font-semibold tracking-wide text-cyan-glow hover:opacity-80 transition-opacity">OBSYD</a>
         <div className="font-mono text-[10px] text-neutral-600 tracking-wider">European Electricity Desk</div>
       </div>
 
@@ -82,14 +94,18 @@ function SidebarContent({ tabs, activeTab, onNavigate, onOpenPalette, onOpenSett
             title="Toggle light / dark theme"
             className="font-mono text-[10px] px-2 py-1 rounded border border-border text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
           >
-            {theme === 'light' ? '☾ Dark' : '☀ Light'}
+            <span className="inline-flex items-center gap-1.5">
+              {theme === 'light' ? <><UtilIcon name="moon" /> Dark</> : <><UtilIcon name="sun" /> Light</>}
+            </span>
           </button>
           <button
             onClick={onOpenSettings}
             title="Settings"
             className="font-mono text-[10px] px-2 py-1 rounded border border-border text-neutral-500 hover:text-cyan-glow hover:border-cyan-glow/40 transition-colors"
           >
-            ⚙ Settings
+            <span className="inline-flex items-center gap-1.5">
+              <UtilIcon name="sliders" /> Settings
+            </span>
           </button>
         </div>
         <div className="px-1"><AuthButton /></div>

--- a/frontend/src/components/SparkSpreadPanel.jsx
+++ b/frontend/src/components/SparkSpreadPanel.jsx
@@ -47,6 +47,7 @@ export default function SparkSpreadPanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A44 power · TTF gas"
       id="spark-spread"
       freshness={data}
       title={`SPARK SPREAD · ${zoneLabel} · CCGT MARGIN`}

--- a/frontend/src/components/UnitGenerationPanel.jsx
+++ b/frontend/src/components/UnitGenerationPanel.jsx
@@ -74,6 +74,7 @@ export default function UnitGenerationPanel({ zone = 'DE_LU' }) {
 
   return (
     <Panel
+      source="ENTSO-E A73 · per-unit actual generation"
       id="unit-generation"
       title="PLANT OUTPUT · LATEST PUBLISHED READINGS"
       freshness={data}


### PR DESCRIPTION
## What

Final pass of the academic-institutional redesign (#161 foundations, #162 pages). Layout and data density untouched — the chrome becomes scholarly apparatus:

- **Panel**: small-caps titles (UPPERCASE · SUBTITLE kept, textContent unchanged), real-mono chips, new optional `source` prop → visible provenance footer line, wired on 15 top panels with the exact ENTSO-E/Energy-Charts/GIE claims that used to hide in ⓘ popovers.
- **One staleness vocabulary**: `StaleChip` exported from FreshnessCaption; adopted in PowerSituationHeader (kills its private StaleTag + inline worst-stale markup) and PowerOverviewMatrix (bare " stale" text).
- **PowerSituationHeader**: private STATE_STYLE deleted → canonical `ZONE_STATE` from utils/zoneState; `// POWER SITUATION` → small caps.
- **DeskFooter** on every tab: sources · Cite this desk (DOI) · API docs · How to read this desk (jumps to the EUROPE glossary).
- **Sidebar**: serif small-caps wordmark, SVGs replace the last pictographs (☾/☀/⚙); RecordChip drops ⚡; last rendered `// ` eyebrows removed.

## Verification

Build clean · lint delta 0 · Playwright: POWER SITUATION textContent intact (zone-coherence harness ALL PASS), source lines render on power+gas tabs, DeskFooter DOI/API links, how-to-read navigation works, no pictographs remain · desk eyeballed light+dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbYecg1KBfMZRFb6wRWX8s