### PR TITLE
Display face: drop the serif, go all-sans (FRED/IEA line)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,6 @@
         "@deck.gl/extensions": "^9.2.10",
         "@deck.gl/layers": "^9.2.10",
         "@deck.gl/react": "^9.2.10",
-        "@fontsource-variable/source-serif-4": "^5.3.0",
         "@tailwindcss/vite": "^4.2.1",
         "deck.gl": "^9.2.10",
         "lightweight-charts": "^5.1.0",
@@ -1392,15 +1391,6 @@
       "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@fontsource-variable/source-serif-4": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/source-serif-4/-/source-serif-4-5.3.0.tgz",
-      "integrity": "sha512-9vch9WqxjaaA+1o9Ur8pOgIGbCYLjRReOUel23A6lOpD1syptgjtkORevvNmldJ5kGXQL29onQUqI5Ltz0s3bQ==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "@deck.gl/extensions": "^9.2.10",
     "@deck.gl/layers": "^9.2.10",
     "@deck.gl/react": "^9.2.10",
-    "@fontsource-variable/source-serif-4": "^5.3.0",
     "@tailwindcss/vite": "^4.2.1",
     "deck.gl": "^9.2.10",
     "lightweight-charts": "^5.1.0",

--- a/frontend/src/components/DevDocsPage.jsx
+++ b/frontend/src/components/DevDocsPage.jsx
@@ -46,7 +46,7 @@ export default function DevDocsPage() {
     <DocShell>
       {/* HEADER */}
       <SectionLabel className="mb-5">API &amp; DEVELOPER DOCS</SectionLabel>
-      <h1 className="font-serif text-3xl sm:text-4xl font-semibold tracking-tight text-neutral-100 leading-tight mb-4">
+      <h1 className="font-display text-3xl sm:text-4xl font-bold tracking-tight text-neutral-100 leading-tight mb-4">
         The European power record, one request away.
       </h1>
       <p className="text-[14px] text-neutral-400 leading-relaxed max-w-2xl mb-6">

--- a/frontend/src/components/Landing.jsx
+++ b/frontend/src/components/Landing.jsx
@@ -80,7 +80,7 @@ function LiveFigure() {
       <div className="max-w-5xl mx-auto px-5 py-12">
         <SectionLabel className="mb-5">LIVE FROM THE DESK</SectionLabel>
         <figure>
-          <p className="font-serif text-xl sm:text-2xl leading-relaxed text-neutral-200 max-w-3xl">
+          <p className="font-display text-xl sm:text-2xl leading-relaxed text-neutral-200 max-w-3xl">
             {lead}{moverText ? ' — ' : '. '}
             {moverText && <>{moverText}. </>}
             {spreadText && <>{spreadText} </>}
@@ -132,7 +132,7 @@ export default function Landing() {
       {/* HERO */}
       <section className="max-w-5xl mx-auto px-5 pt-16 pb-14 sm:pt-24 sm:pb-20">
         <SectionLabel className="mb-6">THE EUROPEAN ELECTRICITY DESK</SectionLabel>
-        <h1 className="font-serif text-4xl sm:text-5xl font-semibold tracking-tight text-neutral-100 leading-[1.15] mb-6 max-w-3xl">
+        <h1 className="font-display text-4xl sm:text-5xl font-bold tracking-tight text-neutral-100 leading-[1.15] mb-6 max-w-3xl">
           The European power grid — every zone, one desk, free.
         </h1>
         <p className="text-[15px] text-neutral-400 max-w-2xl leading-relaxed mb-8">
@@ -164,14 +164,14 @@ export default function Landing() {
       {/* HOW IT WORKS */}
       <section id="how" className="max-w-5xl mx-auto px-5 py-16 sm:py-20">
         <SectionLabel className="mb-4">HOW IT WORKS</SectionLabel>
-        <h2 className="font-serif text-2xl sm:text-3xl font-semibold text-neutral-100 mb-10">
+        <h2 className="font-display text-2xl sm:text-3xl font-semibold text-neutral-100 mb-10">
           See the situation. Catch the stress. Stay honest.
         </h2>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-14">
           {PILLARS.map((p) => (
             <div key={p.title} className="border-t-2 border-border pt-4">
-              <div className="font-serif text-[17px] font-semibold text-neutral-100 mb-2 leading-snug">
+              <div className="font-display text-[17px] font-semibold text-neutral-100 mb-2 leading-snug">
                 {p.title}
               </div>
               <div className="text-[13px] text-neutral-500 leading-relaxed">{p.body}</div>
@@ -214,7 +214,7 @@ export default function Landing() {
         <div className="max-w-5xl mx-auto px-5 py-16 sm:py-20 grid grid-cols-1 md:grid-cols-2 gap-10">
           <div>
             <SectionLabel className="mb-4">WHY OBSYD</SectionLabel>
-            <h2 className="font-serif text-2xl font-semibold text-neutral-100 mb-5 leading-snug">
+            <h2 className="font-display text-2xl font-semibold text-neutral-100 mb-5 leading-snug">
               The official power record, turned into a desk.
             </h2>
             <p className="text-[13px] text-neutral-400 leading-relaxed max-w-lg">
@@ -246,7 +246,7 @@ export default function Landing() {
       {/* ENERGY WATCH */}
       <section className="max-w-5xl mx-auto px-5 py-16 sm:py-20">
         <SectionLabel className="mb-4">YOUR ENERGY WATCH</SectionLabel>
-        <h2 className="font-serif text-2xl sm:text-3xl font-semibold text-neutral-100 mb-4">
+        <h2 className="font-display text-2xl sm:text-3xl font-semibold text-neutral-100 mb-4">
           Don&apos;t watch the desk. Let it watch for you.
         </h2>
         <p className="text-[13px] text-neutral-400 leading-relaxed max-w-2xl mb-10">
@@ -289,7 +289,7 @@ export default function Landing() {
       <section id="developers" className="border-y border-border bg-surface">
         <div className="max-w-5xl mx-auto px-5 py-16 sm:py-20">
           <SectionLabel className="mb-4">FOR DEVELOPERS</SectionLabel>
-          <h2 className="font-serif text-2xl sm:text-3xl font-semibold text-neutral-100 mb-3">
+          <h2 className="font-display text-2xl sm:text-3xl font-semibold text-neutral-100 mb-3">
             Every number, straight into your notebook.
           </h2>
           <p className="text-[13px] text-neutral-400 max-w-2xl mb-7 leading-relaxed">
@@ -324,13 +324,13 @@ export default function Landing() {
       {/* PRICING */}
       <section id="pricing" className="max-w-5xl mx-auto px-5 py-16 sm:py-20">
         <SectionLabel className="mb-4">PRICING</SectionLabel>
-        <h2 className="font-serif text-2xl sm:text-3xl font-semibold text-neutral-100 mb-8">
+        <h2 className="font-display text-2xl sm:text-3xl font-semibold text-neutral-100 mb-8">
           It&apos;s free. All of it.
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl">
           <div className="border border-border bg-surface rounded p-6">
             <div className="smallcaps text-[11px] text-neutral-500 mb-1">CLOUD</div>
-            <div className="font-serif text-3xl text-neutral-100 mb-1">€0</div>
+            <div className="font-display text-3xl text-neutral-100 mb-1">€0</div>
             <div className="text-[11px] text-neutral-500 mb-5">on obsyd.dev · no card, no account needed</div>
             <ul className="text-[12px] text-neutral-400 space-y-1.5">
               <li>· Full power desk + anomaly radar</li>
@@ -341,7 +341,7 @@ export default function Landing() {
           </div>
           <div className="border border-border bg-surface rounded p-6">
             <div className="smallcaps text-[11px] text-neutral-500 mb-1">SELF-HOST</div>
-            <div className="font-serif text-3xl text-neutral-100 mb-1">€0</div>
+            <div className="font-display text-3xl text-neutral-100 mb-1">€0</div>
             <div className="text-[11px] text-neutral-500 mb-5">AGPL-3.0 · your infra, your keys</div>
             <ul className="text-[12px] text-neutral-400 space-y-1.5">
               <li>· The exact same code, end to end</li>
@@ -357,7 +357,7 @@ export default function Landing() {
       <section id="cite" className="border-y border-border bg-surface">
         <div className="max-w-5xl mx-auto px-5 py-16 sm:py-20">
           <SectionLabel className="mb-4">CITE OBSYD</SectionLabel>
-          <h2 className="font-serif text-2xl font-semibold text-neutral-100 mb-4">
+          <h2 className="font-display text-2xl font-semibold text-neutral-100 mb-4">
             Citable, like the record it reads.
           </h2>
           <p className="text-[13px] text-neutral-400 max-w-2xl mb-6 leading-relaxed">

--- a/frontend/src/components/LegalPage.jsx
+++ b/frontend/src/components/LegalPage.jsx
@@ -25,20 +25,20 @@ const EMAIL = 'obsyd.dev@pm.me'
 function Impressum() {
   return (
     <>
-      <h1 className="font-serif text-2xl font-semibold text-neutral-100 mb-6">Impressum</h1>
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
+      <h1 className="font-display text-2xl font-semibold text-neutral-100 mb-6">Impressum</h1>
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
         Anbieter (§ 5 DDG, § 18 Abs. 1 MStV)
       </h2>
       {ADDRESS}
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">Kontakt</h2>
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">Kontakt</h2>
       <p>
         E-Mail: <a className="text-cyan-glow" href={`mailto:${EMAIL}`}>{EMAIL}</a>
       </p>
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
         Inhaltlich verantwortlich (§ 18 Abs. 2 MStV)
       </h2>
       <p>Johannes Weisser (Anschrift wie oben)</p>
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">Hinweise</h2>
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">Hinweise</h2>
       <p className="leading-relaxed">
         OBSYD ist ein kostenloses, quelloffenes (AGPL-3.0) Beobachtungswerkzeug für
         den europäischen Strommarkt. Alle Darstellungen sind deskriptiv und beruhen
@@ -53,15 +53,15 @@ function Impressum() {
 function Datenschutz() {
   return (
     <>
-      <h1 className="font-serif text-2xl font-semibold text-neutral-100 mb-6">Datenschutzerklärung</h1>
+      <h1 className="font-display text-2xl font-semibold text-neutral-100 mb-6">Datenschutzerklärung</h1>
 
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">Verantwortlicher</h2>
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">Verantwortlicher</h2>
       {ADDRESS}
       <p className="mt-2">
         E-Mail: <a className="text-cyan-glow" href={`mailto:${EMAIL}`}>{EMAIL}</a>
       </p>
 
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
         1. Server-Logs (Hosting)
       </h2>
       <p className="leading-relaxed">
@@ -73,7 +73,7 @@ function Datenschutz() {
         auf einem Server in Deutschland (Frankfurt am Main).
       </p>
 
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
         2. Reichweitenmessung (Plausible)
       </h2>
       <p className="leading-relaxed">
@@ -84,7 +84,7 @@ function Datenschutz() {
         aggregierte Nutzungsstatistik).
       </p>
 
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">
         3. Login per Magic-Link (optional)
       </h2>
       <p className="leading-relaxed">
@@ -100,14 +100,14 @@ function Datenschutz() {
         E-Mail-Adresse.
       </p>
 
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">4. Keine Weitergabe</h2>
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">4. Keine Weitergabe</h2>
       <p className="leading-relaxed">
         Eine Weitergabe personenbezogener Daten an Dritte findet über die genannten
         Auftragsverarbeiter hinaus nicht statt. Es findet keine automatisierte
         Entscheidungsfindung und kein Profiling statt.
       </p>
 
-      <h2 className="font-serif text-[16px] font-semibold text-neutral-200 mt-6 mb-2">5. Ihre Rechte</h2>
+      <h2 className="font-display text-[16px] font-semibold text-neutral-200 mt-6 mb-2">5. Ihre Rechte</h2>
       <p className="leading-relaxed">
         Sie haben nach Maßgabe der Art. 15–21 DSGVO das Recht auf Auskunft,
         Berichtigung, Löschung, Einschränkung der Verarbeitung, Datenübertragbarkeit

--- a/frontend/src/components/NarrativeHero.jsx
+++ b/frontend/src/components/NarrativeHero.jsx
@@ -26,7 +26,7 @@ export default function NarrativeHero() {
         <span className="w-1 h-4 rounded-full bg-cyan-glow" />
         <h2 className="font-mono text-[13px] font-semibold text-neutral-300">Europe right now</h2>
       </div>
-      <p className="font-serif text-[15px] leading-relaxed text-neutral-400">
+      <p className="font-display text-[15px] leading-relaxed text-neutral-400">
         <span className="text-neutral-200 font-medium">{lead}{moverText ? ' — ' : '. '}</span>
         {moverText && <>{moverText}. </>}
         {spreadText && <>{spreadText} </>}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -61,7 +61,7 @@ function SidebarContent({ tabs, activeTab, onNavigate, onOpenPalette, onOpenSett
   return (
     <div className="flex flex-col h-full">
       <div className="px-4 py-4 border-b border-border">
-        <a href="/" title="Back to the landing page" className="block font-serif smallcaps text-xl font-semibold tracking-wide text-cyan-glow hover:opacity-80 transition-opacity">OBSYD</a>
+        <a href="/" title="Back to the landing page" className="block font-display smallcaps text-xl font-semibold tracking-wide text-cyan-glow hover:opacity-80 transition-opacity">OBSYD</a>
         <div className="font-mono text-[10px] text-neutral-600 tracking-wider">European Electricity Desk</div>
       </div>
 

--- a/frontend/src/components/doc/DocShell.jsx
+++ b/frontend/src/components/doc/DocShell.jsx
@@ -4,7 +4,7 @@
  * language lives. Multi-export file, following the Panel.jsx pattern.
  *
  * All colors come from tokens/utility classes so both themes keep working;
- * typography leans on --font-serif (headings/wordmark) and --font-code (code).
+ * typography leans on --font-display (headings/wordmark) and --font-code (code).
  */
 
 const GITHUB = 'https://github.com/jo20ow/Obsyd'
@@ -12,7 +12,7 @@ const GITHUB = 'https://github.com/jo20ow/Obsyd'
 // Serif small-caps wordmark — the brand mark on every document page.
 export function Wordmark({ href = '/', back = false }) {
   return (
-    <a href={href} className="font-serif smallcaps text-[17px] font-semibold tracking-wide text-cyan-glow hover:opacity-80 transition-opacity">
+    <a href={href} className="font-display smallcaps text-[17px] font-semibold tracking-wide text-cyan-glow hover:opacity-80 transition-opacity">
       {back ? '← Obsyd' : 'Obsyd'}
     </a>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,9 +15,12 @@
      so this token stays the single lever — pointing it at the sans flips the whole
      app from one place. Numbers stay column-aligned via tabular-nums on body. */
   --font-mono: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  /* Display serif for headlines, document h2s and the desk's narrative lede —
-     bundled Source Serif 4 variable (OFL, self-hosted via @fontsource, no CDN). */
-  --font-serif: "Source Serif 4 Variable", Georgia, "Times New Roman", serif;
+  /* Display face for headlines, document h2s and the desk's narrative lede.
+     Owner call 2026-08-29: NO serif — data-infrastructure sites (FRED, IEA,
+     Eurostat) are all-sans; hierarchy comes from weight/size, not a second
+     family. Same system stack as --font-mono, kept as its own token so the
+     display tier stays independently swappable. */
+  --font-display: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   /* REAL monospace — code blocks, .num data cells, chart axis ticks. System
      stack, zero bytes shipped. (--font-mono is the sans lever, not actual mono.) */
   --font-code: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
@@ -127,10 +130,10 @@ html.light .recharts-default-tooltip .recharts-tooltip-item { color: #111827 !im
 .prose-doc { font-size: 15px; line-height: 1.7; }
 .prose-doc > p { max-width: 65ch; }
 .prose-doc h1 {
-  font-family: var(--font-serif); font-weight: 600; font-size: 28px;
+  font-family: var(--font-display); font-weight: 700; font-size: 27px;
   line-height: 1.25; letter-spacing: -0.01em; margin: 0 0 1rem;
 }
 .prose-doc h2 {
-  font-family: var(--font-serif); font-weight: 600; font-size: 19px;
+  font-family: var(--font-display); font-weight: 600; font-size: 17px;
   line-height: 1.35; margin: 1.75rem 0 0.5rem;
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import '@fontsource-variable/source-serif-4'
 import './index.css'
 import App from './App.jsx'
 import { ModeProvider } from './context/ModeContext.jsx'


### PR DESCRIPTION
Owner feedback on #162/#163: the serif headlines read wrong for a data tool. Research data infrastructure (FRED, IEA, Eurostat, ECB Data Portal) is all-sans — hierarchy from weight/size. The serif was one token deep: `--font-serif` → `--font-display` (system sans), ~28 class usages swept, h1 weights bumped for sans presence, Source Serif 4 package removed (zero font bytes again). Everything else from the redesign unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbYecg1KBfMZRFb6wRWX8s